### PR TITLE
updating category attribute test to optional passing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,3 +36,16 @@ jobs:
         else
           bundle exec rake schema:vet
         fi
+
+  orphan_detection:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: ruby/setup-ruby@d5126b9b3579e429dd52e51e68624dda2e05be25 # v1.267.0
+      with:
+        bundler-cache: true
+        working-directory: dev
+    - name: Run orphan detection tests
+      working-directory: dev
+      run: bundle exec rake test:orphan

--- a/dev/Rakefile
+++ b/dev/Rakefile
@@ -16,7 +16,16 @@ namespace :test do
   desc "Run integration tests"
   Rake::TestTask.new(:integration) do |t|
     t.libs << "test"
-    t.pattern = "test/integration/**/*_test.rb"
+    t.test_files = FileList["test/integration/**/*_test.rb"].exclude(
+      "test/integration/orphan_detection_test.rb",
+    )
+    t.options = "--enable-silence"
+  end
+
+  desc "Run orphan detection tests (non-blocking)"
+  Rake::TestTask.new(:orphan) do |t|
+    t.libs << "test"
+    t.test_files = FileList["test/integration/orphan_detection_test.rb"]
     t.options = "--enable-silence"
   end
 

--- a/dev/test/integration/orphan_detection_test.rb
+++ b/dev/test/integration/orphan_detection_test.rb
@@ -21,9 +21,6 @@ module ProductTaxonomy
     end
 
     test "All attributes belong to at least one category" do
-      # Attributes intentionally not assigned to any category. These are either:
-      # - Extended attributes that duplicate a base attribute already on the category
-      # - Attributes too specific for a parent category (would not apply to all children)
       known_orphan_attributes = [
         "accessory_material",
         "arrow/bolt_material",


### PR DESCRIPTION
resolves https://github.com/orgs/shop/projects/165/views/22?sliceBy%5Bvalue%5D=hadijafar&pane=issue&itemId=169149084&issue=shop%7Cissues-taxonomy%7C325

### TL;DR

Added a separate CI job for orphan detection tests that runs independently and doesn't block the main test suite.

### What changed?

- Created a new `orphan_detection` job in the GitHub Actions workflow that runs with `continue-on-error: true`
- Added a new Rake task `test:orphan` that specifically runs the orphan detection test file
- Excluded `orphan_detection_test.rb` from the main integration test suite
- Removed explanatory comments from the orphan detection test file

### How to test?

Run `bundle exec rake test:orphan` in the dev directory to execute the orphan detection tests separately, or trigger the GitHub Actions workflow to see the new job in action.

### Why make this change?

This isolates orphan detection tests from the main test suite to prevent blocking large taxonomy additions