### PR TITLE
Fix Spanish translation of "Prints" art category (Láminas)

### DIFF
--- a/data/localizations/categories/es.yml
+++ b/data/localizations/categories/es.yml
@@ -14194,11 +14194,11 @@ es:
     hg-3-4-1:
       name: Tapicería decorativa
     hg-3-4-2:
-      name: Carteles, copias y arte visual
+      name: Carteles, láminas y arte visual
     hg-3-4-2-1:
       name: Póster
     hg-3-4-2-2:
-      name: Huellas dactilares
+      name: Láminas
     hg-3-4-2-3:
       name: Obras de arte visuales
     hg-3-4-2-4:


### PR DESCRIPTION
Fixes the Spanish translation of the **Prints** art category, which was rendered as "Huellas dactilares" (*fingerprints*) — a translation error grabbing the biometric sense of the word. The category is *Home & Garden > Decor > Artwork > Posters, Prints, & Visual Artwork > Prints*, i.e. prints in the art/printmaking sense.

### Change
| Key | Before | After |
|---|---|---|
| `hg-3-4-2-2` (Prints) | Huellas dactilares | **Láminas** |
| `hg-3-4-2` (Posters, Prints, & Visual Artwork) | Carteles, copias y arte visual | Carteles, **láminas** y arte visual |

"Láminas" is the natural Spanish term for decorative art prints, is already used elsewhere in `es.yml` (e.g. "Láminas para ventana"), and aligns with the other locales (fr *Impressions*, it *Stampe*, de *Drucke*, pt *Impressões*). Applied to both parent and child so they stay consistent.

Per repo convention, localized `dist/` is regenerated at release time, so only the source localization is changed here.
