### PR TITLE
Add new digital product categories

### DIFF
--- a/data/categories/ae_arts_entertainment.yml
+++ b/data/categories/ae_arts_entertainment.yml
@@ -9794,6 +9794,7 @@
   - ae-2-1-6-5-1
   - ae-2-1-6-5-2
   - ae-2-1-6-5-3
+  - ae-2-1-6-5-4
   attributes:
   - mold_material
   - pattern_distribution_format
@@ -9870,6 +9871,26 @@
   - sewing_pattern_size_range
   - skill_level
   - tiling_format
+  return_reasons:
+  - size
+  - style
+  - difficulty_level
+  - changed_my_mind
+  - item_not_as_described
+  - received_the_wrong_item
+  - damaged_or_defective
+  - unknown
+  - other_reason
+- id: ae-2-1-6-5-4
+  name: Digital Sewing Patterns
+  children: []
+  attributes:
+  - mold_material
+  - pattern_distribution_format
+  - sewing_pattern_notions_required
+  - sewing_pattern_recommended_fabric
+  - sewing_pattern_size_range
+  - skill_level
   return_reasons:
   - size
   - style

--- a/data/categories/hb_health_beauty.yml
+++ b/data/categories/hb_health_beauty.yml
@@ -2379,6 +2379,7 @@
   - hb-1-9-5
   - hb-1-9-6
   - hb-1-9-7
+  - hb-1-9-8
   attributes:
   - allergen_information
   - dietary_preferences
@@ -3790,6 +3791,22 @@
   - format
   - ingredients
   - scent
+  - changed_my_mind
+  - item_not_as_described
+  - received_the_wrong_item
+  - damaged_or_defective
+  - unknown
+  - other_reason
+- id: hb-1-9-8
+  name: Digital Meal Plans
+  children: []
+  attributes:
+  - age_group
+  - dietary_preferences
+  - dietary_use
+  - target_gender
+  return_reasons:
+  - dietary_requirements
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item

--- a/data/categories/me_media.yml
+++ b/data/categories/me_media.yml
@@ -10,6 +10,8 @@
   - me-6
   - me-7
   - me-8
+  - me-9
+  - me-10
   attributes:
   - age_restrictions
   return_reasons:
@@ -540,6 +542,89 @@
   - time_period
   return_reasons:
   - academic_level
+  - changed_my_mind
+  - item_not_as_described
+  - received_the_wrong_item
+  - damaged_or_defective
+  - unknown
+  - other_reason
+- id: me-9
+  name: Online Courses
+  children: []
+  attributes:
+  - academic_level
+  - language_version
+  - media_format
+  - subject_area
+  - target_audience
+  return_reasons:
+  - incompatible
+  - language
+  - changed_my_mind
+  - item_not_as_described
+  - received_the_wrong_item
+  - damaged_or_defective
+  - unknown
+  - other_reason
+- id: me-10
+  name: Printables
+  children:
+  - me-10-1
+  - me-10-2
+  - me-10-3
+  attributes:
+  - file_format_type
+  return_reasons:
+  - style
+  - resolution
+  - incompatible
+  - changed_my_mind
+  - item_not_as_described
+  - received_the_wrong_item
+  - damaged_or_defective
+  - unknown
+  - other_reason
+- id: me-10-1
+  name: Wall Art
+  children: []
+  attributes:
+  - artwork_type
+  - file_format_type
+  return_reasons:
+  - style
+  - resolution
+  - incompatible
+  - changed_my_mind
+  - item_not_as_described
+  - received_the_wrong_item
+  - damaged_or_defective
+  - unknown
+  - other_reason
+- id: me-10-2
+  name: Planners
+  children: []
+  attributes:
+  - file_format_type
+  - template_type
+  return_reasons:
+  - style
+  - resolution
+  - incompatible
+  - changed_my_mind
+  - item_not_as_described
+  - received_the_wrong_item
+  - damaged_or_defective
+  - unknown
+  - other_reason
+- id: me-10-3
+  name: Activity Sheets
+  children: []
+  attributes:
+  - file_format_type
+  return_reasons:
+  - style
+  - resolution
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item

--- a/data/categories/so_software.yml
+++ b/data/categories/so_software.yml
@@ -666,6 +666,8 @@
   - so-2-5
   - so-2-6
   - so-2-7
+  - so-2-8
+  - so-2-9
   attributes:
   - operating_system
   - software_features
@@ -789,6 +791,39 @@
   attributes:
   - software_features
   return_reasons:
+  - incompatible
+  - changed_my_mind
+  - item_not_as_described
+  - received_the_wrong_item
+  - damaged_or_defective
+  - unknown
+  - other_reason
+- id: so-2-8
+  name: SVG & Cut Files
+  children: []
+  attributes:
+  - file_format_type
+  - operating_system
+  - software_features
+  return_reasons:
+  - style
+  - incompatible
+  - changed_my_mind
+  - item_not_as_described
+  - received_the_wrong_item
+  - damaged_or_defective
+  - unknown
+  - other_reason
+- id: so-2-9
+  name: Photo Editing Presets & LUTs
+  children: []
+  attributes:
+  - compatible_software_platform
+  - file_format_type
+  - operating_system
+  - software_features
+  return_reasons:
+  - style
   - incompatible
   - changed_my_mind
   - item_not_as_described

--- a/data/integrations/google/2021-09-21/mappings/from_shopify.yml
+++ b/data/integrations/google/2021-09-21/mappings/from_shopify.yml
@@ -5808,6 +5808,11 @@ rules:
     product_category_id:
     - '3697'
 - input:
+    product_category_id: ae-2-1-6-5-4
+  output:
+    product_category_id:
+    - '3697'
+- input:
     product_category_id: ae-2-1-7
   output:
     product_category_id:
@@ -35398,6 +35403,11 @@ rules:
     product_category_id:
     - '2890'
 - input:
+    product_category_id: hb-1-9-8
+  output:
+    product_category_id:
+    - '2890'
+- input:
     product_category_id: hb-1-10
   output:
     product_category_id:
@@ -51089,6 +51099,31 @@ rules:
     - '543528'
 - input:
     product_category_id: me-8
+  output:
+    product_category_id:
+    - '783'
+- input:
+    product_category_id: me-9
+  output:
+    product_category_id:
+    - '783'
+- input:
+    product_category_id: me-10
+  output:
+    product_category_id:
+    - '783'
+- input:
+    product_category_id: me-10-1
+  output:
+    product_category_id:
+    - '783'
+- input:
+    product_category_id: me-10-2
+  output:
+    product_category_id:
+    - '783'
+- input:
+    product_category_id: me-10-3
   output:
     product_category_id:
     - '783'
@@ -67987,6 +68022,16 @@ rules:
   output:
     product_category_id:
     - '5935'
+- input:
+    product_category_id: so-2-8
+  output:
+    product_category_id:
+    - '5032'
+- input:
+    product_category_id: so-2-9
+  output:
+    product_category_id:
+    - '5032'
 - input:
     product_category_id: so-3
   output:

--- a/data/localizations/categories/en.yml
+++ b/data/localizations/categories/en.yml
@@ -3485,6 +3485,9 @@ en:
     ae-2-1-6-5-3:
       # Arts & Entertainment > Hobbies & Creative Arts > Arts & Crafts > Crafting Patterns & Molds > Sewing Patterns > Home Decor Sewing Patterns
       name: Home Decor Sewing Patterns
+    ae-2-1-6-5-4:
+      # Arts & Entertainment > Hobbies & Creative Arts > Arts & Crafts > Crafting Patterns & Molds > Sewing Patterns > Digital Sewing Patterns
+      name: Digital Sewing Patterns
     ae-2-1-7:
       # Arts & Entertainment > Hobbies & Creative Arts > Arts & Crafts > Clothing Sewing Materials
       name: Clothing Sewing Materials
@@ -21278,6 +21281,9 @@ en:
     hb-1-9-7-6:
       # Health & Beauty > Health Care > Fitness & Nutrition > Weight Loss > Weight Loss Topical & Patch Treatments
       name: Weight Loss Topical & Patch Treatments
+    hb-1-9-8:
+      # Health & Beauty > Health Care > Fitness & Nutrition > Digital Meal Plans
+      name: Digital Meal Plans
     hb-1-10:
       # Health & Beauty > Health Care > Hearing Aids
       name: Hearing Aids
@@ -30695,6 +30701,21 @@ en:
     me-8:
       # Media > Academic Papers & Studies
       name: Academic Papers & Studies
+    me-9:
+      # Media > Online Courses
+      name: Online Courses
+    me-10:
+      # Media > Printables
+      name: Printables
+    me-10-1:
+      # Media > Printables > Wall Art
+      name: Wall Art
+    me-10-2:
+      # Media > Printables > Planners
+      name: Planners
+    me-10-3:
+      # Media > Printables > Activity Sheets
+      name: Activity Sheets
     na:
       # Uncategorized
       name: Uncategorized
@@ -41027,6 +41048,12 @@ en:
     so-2-7:
       # Software > Digital Goods & Currency > Virtual Currency
       name: Virtual Currency
+    so-2-8:
+      # Software > Digital Goods & Currency > SVG & Cut Files
+      name: SVG & Cut Files
+    so-2-9:
+      # Software > Digital Goods & Currency > Photo Editing Presets & LUTs
+      name: Photo Editing Presets & LUTs
     so-3:
       # Software > Video Game Software
       name: Video Game Software

--- a/dist/en/categories.txt
+++ b/dist/en/categories.txt
@@ -1583,6 +1583,7 @@ gid://shopify/TaxonomyCategory/ae-2-1-6-4-3      : Arts & Entertainment > Hobbie
 gid://shopify/TaxonomyCategory/ae-2-1-6-5        : Arts & Entertainment > Hobbies & Creative Arts > Arts & Crafts > Crafting Patterns & Molds > Sewing Patterns
 gid://shopify/TaxonomyCategory/ae-2-1-6-5-1      : Arts & Entertainment > Hobbies & Creative Arts > Arts & Crafts > Crafting Patterns & Molds > Sewing Patterns > Accessory Sewing Patterns
 gid://shopify/TaxonomyCategory/ae-2-1-6-5-2      : Arts & Entertainment > Hobbies & Creative Arts > Arts & Crafts > Crafting Patterns & Molds > Sewing Patterns > Clothing Sewing Patterns
+gid://shopify/TaxonomyCategory/ae-2-1-6-5-4      : Arts & Entertainment > Hobbies & Creative Arts > Arts & Crafts > Crafting Patterns & Molds > Sewing Patterns > Digital Sewing Patterns
 gid://shopify/TaxonomyCategory/ae-2-1-6-5-3      : Arts & Entertainment > Hobbies & Creative Arts > Arts & Crafts > Crafting Patterns & Molds > Sewing Patterns > Home Decor Sewing Patterns
 gid://shopify/TaxonomyCategory/ae-2-2            : Arts & Entertainment > Hobbies & Creative Arts > Collectibles
 gid://shopify/TaxonomyCategory/ae-2-2-1          : Arts & Entertainment > Hobbies & Creative Arts > Collectibles > Autographs
@@ -7036,6 +7037,7 @@ gid://shopify/TaxonomyCategory/hb-1-8-6-6        : Health & Beauty > Health Care
 gid://shopify/TaxonomyCategory/hb-1-8-11         : Health & Beauty > Health Care > First Aid > Resuscitation & Airway Management Supplies
 gid://shopify/TaxonomyCategory/hb-1-8-12         : Health & Beauty > Health Care > First Aid > Splints & Immobilization Supplies
 gid://shopify/TaxonomyCategory/hb-1-9            : Health & Beauty > Health Care > Fitness & Nutrition
+gid://shopify/TaxonomyCategory/hb-1-9-8          : Health & Beauty > Health Care > Fitness & Nutrition > Digital Meal Plans
 gid://shopify/TaxonomyCategory/hb-1-9-1          : Health & Beauty > Health Care > Fitness & Nutrition > Nutrition Bars
 gid://shopify/TaxonomyCategory/hb-1-9-1-1        : Health & Beauty > Health Care > Fitness & Nutrition > Nutrition Bars > Energy Bars
 gid://shopify/TaxonomyCategory/hb-1-9-1-2        : Health & Beauty > Health Care > Fitness & Nutrition > Nutrition Bars > Meal Replacement Bars
@@ -10221,10 +10223,15 @@ gid://shopify/TaxonomyCategory/me-3-2            : Media > Music & Sound Recordi
 gid://shopify/TaxonomyCategory/me-3-4            : Media > Music & Sound Recordings > Records & LPs
 gid://shopify/TaxonomyCategory/me-3-5            : Media > Music & Sound Recordings > Spoken Word & Field Recordings
 gid://shopify/TaxonomyCategory/me-3-6            : Media > Music & Sound Recordings > Vinyl
+gid://shopify/TaxonomyCategory/me-9              : Media > Online Courses
 gid://shopify/TaxonomyCategory/me-4              : Media > Podcasts & Live Streams
 gid://shopify/TaxonomyCategory/me-4-1            : Media > Podcasts & Live Streams > Live Streams
 gid://shopify/TaxonomyCategory/me-4-2            : Media > Podcasts & Live Streams > Podcasts
 gid://shopify/TaxonomyCategory/me-4-3            : Media > Podcasts & Live Streams > Radio Shows
+gid://shopify/TaxonomyCategory/me-10             : Media > Printables
+gid://shopify/TaxonomyCategory/me-10-3           : Media > Printables > Activity Sheets
+gid://shopify/TaxonomyCategory/me-10-2           : Media > Printables > Planners
+gid://shopify/TaxonomyCategory/me-10-1           : Media > Printables > Wall Art
 gid://shopify/TaxonomyCategory/me-5              : Media > Product Manuals
 gid://shopify/TaxonomyCategory/me-6              : Media > Sheet Music
 gid://shopify/TaxonomyCategory/me-7              : Media > Videos
@@ -10594,6 +10601,8 @@ gid://shopify/TaxonomyCategory/so-2-2            : Software > Digital Goods & Cu
 gid://shopify/TaxonomyCategory/so-2-3            : Software > Digital Goods & Currency > Digital Artwork
 gid://shopify/TaxonomyCategory/so-2-4            : Software > Digital Goods & Currency > Document Templates
 gid://shopify/TaxonomyCategory/so-2-5            : Software > Digital Goods & Currency > Fonts
+gid://shopify/TaxonomyCategory/so-2-9            : Software > Digital Goods & Currency > Photo Editing Presets & LUTs
+gid://shopify/TaxonomyCategory/so-2-8            : Software > Digital Goods & Currency > SVG & Cut Files
 gid://shopify/TaxonomyCategory/so-2-6            : Software > Digital Goods & Currency > Stock Photographs & Video Footage
 gid://shopify/TaxonomyCategory/so-2-7            : Software > Digital Goods & Currency > Virtual Currency
 gid://shopify/TaxonomyCategory/so-3              : Software > Video Game Software

--- a/dist/en/integrations/google/shopify_2026-05_to_google_2021-09-21.txt
+++ b/dist/en/integrations/google/shopify_2026-05_to_google_2021-09-21.txt
@@ -4749,6 +4749,9 @@
 → Arts & Entertainment > Hobbies & Creative Arts > Arts & Crafts > Crafting Patterns & Molds > Sewing Patterns > Clothing Sewing Patterns
 ⇒ Arts & Entertainment > Hobbies & Creative Arts > Arts & Crafts > Crafting Patterns & Molds > Sewing Patterns
 
+→ Arts & Entertainment > Hobbies & Creative Arts > Arts & Crafts > Crafting Patterns & Molds > Sewing Patterns > Digital Sewing Patterns
+⇒ Arts & Entertainment > Hobbies & Creative Arts > Arts & Crafts > Crafting Patterns & Molds > Sewing Patterns
+
 → Arts & Entertainment > Hobbies & Creative Arts > Arts & Crafts > Crafting Patterns & Molds > Sewing Patterns > Home Decor Sewing Patterns
 ⇒ Arts & Entertainment > Hobbies & Creative Arts > Arts & Crafts > Crafting Patterns & Molds > Sewing Patterns
 
@@ -21069,6 +21072,9 @@
 → Health & Beauty > Health Care > Fitness & Nutrition
 ⇒ Health & Beauty > Health Care > Fitness & Nutrition
 
+→ Health & Beauty > Health Care > Fitness & Nutrition > Digital Meal Plans
+⇒ Health & Beauty > Health Care > Fitness & Nutrition
+
 → Health & Beauty > Health Care > Fitness & Nutrition > Nutrition Bars
 ⇒ Health & Beauty > Health Care > Fitness & Nutrition > Nutrition Bars
 
@@ -30624,6 +30630,9 @@
 → Media > Music & Sound Recordings > Vinyl
 ⇒ Media > Music & Sound Recordings
 
+→ Media > Online Courses
+⇒ Media
+
 → Media > Podcasts & Live Streams
 ⇒ Media
 
@@ -30634,6 +30643,18 @@
 ⇒ Media
 
 → Media > Podcasts & Live Streams > Radio Shows
+⇒ Media
+
+→ Media > Printables
+⇒ Media
+
+→ Media > Printables > Activity Sheets
+⇒ Media
+
+→ Media > Printables > Planners
+⇒ Media
+
+→ Media > Printables > Wall Art
 ⇒ Media
 
 → Media > Product Manuals
@@ -31550,6 +31571,12 @@
 
 → Software > Digital Goods & Currency > Fonts
 ⇒ Software > Digital Goods & Currency > Fonts
+
+→ Software > Digital Goods & Currency > Photo Editing Presets & LUTs
+⇒ Software > Digital Goods & Currency
+
+→ Software > Digital Goods & Currency > SVG & Cut Files
+⇒ Software > Digital Goods & Currency
 
 → Software > Digital Goods & Currency > Stock Photographs & Video Footage
 ⇒ Software > Digital Goods & Currency > Stock Photographs & Video Footage


### PR DESCRIPTION
## What

Adds the non-overlapping categories requested by Growth, placed by first principles. Clear duplicates were skipped.

### Added (9 nodes)

| Node | Path |
|---|---|
| `so-2-8` | Software › Digital Goods & Currency › **SVG & Cut Files** |
| `so-2-9` | Software › Digital Goods & Currency › **Photo Editing Presets & LUTs** |
| `me-10` | Media › **Printables** |
| `me-10-1` | Media › Printables › **Wall Art** |
| `me-10-2` | Media › Printables › **Planners** |
| `me-10-3` | Media › Printables › **Activity Sheets** |
| `me-9` | Media › **Online Courses** |
| `hb-1-9-8` | Health & Beauty › Health Care › Fitness & Nutrition › **Digital Meal Plans** |
| `ae-2-1-6-5-4` | Arts & Entertainment › Hobbies & Creative Arts › Arts & Crafts › Crafting Patterns & Molds › Sewing Patterns › **Digital Sewing Patterns** |

### Skipped as duplicates / overlaps

- **Ebooks** — already `me-1-2` E-Books
- **Design Templates** — overlaps `so-2-4` Document Templates

## Attributes & return reasons

Each node was given sibling-consistent attributes and return_reasons (e.g. the Software nodes share `file_format_type` / `operating_system` / `software_features`, plus `template_type` on Planners and `compatible_software_platform` on Presets/LUTs). These were chosen by analogy to neighbours.