### PR TITLE
Fix AlphanumericSorter crash on mixed sequential-text values

### DIFF
--- a/dev/lib/product_taxonomy/alphanumeric_sorter.rb
+++ b/dev/lib/product_taxonomy/alphanumeric_sorter.rb
@@ -37,13 +37,13 @@ module ProductTaxonomy
 
       def normalize_sequential(match)
         [
-          normalize_text(match[:primary_text]),
+          normalize_text(match[:primary_text]) || "",
           normalize_single_number(match[:primary_step]),
           normalize_text(match[:primary_unit] || match[:secondary_unit]) || "",
           normalize_text(match[:seperator]) || "-",
-          normalize_text(match[:secondary_text]),
+          normalize_text(match[:secondary_text]) || "",
           normalize_single_number(match[:secondary_step]),
-          normalize_text(match[:trailing_text]),
+          normalize_text(match[:trailing_text]) || "",
         ]
       end
 

--- a/dev/test/alphanumeric_sorter_test.rb
+++ b/dev/test/alphanumeric_sorter_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ProductTaxonomy
+  class AlphanumericSorterTest < TestCase
+    test "sort orders single-word values alphabetically" do
+      assert_equal(["Blue", "Green", "Red"], AlphanumericSorter.sort(["Red", "Green", "Blue"]))
+    end
+
+    test "sort orders numeric values numerically rather than lexically" do
+      assert_equal(["2", "10", "100"], AlphanumericSorter.sort(["100", "2", "10"]))
+    end
+
+    test "sort moves 'other' to the end when other_last is set" do
+      assert_equal(
+        ["Animal", "Striped", "Other"],
+        AlphanumericSorter.sort(["Other", "Striped", "Animal"], other_last: true),
+      )
+    end
+
+    test "sort handles a set mixing names with and without a matched secondary-text segment" do
+      names = [
+        "CCS1-bilindtag til J1772-stik",
+        "CCS1-bilindtag til CHAdeMO-stik",
+      ]
+
+      assert_equal(
+        [
+          "CCS1-bilindtag til CHAdeMO-stik",
+          "CCS1-bilindtag til J1772-stik",
+        ],
+        AlphanumericSorter.sort(names),
+      )
+    end
+
+    test "normalize_value never returns a nil sort-key slot for any name shape" do
+      shapes = [
+        "Red",                                # plain text
+        "Red-Blue",                           # separator with no digits
+        "Size 1-2",                           # sequential text with a full range
+        "2x large",                           # number with a unit
+        "100",                                # bare number
+        "2 5/8 in",                           # fraction with a unit
+        "10x20 cm",                           # numeric dimension
+        "CCS1-bilindtag til CHAdeMO-stik",    # sequential, unmatched secondary text
+        "CCS1-bilindtag til J1772-stik",      # sequential, matched secondary text
+        "Type 2-bilindtag (Mennekes) til Type 1-stik (J1772)",
+        "abc-",                               # trailing separator
+        "-abc",                               # leading separator
+      ]
+
+      shapes.each do |shape|
+        AlphanumericSorter.normalize_value(shape).each_with_index do |slot, index|
+          assert(
+            slot.is_a?(String) || slot.is_a?(Numeric),
+            "Sort-key slot #{index} for #{shape.inspect} is #{slot.inspect}; " \
+              "nil slots make Array#<=> fail during sort",
+          )
+        end
+      end
+    end
+  end
+end

--- a/dev/test/models/value_test.rb
+++ b/dev/test/models/value_test.rb
@@ -213,6 +213,15 @@ module ProductTaxonomy
       assert_equal ["Animal", "Rayé", "Autre"], sorted_values.map { _1.name(locale: "fr") }
     end
 
+    test "Value.sort_by_localized_name sorts localized values that mix matched and unmatched secondary text" do
+      values = stub_ev_connector_da_values
+
+      assert_equal(
+        ["CCS1-bilindtag til CHAdeMO-stik", "CCS1-bilindtag til J1772-stik"],
+        Value.sort_by_localized_name(values, locale: "da").map { _1.name(locale: "da") },
+      )
+    end
+
     test "next_id returns 1 when there are no values" do
       Value.reset
       assert_equal 1, Value.next_id
@@ -340,6 +349,37 @@ module ProductTaxonomy
         Value.new(id: 1, name: "Animal", handle: "pattern__animal", friendly_id: "pattern__animal"),
         Value.new(id: 2, name: "Striped", handle: "pattern__striped", friendly_id: "pattern__striped"),
         Value.new(id: 3, name: "Other", handle: "pattern__other", friendly_id: "pattern__other"),
+      ]
+    end
+
+    def stub_ev_connector_da_values
+      da_yaml = <<~YAML
+        da:
+          values:
+            ev_connector_adapter_direction__ccs1_vehicle_inlet_to_chademo_plug:
+              name: "CCS1-bilindtag til CHAdeMO-stik"
+            ev_connector_adapter_direction__ccs1_vehicle_inlet_to_j1772_plug:
+              name: "CCS1-bilindtag til J1772-stik"
+      YAML
+      Dir.stubs(:glob)
+        .with(File.join(ProductTaxonomy.data_path, "localizations", "values", "*.yml"))
+        .returns(["fake/path/da.yml"])
+      YAML.stubs(:safe_load_file).with("fake/path/da.yml").returns(YAML.safe_load(da_yaml))
+
+      # Real records from data/values.yml (ids 58183 / 58182).
+      [
+        Value.new(
+          id: 58183,
+          name: "CCS1 vehicle inlet to J1772 plug",
+          handle: "ev-connector-adapter-direction__ccs1-vehicle-inlet-to-j1772-plug",
+          friendly_id: "ev_connector_adapter_direction__ccs1_vehicle_inlet_to_j1772_plug",
+        ),
+        Value.new(
+          id: 58182,
+          name: "CCS1 vehicle inlet to CHAdeMO plug",
+          handle: "ev-connector-adapter-direction__ccs1-vehicle-inlet-to-chademo-plug",
+          friendly_id: "ev_connector_adapter_direction__ccs1_vehicle_inlet_to_chademo_plug",
+        ),
       ]
     end
   end


### PR DESCRIPTION
## What

`bin/product_taxonomy dist/release` crashes with `ArgumentError: comparison of Array with Array failed` (in `Value.sort_by_localized_name`) when generating the `da` locale files for the new `ev_connector_adapter_direction` attribute. Latent sorter bug, not a data problem — translations are complete.

## Root cause

`AlphanumericSorter#normalize_sequential` builds three sort-key slots straight from regex captures with no fallback (`primary_text`, `secondary_text`, `trailing_text`). The range capture only matches when a number follows the separator, so within one attribute, names with digits parse differently from names without:

| `da` name | `secondary_text` slot |
| --- | --- |
| `CCS1-bilindtag til CHAdeMO-stik` | `nil` |
| `CCS1-bilindtag til J1772-stik` | `"bilindtag til j"` |

`sort_by` then compares a `nil` slot against a `String`: `nil <=> "..."` → `nil`, so `Array#<=>` returns `nil` → `ArgumentError`. `en`/`fr` land `nil` in that slot uniformly, so they never crash.

## Fix

Add the `|| ""` fallback the numeric branch (`normalize_numerical`) already uses to the three text slots. Only `secondary_text` can be `nil` with the current pattern — the other two fallbacks are defensive. Every slot is now always a `String`/number, so `<=>` can't fail. Sort order is unchanged for working cases (a `nil` slot was never sortable); `dist/` output is identical.

## Tests

`AlphanumericSorter` had none. Adds a unit test file — including an invariant test that every sort-key slot is a `String` or `Numeric` across 12 name shapes — plus an end-to-end `Value.sort_by_localized_name` test using the real `da` EV-connector records from `data/values.yml`.

- Full `dev` unit suite green (432 runs, 0 failures).
- Reverting only the source fix: the sorting tests reproduce the exact `ArgumentError`, and the invariant test pinpoints the `nil` slot.