### PR TITLE
[UoM prototype] Add measurement attribute support prototype (1/4)

### DIFF
--- a/data/categories/ap_animals_pet_supplies.yml
+++ b/data/categories/ap_animals_pet_supplies.yml
@@ -115,6 +115,7 @@
   - ap-2-1-1-2
   attributes:
   - color
+  - height
   - lumber/wood_type
   - material
   - pattern

--- a/data/localizations/attributes/en.yml
+++ b/data/localizations/attributes/en.yml
@@ -11630,6 +11630,9 @@ en:
     heel_shoe_type:
       name: Heel shoe type
       description: Identifies the style of heel on a shoe, such as platform heels or wedge heels
+    height:
+      name: Height
+      description: Specifies the vertical measurement from bottom to top, determining space requirements and compatibility with other items.
     height_adjustment:
       name: Height adjustment
       description: Specifies if a product's height can be altered, e.g. fixed height, adjustable height

--- a/dev/lib/product_taxonomy/models/attribute.rb
+++ b/dev/lib/product_taxonomy/models/attribute.rb
@@ -60,6 +60,9 @@ module ProductTaxonomy
           handle: attribute_data["handle"],
           values: values_by_friendly_id,
           is_manually_sorted: attribute_data["sorting"] == "custom",
+          type: attribute_data["type"],
+          measurement_type: attribute_data["measurement_type"],
+          supported_units: attribute_data["supported_units"],
         )
       end
 
@@ -80,13 +83,17 @@ module ProductTaxonomy
     validates :friendly_id, presence: true, on: :create
     validates :handle, presence: true, on: :create
     validates :description, presence: true, on: :create
-    validates :values, presence: true, if: -> { self.class == Attribute }, on: :create
+    validates :values, presence: true, if: -> { self.class == Attribute && closed_list? }, on: :create
+    validates :type, inclusion: { in: ["closed_list", "measurement"] }, on: :create
+    validates :measurement_type, presence: true, if: :measurement?, on: :create
+    validates :supported_units, presence: true, if: :measurement?, on: :create
     validates_with ProductTaxonomy::Indexed::UniquenessValidator, attributes: [:friendly_id], on: :create
     validate :values_valid?, on: :create
+    validate :measurement_values_absent?, on: :create
 
     localized_attr_reader :name, :description
 
-    attr_reader :id, :friendly_id, :handle, :values, :extended_attributes
+    attr_reader :id, :friendly_id, :handle, :values, :extended_attributes, :type, :measurement_type, :supported_units
 
     # @param id [Integer] The ID of the attribute.
     # @param name [String] The name of the attribute.
@@ -95,15 +102,29 @@ module ProductTaxonomy
     # @param handle [String] The handle of the attribute.
     # @param values [Array<Value, String>] An array of resolved {Value} objects. When resolving fails, use the friendly
     # ID instead.
-    def initialize(id:, name:, description:, friendly_id:, handle:, values:, is_manually_sorted: false)
+    def initialize(
+      id:,
+      name:,
+      description:,
+      friendly_id:,
+      handle:,
+      values: [],
+      is_manually_sorted: false,
+      type: nil,
+      measurement_type: nil,
+      supported_units: nil
+    )
       @id = id
       @name = name
       @description = description
       @friendly_id = friendly_id
       @handle = handle
-      @values = values
+      @values = values || []
       @extended_attributes = []
       @is_manually_sorted = is_manually_sorted
+      @type = type || "closed_list"
+      @measurement_type = measurement_type
+      @supported_units = supported_units
     end
 
     # Add an extended attribute to the attribute.
@@ -141,6 +162,20 @@ module ProductTaxonomy
       @is_manually_sorted
     end
 
+    # Whether the attribute is a closed list of predefined values.
+    #
+    # @return [Boolean]
+    def closed_list?
+      type == "closed_list"
+    end
+
+    # Whether the attribute is a measurement with supported units.
+    #
+    # @return [Boolean]
+    def measurement?
+      type == "measurement"
+    end
+
     # Get the sorted values of the attribute.
     #
     # @param locale [String] The locale to sort by.
@@ -156,6 +191,8 @@ module ProductTaxonomy
     private
 
     def values_valid?
+      return unless closed_list?
+
       values&.each do |value|
         next if value.is_a?(Value)
 
@@ -165,6 +202,17 @@ module ProductTaxonomy
           message: "not found for friendly ID \"#{value}\"",
         )
       end
+    end
+
+    def measurement_values_absent?
+      return unless measurement?
+      return if values.blank?
+
+      errors.add(
+        :values,
+        :present,
+        message: "must be blank for measurement attributes",
+      )
     end
   end
 end

--- a/dev/lib/product_taxonomy/models/extended_attribute.rb
+++ b/dev/lib/product_taxonomy/models/extended_attribute.rb
@@ -31,6 +31,9 @@ module ProductTaxonomy
         friendly_id:,
         values: values_from.try(:values),
         is_manually_sorted: values_from.try(:manually_sorted?) || false,
+        type: values_from.try(:type),
+        measurement_type: values_from.try(:measurement_type),
+        supported_units: values_from.try(:supported_units),
       )
     end
 

--- a/dev/lib/product_taxonomy/models/serializers/attribute/data/data_serializer.rb
+++ b/dev/lib/product_taxonomy/models/serializers/attribute/data/data_serializer.rb
@@ -29,15 +29,26 @@ module ProductTaxonomy
                   "values_from" => attribute.values_from.friendly_id,
                 }
               else
-                {
+                serialized = {
                   "id" => attribute.id,
                   "name" => attribute.name,
                   "description" => attribute.description,
                   "friendly_id" => attribute.friendly_id,
                   "handle" => attribute.handle,
+                  "type" => attribute.type,
                   "sorting" => attribute.manually_sorted? ? "custom" : nil,
-                  "values" => attribute.sorted_values.map(&:friendly_id),
-                }.compact
+                }
+
+                if attribute.measurement?
+                  serialized.merge!(
+                    "measurement_type" => attribute.measurement_type,
+                    "supported_units" => attribute.supported_units,
+                  )
+                else
+                  serialized["values"] = attribute.sorted_values.map(&:friendly_id)
+                end
+
+                serialized.compact
               end
             end
           end

--- a/dev/lib/product_taxonomy/models/serializers/attribute/dist/json_serializer.rb
+++ b/dev/lib/product_taxonomy/models/serializers/attribute/dist/json_serializer.rb
@@ -17,21 +17,35 @@ module ProductTaxonomy
             # @param locale [String] The locale to use for localized attributes.
             # @return [Hash]
             def serialize(attribute, locale: "en")
-              {
+              serialized = {
                 "id" => attribute.gid,
                 "name" => attribute.name(locale:),
                 "handle" => attribute.handle,
                 "description" => attribute.description(locale:),
-                "extended_attributes" => attribute.extended_attributes.sort_by(&:name).map do |ext_attr|
-                  {
-                    "name" => ext_attr.name(locale:),
-                    "handle" => ext_attr.handle,
-                  }
-                end,
-                "values" => attribute.sorted_values(locale:).map do |value|
-                  Serializers::Value::Dist::JsonSerializer.serialize(value, locale:)
-                end,
+                "type" => attribute.type,
               }
+
+              if attribute.measurement?
+                serialized.merge!(
+                  "measurement_type" => attribute.measurement_type,
+                  "supported_units" => attribute.supported_units,
+                )
+              end
+
+              serialized["extended_attributes"] = attribute.extended_attributes.sort_by(&:name).map do |ext_attr|
+                {
+                  "name" => ext_attr.name(locale:),
+                  "handle" => ext_attr.handle,
+                }
+              end
+
+              unless attribute.measurement?
+                serialized["values"] = attribute.sorted_values(locale:).map do |value|
+                  Serializers::Value::Dist::JsonSerializer.serialize(value, locale:)
+                end
+              end
+
+              serialized
             end
           end
         end

--- a/dev/lib/product_taxonomy/models/serializers/category/dist/json_serializer.rb
+++ b/dev/lib/product_taxonomy/models/serializers/category/dist/json_serializer.rb
@@ -35,6 +35,7 @@ module ProductTaxonomy
                     "name" => attr.name(locale:),
                     "handle" => attr.handle,
                     "description" => attr.description(locale:),
+                    "type" => attr.type,
                     "extended" => attr.is_a?(ExtendedAttribute),
                   }
                 end,

--- a/dev/schema/data/attributes_schema.cue
+++ b/dev/schema/data/attributes_schema.cue
@@ -2,17 +2,23 @@
 
 base_attributes!: [
 	...{
-		id!:          int
-		name!:        string
-		friendly_id!: string
-		handle!:      string
-		values!: [_, ...string & =~#reference_regex] // at least one; all strings
+		id!:               int
+		name!:             string
+		description?:      string
+		friendly_id!:      string
+		handle!:           string
+		type!:             "closed_list" | "measurement"
+		sorting?:          string
+		values?:           [_, ...string & =~#reference_regex]
+		measurement_type?: string
+		supported_units?:  [_, ...string]
 	},
 ]
 
 extended_attributes!: [
 	...{
 		name!:        string
+		description?: string
 		friendly_id!: string
 		handle!:      string
 		values_from!: string

--- a/dev/schema/data/attributes_schema.cue
+++ b/dev/schema/data/attributes_schema.cue
@@ -1,19 +1,30 @@
 #reference_regex: "^.+__.+$"
 
-base_attributes!: [
-	...{
-		id!:               int
-		name!:             string
-		description?:      string
-		friendly_id!:      string
-		handle!:           string
-		type!:             "closed_list" | "measurement"
-		sorting?:          string
-		values?:           [_, ...string & =~#reference_regex]
-		measurement_type?: string
-		supported_units?:  [_, ...string]
-	},
-]
+#base_attribute_common: {
+	id!:          int
+	name!:        string
+	description?: string
+	friendly_id!: string
+	handle!:      string
+	sorting?:     string
+	...
+}
+
+#closed_list_attribute: #base_attribute_common & {
+	type!: "closed_list"
+	values!: [string & =~#reference_regex, ...string & =~#reference_regex]
+	measurement_type?: _|_
+	supported_units?:  _|_
+}
+
+#measurement_attribute: #base_attribute_common & {
+	type!:             "measurement"
+	measurement_type!: string
+	supported_units!: [string, ...string]
+	values?: _|_
+}
+
+base_attributes!: [...(#closed_list_attribute | #measurement_attribute)]
 
 extended_attributes!: [
 	...{

--- a/dev/schema/dist/attributes_schema.cue
+++ b/dev/schema/dist/attributes_schema.cue
@@ -4,22 +4,25 @@
 #attribute_gid_regex: "^gid://shopify/TaxonomyAttribute/\\d+$"
 #value_gid_regex:     "^gid://shopify/TaxonomyValue/\\d+$"
 
-
 #version_regex: "^\\d{4}-\\d{2}(-(unstable|beta\\d+))?$"
 version!: string & =~#version_regex
 
 attributes!: [
 	...{
-		id!:     string & =~#attribute_gid_regex
-		name!:   string
-		handle!: string
+		id!:                  string & =~#attribute_gid_regex
+		name!:                string
+		handle!:              string
+		description?:         string
+		type!:                "closed_list" | "measurement"
+		measurement_type?:    string
+		supported_units?:     [_, ...string]
 		extended_attributes!: [
 			...{
 				name!:   string
 				handle!: string
 			},
 		]
-		values!: [
+		values?: [
 			...{
 				id!:     string & =~#value_gid_regex
 				name!:   string

--- a/dev/schema/dist/attributes_schema.cue
+++ b/dev/schema/dist/attributes_schema.cue
@@ -5,29 +5,40 @@
 #value_gid_regex:     "^gid://shopify/TaxonomyValue/\\d+$"
 
 #version_regex: "^\\d{4}-\\d{2}(-(unstable|beta\\d+))?$"
-version!: string & =~#version_regex
+version!:       string & =~#version_regex
 
-attributes!: [
-	...{
-		id!:                  string & =~#attribute_gid_regex
-		name!:                string
-		handle!:              string
-		description?:         string
-		type!:                "closed_list" | "measurement"
-		measurement_type?:    string
-		supported_units?:     [_, ...string]
-		extended_attributes!: [
-			...{
-				name!:   string
-				handle!: string
-			},
-		]
-		values?: [
-			...{
-				id!:     string & =~#value_gid_regex
-				name!:   string
-				handle!: string
-			},
-		]
-	},
-]
+#attribute_common: {
+	id!:          string & =~#attribute_gid_regex
+	name!:        string
+	handle!:      string
+	description?: string
+	extended_attributes!: [
+		...{
+			name!:   string
+			handle!: string
+		},
+	]
+	...
+}
+
+#value_reference: {
+	id!:     string & =~#value_gid_regex
+	name!:   string
+	handle!: string
+}
+
+#closed_list_attribute: #attribute_common & {
+	type!: "closed_list"
+	values!: [#value_reference, ...#value_reference]
+	measurement_type?: _|_
+	supported_units?:  _|_
+}
+
+#measurement_attribute: #attribute_common & {
+	type!:             "measurement"
+	measurement_type!: string
+	supported_units!: [string, ...string]
+	values?: _|_
+}
+
+attributes!: [...(#closed_list_attribute | #measurement_attribute)]

--- a/dev/schema/dist/categories_schema.cue
+++ b/dev/schema/dist/categories_schema.cue
@@ -24,6 +24,7 @@ verticals!: [...{
 			id!:       string & =~#attribute_gid_regex
 			name!:     string
 			handle!:   string
+			type!:     "closed_list" | "measurement"
 			extended!: bool
 		}]
 		children!: [..._category_reference]

--- a/dev/schema/dist/categories_schema.cue
+++ b/dev/schema/dist/categories_schema.cue
@@ -2,15 +2,40 @@
 // Data validations are handled by the application test-suite
 
 #attribute_gid_regex: "^gid://shopify/TaxonomyAttribute/\\d+$"
-#category_gid_regex: "^gid://shopify/TaxonomyCategory/[a-zA-Z]{2}(-\\d+)*$"
+#category_gid_regex:  "^gid://shopify/TaxonomyCategory/[a-zA-Z]{2}(-\\d+)*$"
 
 _category_reference: {
 	id!:   string & =~#category_gid_regex
 	name!: string
 }
 
+#attribute_reference_common: {
+	id!:          string & =~#attribute_gid_regex
+	name!:        string
+	handle!:      string
+	description?: string
+	extended!:    bool
+	...
+}
+
+#closed_list_attribute_reference: #attribute_reference_common & {
+	type!:             "closed_list"
+	values?:           _|_
+	measurement_type?: _|_
+	supported_units?:  _|_
+}
+
+#measurement_attribute_reference: #attribute_reference_common & {
+	type!:             "measurement"
+	values?:           _|_
+	measurement_type?: _|_
+	supported_units?:  _|_
+}
+
+#attribute_reference: #closed_list_attribute_reference | #measurement_attribute_reference
+
 #version_regex: "^\\d{4}-\\d{2}(-(unstable|beta\\d+))?$"
-version!: string & =~#version_regex
+version!:       string & =~#version_regex
 verticals!: [...{
 	name!:   string
 	prefix!: string & =~"^[a-zA-Z]{2}$"
@@ -20,13 +45,7 @@ verticals!: [...{
 		level!:     int & >=0
 		full_name!: string
 		parent_id:  null | string & =~#category_gid_regex
-		attributes!: [...{
-			id!:       string & =~#attribute_gid_regex
-			name!:     string
-			handle!:   string
-			type!:     "closed_list" | "measurement"
-			extended!: bool
-		}]
+		attributes!: [...#attribute_reference]
 		children!: [..._category_reference]
 		ancestors!: [..._category_reference]
 	}]

--- a/dev/test/integration/all_data_files_import_test.rb
+++ b/dev/test/integration/all_data_files_import_test.rb
@@ -59,7 +59,14 @@ module ProductTaxonomy
         assert_equal raw_attribute["handle"], real_attribute.handle
         assert_equal raw_attribute["description"], real_attribute.description
         assert_equal raw_attribute["friendly_id"], real_attribute.friendly_id
-        assert_equal raw_attribute["values"], real_attribute.values.map(&:friendly_id)
+        assert_equal raw_attribute.fetch("type"), real_attribute.type
+        if real_attribute.measurement?
+          assert_equal raw_attribute["measurement_type"], real_attribute.measurement_type
+          assert_equal raw_attribute["supported_units"], real_attribute.supported_units
+          assert_empty real_attribute.values
+        else
+          assert_equal raw_attribute["values"], real_attribute.values.map(&:friendly_id)
+        end
       end
 
       extended_attributes.each do |raw_attribute|

--- a/dev/test/models/attribute_test.rb
+++ b/dev/test/models/attribute_test.rb
@@ -94,6 +94,93 @@ module ProductTaxonomy
       assert_equal ["pattern__abstract"], clothing_pattern.values.map(&:friendly_id)
     end
 
+    test "load_from_source loads measurement attributes" do
+      attributes_yaml_content = <<~YAML
+        ---
+        base_attributes:
+        - id: 12429
+          name: Height
+          description: Specifies the vertical measurement from bottom to top.
+          friendly_id: height
+          handle: height
+          type: measurement
+          measurement_type: dimension
+          supported_units:
+          - cm
+          - in
+        extended_attributes: []
+      YAML
+
+      Attribute.load_from_source(YAML.safe_load(attributes_yaml_content))
+
+      height = Attribute.find_by(friendly_id: "height")
+      assert_instance_of Attribute, height
+      assert_equal "height", height.handle
+      assert_equal "measurement", height.type
+      assert height.measurement?
+      refute height.closed_list?
+      assert_equal "dimension", height.measurement_type
+      assert_equal ["cm", "in"], height.supported_units
+      assert_empty height.values
+    end
+
+    test "load_from_source raises an error if a measurement attribute is missing measurement fields" do
+      yaml_content = <<~YAML
+        ---
+        base_attributes:
+        - id: 12429
+          name: Height
+          description: Specifies the vertical measurement from bottom to top.
+          friendly_id: height
+          handle: height
+          type: measurement
+        extended_attributes: []
+      YAML
+
+      error = assert_raises(ActiveModel::ValidationError) do
+        Attribute.load_from_source(YAML.safe_load(yaml_content))
+      end
+      expected_errors = {
+        measurement_type: [{ error: :blank }],
+        supported_units: [{ error: :blank }],
+      }
+      assert_equal expected_errors, error.model.errors.details
+    end
+
+    test "load_from_source raises an error if a measurement attribute has values" do
+      attributes_yaml_content = <<~YAML
+        ---
+        base_attributes:
+        - id: 12429
+          name: Height
+          description: Specifies the vertical measurement from bottom to top.
+          friendly_id: height
+          handle: height
+          type: measurement
+          measurement_type: dimension
+          supported_units:
+          - cm
+          values:
+          - height__centimeters_cm
+        extended_attributes: []
+      YAML
+      values_yaml_content = <<~YAML
+        - id: 1
+          name: centimeters (cm)
+          friendly_id: height__centimeters_cm
+          handle: height__centimeters-cm
+      YAML
+      Value.load_from_source(YAML.safe_load(values_yaml_content))
+
+      error = assert_raises(ActiveModel::ValidationError) do
+        Attribute.load_from_source(YAML.safe_load(attributes_yaml_content))
+      end
+      expected_errors = {
+        values: [{ error: :present }],
+      }
+      assert_equal expected_errors, error.model.errors.details
+    end
+
     test "load_from_source raises an error if the source YAML does not follow the expected schema" do
       yaml_content = <<~YAML
         ---

--- a/dev/test/models/extended_attribute_test.rb
+++ b/dev/test/models/extended_attribute_test.rb
@@ -4,6 +4,64 @@ require "test_helper"
 
 module ProductTaxonomy
   class ExtendedAttributeTest < TestCase
+    test "inherits closed-list metadata from base attribute" do
+      value = Value.new(
+        id: 1,
+        name: "Black",
+        friendly_id: "color__black",
+        handle: "color__black",
+      )
+      attribute = Attribute.new(
+        id: 1,
+        name: "Color",
+        description: "Defines the primary color or pattern, such as blue or striped",
+        friendly_id: "color",
+        handle: "color",
+        values: [value],
+      )
+      extended_attribute = ExtendedAttribute.new(
+        name: "Clothing Color",
+        description: "Color of the clothing",
+        friendly_id: "clothing_color",
+        handle: "clothing_color",
+        values_from: attribute,
+      )
+
+      assert_equal "closed_list", extended_attribute.type
+      assert extended_attribute.closed_list?
+      refute extended_attribute.measurement?
+      assert_nil extended_attribute.measurement_type
+      assert_nil extended_attribute.supported_units
+      assert_equal [value], extended_attribute.values
+    end
+
+    test "inherits measurement metadata from base attribute" do
+      attribute = Attribute.new(
+        id: 12429,
+        name: "Height",
+        description: "Specifies the vertical measurement from bottom to top.",
+        friendly_id: "height",
+        handle: "height",
+        type: "measurement",
+        measurement_type: "dimension",
+        supported_units: ["cm", "in"],
+      )
+      extended_attribute = ExtendedAttribute.new(
+        name: "Interior Height",
+        description: "Specifies the interior vertical measurement from bottom to top.",
+        friendly_id: "interior_height",
+        handle: "interior_height",
+        values_from: attribute,
+      )
+
+      assert_equal "measurement", extended_attribute.type
+      assert extended_attribute.measurement?
+      refute extended_attribute.closed_list?
+      assert_equal "dimension", extended_attribute.measurement_type
+      assert_equal ["cm", "in"], extended_attribute.supported_units
+      assert_empty extended_attribute.values
+    end
+
     test "validates values_from is an attribute" do
       extended_attribute = ExtendedAttribute.new(
         name: "Clothing Color",

--- a/dev/test/models/serializers/attribute/data/data_serializer_test.rb
+++ b/dev/test/models/serializers/attribute/data/data_serializer_test.rb
@@ -44,10 +44,37 @@ module ProductTaxonomy
               "description" => "Defines the primary color or pattern, such as blue or striped",
               "friendly_id" => "color",
               "handle" => "color",
+              "type" => "closed_list",
               "values" => ["color__black"]
             }
 
             assert_equal expected, DataSerializer.serialize(@base_attribute)
+          end
+
+          test "serialize returns the expected data structure for measurement attribute" do
+            measurement_attribute = ProductTaxonomy::Attribute.new(
+              id: 12429,
+              name: "Height",
+              description: "Specifies the vertical measurement from bottom to top.",
+              friendly_id: "height",
+              handle: "height",
+              type: "measurement",
+              measurement_type: "dimension",
+              supported_units: ["cm", "in"]
+            )
+
+            expected = {
+              "id" => 12429,
+              "name" => "Height",
+              "description" => "Specifies the vertical measurement from bottom to top.",
+              "friendly_id" => "height",
+              "handle" => "height",
+              "type" => "measurement",
+              "measurement_type" => "dimension",
+              "supported_units" => ["cm", "in"]
+            }
+
+            assert_equal expected, DataSerializer.serialize(measurement_attribute)
           end
 
           test "serialize returns the expected data structure for extended attribute" do
@@ -70,6 +97,7 @@ module ProductTaxonomy
                 "description" => "Defines the primary color or pattern, such as blue or striped",
                 "friendly_id" => "color",
                 "handle" => "color",
+                "type" => "closed_list",
                 "values" => ["color__black"]
               }],
               "extended_attributes" => [{
@@ -102,6 +130,7 @@ module ProductTaxonomy
               "description" => "Defines the size of the product",
               "friendly_id" => "size",
               "handle" => "size",
+              "type" => "closed_list",
               "sorting" => "custom",
               "values" => ["color__black"]
             }

--- a/dev/test/models/serializers/attribute/dist/json_serializer_test.rb
+++ b/dev/test/models/serializers/attribute/dist/json_serializer_test.rb
@@ -37,6 +37,7 @@ module ProductTaxonomy
               "name" => "Color",
               "handle" => "color",
               "description" => "Defines the primary color or pattern, such as blue or striped",
+              "type" => "closed_list",
               "extended_attributes" => [
                 {
                   "name" => "Clothing Color",
@@ -54,6 +55,31 @@ module ProductTaxonomy
             assert_equal expected_json, JsonSerializer.serialize(@attribute)
           end
 
+          test "serialize returns the JSON representation of a measurement attribute" do
+            measurement_attribute = ProductTaxonomy::Attribute.new(
+              id: 12429,
+              name: "Height",
+              description: "Specifies the vertical measurement from bottom to top.",
+              friendly_id: "height",
+              handle: "height",
+              type: "measurement",
+              measurement_type: "dimension",
+              supported_units: ["cm", "in"],
+            )
+
+            expected_json = {
+              "id" => "gid://shopify/TaxonomyAttribute/12429",
+              "name" => "Height",
+              "handle" => "height",
+              "description" => "Specifies the vertical measurement from bottom to top.",
+              "extended_attributes" => [],
+              "type" => "measurement",
+              "measurement_type" => "dimension",
+              "supported_units" => ["cm", "in"],
+            }
+            assert_equal expected_json, JsonSerializer.serialize(measurement_attribute)
+          end
+
           test "serialize returns the localized JSON representation of the attribute" do
             stub_localizations
 
@@ -62,6 +88,7 @@ module ProductTaxonomy
               "name" => "Nom en français",
               "handle" => "color",
               "description" => "Description en français",
+              "type" => "closed_list",
               "extended_attributes" => [
                 {
                   "name" => "Nom en français (extended)",
@@ -88,6 +115,7 @@ module ProductTaxonomy
                 "name" => "Color",
                 "handle" => "color",
                 "description" => "Defines the primary color or pattern, such as blue or striped",
+                "type" => "closed_list",
                 "extended_attributes" => [
                   {
                     "name" => "Clothing Color",
@@ -117,6 +145,7 @@ module ProductTaxonomy
                   "name" => "Aaaa",
                   "handle" => "aaaa",
                   "description" => "Aaaa",
+                  "type" => "closed_list",
                   "extended_attributes" => [],
                   "values" => [],
                 },
@@ -125,6 +154,7 @@ module ProductTaxonomy
                   "name" => "Bbbb",
                   "handle" => "bbbb",
                   "description" => "Bbbb",
+                  "type" => "closed_list",
                   "extended_attributes" => [],
                   "values" => [],
                 },
@@ -133,6 +163,7 @@ module ProductTaxonomy
                   "name" => "Cccc",
                   "handle" => "cccc",
                   "description" => "Cccc",
+                  "type" => "closed_list",
                   "extended_attributes" => [],
                   "values" => [],
                 },
@@ -207,6 +238,7 @@ module ProductTaxonomy
               "name" => "Color",
               "handle" => "color",
               "description" => "Defines the primary color or pattern, such as blue or striped",
+              "type" => "closed_list",
               "extended_attributes" => [
                 {
                   "name" => "Aaaa",

--- a/dev/test/models/serializers/category/dist/json_serializer_test.rb
+++ b/dev/test/models/serializers/category/dist/json_serializer_test.rb
@@ -178,6 +178,53 @@ module ProductTaxonomy
             assert_equal ["Aaaa", "Bbbb", "Cccc"], actual_json
           end
 
+          test "serialize includes type for closed-list category attributes" do
+            value = ProductTaxonomy::Value.new(id: 1, name: "Black", friendly_id: "black", handle: "black")
+            attribute = ProductTaxonomy::Attribute.new(
+              id: 1,
+              name: "Color",
+              friendly_id: "color",
+              handle: "color",
+              description: "Defines the primary color or pattern, such as blue or striped",
+              values: [value],
+            )
+            @child.add_attribute(attribute)
+
+            expected_attribute_json = {
+              "id" => "gid://shopify/TaxonomyAttribute/1",
+              "name" => "Color",
+              "handle" => "color",
+              "description" => "Defines the primary color or pattern, such as blue or striped",
+              "type" => "closed_list",
+              "extended" => false,
+            }
+            assert_equal [expected_attribute_json], JsonSerializer.serialize(@child)["attributes"]
+          end
+
+          test "serialize includes type for measurement category attributes" do
+            measurement_attribute = ProductTaxonomy::Attribute.new(
+              id: 12429,
+              name: "Height",
+              friendly_id: "height",
+              handle: "height",
+              description: "Specifies the vertical measurement from bottom to top.",
+              type: "measurement",
+              measurement_type: "dimension",
+              supported_units: ["cm", "in"],
+            )
+            @child.add_attribute(measurement_attribute)
+
+            expected_attribute_json = {
+              "id" => "gid://shopify/TaxonomyAttribute/12429",
+              "name" => "Height",
+              "handle" => "height",
+              "description" => "Specifies the vertical measurement from bottom to top.",
+              "type" => "measurement",
+              "extended" => false,
+            }
+            assert_equal [expected_attribute_json], JsonSerializer.serialize(@child)["attributes"]
+          end
+
           test "serialize preserves return_reasons order from YAML" do
             rr1 = ProductTaxonomy::ReturnReason.new(
               id: 1,

--- a/dist/en/attributes.txt
+++ b/dist/en/attributes.txt
@@ -3740,6 +3740,7 @@ gid://shopify/TaxonomyAttribute/7799  : Heating technology
 gid://shopify/TaxonomyAttribute/128   : Heel height type
 gid://shopify/TaxonomyAttribute/6718  : Heel shape
 gid://shopify/TaxonomyAttribute/3267  : Heel shoe type
+gid://shopify/TaxonomyAttribute/12429 : Height
 gid://shopify/TaxonomyAttribute/2404  : Height adjustment
 gid://shopify/TaxonomyAttribute/5060  : Helicobacter pylori detection method
 gid://shopify/TaxonomyAttribute/8418  : Helicopter mission type


### PR DESCRIPTION
## What this unblocks

This PR introduces the first public taxonomy package support for measurement-based attributes. Today, taxonomy attributes are effectively all closed-list attributes backed by predefined values. This change adds the minimum schema/model/dist support needed for attributes whose value is a measurement with supported units.

The goal of this first PR is to unblock downstream review and integration work with one concrete example, while keeping the broader vocabulary rollout and tooling work separated into follow-up PRs.

## Example: Height on Bird Cage Accessories

This PR adds a new `Height` measurement attribute and assigns it to `Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories` (`ap-2-1-1`).

In source data, it looks like:

```yaml
- id: 12429
  name: Height
  description: Specifies the vertical measurement from bottom to top, determining space requirements and compatibility with other items.
  friendly_id: height
  handle: height
  type: measurement
  measurement_type: dimension
  supported_units:
  - cm
  - in
```

In the public dist attribute JSON, it emits as:

```json
{
  "id": "gid://shopify/TaxonomyAttribute/12429",
  "name": "Height",
  "handle": "height",
  "type": "measurement",
  "measurement_type": "dimension",
  "supported_units": ["cm", "in"]
}
```

Category attribute references now also include the attribute type, so consumers can distinguish measurement attributes from closed-list attributes.

## Explicit closed-list attributes

Since attributes are no longer all implicitly closed-list attributes, this PR makes the existing vocabulary explicit by adding:

```yaml
type: closed_list
```

to existing base attributes, and by emitting:

```json
"type": "closed_list"
```

in generated dist JSON for closed-list attributes and category attribute references.

## Other changes in this package

To support this first measurement attribute package, this PR also updates:

- Ruby taxonomy attribute model loading and validation
- attribute data/dist serializers
- category dist serializer attribute references
- CUE schemas for source and generated dist files
- tests covering measurement attributes, explicit closed-list attributes, and generated dist output
- generated `dist/en` files

Measurement attributes require `measurement_type` and `supported_units`, and do not use predefined `values`.

## Follow-ups

This PR intentionally keeps the scope to the first unblocker package. Follow-up stacked PRs will cover:

- the full measurement vocabulary rollout/alignment
- downstream dependency updates, including tooling such as the visualizer
