### PR TITLE
[UoM prototype] Import measurement attribute vocabulary (2/4)

### DIFF
--- a/data/categories/aa_apparel_accessories.yml
+++ b/data/categories/aa_apparel_accessories.yml
@@ -51,13 +51,16 @@
   - aa-1-25
   attributes:
   - age_group
+  - bust/chest_size
   - care_instructions
   - clothing_features
   - color
   - fabric
+  - hip_size
   - pattern
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -84,11 +87,14 @@
   - activewear_clothing_features
   - activity
   - age_group
+  - bust/chest_size
   - color
   - fabric
+  - hip_size
   - pattern
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -119,12 +125,18 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pants_length_type
   - pattern
   - pocket_type
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -147,13 +159,19 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
   - leg_opening_style
+  - outseam_length
   - pants_length_type
   - pattern
   - pocket_type
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -175,13 +193,19 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
   - leggings_waistband_style
+  - outseam_length
   - pants_length_type
   - pattern
   - pocket_type
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -204,13 +228,19 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
   - liner_type
+  - outseam_length
   - pants_length_type
   - pattern
   - pocket_type
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -232,12 +262,18 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pants_length_type
   - pattern
   - pocket_type
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -257,12 +293,18 @@
   - activity
   - color
   - fabric
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pants_length_type
   - pattern
   - pocket_type
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -284,12 +326,18 @@
   - age_group
   - color
   - fabric
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pants_length_type
   - pattern
   - pocket_type
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -310,14 +358,20 @@
   - activity
   - color
   - fabric
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pant_cuff_style
   - pants_length_type
   - pattern
   - pocket_closure_type
   - pocket_type
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -338,13 +392,19 @@
   - activity
   - color
   - fabric
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pant_leg_conversion_type
   - pants_length_type
   - pattern
   - pocket_type
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -369,15 +429,21 @@
   - activewear_clothing_features
   - activity
   - age_group
+  - back_length
+  - bust/chest_size
   - clothing_features
   - color
   - fabric
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   - zipper_style
   return_reasons:
   - too_big
@@ -398,14 +464,20 @@
   - activewear_clothing_features
   - activity
   - age_group
+  - back_length
+  - bust/chest_size
   - color
   - fabric
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -424,14 +496,20 @@
   - activewear_clothing_features
   - activity
   - age_group
+  - back_length
+  - bust/chest_size
   - color
   - fabric
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -450,14 +528,20 @@
   - activewear_clothing_features
   - activity
   - age_group
+  - back_length
+  - bust/chest_size
   - color
   - fabric
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -501,9 +585,15 @@
   - color
   - combat_shorts_cut_style
   - fabric
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pattern
+  - rise
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -526,15 +616,23 @@
   - age_group
   - battery_size
   - battery_type
+  - bust/chest_size
   - color
   - dance_occasion
+  - dress_length
   - fabric
+  - hip_size
   - integrated_bottom_type
   - pattern
+  - shoulder_width
   - size
   - skirt/dress_length_type
+  - skirt_length
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -601,6 +699,7 @@
   attributes:
   - activewear_clothing_features
   - age_group
+  - bra_band_size
   - bra_closure_type
   - bra_coverage
   - bra_features
@@ -608,6 +707,7 @@
   - bra_strap_type
   - bra_style
   - bra_support_level
+  - bust/chest_size
   - care_instructions
   - color
   - cup_size
@@ -616,6 +716,8 @@
   - size
   - sports_bra_padding_type
   - target_gender
+  - top_length
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -638,14 +740,20 @@
   - activewear_clothing_features
   - activity
   - age_group
+  - back_length
+  - bust/chest_size
   - color
   - fabric
   - hood_design
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -665,16 +773,22 @@
   - activewear_clothing_features
   - activity
   - age_group
+  - back_length
+  - bust/chest_size
   - color
   - fabric
   - hood_design
   - hood_type
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -693,15 +807,21 @@
   - activewear_clothing_features
   - activity
   - age_group
+  - back_length
+  - bust/chest_size
   - color
   - fabric
   - hood_design
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -719,14 +839,20 @@
   attributes:
   - activewear_clothing_features
   - activity
+  - back_length
+  - bust/chest_size
   - color
   - fabric
   - hood_design
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -748,13 +874,19 @@
   - activewear_clothing_features
   - activity
   - age_group
+  - back_length
+  - bust/chest_size
   - color
   - fabric
   - insulation_fill_material
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -774,16 +906,22 @@
   - activewear_clothing_features
   - activity
   - age_group
+  - back_length
   - battery_size
   - battery_type
+  - bust/chest_size
   - color
   - fabric
   - insulation_fill_material
   - neckline
   - packability
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - target_gender
+  - top_length
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -803,16 +941,22 @@
   - activewear_clothing_features
   - activity
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
   - insulation_fill_material
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   - zipper_opening_length
   return_reasons:
   - too_big
@@ -923,20 +1067,26 @@
   attributes:
   - age_group
   - back_design
+  - bust/chest_size
   - care_instructions
   - clothing_features
   - color
+  - dress_length
   - dress_occasion
   - dress_style
   - fabric
   - hemline_style
+  - hip_size
   - neckline
   - pattern
+  - shoulder_width
   - size
   - skirt/dress_length_type
+  - sleeve_length
   - sleeve_length_type
   - target_gender
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -969,13 +1119,17 @@
   attributes:
   - age_group
   - bra_padding_type
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - garment_length
+  - hip_size
   - intimate_apparel_features
   - pattern
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -991,14 +1145,21 @@
   name: Bodysuits
   children: []
   attributes:
+  - bra_band_size
+  - bust/chest_size
   - care_instructions
   - color
   - cup_size
   - fabric
+  - garment_length
+  - hip_size
+  - inseam_length
   - intimate_apparel_features
+  - outseam_length
   - pattern
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1022,8 +1183,10 @@
   attributes:
   - color
   - fabric
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1043,8 +1206,10 @@
   - color
   - cup_size
   - fabric
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1063,10 +1228,13 @@
   - aa-1-6-2-2-1
   - aa-1-6-2-2-2
   attributes:
+  - added_length
   - color
   - fabric
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1116,8 +1284,10 @@
   - color
   - enhancement_level
   - fabric
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1136,8 +1306,10 @@
   attributes:
   - color
   - fabric
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1183,17 +1355,20 @@
   name: Bras
   children: []
   attributes:
+  - bra_band_size
   - bra_closure_type
   - bra_coverage
   - bra_features
   - bra_strap_type
   - bra_style
+  - bust/chest_size
   - care_instructions
   - color
   - cup_size
   - fabric
   - pattern
   - target_gender
+  - top_length
   return_reasons:
   - band_too_big
   - band_too_small
@@ -1213,14 +1388,17 @@
   children: []
   attributes:
   - age_group
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - garment_length
   - intimate_apparel_features
   - neckline
   - pattern
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1239,12 +1417,15 @@
   - care_instructions
   - color
   - fabric
+  - garment_length
+  - hip_size
   - hosiery_toe_style
   - intimate_apparel_features
   - pattern
   - seam_design
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1263,11 +1444,14 @@
   - care_instructions
   - color
   - fabric
+  - inseam_length
   - intimate_apparel_features
   - jockstrap_design_features
+  - outseam_length
   - pattern
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1290,8 +1474,11 @@
   attributes:
   - color
   - fabric
+  - garment_length
+  - hip_size
   - pattern
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1310,10 +1497,13 @@
   - care_instructions
   - color
   - fabric
+  - garment_length
+  - hip_size
   - intimate_apparel_features
   - pattern
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1335,10 +1525,13 @@
   - color
   - embellishment_type
   - fabric
+  - garment_length
+  - hip_size
   - intimate_apparel_features
   - pattern
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1395,6 +1588,8 @@
   - care_instructions
   - color
   - fabric
+  - garment_length
+  - hip_size
   - intimate_apparel_features
   - pantyhose_crotch_style
   - pantyhose_style
@@ -1402,6 +1597,7 @@
   - size
   - target_gender
   - toe_reinforcement_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1456,13 +1652,17 @@
   - aa-1-6-9-1
   - aa-1-6-9-2
   attributes:
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - garment_length
+  - hip_size
   - intimate_apparel_features
   - pattern
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1522,14 +1722,17 @@
   - aa-1-6-10-7
   - aa-1-6-10-8
   attributes:
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - garment_length
   - intimate_apparel_features
   - pattern
   - shapewear_support_level
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1546,16 +1749,22 @@
   name: Bodysuits
   children: []
   attributes:
+  - bust/chest_size
   - bust_design
   - care_instructions
   - color
   - fabric
+  - garment_length
+  - hip_size
+  - inseam_length
   - intimate_apparel_features
+  - outseam_length
   - pattern
   - post_surgery_stage_suitability
   - shapewear_support_level
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1572,14 +1781,20 @@
   name: Full Body Shapes
   children: []
   attributes:
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - garment_length
+  - hip_size
+  - inseam_length
   - intimate_apparel_features
+  - outseam_length
   - pattern
   - shapewear_support_level
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1599,12 +1814,14 @@
   - care_instructions
   - color
   - fabric
+  - hip_size
   - intimate_apparel_features
   - pattern
   - shapewear_enhancement_feature
   - shapewear_support_level
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1625,11 +1842,13 @@
   - care_instructions
   - color
   - fabric
+  - garment_length
   - intimate_apparel_features
   - pattern
   - shapewear_support_level
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1650,12 +1869,15 @@
   - care_instructions
   - color
   - fabric
+  - garment_length
   - heat_retention_technology
   - intimate_apparel_features
   - pattern
   - shapewear_support_level
   - size
   - target_gender
+  - waist_reduction_potential
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1747,6 +1969,7 @@
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1762,6 +1985,7 @@
   name: Bikinis
   children: []
   attributes:
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
@@ -1771,6 +1995,7 @@
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1790,11 +2015,14 @@
   - color
   - fabric
   - gusset_material
+  - inseam_length
   - intimate_apparel_features
+  - outseam_length
   - pattern
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1819,6 +2047,7 @@
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1843,6 +2072,7 @@
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1858,6 +2088,7 @@
   name: Period Underwear
   children: []
   attributes:
+  - absorbency_capacity
   - absorbency_level
   - care_instructions
   - color
@@ -1869,6 +2100,7 @@
   - target_gender
   - underwear_style
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1894,6 +2126,7 @@
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1969,13 +2202,16 @@
   name: Women's Undershirts
   children: []
   attributes:
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
   - intimate_apparel_features
   - pattern
   - size
+  - sleeve_length
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -1991,13 +2227,16 @@
   name: Women's Underwear Slips
   children: []
   attributes:
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - garment_length
   - intimate_apparel_features
   - pattern
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2085,12 +2324,17 @@
   - aa-1-7-11
   attributes:
   - belly_panel_style
+  - bust/chest_size
   - color
   - fabric
+  - garment_length
+  - hip_size
   - nursing_access_type
   - pattern
   - pregnancy_stage_suitability
+  - sleeve_length
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2108,10 +2352,12 @@
   children: []
   attributes:
   - belly_panel_style
+  - bra_band_size
   - bra_closure_type
   - bra_coverage
   - bra_features
   - bra_strap_type
+  - bust/chest_size
   - care_instructions
   - color
   - cup_size
@@ -2121,6 +2367,7 @@
   - pregnancy_stage_suitability
   - pumping_compatibility
   - target_gender
+  - top_length
   return_reasons:
   - band_too_big
   - band_too_small
@@ -2140,20 +2387,26 @@
   children: []
   attributes:
   - belly_panel_style
+  - bust/chest_size
   - care_instructions
   - color
+  - dress_length
   - dress_occasion
   - dress_style
   - fabric
+  - hip_size
   - maternity_clothing_features
   - neckline
   - nursing_access_type
   - pattern
   - pregnancy_stage_suitability
+  - shoulder_width
   - size
   - skirt/dress_length_type
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2172,19 +2425,25 @@
   children: []
   attributes:
   - belly_panel_style
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - garment_length
+  - hip_size
+  - inseam_length
   - maternity_clothing_features
   - neckline
   - nursing_access_type
   - one_piece_style
+  - outseam_length
   - pants_length_type
   - pattern
   - pregnancy_stage_suitability
   - size
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2216,14 +2475,20 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
   - maternity_clothing_features
   - maternity_waistband_style
   - nursing_access_type
+  - outseam_length
   - pants_length_type
   - pattern
   - pregnancy_stage_suitability
+  - rise
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2244,15 +2509,21 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
   - maternity_clothing_features
   - maternity_panel_type
   - maternity_waistband_style
   - nursing_access_type
+  - outseam_length
   - pants_length_type
   - pattern
   - pregnancy_stage_suitability
+  - rise
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2273,14 +2544,20 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
   - maternity_clothing_features
   - maternity_waistband_style
   - nursing_access_type
+  - outseam_length
   - pants_length_type
   - pattern
   - pregnancy_stage_suitability
+  - rise
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - waist_too_big
   - waist_too_small
@@ -2303,14 +2580,20 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
   - maternity_clothing_features
   - maternity_waistband_style
   - nursing_access_type
+  - outseam_length
   - pants_length_type
   - pattern
   - pregnancy_stage_suitability
+  - rise
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - waist_too_big
   - waist_too_small
@@ -2333,14 +2616,20 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
   - maternity_clothing_features
   - maternity_waistband_style
   - nursing_access_type
+  - outseam_length
   - pants_length_type
   - pattern
   - pregnancy_stage_suitability
+  - rise
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2361,14 +2650,20 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
   - maternity_clothing_features
   - maternity_waistband_style
   - nursing_access_type
+  - outseam_length
   - pants_length_type
   - pattern
   - pregnancy_stage_suitability
+  - rise
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2389,14 +2684,20 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
   - maternity_clothing_features
   - maternity_waistband_style
   - nursing_access_type
+  - outseam_length
   - pants_length_type
   - pattern
   - pregnancy_stage_suitability
+  - rise
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2417,14 +2718,20 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
   - maternity_clothing_features
   - maternity_waistband_style
   - nursing_access_type
+  - outseam_length
   - pants_length_type
   - pattern
   - pregnancy_stage_suitability
+  - rise
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2445,14 +2752,20 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
   - maternity_clothing_features
   - maternity_waistband_style
   - nursing_access_type
+  - outseam_length
   - pants_length_type
   - pattern
   - pregnancy_stage_suitability
+  - rise
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - waist_too_big
   - waist_too_small
@@ -2546,13 +2859,16 @@
   - care_instructions
   - color
   - fabric
+  - hip_size
   - maternity_clothing_features
   - nursing_access_type
   - pattern
   - pregnancy_stage_suitability
   - size
   - skirt/dress_length_type
+  - skirt_length
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2569,16 +2885,21 @@
   children: []
   attributes:
   - belly_panel_style
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - inseam_length
   - maternity_clothing_features
   - maternity_sleepwear_style
   - nursing_access_type
   - pattern
   - pregnancy_stage_suitability
   - size
+  - sleeve_length
   - target_gender
+  - top_length
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2602,6 +2923,7 @@
   - aa-1-7-7-21
   attributes:
   - belly_panel_style
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
@@ -2611,6 +2933,7 @@
   - pregnancy_stage_suitability
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2631,12 +2954,15 @@
   - care_instructions
   - color
   - fabric
+  - inseam_length
   - maternity_clothing_features
   - nursing_access_type
+  - outseam_length
   - pattern
   - pregnancy_stage_suitability
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2655,16 +2981,24 @@
   attributes:
   - belly_panel_style
   - burkini_pieces_included
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
+  - inseam_length
   - maternity_clothing_features
   - nursing_access_type
+  - outseam_length
   - pattern
   - pregnancy_stage_suitability
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2682,6 +3016,7 @@
   children: []
   attributes:
   - belly_panel_style
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
@@ -2692,6 +3027,7 @@
   - size
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2709,17 +3045,23 @@
   children: []
   attributes:
   - belly_panel_style
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - garment_length
+  - hip_size
   - maternity_clothing_features
   - nursing_access_type
   - pattern
   - pregnancy_stage_suitability
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
   - trim_detail
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2737,17 +3079,23 @@
   children: []
   attributes:
   - belly_panel_style
+  - bust/chest_size
   - care_instructions
   - color
+  - dress_length
   - fabric
+  - hip_size
   - maternity_clothing_features
   - nursing_access
   - nursing_access_type
   - pattern
   - pregnancy_stage_suitability
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2765,9 +3113,12 @@
   children: []
   attributes:
   - belly_panel_style
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - garment_length
+  - hip_size
   - maternity_clothing_features
   - nursing_access_type
   - pattern
@@ -2775,6 +3126,7 @@
   - size
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2792,6 +3144,7 @@
   children: []
   attributes:
   - belly_panel_style
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
@@ -2799,9 +3152,13 @@
   - nursing_access_type
   - pattern
   - pregnancy_stage_suitability
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2827,6 +3184,7 @@
   - aa-1-7-8-11
   attributes:
   - belly_panel_style
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
@@ -2835,10 +3193,14 @@
   - nursing_access_type
   - pattern
   - pregnancy_stage_suitability
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2855,6 +3217,7 @@
   children: []
   attributes:
   - belly_panel_style
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
@@ -2863,10 +3226,14 @@
   - nursing_access_type
   - pattern
   - pregnancy_stage_suitability
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2884,6 +3251,7 @@
   attributes:
   - belly_panel_style
   - bodysuit_bottom_coverage
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
@@ -2892,10 +3260,14 @@
   - nursing_access_type
   - pattern
   - pregnancy_stage_suitability
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2912,6 +3284,7 @@
   children: []
   attributes:
   - belly_panel_style
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
@@ -2920,10 +3293,14 @@
   - nursing_access_type
   - pattern
   - pregnancy_stage_suitability
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -2945,6 +3322,7 @@
   attributes:
   - age_group
   - belly_panel_style
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
@@ -2953,10 +3331,14 @@
   - nursing_access_type
   - pattern
   - pregnancy_stage_suitability
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3073,6 +3455,7 @@
   children: []
   attributes:
   - belly_panel_style
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
@@ -3081,10 +3464,14 @@
   - nursing_access_type
   - pattern
   - pregnancy_stage_suitability
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3101,6 +3488,7 @@
   children: []
   attributes:
   - belly_panel_style
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
@@ -3109,10 +3497,14 @@
   - nursing_access_type
   - pattern
   - pregnancy_stage_suitability
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3129,6 +3521,7 @@
   children: []
   attributes:
   - belly_panel_style
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
@@ -3137,10 +3530,14 @@
   - nursing_access_type
   - pattern
   - pregnancy_stage_suitability
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3157,6 +3554,7 @@
   children: []
   attributes:
   - belly_panel_style
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
@@ -3165,10 +3563,14 @@
   - nursing_access_type
   - pattern
   - pregnancy_stage_suitability
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3251,6 +3653,7 @@
   - pattern
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3270,10 +3673,13 @@
   - color
   - fabric
   - fly_type
+  - inseam_length
   - intimate_apparel_features
+  - outseam_length
   - pattern
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3290,14 +3696,19 @@
   name: Men's Undershirts
   children: []
   attributes:
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
   - intimate_apparel_features
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - target_gender
   - undershirt_style
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3330,6 +3741,7 @@
   - pouch_style
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3348,11 +3760,14 @@
   - care_instructions
   - color
   - fabric
+  - inseam_length
   - intimate_apparel_features
+  - outseam_length
   - pattern
   - pouch_style
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3371,11 +3786,14 @@
   - care_instructions
   - color
   - fabric
+  - inseam_length
   - intimate_apparel_features
+  - outseam_length
   - pattern
   - pouch_style
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3399,6 +3817,7 @@
   - pouch_style
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3417,13 +3836,16 @@
   - care_instructions
   - color
   - fabric
+  - inseam_length
   - intimate_apparel_features
+  - outseam_length
   - pattern
   - pouch_style
   - protective_cup_configuration
   - rear_coverage
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3442,11 +3864,15 @@
   - care_instructions
   - color
   - fabric
+  - hip_size
+  - inseam_length
   - intimate_apparel_features
+  - outseam_length
   - pattern
   - pouch_style
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3471,6 +3897,7 @@
   - pouch_style
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3489,12 +3916,15 @@
   - care_instructions
   - color
   - fabric
+  - inseam_length
   - intimate_apparel_features
   - leg_length
+  - outseam_length
   - pattern
   - pouch_style
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3513,11 +3943,14 @@
   - care_instructions
   - color
   - fabric
+  - inseam_length
   - intimate_apparel_features
+  - outseam_length
   - pattern
   - pouch_style
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3553,17 +3986,23 @@
   children: []
   attributes:
   - age_group
+  - bust/chest_size
   - clothing_features
   - color
   - fabric
+  - garment_length
+  - hip_size
+  - inseam_length
   - neckline
   - one_piece_style
+  - outseam_length
   - pants_length_type
   - pattern
   - size
   - sleeve_length_type
   - target_gender
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3588,16 +4027,23 @@
   - aa-1-10-8
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
   - hood_style
   - outerwear_clothing_features
+  - outerwear_length
   - outerwear_pieces_included
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3617,12 +4063,19 @@
   - care_instructions
   - color
   - fabric
+  - hip_size
+  - inseam_length
+  - leg_opening
   - neckline
   - outerwear_clothing_features
+  - outseam_length
   - pattern
+  - rise
   - size
   - sleeve_length_type
   - target_gender
+  - thigh_circumference
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3656,17 +4109,24 @@
   - aa-1-10-2-18
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - clothing_features
   - color
   - fabric
+  - hip_size
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3683,15 +4143,22 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3709,15 +4176,22 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3734,15 +4208,22 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3759,16 +4240,23 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - outerwear_length_type
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3785,15 +4273,22 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3811,15 +4306,22 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3839,15 +4341,22 @@
   - aa-1-10-2-8-2
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3906,15 +4415,22 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3932,16 +4448,23 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
   - layer_construction
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3959,15 +4482,22 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -3984,15 +4514,22 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4009,16 +4546,23 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
   - front_closure_style
+  - hip_size
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4035,15 +4579,22 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4060,15 +4611,22 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4086,15 +4644,22 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4112,15 +4677,22 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4163,11 +4735,17 @@
   - care_instructions
   - color
   - fabric
+  - hip_size
+  - inseam_length
+  - leg_opening
   - outerwear_clothing_features
+  - outseam_length
   - pattern
+  - rise
   - size
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4185,16 +4763,23 @@
   children: []
   attributes:
   - age_group
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
+  - inseam_length
   - outerwear_clothing_features
+  - outerwear_length
+  - outseam_length
   - pattern
   - rain_suit_configuration
+  - rise
   - seam_sealing_type
   - size
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4215,14 +4800,21 @@
   - aa-1-10-5-3
   attributes:
   - age_group
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
+  - inseam_length
   - outerwear_clothing_features
+  - outerwear_length
+  - outseam_length
   - pattern
+  - rise
   - size
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4300,15 +4892,22 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
   - neckline
   - outerwear_clothing_features
+  - outerwear_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - target_gender
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4326,15 +4925,23 @@
   children: []
   attributes:
   - age_group
+  - bust/chest_size
   - care_instructions
   - color
   - fabric
+  - hip_size
+  - inseam_length
   - neckline
   - outerwear_clothing_features
+  - outseam_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - top_length
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4375,9 +4982,11 @@
   - activewear_clothing_features
   - activity
   - age_group
+  - back_length
   - bra_features
   - bra_strap_type
   - bra_support_level
+  - bust/chest_size
   - care_instructions
   - clothing_features
   - color
@@ -4386,17 +4995,25 @@
   - dress_style
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
   - neckline
+  - outseam_length
   - pants_length_type
   - pattern
+  - rise
+  - shoulder_width
   - size
   - skirt/dress_length_type
   - skirt_style
+  - sleeve_length
   - sleeve_length_type
   - stitching_state
   - target_gender
   - top_length_type
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4427,12 +5044,18 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pants_length_type
   - pattern
   - pocket_style
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   - waistband_style
   return_reasons:
   - too_big
@@ -4454,13 +5077,19 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
   - leg_cuff_style
+  - leg_opening
+  - outseam_length
   - pants_length_type
   - pattern
   - pocket_style
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   - waistband_style
   return_reasons:
   - too_big
@@ -4483,12 +5112,18 @@
   - fabric
   - fit
   - front_style
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pants_length_type
   - pattern
   - pocket_style
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   - waistband_style
   return_reasons:
   - waist_too_big
@@ -4514,12 +5149,18 @@
   - distressing_style
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pants_length_type
   - pattern
   - pocket_style
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   - waistband_style
   return_reasons:
   - waist_too_big
@@ -4544,12 +5185,18 @@
   - distressing_level
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pants_length_type
   - pattern
   - pocket_style
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   - waistband_style
   return_reasons:
   - too_big
@@ -4572,12 +5219,18 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pants_length_type
   - pattern
   - pocket_style
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   - waistband_style
   return_reasons:
   - too_big
@@ -4599,12 +5252,18 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pants_length_type
   - pattern
   - pocket_style
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   - waistband_style
   return_reasons:
   - too_big
@@ -4628,12 +5287,18 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pants_length_type
   - pattern
   - pocket_style
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   - waistband_style
   return_reasons:
   - waist_too_big
@@ -4714,19 +5379,25 @@
   - aa-1-13-15
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - clothing_features
   - color
   - fabric
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - sleeve_style
   - stretch_level
   - target_gender
   - top_fit
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4743,18 +5414,24 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - clothing_features
   - color
   - fabric
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - sleeve_style
   - stretch_level
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4771,18 +5448,24 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - clothing_features
   - color
   - fabric
   - neckline
   - one_piece_style
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - sleeve_style
   - stretch_level
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4799,6 +5482,8 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - clothing_features
   - color
@@ -4806,12 +5491,16 @@
   - knit_pattern
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - sleeve_style
   - stretch_level
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4829,17 +5518,23 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - clothing_features
   - color
   - fabric
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - sleeve_style
   - stretch_level
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4857,18 +5552,24 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - clothing_features
   - color
   - fabric
   - neckline
   - pattern
   - placket_type
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - sleeve_style
   - stretch_level
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4888,6 +5589,8 @@
   - aa-1-13-7-2
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - chest_pocket_style
   - clothing_features
@@ -4896,12 +5599,16 @@
   - neckline
   - pattern
   - shirt_cuff_style
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - sleeve_style
   - stretch_level
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4970,6 +5677,8 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - clothing_features
   - color
@@ -4977,12 +5686,16 @@
   - fabric
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - sleeve_style
   - stretch_level
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -4999,20 +5712,26 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - clothing_features
   - color
   - fabric
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - sleeve_style
   - strap_width
   - stretch_level
   - tank_top_back_style
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5029,17 +5748,23 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - clothing_features
   - color
   - fabric
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - sleeve_style
   - stretch_level
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5056,18 +5781,24 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - clothing_features
   - color
   - fabric
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - sleeve_style
   - stretch_level
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5085,18 +5816,24 @@
   attributes:
   - activity
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - clothing_features
   - color
   - fabric
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - sleeve_style
   - stretch_level
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5114,19 +5851,25 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - clothing_features
   - color
   - fabric
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - sleeve_style
   - stretch_level
   - sweatshirt_pocket_type
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5181,10 +5924,16 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pattern
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5205,10 +5954,16 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pattern
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5230,10 +5985,16 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pattern
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5254,10 +6015,16 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pattern
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5278,10 +6045,16 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pattern
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5304,11 +6077,17 @@
   - fabric
   - fit
   - hem_style
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pants_length_type
   - pattern
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5329,10 +6108,16 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pattern
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5353,10 +6138,16 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pattern
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5377,10 +6168,16 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pattern
+  - rise
   - size
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5403,12 +6200,15 @@
   - clothing_features
   - color
   - fabric
+  - hip_size
   - pattern
   - size
   - skirt/dress_length_type
+  - skirt_length
   - skirt_style
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5428,9 +6228,15 @@
   - clothing_features
   - color
   - fabric
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pattern
+  - rise
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5454,13 +6260,17 @@
   - aa-1-17-7
   attributes:
   - age_group
+  - bust/chest_size
   - clothing_features
   - color
   - fabric
+  - garment_length
+  - hip_size
   - pattern
   - size
   - sleepwear_set_pieces_included
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5480,11 +6290,15 @@
   - color
   - fabric
   - fly_style
+  - hip_size
+  - inseam_length
+  - outseam_length
   - pattern
   - size
   - sleepwear_set_pieces_included
   - target_gender
   - thermal_set_components
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5511,6 +6325,7 @@
   - size
   - sleepwear_set_pieces_included
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5543,6 +6358,7 @@
   - sleepwear_set_pieces_included
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5562,12 +6378,15 @@
   - color
   - fabric
   - fit
+  - inseam_length
+  - outseam_length
   - pants_length_type
   - pattern
   - size
   - sleepwear_set_pieces_included
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5588,12 +6407,18 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pants_length_type
   - pattern
+  - rise
   - size
   - sleepwear_set_pieces_included
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5613,12 +6438,17 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - outseam_length
   - pants_length_type
   - pattern
+  - rise
   - size
   - sleepwear_set_pieces_included
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5640,12 +6470,18 @@
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
+  - leg_opening
+  - outseam_length
   - pants_length_type
   - pattern
+  - rise
   - size
   - sleepwear_set_pieces_included
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5666,12 +6502,15 @@
   - color
   - fabric
   - fit
+  - hip_size
   - pattern
   - size
   - skirt/dress_length_type
+  - skirt_length
   - sleepwear_set_pieces_included
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5710,15 +6549,21 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - clothing_features
   - color
   - fabric
   - fabric_texture
   - pattern
+  - shoulder_width
   - size
   - sleepwear_set_pieces_included
+  - sleeve_length
   - target_gender
+  - top_length
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5754,9 +6599,11 @@
   children: []
   attributes:
   - age_group
+  - bust/chest_size
   - clothing_features
   - color
   - fabric
+  - garment_length
   - nightgown_style
   - pattern
   - size
@@ -5764,6 +6611,7 @@
   - sleepwear_set_pieces_included
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5780,16 +6628,23 @@
   children: []
   attributes:
   - age_group
+  - bust/chest_size
   - clothing_features
   - color
   - fabric
+  - hip_size
+  - inseam_length
   - neckline
+  - outseam_length
   - pattern
+  - shoulder_width
   - size
   - sleepwear_set_pieces_included
+  - sleeve_length
   - sleeve_length_type
   - target_gender
   - top_length_type
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5806,14 +6661,20 @@
   children: []
   attributes:
   - age_group
+  - bust/chest_size
   - clothing_features
   - color
   - fabric
+  - garment_length
+  - hip_size
   - pattern
   - robe_style
+  - shoulder_width
   - size
   - sleepwear_set_pieces_included
+  - sleeve_length
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -5831,15 +6692,22 @@
   children: []
   attributes:
   - age_group
+  - bust/chest_size
   - clothing_features
   - color
   - fabric
+  - garment_length
+  - hip_size
+  - inseam_length
+  - outseam_length
   - pattern
   - rear_opening_type
   - size
   - sleepwear_set_pieces_included
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6247,19 +7115,29 @@
   - aa-1-19-4
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - care_instructions
   - clothing_features
   - color
   - fabric
   - front_button_configuration
+  - hip_size
+  - inseam_length
   - jacket_vent_style
   - lapel_style
+  - leg_opening
   - neckline
+  - outseam_length
   - pattern
+  - rise
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - suit_pieces
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6276,19 +7154,29 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - clothing_features
   - color
   - fabric
   - fit
+  - hip_size
+  - inseam_length
   - jacket_breast_style
   - jacket_vent_style
   - lapel_style
+  - leg_opening
+  - outseam_length
   - pants_length_type
   - pattern
+  - rise
+  - shoulder_width
   - size
+  - sleeve_length
   - suit_pieces
   - target_gender
   - waist_rise
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6305,16 +7193,23 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - clothing_features
   - color
   - fabric
+  - hip_size
   - jacket_vent_style
   - lapel_style
   - pattern
+  - shoulder_width
   - size
   - skirt/dress_length_type
+  - skirt_length
+  - sleeve_length
   - suit_pieces
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6333,16 +7228,26 @@
   - aa-1-19-3-2
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - clothing_features
   - color
   - fabric
+  - hip_size
+  - inseam_length
   - jacket_vent_style
   - lapel_style
+  - leg_opening
+  - outseam_length
   - pattern
+  - rise
+  - shoulder_width
   - size
+  - sleeve_length
   - suit_pieces
   - target_gender
   - vent_style
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6445,15 +7350,18 @@
   - aa-1-20-30
   attributes:
   - age_group
+  - bust/chest_size
   - color
   - coverage_level
   - fabric
+  - garment_length
   - lining_type
   - pattern
   - size
   - sleeve_length_type
   - swimwear_features
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6475,11 +7383,17 @@
   - coverage_level
   - fabric
   - fabric_stretch_type
+  - hip_size
+  - inseam_length
+  - leg_opening
   - lining_type
+  - outseam_length
   - pattern
+  - rise
   - size
   - swimwear_features
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6499,11 +7413,14 @@
   - color
   - coverage_level
   - fabric
+  - inseam_length
   - lining_type
+  - outseam_length
   - pattern
   - size
   - swimwear_features
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6531,6 +7448,7 @@
   - size
   - swimwear_features
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6548,16 +7466,24 @@
   children: []
   attributes:
   - age_group
+  - bust/chest_size
   - color
   - coverage_level
   - fabric
+  - hip_size
+  - inseam_length
   - lining_type
+  - outseam_length
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - swimwear_features
   - swimwear_set_pieces_included
   - target_gender
+  - top_length
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6576,6 +7502,7 @@
   attributes:
   - age_group
   - bikini_top_style
+  - bust/chest_size
   - color
   - coverage_level
   - fabric
@@ -6586,6 +7513,7 @@
   - sleeve_length_type
   - swimwear_features
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6603,16 +7531,22 @@
   children: []
   attributes:
   - age_group
+  - bust/chest_size
   - color
   - coverage_level
   - fabric
+  - garment_length
+  - hip_size
   - lining_type
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - swimwear_features
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6630,14 +7564,20 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - color
   - coverage_level
   - fabric
   - lining_type
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - swimwear_features
   - target_gender
+  - top_length
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6655,15 +7595,21 @@
   children: []
   attributes:
   - age_group
+  - bust/chest_size
   - color
   - coverage_level
+  - dress_length
   - fabric
+  - hip_size
   - lining_type
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - swimwear_features
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6681,15 +7627,19 @@
   children: []
   attributes:
   - age_group
+  - bust/chest_size
   - color
   - coverage_level
   - fabric
+  - garment_length
+  - hip_size
   - lining_type
   - pattern
   - size
   - sleeve_length_type
   - swimwear_features
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6707,15 +7657,21 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - color
   - coverage_level
   - fabric
   - lining_type
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - swimwear_features
   - target_gender
+  - top_length
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6732,15 +7688,21 @@
   children: []
   attributes:
   - age_group
+  - back_length
+  - bust/chest_size
   - color
   - coverage_level
   - fabric
   - lining_type
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - swimwear_features
   - target_gender
+  - top_length
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6759,6 +7721,7 @@
   - aa-1-20-25-1
   - aa-1-20-25-2
   attributes:
+  - absorbent_capacity_volume
   - age_group
   - color
   - coverage_level
@@ -6786,6 +7749,7 @@
   name: Period Bikinis
   children: []
   attributes:
+  - absorbent_capacity_volume
   - age_group
   - color
   - coverage_level
@@ -6807,6 +7771,7 @@
   name: Period One-Piece Swimsuits
   children: []
   attributes:
+  - absorbent_capacity_volume
   - age_group
   - color
   - coverage_level
@@ -6936,16 +7901,22 @@
   - aa-1-22-2
   attributes:
   - age_group
+  - bust/chest_size
   - color
+  - dress_length
   - dress_occasion
   - dress_style
   - fabric
+  - hip_size
   - neckline
   - pattern
+  - shoulder_width
   - size
   - skirt/dress_length_type
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -6966,19 +7937,25 @@
   - aa-1-22-1-4
   attributes:
   - age_group
+  - bust/chest_size
   - clothing_features
   - color
   - dress_embellishment
+  - dress_length
   - dress_occasion
   - dress_style
   - dress_train_type
   - fabric
+  - hip_size
   - neckline
   - pattern
+  - shoulder_width
   - size
   - skirt/dress_length_type
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -7094,18 +8071,24 @@
   name: Wedding Dresses
   children: []
   attributes:
+  - bust/chest_size
   - clothing_features
   - color
+  - dress_length
   - dress_style
   - embellishment/trim_material
   - fabric
+  - hip_size
   - jewelry_material
   - neckline
   - pattern
+  - shoulder_width
   - size
   - skirt/dress_length_type
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -7134,13 +8117,19 @@
   - aa-1-23-12
   attributes:
   - age_group
+  - bust/chest_size
   - color
   - fabric
+  - garment_length
+  - hip_size
   - neckline
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -7160,12 +8149,18 @@
   - aa-1-23-1-3
   attributes:
   - age_group
+  - bust/chest_size
   - color
   - fabric
+  - garment_length
+  - hip_size
   - pattern
+  - shoulder_width
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -7238,13 +8233,20 @@
   - aa-1-23-2-2
   attributes:
   - age_group
+  - bust/chest_size
   - color
   - embellishment_technique
   - fabric
+  - garment_length
+  - hip_size
   - pattern
+  - saree_length
   - set_items_included
+  - shoulder_width
   - size
+  - sleeve_length
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -7265,6 +8267,7 @@
   - embellishment_technique
   - fabric
   - pattern
+  - saree_length
   - set_items_included
   - size
   - target_gender
@@ -7284,6 +8287,7 @@
   - embellishment_technique
   - fabric
   - pattern
+  - saree_length
   - set_items_included
   - size
   - target_gender
@@ -7505,10 +8509,15 @@
   - fabric
   - flame_resistance_standard
   - high_visibility_class
+  - hip_size
+  - inseam_length
+  - outseam_length
   - pattern
   - reflective_tape_pattern
   - size
+  - sleeve_length
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -7528,16 +8537,22 @@
   - aa-1-24-1-3
   attributes:
   - age_group
+  - bust/chest_size
   - clothing_features
   - color
   - fabric
   - flame_resistance_standard
   - high_visibility_class
+  - hip_size
+  - inseam_length
   - knee_pad_pocket_type
+  - leg_opening
+  - outseam_length
   - pattern
   - reinforced_areas
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -7620,14 +8635,22 @@
   children: []
   attributes:
   - age_group
+  - bust/chest_size
   - clothing_features
+  - collar_size
   - color
   - fabric
   - flame_resistance_standard
   - high_visibility_class
+  - hip_size
+  - inseam_length
+  - outseam_length
   - pattern
   - size
+  - sleeve_length
   - target_gender
+  - torso_length
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -7651,14 +8674,21 @@
   - aa-1-24-3-6
   attributes:
   - age_group
+  - bust/chest_size
   - clothing_features
+  - collar_size
   - color
   - fabric
   - flame_resistance_standard
   - high_visibility_class
+  - hip_size
+  - inseam_length
+  - outseam_length
   - pattern
   - size
+  - sleeve_length
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -7803,15 +8833,22 @@
   - aa-1-24-4-7
   attributes:
   - age_group
+  - bust/chest_size
   - clothing_features
+  - collar_size
   - color
   - fabric
   - flame_resistance_standard
   - high_visibility_class
+  - hip_size
+  - inseam_length
   - military_branch
+  - outseam_length
   - pattern
   - size
+  - sleeve_length
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -7983,18 +9020,25 @@
   - aa-1-24-5-7
   attributes:
   - age_group
+  - bust/chest_size
   - clothing_features
+  - collar_size
   - color
   - fabric
   - flame_resistance_standard
   - high_visibility_class
+  - hip_size
+  - inseam_length
   - logo_application_method
+  - outseam_length
   - pants_length_type
   - pattern
   - size
   - skirt/dress_length_type
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -8182,16 +9226,23 @@
   - aa-1-24-6-3
   attributes:
   - age_group
+  - bust/chest_size
   - clothing_features
+  - collar_size
   - color
   - fabric
   - flame_resistance_standard
   - high_visibility_class
+  - hip_size
+  - inseam_length
+  - outseam_length
   - pattern
   - size
+  - sleeve_length
   - target_gender
   - uniform_pieces_included
   - uniform_role
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -8254,16 +9305,23 @@
   attributes:
   - activity
   - age_group
+  - bust/chest_size
   - clothing_features
+  - collar_size
   - color
   - fabric
   - flame_resistance_standard
   - high_visibility_class
+  - hip_size
+  - inseam_length
+  - outseam_length
   - pants_length_type
   - pattern
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -8281,17 +9339,24 @@
   children: []
   attributes:
   - age_group
+  - bust/chest_size
   - clothing_features
+  - collar_size
   - collar_style
   - color
   - cuff_style
   - fabric
   - flame_resistance_standard
   - high_visibility_class
+  - hip_size
+  - inseam_length
+  - outseam_length
   - pattern
   - size
+  - sleeve_length
   - sleeve_length_type
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -8318,10 +9383,13 @@
   - color
   - fabric
   - flame_resistance_standard
+  - height
   - high_visibility_class
+  - length
   - pattern
   - size
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10439,6 +11507,7 @@
   children: []
   attributes:
   - age_group
+  - bra_band_size
   - color
   - cup_size
   - fabric
@@ -10720,9 +11789,11 @@
   - care_instructions
   - color
   - fabric
+  - length
   - material
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10744,8 +11815,10 @@
   - age_group
   - color
   - fabric
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10765,9 +11838,11 @@
   - age_group
   - color
   - fabric
+  - length
   - pattern
   - target_gender
   - thermal_weight
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10785,6 +11860,7 @@
   attributes:
   - accessory_pieces_included
   - age_group
+  - circumference
   - color
   - fabric
   - pattern
@@ -10810,8 +11886,10 @@
   - age_group
   - color
   - fabric
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10834,8 +11912,10 @@
   - clothing_accessory_material
   - clothing_features
   - color
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10861,9 +11941,11 @@
   - age_group
   - color
   - fabric
+  - length
   - pattern
   - target_gender
   - veil_length_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10991,8 +12073,11 @@
   - age_group
   - color
   - fabric
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -11013,8 +12098,10 @@
   - age_group
   - color
   - fabric
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -11033,10 +12120,13 @@
   - accessory_pieces_included
   - age_group
   - color
+  - height
   - jewelry_material
   - jewelry_type
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -11056,9 +12146,11 @@
   - age_group
   - color
   - decoration_material
+  - length
   - pattern
   - rib_material
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -11080,8 +12172,11 @@
   - color
   - earmuff_style
   - fabric
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -11106,8 +12201,11 @@
   - handwear_features
   - handwear_material
   - handwear_type
+  - length
+  - palm_circumference
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -11141,8 +12239,10 @@
   - accessory_pieces_included
   - age_group
   - color
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -11162,10 +12262,13 @@
   attributes:
   - accessory_pieces_included
   - age_group
+  - circumference
   - color
   - fabric
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -11219,9 +12322,12 @@
   - age_group
   - bristle_material
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - target_gender
+  - width
   - wood_finish
   return_reasons:
   - too_big
@@ -11246,8 +12352,10 @@
   - fabric
   - hair_extension_texture
   - hair_quality_grade
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -11269,9 +12377,11 @@
   - embellishment/trim_material
   - fabric
   - jewelry_material
+  - length
   - lumber/wood_type
   - pattern
   - target_gender
+  - width
   - wood_finish
   return_reasons:
   - too_big
@@ -11291,6 +12401,7 @@
   attributes:
   - accessory_pieces_included
   - age_group
+  - circumference
   - color
   - fabric
   - hair_net_style
@@ -11321,10 +12432,13 @@
   - construction
   - embellishment/trim_material
   - fabric
+  - height
   - jewelry_material
+  - length
   - material
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -11405,6 +12519,7 @@
   attributes:
   - accessory_pieces_included
   - age_group
+  - circumference
   - color
   - fabric
   - pattern
@@ -11426,6 +12541,7 @@
   attributes:
   - accessory_pieces_included
   - age_group
+  - circumference
   - color
   - construction
   - embellishment/trim_material
@@ -11453,11 +12569,14 @@
   attributes:
   - accessory_pieces_included
   - age_group
+  - circumference
   - color
   - fabric
+  - length
   - pattern
   - ponytail_holder_style
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -11512,6 +12631,7 @@
   attributes:
   - accessory_pieces_included
   - age_group
+  - circumference
   - color
   - construction
   - embellishment/trim_material
@@ -11537,6 +12657,7 @@
   attributes:
   - accessory_pieces_included
   - age_group
+  - circumference
   - color
   - pattern
   - target_gender
@@ -11559,8 +12680,10 @@
   - age_group
   - cap_construction
   - cap_size
+  - circumference
   - color
   - fabric
+  - hair_length
   - hair_type
   - lace_area_size
   - lace_type
@@ -11643,8 +12766,10 @@
   - age_group
   - color
   - fabric
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -11665,8 +12790,10 @@
   - age_group
   - color
   - fabric
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -11710,6 +12837,8 @@
   - accessory_pieces_included
   - accessory_size
   - age_group
+  - brim_depth
+  - circumference
   - color
   - fabric
   - headwear_features
@@ -11734,7 +12863,9 @@
   - accessory_pieces_included
   - accessory_size
   - age_group
+  - brim_depth
   - cap_fit_type
+  - circumference
   - color
   - crown_profile
   - fabric
@@ -11760,6 +12891,8 @@
   - accessory_size
   - age_group
   - beanie_style
+  - brim_depth
+  - circumference
   - color
   - fabric
   - headwear_features
@@ -11784,6 +12917,8 @@
   - accessory_size
   - age_group
   - beret_style
+  - brim_depth
+  - circumference
   - color
   - fabric
   - headwear_features
@@ -11807,6 +12942,9 @@
   - accessory_pieces_included
   - accessory_size
   - age_group
+  - brim_depth
+  - brim_width
+  - circumference
   - color
   - crown_style
   - fabric
@@ -11831,6 +12969,8 @@
   - accessory_pieces_included
   - accessory_size
   - age_group
+  - brim_depth
+  - circumference
   - color
   - fabric
   - headwear_features
@@ -11854,6 +12994,8 @@
   - accessory_pieces_included
   - accessory_size
   - age_group
+  - brim_depth
+  - circumference
   - color
   - fabric
   - headwear_features
@@ -11877,7 +13019,10 @@
   - accessory_pieces_included
   - accessory_size
   - age_group
+  - brim_depth
+  - circumference
   - color
+  - crown_height
   - fabric
   - headwear_features
   - pattern
@@ -11901,6 +13046,8 @@
   - accessory_pieces_included
   - accessory_size
   - age_group
+  - brim_depth
+  - circumference
   - color
   - fabric
   - headwear_features
@@ -11924,6 +13071,8 @@
   - accessory_pieces_included
   - accessory_size
   - age_group
+  - brim_depth
+  - circumference
   - color
   - fabric
   - headwear_features
@@ -11948,6 +13097,8 @@
   - accessory_pieces_included
   - accessory_size
   - age_group
+  - brim_depth
+  - circumference
   - color
   - fabric
   - headwear_features
@@ -11971,7 +13122,9 @@
   - accessory_pieces_included
   - accessory_size
   - age_group
+  - brim_depth
   - chin_strap_type
+  - circumference
   - color
   - fabric
   - headwear_features
@@ -11995,6 +13148,8 @@
   - accessory_pieces_included
   - accessory_size
   - age_group
+  - brim_depth
+  - circumference
   - color
   - fabric
   - headwear_features
@@ -12019,6 +13174,8 @@
   - accessory_pieces_included
   - accessory_size
   - age_group
+  - brim_depth
+  - circumference
   - color
   - fabric
   - headwear_features
@@ -12042,6 +13199,8 @@
   - accessory_pieces_included
   - accessory_size
   - age_group
+  - brim_depth
+  - circumference
   - color
   - fabric
   - front_decoration_type
@@ -12066,6 +13225,8 @@
   - accessory_pieces_included
   - accessory_size
   - age_group
+  - brim_depth
+  - circumference
   - color
   - fabric
   - headwear_features
@@ -12089,6 +13250,8 @@
   - accessory_pieces_included
   - accessory_size
   - age_group
+  - brim_depth
+  - circumference
   - color
   - ear_coverage_type
   - fabric
@@ -12299,6 +13462,7 @@
   - accessory_pieces_included
   - accessory_size
   - age_group
+  - circumference
   - color
   - compatible_hair_length
   - fabric
@@ -12322,6 +13486,7 @@
   attributes:
   - accessory_pieces_included
   - age_group
+  - circumference
   - color
   - fabric
   - fascinator_style
@@ -12345,6 +13510,7 @@
   attributes:
   - accessory_pieces_included
   - age_group
+  - circumference
   - color
   - fabric
   - pattern
@@ -12366,6 +13532,7 @@
   attributes:
   - accessory_pieces_included
   - age_group
+  - circumference
   - color
   - fabric
   - headwear_intended_use
@@ -12430,9 +13597,11 @@
   - age_group
   - color
   - fabric
+  - length
   - pattern
   - size
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -12451,8 +13620,10 @@
   - accessory_pieces_included
   - color
   - lei_closure_style
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -12471,8 +13642,10 @@
   - accessory_pieces_included
   - color
   - fabric
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -12493,8 +13666,10 @@
   - age_group
   - color
   - fabric
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -12518,9 +13693,11 @@
   - age_group
   - color
   - fabric
+  - length
   - pattern
   - target_gender
   - weave_finish
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -12596,10 +13773,13 @@
   attributes:
   - accessory_pieces_included
   - color
+  - height
   - jewelry_material
+  - length
   - pattern
   - shape
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -12619,8 +13799,10 @@
   - age_group
   - color
   - fabric
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -12644,10 +13826,12 @@
   - color
   - edge_finish
   - fabric
+  - length
   - opacity_level
   - pattern
   - scarf/shawl_style
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -12673,6 +13857,7 @@
   - eyewear_frame_pattern
   - eyewear_lens_material
   - fabric
+  - height
   - lens_color
   - lens_pattern
   - lens_polarization
@@ -12681,6 +13866,7 @@
   - target_gender
   - temple_color
   - temple_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -12699,10 +13885,12 @@
   - closure_type
   - color
   - fabric
+  - length
   - pattern
   - size
   - suspender_style
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -12722,8 +13910,10 @@
   - color
   - fabric
   - jewelry_type
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -12747,10 +13937,12 @@
   attributes:
   - accessory_pieces_included
   - age_group
+  - circumference
   - color
   - material
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -12862,8 +14054,10 @@
   - age_group
   - color
   - fabric
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13182,9 +14376,11 @@
   - care_instructions
   - color
   - fabric
+  - length
   - material
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13203,8 +14399,10 @@
   - accessory_size
   - age_group
   - color
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13223,9 +14421,14 @@
   - age_group
   - color
   - footwear_material
+  - heel_height
+  - length
   - pattern
+  - platform_height
+  - shoe_height
   - shoe_size
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13250,13 +14453,16 @@
   - aa-3-3-5
   attributes:
   - age_group
+  - bust/chest_size
   - color
   - costume_components_included
   - costume_theme
   - fabric
+  - length
   - pattern
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -13273,13 +14479,16 @@
   children: []
   attributes:
   - age_group
+  - bust/chest_size
   - color
   - costume_components_included
   - costume_theme
   - fabric
+  - length
   - pattern
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -13296,13 +14505,16 @@
   children: []
   attributes:
   - age_group
+  - bust/chest_size
   - color
   - costume_components_included
   - costume_theme
   - fabric
+  - length
   - pattern
   - size
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -13376,6 +14588,7 @@
   children: []
   attributes:
   - age_group
+  - circumference
   - color
   - fabric
   - pattern
@@ -13423,8 +14636,10 @@
   - care_instructions
   - carry_options
   - color
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13441,9 +14656,11 @@
   children: []
   attributes:
   - color
+  - length
   - material
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13462,8 +14679,10 @@
   - color
   - lanyard_attachment_hardware
   - lanyard_style
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -13480,9 +14699,11 @@
   children: []
   attributes:
   - color
+  - length
   - pattern
   - strand_configuration
   - target_gender
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -13587,9 +14808,12 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
   - target_gender
   - wallet_features
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13612,8 +14836,11 @@
   - attachment_options
   - clip_style
   - color
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13682,9 +14909,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - target_gender
   - wallet_features
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13703,8 +14933,11 @@
   - age_group
   - checkbook_loading_orientation
   - color
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13750,11 +14983,16 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13776,11 +15014,16 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13802,11 +15045,16 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13828,11 +15076,16 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13855,11 +15108,16 @@
   - bag/case_storage_features
   - bag_embellishment
   - bag_size_descriptor
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13881,11 +15139,16 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13907,11 +15170,16 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13934,12 +15202,17 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - target_gender
+  - width
   - wood_finish
   return_reasons:
   - too_big
@@ -13963,11 +15236,16 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13989,11 +15267,16 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14015,11 +15298,16 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14041,11 +15329,16 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14067,11 +15360,16 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14093,11 +15391,16 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14119,12 +15422,17 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
   - fur_type
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14146,13 +15454,18 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
   - leather_type
+  - length
   - number_of_compartments
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14174,12 +15487,17 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
   - leather_type
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14201,11 +15519,16 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14228,12 +15551,17 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
   - tote_handle_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14255,11 +15583,16 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14278,9 +15611,14 @@
   - age_group
   - bag/case_material
   - bag_embellishment
+  - bag_strap_drop_length
   - color
+  - handle_length
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14303,6 +15641,7 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
@@ -14326,6 +15665,7 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
@@ -14349,6 +15689,7 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_embellishment
+  - bag_strap_drop_length
   - care_instructions
   - carry_options
   - color
@@ -14377,9 +15718,13 @@
   - clip_mechanism_type
   - clothing_accessory_material
   - color
+  - depth
+  - height
+  - length
   - pattern
   - target_gender
   - wallet_features
+  - width
   return_reasons:
   - size
   - color
@@ -14398,9 +15743,13 @@
   - age_group
   - clothing_accessory_material
   - color
+  - depth
+  - height
+  - length
   - pattern
   - target_gender
   - wallet_features
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14419,9 +15768,13 @@
   - age_group
   - clothing_accessory_material
   - color
+  - depth
+  - height
+  - length
   - pattern
   - target_gender
   - wallet_features
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14439,10 +15792,14 @@
   attributes:
   - clothing_accessory_material
   - color
+  - depth
+  - height
   - key_attachment_mechanism
+  - length
   - pattern
   - target_gender
   - wallet_features
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14460,9 +15817,14 @@
   attributes:
   - clothing_accessory_material
   - color
+  - depth
+  - height
+  - length
   - pattern
+  - strap_drop_length
   - target_gender
   - wallet_features
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14480,9 +15842,13 @@
   attributes:
   - clothing_accessory_material
   - color
+  - depth
+  - height
+  - length
   - pattern
   - target_gender
   - wallet_features
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14502,10 +15868,14 @@
   - carry_options
   - clothing_accessory_material
   - color
+  - depth
+  - height
   - leather_type
+  - length
   - pattern
   - target_gender
   - wallet_features
+  - width
   return_reasons:
   - size
   - color
@@ -14523,10 +15893,14 @@
   attributes:
   - clothing_accessory_material
   - color
+  - depth
+  - height
   - leather_type
+  - length
   - pattern
   - target_gender
   - wallet_features
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14581,10 +15955,12 @@
   - gemstone_clarity_grade
   - jewelry_material
   - jewelry_type
+  - length
   - pattern
   - stone_creation_method
   - stone_cut_grade
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14605,8 +15981,10 @@
   - color
   - jewelry_material
   - jewelry_type
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14628,9 +16006,11 @@
   - gemstone_type
   - jewelry_material
   - jewelry_type
+  - length
   - pattern
   - target_gender
   - threading_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14648,12 +16028,15 @@
   attributes:
   - age_group
   - bracelet_design
+  - circumference
   - color
   - jewelry_material
   - jewelry_type
+  - length
   - necklace_design
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14673,11 +16056,14 @@
   attributes:
   - age_group
   - color
+  - height
   - jewelry_material
   - jewelry_type
+  - length
   - pattern
   - pin_backing_type
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14733,11 +16119,14 @@
   attributes:
   - age_group
   - color
+  - drop
   - jewelry_material
   - jewelry_type
+  - length
   - pattern
   - stone_setting_type
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14791,13 +16180,16 @@
   attributes:
   - age_group
   - color
+  - drop
   - earring_closure_type
   - earring_design
   - jewelry_material
   - jewelry_type
+  - length
   - metal_purity
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14814,14 +16206,18 @@
   children: []
   attributes:
   - age_group
+  - circumference
   - color
+  - drop
   - jewelry_material
   - jewelry_pieces_included
   - jewelry_type
+  - length
   - necklace_design
   - pattern
   - ring_size
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14841,10 +16237,12 @@
   - color
   - jewelry_material
   - jewelry_type
+  - length
   - necklace_design
   - necklace_length_type
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -14863,7 +16261,9 @@
   - aa-6-9-2
   attributes:
   - age_group
+  - circumference
   - color
+  - embellishment_height
   - gemstone_cut_style
   - gemstone_type
   - jewelry_material
@@ -14873,6 +16273,7 @@
   - ring_size
   - stone_shape
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14942,11 +16343,14 @@
   attributes:
   - age_group
   - color
+  - depth
+  - length
   - material
   - pattern
   - protection_coverage_area
   - target_gender
   - watch_accessory_style
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14967,13 +16371,16 @@
   - band_material
   - clasp_type
   - color
+  - compatible_case_width
   - construction
   - embellishment/trim_material
   - jewelry_material
+  - length
   - pattern
   - target_gender
   - watch_accessory_style
   - watch_band_design
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14992,9 +16399,11 @@
   attributes:
   - age_group
   - color
+  - length
   - pattern
   - sticker_decal_features
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15016,8 +16425,11 @@
   - battery_type
   - color
   - connectivity_technology
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   - winding_direction
   return_reasons:
   - too_big
@@ -15126,10 +16538,14 @@
   attributes:
   - age_group
   - band_color
+  - band_length
   - band_pattern
+  - band_width
   - case_color
+  - case_depth
   - case_material
   - case_pattern
+  - case_width
   - crystal_material
   - dial_color
   - dial_pattern
@@ -15155,9 +16571,13 @@
   attributes:
   - age_group
   - band_color
+  - band_length
   - band_pattern
+  - band_width
   - case_color
+  - case_depth
   - case_pattern
+  - case_width
   - connectivity_technology
   - dial_color
   - dial_pattern
@@ -15214,8 +16634,11 @@
   - age_group
   - care_instructions
   - color
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15235,10 +16658,13 @@
   - age_group
   - clothing_accessory_material
   - color
+  - height
   - insulation_type
+  - length
   - pattern
   - shoe_size
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15258,10 +16684,13 @@
   - clothing_accessory_material
   - color
   - gaiter_height_type
+  - height
+  - length
   - pattern
   - shoe_size
   - target_gender
   - underfoot_strap_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15284,9 +16713,12 @@
   - age_group
   - color
   - fabric
+  - height
+  - length
   - pattern
   - shoe_size
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15360,10 +16792,13 @@
   - age_group
   - clothing_accessory_material
   - color
+  - height
+  - length
   - pattern
   - shoe_size
   - suitable_surface_type
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15462,10 +16897,13 @@
   - color
   - foot_arch_type_suitability
   - foot_support_level
+  - height
   - insert_coverage_area
+  - length
   - pattern
   - shoe_size
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15486,9 +16924,11 @@
   - color
   - foot_support_level
   - insert_coverage_area
+  - length
   - pattern
   - shoe_size
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15509,12 +16949,15 @@
   - color
   - foot_arch_type_compatibility
   - foot_support_level
+  - height
   - insert_coverage_area
   - insert_length_type
   - insole_attachment_method
+  - length
   - pattern
   - shoe_size
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15535,10 +16978,13 @@
   - clothing_accessory_material
   - color
   - foot_support_level
+  - height
   - insert_coverage_area
+  - length
   - pattern
   - shoe_size
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15560,10 +17006,13 @@
   - clothing_accessory_material
   - color
   - foot_support_level
+  - height
   - insert_coverage_area
+  - length
   - pattern
   - shoe_size
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15640,9 +17089,11 @@
   - age_group
   - clothing_accessory_material
   - color
+  - length
   - pattern
   - shoelace_aglet_material
   - target_gender
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -15662,9 +17113,13 @@
   - clothing_accessory_material
   - color
   - equestrian_discipline
+  - height
+  - length
   - pattern
   - rowel_type
+  - spur_shank_length
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15694,14 +17149,19 @@
   - color
   - footwear_construction_method
   - footwear_material
+  - heel_height
   - heel_height_type
   - lining_material
   - occasion_style
   - outsole_material
   - pattern
+  - platform_height
   - shoe_features
   - shoe_fit
+  - shoe_height
+  - shoe_length
   - shoe_size
+  - shoe_width
   - target_gender
   - toe_protection_type
   - toe_style
@@ -15730,13 +17190,19 @@
   - color
   - footwear_material
   - footwear_support_type
+  - heel_height
   - heel_height_type
+  - heel_to_toe_drop
   - lining_material
   - outsole_material
   - pattern
+  - platform_height
   - shoe_features
   - shoe_fit
+  - shoe_height
+  - shoe_length
   - shoe_size
+  - shoe_width
   - target_gender
   - toe_style
   return_reasons:
@@ -15758,19 +17224,27 @@
   children: []
   attributes:
   - age_group
+  - ankle_circumference
   - boot_style
+  - calf_circumference
   - care_instructions
   - closure_type
   - color
   - footwear_material
+  - heel_height
   - heel_height_type
+  - insulation_weight
   - lining_material
   - occasion_style
   - outsole_material
   - pattern
+  - platform_height
   - shoe_features
   - shoe_fit
+  - shoe_height
+  - shoe_length
   - shoe_size
+  - shoe_width
   - target_gender
   - toe_style
   return_reasons:
@@ -15796,15 +17270,20 @@
   - closure_type
   - color
   - footwear_material
+  - heel_height
   - heel_height_type
   - lining_material
   - occasion_style
   - outsole_material
   - pattern
+  - platform_height
   - sandal_style
   - shoe_features
   - shoe_fit
+  - shoe_height
+  - shoe_length
   - shoe_size
+  - shoe_width
   - target_gender
   - toe_style
   return_reasons:
@@ -15830,14 +17309,19 @@
   - closure_type
   - color
   - footwear_material
+  - heel_height
   - heel_height_type
   - lining_material
   - occasion_style
   - outsole_material
   - pattern
+  - platform_height
   - shoe_features
   - shoe_fit
+  - shoe_height
+  - shoe_length
   - shoe_size
+  - shoe_width
   - slipper_style
   - target_gender
   - toe_style
@@ -15865,15 +17349,20 @@
   - closure_type
   - color
   - footwear_material
+  - heel_height
   - heel_height_type
   - lining_material
   - occasion_style
   - outsole_material
   - pattern
+  - platform_height
   - pronation_support
   - shoe_features
   - shoe_fit
+  - shoe_height
+  - shoe_length
   - shoe_size
+  - shoe_width
   - sneaker_style
   - target_gender
   - toe_style
@@ -15902,14 +17391,19 @@
   - color
   - flat_shoe_style
   - footwear_material
+  - heel_height
   - insole_material
   - lining_material
   - occasion_style
   - outsole_material
   - pattern
+  - platform_height
   - shoe_features
   - shoe_fit
+  - shoe_height
+  - shoe_length
   - shoe_size
+  - shoe_width
   - target_gender
   - toe_style
   return_reasons:
@@ -15935,6 +17429,7 @@
   - closure_type
   - color
   - footwear_material
+  - heel_height
   - heel_height_type
   - heel_shape
   - heel_shoe_type
@@ -15942,9 +17437,13 @@
   - occasion_style
   - outsole_material
   - pattern
+  - platform_height
   - shoe_features
   - shoe_fit
+  - shoe_height
+  - shoe_length
   - shoe_size
+  - shoe_width
   - target_gender
   - toe_style
   return_reasons:

--- a/data/categories/ae_arts_entertainment.yml
+++ b/data/categories/ae_arts_entertainment.yml
@@ -94,8 +94,11 @@
   - alcohol/solvent_content
   - battery_size
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -115,8 +118,12 @@
   - candle_container_type_included
   - candle_kit_items_included
   - candle_type
+  - height
+  - length
+  - wax_included_weight
   - wax_type
   - wick_type_included
+  - width
   return_reasons:
   - size
   - color
@@ -135,8 +142,11 @@
   - alcohol/solvent_content
   - color
   - drawing/painting_kit_items_included
+  - height
+  - length
   - pattern
   - surface_types_included
+  - width
   return_reasons:
   - size
   - color
@@ -158,8 +168,11 @@
   - fabric_repair_kit_application_method
   - fabric_repair_kit_components_included
   - fabric_repair_kit_intended_use
+  - height
+  - length
   - pattern
   - suitable_for_fabric_type
+  - width
   return_reasons:
   - size
   - color
@@ -174,13 +187,16 @@
   children: []
   attributes:
   - age_group
+  - height
   - incense_base_material
   - incense_fragrance
   - incense_kit_items_included
   - incense_making_method
   - incense_type
   - instruction_format
+  - length
   - safety_equipment_included
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -195,9 +211,12 @@
   attributes:
   - age_group
   - color
+  - height
   - jewelry_material
   - jewelry_set_type
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -213,6 +232,9 @@
   children: []
   attributes:
   - age_group
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -229,11 +251,14 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - material
   - needlecraft_kit_items_included
   - needlecraft_kit_project_type
   - needlecraft_kit_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -252,7 +277,10 @@
   - age_group
   - album_type
   - embellishments
+  - height
+  - length
   - scrapbook_paper_type
+  - width
   return_reasons:
   - size
   - color
@@ -271,7 +299,10 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -288,6 +319,9 @@
   attributes:
   - age_group
   - doll_making_kit_components_included
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -303,6 +337,9 @@
   children: []
   attributes:
   - age_group
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -372,7 +409,10 @@
   - ae-2-1-2-1-7
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -390,8 +430,11 @@
   - ae-2-1-2-1-1-2
   attributes:
   - color
+  - height
+  - length
   - paper_finish
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -407,10 +450,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - paper_color_family
   - paper_finish
   - paper_size
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -426,9 +472,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - paper_finish
   - paper_size
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -444,8 +493,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - paper_size
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -462,8 +514,11 @@
   - color
   - craft_foil_application_method
   - craft_foil_format
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -478,10 +533,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - paper_format
   - paper_size
   - paper_texture
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -497,9 +555,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - origami_paper_shape
   - origami_paper_sidedness
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -517,9 +578,12 @@
   attributes:
   - color
   - creative_art_project_type
+  - height
+  - length
   - paper_size
   - pattern
   - transfer_paper_technique
+  - width
   return_reasons:
   - size
   - color
@@ -535,11 +599,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - paper_finish
   - paper_size
   - pattern
   - suitable_for_art_technique
   - vellum_opacity_level
+  - width
   return_reasons:
   - size
   - color
@@ -580,13 +647,17 @@
   attributes:
   - accessory_size
   - button/snap_closure_type
+  - button_snap_diameter
   - color
   - construction
   - embellishment/trim_material
   - fastener_material
+  - height
   - jewelry_material
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -607,12 +678,16 @@
   - button_application
   - button_attachment_type
   - button_finish
+  - button_snap_diameter
   - color
   - construction
   - embellishment/trim_material
   - fastener_material
+  - height
   - jewelry_material
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -629,10 +704,14 @@
   attributes:
   - accessory_size
   - button/snap_closure_type
+  - button_snap_diameter
   - color
   - fastener_material
+  - height
+  - length
   - pattern
   - snap_installation_method
+  - width
   return_reasons:
   - size
   - color
@@ -651,8 +730,11 @@
   - construction
   - embellishment/trim_material
   - fastener_material
+  - height
   - jewelry_material
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -674,7 +756,10 @@
   - color
   - eyelet_grommet_installation_method
   - fastener_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -693,7 +778,10 @@
   - color
   - eyelet_grommet_installation_method
   - fastener_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -715,7 +803,10 @@
   - grommet_application_material
   - grommet_duty_rating
   - grommet_style
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -734,10 +825,14 @@
   - color
   - eyelet_grommet_installation_method
   - fastener_material
+  - height
   - hook_and_eye_size_hook_number
   - hooks_eyes_attachment_method
+  - hooks_eyes_strip_length
   - included_fastener_components
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -759,9 +854,12 @@
   - color
   - compatible_surface
   - fastener_material
+  - height
   - hook_and_loop_fastener_duty_rating
   - hook_and_loop_fastener_format
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -778,11 +876,14 @@
   - color
   - compatible_surface
   - fastener_material
+  - height
   - hook_and_loop_fastener_duty_rating
   - hook_and_loop_fastener_format
   - hook_and_loop_fastener_side
+  - length
   - pattern
   - suitable_mounting_surface_material
+  - width
   return_reasons:
   - size
   - color
@@ -799,10 +900,13 @@
   - color
   - compatible_surface
   - fastener_material
+  - height
   - hook_and_loop_fastener_duty_rating
   - hook_and_loop_fastener_format
   - hook_loop_side
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -819,11 +923,14 @@
   - color
   - compatible_surface
   - fastener_material
+  - height
   - hook_and_loop_fastener_duty_rating
   - hook_and_loop_fastener_format
+  - length
   - pattern
   - self_adhesive_hook_loop_backing_type
   - self_adhesive_hook_loop_fastener_shape
+  - width
   return_reasons:
   - size
   - color
@@ -840,13 +947,17 @@
   - color
   - compatible_surface
   - fastener_material
+  - height
   - hook_and_loop_fastener_duty_rating
   - hook_and_loop_fastener_format
   - hook_loop_format
+  - length
+  - package_length
   - pattern
   - sew_on_edge_finish
   - softness_level
   - strength_grade
+  - width
   return_reasons:
   - size
   - color
@@ -863,8 +974,11 @@
   - color
   - compatible_zipper_size
   - fastener_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   - zipper_pull_strap_cord_tab_material
   - zipper_pull_style
   return_reasons:
@@ -886,9 +1000,13 @@
   - ae-2-1-2-2-6-3
   - ae-2-1-2-2-6-4
   attributes:
+  - chain_length
   - color
   - fastener_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -903,12 +1021,17 @@
   name: Closed-End Zippers
   children: []
   attributes:
+  - chain_length
   - color
   - fastener_material
+  - height
+  - length
   - pattern
+  - width
   - zipper_gauge
   - zipper_pull_side
   - zipper_slider_material
+  - zipper_tape_width
   - zipper_teeth_type
   return_reasons:
   - size
@@ -924,9 +1047,13 @@
   name: Open-End Zippers
   children: []
   attributes:
+  - chain_length
   - color
   - fastener_material
+  - height
+  - length
   - pattern
+  - width
   - zipper_slider_pull_configuration
   - zipper_tape_material
   return_reasons:
@@ -943,11 +1070,16 @@
   name: Reversible Zippers
   children: []
   attributes:
+  - chain_length
   - color
   - fastener_material
+  - height
+  - length
   - pattern
+  - width
   - zipper_application
   - zipper_chain_type
+  - zipper_chain_width
   - zipper_end_type
   - zipper_pull_material
   - zipper_reversibility_mechanism
@@ -965,9 +1097,13 @@
   name: Two-Way Zippers
   children: []
   attributes:
+  - chain_length
   - color
   - fastener_material
+  - height
+  - length
   - pattern
+  - width
   - zipper_separating_type
   return_reasons:
   - size
@@ -1027,6 +1163,7 @@
   - paint_form
   - paint_type
   - pattern
+  - volume
   return_reasons:
   - color
   - consistency
@@ -1045,6 +1182,7 @@
   - art_fixative_application_method
   - finish
   - suitable_for_crafting_material
+  - volume
   return_reasons:
   - finish
   - incompatible
@@ -1085,6 +1223,7 @@
   - color
   - ink_form
   - pattern
+  - volume
   return_reasons:
   - color
   - finish
@@ -1103,6 +1242,7 @@
   - color
   - ink_form
   - pattern
+  - volume
   return_reasons:
   - color
   - finish
@@ -1121,6 +1261,7 @@
   - compatible_writing_surface
   - ink_form
   - pattern
+  - volume
   return_reasons:
   - color
   - finish
@@ -1141,6 +1282,7 @@
   - drawing_ink_permanence
   - ink_form
   - pattern
+  - volume
   return_reasons:
   - color
   - finish
@@ -1157,6 +1299,7 @@
   - color
   - ink_form
   - pattern
+  - volume
   return_reasons:
   - color
   - finish
@@ -1176,6 +1319,7 @@
   - ink_permanence
   - ink_preparation_required
   - pattern
+  - volume
   return_reasons:
   - color
   - finish
@@ -1192,6 +1336,7 @@
   - color
   - ink_form
   - pattern
+  - volume
   - watercolor_ink_water_resistance_after_drying
   return_reasons:
   - color
@@ -1215,6 +1360,7 @@
   - pattern
   - pyrometric_cone_range
   - visual_effect
+  - volume
   return_reasons:
   - color
   - finish
@@ -1231,6 +1377,7 @@
   attributes:
   - dye_form
   - suitable_for_crafting_material
+  - volume
   return_reasons:
   - color
   - incompatible
@@ -1246,11 +1393,14 @@
   attributes:
   - alcohol/solvent_content
   - finish
+  - height
   - ink_pad_application_method
   - ink_pad_permanence
   - ink_pad_size
   - ink_pad_special_effects
   - ink_type
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -1270,6 +1420,7 @@
   - paint_medium_intended_effect
   - paint_medium_type
   - pattern
+  - volume
   return_reasons:
   - color
   - finish
@@ -1310,7 +1461,10 @@
   attributes:
   - foam_form
   - foam_surface_effect
+  - height
+  - length
   - thickness_type
+  - width
   return_reasons:
   - size
   - color
@@ -1332,8 +1486,11 @@
   - ae-2-1-2-4-2-7
   attributes:
   - craft_wood_surface_preparation
+  - height
+  - length
   - lumber/wood_type
   - sustainability_certification
+  - width
   - wood_finish
   - wood_grain_direction
   return_reasons:
@@ -1350,8 +1507,11 @@
   children: []
   attributes:
   - craft_wood_surface_preparation
+  - height
+  - length
   - lumber/wood_type
   - sustainability_certification
+  - width
   - wood_block_surface_preparation
   - wood_finish
   return_reasons:
@@ -1369,8 +1529,11 @@
   children: []
   attributes:
   - craft_wood_surface_preparation
+  - height
+  - length
   - lumber/wood_type
   - sustainability_certification
+  - width
   return_reasons:
   - size
   - color
@@ -1388,8 +1551,11 @@
   - craft_wood_surface_preparation
   - dowel_end_style
   - dowel_surface_texture
+  - height
+  - length
   - lumber/wood_type
   - sustainability_certification
+  - width
   return_reasons:
   - size
   - color
@@ -1405,8 +1571,12 @@
   children: []
   attributes:
   - craft_wood_surface_preparation
+  - height
+  - hole_diameter
+  - length
   - lumber/wood_type
   - sustainability_certification
+  - width
   return_reasons:
   - size
   - color
@@ -1422,8 +1592,11 @@
   children: []
   attributes:
   - craft_wood_surface_preparation
+  - height
+  - length
   - lumber/wood_type
   - sustainability_certification
+  - width
   return_reasons:
   - size
   - color
@@ -1439,8 +1612,12 @@
   children: []
   attributes:
   - craft_wood_surface_preparation
+  - height
+  - length
   - lumber/wood_type
   - sustainability_certification
+  - width
+  - wood_slice_diameter
   - wood_slice_edge_style
   return_reasons:
   - size
@@ -1457,8 +1634,11 @@
   children: []
   attributes:
   - craft_wood_surface_preparation
+  - height
+  - length
   - lumber/wood_type
   - sustainability_certification
+  - width
   return_reasons:
   - size
   - color
@@ -1473,8 +1653,11 @@
   name: Papier Mache Shapes
   children: []
   attributes:
+  - height
+  - length
   - paintable_surface
   - papier_mache_shape
+  - width
   return_reasons:
   - size
   - color
@@ -1489,9 +1672,12 @@
   name: Wreath & Floral Frames
   children: []
   attributes:
+  - height
+  - length
   - material_treatment
   - plant_material
   - shape
+  - width
   - wreath_design
   return_reasons:
   - size
@@ -1515,7 +1701,9 @@
   - alcohol/solvent_content
   - color
   - fusible_application_method
+  - magnet_pull_force
   - pattern
+  - tape_width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -1537,6 +1725,7 @@
   - alcohol/solvent_content
   - recommended_surfaces
   - suitable_for_crafting_material
+  - volume
   - washability
   return_reasons:
   - changed_my_mind
@@ -1554,6 +1743,7 @@
   - clear_glue_finish_after_drying
   - recommended_surfaces
   - suitable_for_crafting_material
+  - volume
   - washability
   return_reasons:
   - changed_my_mind
@@ -1569,6 +1759,7 @@
   - alcohol/solvent_content
   - recommended_surfaces
   - suitable_for_crafting_material
+  - volume
   - washability
   return_reasons:
   - changed_my_mind
@@ -1584,6 +1775,7 @@
   - alcohol/solvent_content
   - recommended_surfaces
   - suitable_for_crafting_material
+  - volume
   - washability
   return_reasons:
   - changed_my_mind
@@ -1598,6 +1790,7 @@
   attributes:
   - recommended_surfaces
   - suitable_for_crafting_material
+  - volume
   - washability
   return_reasons:
   - changed_my_mind
@@ -1617,6 +1810,7 @@
   - glue_base_formulation
   - recommended_surfaces
   - suitable_for_crafting_material
+  - volume
   - washability
   return_reasons:
   - changed_my_mind
@@ -1633,6 +1827,7 @@
   - recommended_surfaces
   - school_glue_washability
   - suitable_for_crafting_material
+  - volume
   - washability
   return_reasons:
   - changed_my_mind
@@ -1649,6 +1844,7 @@
   - fiber_art_project_type
   - glue_safety_standard
   - recommended_surfaces
+  - volume
   - washability
   - white_glue_finish_appearance_when_dry
   - white_glue_washability
@@ -1665,8 +1861,11 @@
   attributes:
   - craft_magnet_application
   - craft_magnet_holding_strength_level
+  - height
+  - length
   - magnet_type
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -1684,7 +1883,9 @@
   - decoration_material
   - decorative_tape_application
   - decorative_tape_format
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1702,7 +1903,9 @@
   - ae-2-1-2-5-4-2
   attributes:
   - color
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1717,7 +1920,9 @@
   children: []
   attributes:
   - color
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1732,8 +1937,10 @@
   children: []
   attributes:
   - color
+  - length
   - pattern
   - tape_finish
+  - width
   return_reasons:
   - size
   - color
@@ -1754,7 +1961,9 @@
   - adhesive_sides
   - color
   - fusible_tape_backing_type
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1771,7 +1980,9 @@
   - adhesive_sides
   - color
   - fusible_tape_backing_type
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1789,7 +2000,9 @@
   - color
   - fusible_hem_tape_application_method
   - fusible_tape_backing_type
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1811,7 +2024,9 @@
   - fusible_seam_tape_washability
   - fusible_seam_tape_waterproof_rating
   - fusible_tape_backing_type
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1828,7 +2043,9 @@
   - adhesive_sides
   - color
   - fusible_tape_backing_type
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1869,8 +2086,11 @@
   - ae-2-1-2-6-1-2
   attributes:
   - dye_technique
+  - height
+  - length
   - material
   - twist_direction
+  - width
   return_reasons:
   - size
   - color
@@ -1888,8 +2108,12 @@
   - beading_thread_size
   - beading_thread_use_case
   - dye_technique
+  - height
+  - length
   - material
+  - thread_length
   - twist_direction
+  - width
   return_reasons:
   - size
   - color
@@ -1903,13 +2127,17 @@
   name: Chain Rolls
   children: []
   attributes:
+  - chain_length
   - construction
   - dye_technique
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - material
   - product_use
   - twist_direction
+  - width
   return_reasons:
   - size
   - color
@@ -1931,11 +2159,14 @@
   - color
   - dye_technique
   - fabric
+  - height
+  - length
   - pattern
   - thread_construction
   - thread_material
   - thread_weight_system
   - twist_direction
+  - width
   return_reasons:
   - color
   - weight
@@ -1952,11 +2183,15 @@
   - color
   - dye_technique
   - fabric
+  - height
+  - length
   - pattern
   - thread_construction
+  - thread_length
   - thread_material
   - thread_weight_system
   - twist_direction
+  - width
   return_reasons:
   - color
   - weight
@@ -1975,14 +2210,18 @@
   - dye_style
   - dye_technique
   - fabric
+  - height
+  - length
   - pattern
   - thread_construction
+  - thread_length
   - thread_material
   - thread_material_fiber
   - thread_standard_size
   - thread_type
   - thread_weight_system
   - twist_direction
+  - width
   return_reasons:
   - color
   - weight
@@ -1999,13 +2238,17 @@
   - color
   - dye_technique
   - fabric
+  - height
+  - length
   - pattern
   - quilting_thread_usage
   - quilting_thread_weight_system
   - thread_construction
+  - thread_length
   - thread_material
   - thread_weight_system
   - twist_direction
+  - width
   return_reasons:
   - color
   - weight
@@ -2022,15 +2265,20 @@
   - color
   - dye_technique
   - fabric
+  - height
   - intended_sewing_application
+  - length
   - pattern
   - sewing_thread_size_system
   - thread_construction
   - thread_finish_treatment
+  - thread_length
   - thread_material
   - thread_package_format
+  - thread_thickness
   - thread_weight_system
   - twist_direction
+  - width
   return_reasons:
   - color
   - weight
@@ -2047,11 +2295,15 @@
   - color
   - dye_technique
   - fabric
+  - height
+  - length
   - pattern
   - thread_construction
+  - thread_length
   - thread_material
   - thread_weight_system
   - twist_direction
+  - width
   return_reasons:
   - color
   - weight
@@ -2075,8 +2327,12 @@
   - color
   - dye_technique
   - fabric
+  - fiber_length
+  - height
+  - length
   - pattern
   - twist_direction
+  - width
   return_reasons:
   - color
   - texture
@@ -2095,9 +2351,13 @@
   - dye_status
   - dye_technique
   - fabric
+  - fiber_length
   - fiber_preparation_type
+  - height
+  - length
   - pattern
   - twist_direction
+  - width
   return_reasons:
   - color
   - texture
@@ -2115,8 +2375,12 @@
   - color
   - dye_technique
   - fabric
+  - fiber_length
+  - height
+  - length
   - pattern
   - twist_direction
+  - width
   return_reasons:
   - color
   - texture
@@ -2134,10 +2398,14 @@
   - color
   - dye_technique
   - fabric
+  - fiber_length
   - fleece_fiber_animal_type
   - fleece_preparation_method
+  - height
+  - length
   - pattern
   - twist_direction
+  - width
   return_reasons:
   - color
   - texture
@@ -2156,8 +2424,13 @@
   - dye_technique
   - fabric
   - fiber_animal_source_type
+  - fiber_length
+  - height
+  - length
   - pattern
+  - staple_length
   - twist_direction
+  - width
   return_reasons:
   - color
   - texture
@@ -2176,9 +2449,13 @@
   - dye_technique
   - dyeing_color_processing
   - fabric
+  - fiber_length
   - fiber_preparation_processing_stage
+  - height
+  - length
   - pattern
   - twist_direction
+  - width
   return_reasons:
   - color
   - texture
@@ -2196,15 +2473,20 @@
   - color
   - dye_technique
   - fabric
+  - fiber_length
   - fiber_luster_level
+  - height
+  - length
   - pattern
   - plant_fiber_type
   - staple_fiber_animal_fiber_type
   - staple_fiber_crimp_level
   - staple_fiber_preparation_type
   - staple_fiber_source_type
+  - staple_fiber_weight
   - twist_direction
   - vegetable_matter_vm_content
+  - width
   return_reasons:
   - color
   - texture
@@ -2222,8 +2504,12 @@
   - color
   - dye_technique
   - fabric
+  - fiber_length
+  - height
+  - length
   - pattern
   - twist_direction
+  - width
   return_reasons:
   - color
   - texture
@@ -2241,11 +2527,15 @@
   - color
   - dye_technique
   - fabric
+  - fiber_length
+  - height
   - knitting_project_type
+  - length
   - material_treatment
   - pattern
   - plant_material
   - twist_direction
+  - width
   - yarn_weight_category
   return_reasons:
   - color
@@ -2265,6 +2555,7 @@
   - ae-2-1-2-7-3
   attributes:
   - color
+  - crafting_wire_diameter
   - pattern
   - temper_hardness
   - wire_coating_type
@@ -2285,9 +2576,14 @@
   attributes:
   - color
   - craft_pipe_cleaner_design
+  - crafting_wire_diameter
+  - height
+  - length
   - pattern
   - temper_hardness
+  - width
   - wire_coating_type
+  - wire_length
   - wire_packaging_type
   - wire_shape_profile
   return_reasons:
@@ -2304,13 +2600,18 @@
   children: []
   attributes:
   - color
+  - crafting_wire_diameter
   - floral_wire_design
+  - height
+  - length
   - material_treatment
   - pattern
   - plant_material
   - temper_hardness
+  - width
   - wire/rope_material
   - wire_coating_type
+  - wire_length
   - wire_packaging_type
   - wire_shape_profile
   return_reasons:
@@ -2335,12 +2636,17 @@
   attributes:
   - beading_wire_strand_count
   - color
+  - crafting_wire_diameter
+  - height
   - jewelry_project_type
+  - length
   - pattern
   - temper_hardness
+  - width
   - wire/rope_material
   - wire_coating_material
   - wire_coating_type
+  - wire_length
   - wire_packaging_type
   - wire_shape_profile
   return_reasons:
@@ -2358,14 +2664,20 @@
   attributes:
   - beading_wire_strand_count
   - color
+  - crafting_wire_diameter
+  - height
   - jewelry_project_type
+  - length
   - pattern
   - temper_hardness
+  - width
   - wire/rope_material
   - wire_coating_material
   - wire_coating_type
+  - wire_length
   - wire_packaging_type
   - wire_shape_profile
+  - wire_spool_length
   return_reasons:
   - gauge
   - color
@@ -2382,12 +2694,17 @@
   - beading_wire_coating_material
   - beading_wire_strand_count
   - color
+  - crafting_wire_diameter
+  - height
   - jewelry_project_type
+  - length
   - pattern
   - temper_hardness
+  - width
   - wire/rope_material
   - wire_coating_material
   - wire_coating_type
+  - wire_length
   - wire_packaging_type
   - wire_shape_profile
   return_reasons:
@@ -2406,12 +2723,17 @@
   - beading_wire_strand_count
   - color
   - craft_wire_finish_coating
+  - crafting_wire_diameter
+  - height
   - jewelry_project_type
+  - length
   - pattern
   - temper_hardness
+  - width
   - wire/rope_material
   - wire_coating_material
   - wire_coating_type
+  - wire_length
   - wire_packaging_type
   - wire_shape_profile
   return_reasons:
@@ -2429,12 +2751,17 @@
   attributes:
   - beading_wire_strand_count
   - color
+  - crafting_wire_diameter
+  - height
   - jewelry_project_type
+  - length
   - pattern
   - temper_hardness
+  - width
   - wire/rope_material
   - wire_coating_material
   - wire_coating_type
+  - wire_length
   - wire_packaging_type
   - wire_shape_profile
   return_reasons:
@@ -2452,15 +2779,21 @@
   attributes:
   - beading_wire_strand_count
   - color
+  - crafting_wire_diameter
+  - height
   - jewelry_project_type
+  - length
   - memory_wire_gauge
   - memory_wire_project_size
+  - memory_wire_wire_diameter
   - pattern
   - temper_hardness
+  - width
   - wire/rope_material
   - wire_coating_material
   - wire_coating_type
   - wire_finish
+  - wire_length
   - wire_packaging_type
   - wire_shape_profile
   return_reasons:
@@ -2478,13 +2811,18 @@
   attributes:
   - beading_wire_strand_count
   - color
+  - crafting_wire_diameter
+  - height
   - jewelry_project_type
+  - length
   - pattern
   - temper_hardness
+  - width
   - wire/rope_material
   - wire_coating_material
   - wire_coating_type
   - wire_construction_type
+  - wire_length
   - wire_packaging_type
   - wire_shape_profile
   return_reasons:
@@ -2502,12 +2840,17 @@
   attributes:
   - beading_wire_strand_count
   - color
+  - crafting_wire_diameter
+  - height
   - jewelry_project_type
+  - length
   - pattern
   - temper_hardness
+  - width
   - wire/rope_material
   - wire_coating_material
   - wire_coating_type
+  - wire_length
   - wire_packaging_type
   - wire_shape_profile
   return_reasons:
@@ -2568,10 +2911,13 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - pattern
   - textile_craft_project_type
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -2590,13 +2936,16 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - material_origin
   - patch_placement_area
   - patch_shape
   - pattern
   - textile_craft_project_type
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -2614,13 +2963,16 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - patch_backing_type
   - patch_border_edge_finish
   - patch_shape
   - pattern
   - textile_craft_project_type
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -2641,12 +2993,15 @@
   - embellishment/trim_material
   - embroidered_coverage_level
   - embroidered_patch_backing_type
+  - height
   - jewelry_material
+  - length
   - patch_shape
   - pattern
   - textile_craft_project_type
   - theme
   - thread_type
+  - width
   return_reasons:
   - size
   - color
@@ -2663,12 +3018,15 @@
   attributes:
   - color
   - embellishment/trim_material
+  - height
+  - length
   - material_treatment
   - patch_shape
   - pattern
   - plant_material
   - textile_craft_project_type
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -2688,11 +3046,16 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - iron_on_applique_application_method
+  - iron_on_applique_application_temperature
+  - iron_on_applique_press_time
   - jewelry_material
+  - length
   - pattern
   - textile_craft_project_type
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -2709,11 +3072,14 @@
   attributes:
   - color
   - embellishment/trim_material
+  - height
+  - length
   - patch_base_material
   - patch_shape
   - pattern
   - textile_craft_project_type
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -2731,7 +3097,9 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - material_treatment
   - patch_backing_material
   - patch_shape
@@ -2740,6 +3108,7 @@
   - sequin_finish
   - textile_craft_project_type
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -2757,9 +3126,12 @@
   - applique_shape
   - color
   - embellishment/trim_material
+  - height
+  - length
   - pattern
   - textile_craft_project_type
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -2778,11 +3150,14 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - material_origin
   - pattern
   - product_classification
   - product_use
+  - width
   return_reasons:
   - size
   - color
@@ -2802,7 +3177,10 @@
   - bow_yo_yo_embellishment_style
   - color
   - embellishment/trim_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2826,13 +3204,16 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - lumber/wood_type
   - pattern
   - sticker_finish
   - sticker_format
   - sticker_material_type
   - theme
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2851,11 +3232,14 @@
   - celebration_type
   - color
   - embellishment/trim_material
+  - height
+  - length
   - pattern
   - sticker_finish
   - sticker_format
   - sticker_material_type
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -2874,11 +3258,14 @@
   - celebration_type
   - color
   - embellishment/trim_material
+  - height
+  - length
   - pattern
   - sticker_finish
   - sticker_format
   - sticker_material_type
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -2897,11 +3284,14 @@
   - celebration_type
   - color
   - embellishment/trim_material
+  - height
+  - length
   - pattern
   - sticker_finish
   - sticker_format
   - sticker_material_type
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -2927,7 +3317,10 @@
   - elastic_recovery_quality
   - elastic_stretch_level
   - embellishment/trim_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2946,7 +3339,10 @@
   - elastic_recovery_quality
   - elastic_stretch_level
   - embellishment/trim_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2960,13 +3356,18 @@
   name: Buttonholes
   children: []
   attributes:
+  - buttonhole_size
+  - buttonhole_spacing
   - color
   - elastic_recovery_quality
   - elastic_stretch_level
   - elastic_structure
   - embellishment/trim_material
   - fold_over_elastic_application
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2984,7 +3385,10 @@
   - elastic_recovery_quality
   - elastic_stretch_level
   - embellishment/trim_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3004,7 +3408,10 @@
   - elastic_stretch_level
   - elastic_type
   - embellishment/trim_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3023,8 +3430,11 @@
   - elastic_stretch_level
   - embellishment/trim_material
   - firmness
+  - height
   - knit_elastic_application
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3044,7 +3454,10 @@
   - elastic_recovery_quality
   - elastic_stretch_level
   - embellishment/trim_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3069,7 +3482,10 @@
   - craft_project_type
   - feather_processing_type
   - feather_product_form
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3090,7 +3506,10 @@
   - feather_form
   - feather_processing_type
   - feather_product_form
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3109,9 +3528,13 @@
   - craft_project_type
   - feather_processing_type
   - feather_product_form
+  - height
+  - length
   - marabou_feather_form
+  - marabou_feather_length
   - marabou_feather_treatment
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3132,8 +3555,11 @@
   - feather_processing_type
   - feather_product_form
   - feather_quantity_unit
+  - height
+  - length
   - ostrich_feather_part
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3154,8 +3580,12 @@
   - feather_grade
   - feather_processing_type
   - feather_product_form
+  - feather_width
+  - height
   - iridescence_level
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3174,7 +3604,10 @@
   - craft_project_type
   - feather_processing_type
   - feather_product_form
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3194,8 +3627,11 @@
   - feather_attachment_format
   - feather_processing_type
   - feather_product_form
+  - height
+  - length
   - pattern
   - synthetic_feather_style
+  - width
   return_reasons:
   - size
   - color
@@ -3218,8 +3654,11 @@
   - feather_processing_type
   - feather_product_form
   - feather_stiffness
+  - height
+  - length
   - pattern
   - processing_state
+  - width
   return_reasons:
   - size
   - color
@@ -3237,12 +3676,15 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_finding_type
   - jewelry_material
+  - length
   - material_origin
   - pattern
   - product_classification
   - product_use
+  - width
   return_reasons:
   - size
   - color
@@ -3265,11 +3707,14 @@
   - ae-2-1-2-8-8-7
   attributes:
   - color
+  - height
+  - length
   - material_origin
   - pattern
   - product_classification
   - product_use
   - stone_shape
+  - width
   return_reasons:
   - size
   - color
@@ -3284,8 +3729,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - stone_shape
+  - width
   return_reasons:
   - size
   - color
@@ -3301,11 +3749,14 @@
   attributes:
   - cabochon_back_type
   - color
+  - height
+  - length
   - material_origin
   - pattern
   - product_classification
   - product_use
   - stone_shape
+  - width
   return_reasons:
   - size
   - color
@@ -3322,11 +3773,14 @@
   - authenticity
   - color
   - crystal_finish
+  - height
+  - length
   - material_origin
   - pattern
   - product_classification
   - product_use
   - stone_shape
+  - width
   return_reasons:
   - size
   - color
@@ -3341,8 +3795,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - stone_shape
+  - width
   return_reasons:
   - size
   - color
@@ -3358,10 +3815,13 @@
   attributes:
   - color
   - glass_stone_application_method
+  - height
+  - length
   - pattern
   - stone_cut_style
   - stone_shape
   - stone_transparency
+  - width
   return_reasons:
   - size
   - color
@@ -3376,11 +3836,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material_origin
   - pattern
   - product_classification
   - product_use
   - stone_shape
+  - width
   return_reasons:
   - size
   - color
@@ -3397,9 +3860,13 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - material_origin
+  - nacre_thickness
   - pattern
+  - pearl_hole_size
   - pearl_luster_grade
   - pearl_matching_level
   - pearl_shape
@@ -3408,6 +3875,7 @@
   - pearl_type
   - product_classification
   - product_use
+  - width
   return_reasons:
   - size
   - color
@@ -3429,9 +3897,12 @@
   - construction
   - embellishment/trim_material
   - finish_effect
+  - height
   - jewelry_material
+  - length
   - pattern
   - stone_shape
+  - width
   return_reasons:
   - size
   - color
@@ -3450,9 +3921,12 @@
   - construction
   - embellishment/trim_material
   - finish_effect
+  - height
   - jewelry_material
+  - length
   - pattern
   - stone_shape
+  - width
   return_reasons:
   - size
   - color
@@ -3469,10 +3943,13 @@
   attributes:
   - color
   - finish_effect
+  - height
   - hotfix_application_tool
+  - length
   - pattern
   - rhinestone_base_color_family
   - stone_shape
+  - width
   return_reasons:
   - size
   - color
@@ -3493,9 +3970,12 @@
   - construction
   - embellishment/trim_material
   - finish_effect
+  - height
   - jewelry_material
+  - length
   - pattern
   - stone_shape
+  - width
   return_reasons:
   - size
   - color
@@ -3514,13 +3994,16 @@
   - construction
   - embellishment/trim_material
   - finish_effect
+  - height
   - jewelry_material
+  - length
   - pattern
   - rhinestone_facet_style
   - rhinestone_hole_reinforcement_material
   - rhinestone_setting_type
   - sew_on_rhinestone_hole_orientation
   - stone_shape
+  - width
   return_reasons:
   - size
   - color
@@ -3549,9 +4032,13 @@
   - color
   - craft_project_type
   - embellishment/trim_material
+  - height
+  - length
   - pattern
   - ribbon_trim_backing_type
   - ribbon_trim_edge_finish
+  - trim_length
+  - width
   return_reasons:
   - size
   - color
@@ -3569,8 +4056,12 @@
   - color
   - craft_project_type
   - embellishment/trim_material
+  - height
+  - length
   - pattern
   - ribbon_trim_backing_type
+  - trim_length
+  - width
   return_reasons:
   - size
   - color
@@ -3588,9 +4079,16 @@
   - color
   - craft_project_type
   - embellishment/trim_material
+  - fringe_drop_length
   - fringe_trim_style
+  - height
+  - length
+  - packaging_length
   - pattern
   - ribbon_trim_backing_type
+  - trim_header_width
+  - trim_length
+  - width
   return_reasons:
   - size
   - color
@@ -3608,11 +4106,15 @@
   - color
   - craft_project_type
   - embellishment/trim_material
+  - height
+  - length
   - pattern
   - ribbon_construction
+  - ribbon_length
   - ribbon_packaging_type
   - ribbon_pattern_style
   - ribbon_trim_backing_type
+  - width
   return_reasons:
   - size
   - color
@@ -3630,8 +4132,12 @@
   - color
   - craft_project_type
   - embellishment/trim_material
+  - height
+  - length
   - pattern
   - ribbon_trim_backing_type
+  - trim_length
+  - width
   return_reasons:
   - size
   - color
@@ -3649,9 +4155,14 @@
   - color
   - craft_project_type
   - embellishment/trim_material
+  - height
+  - length
   - organza_ribbon_transparency_level
   - pattern
+  - ribbon_length
   - ribbon_trim_backing_type
+  - roll_length_per_unit
+  - width
   return_reasons:
   - size
   - color
@@ -3669,9 +4180,13 @@
   - color
   - craft_project_type
   - embellishment/trim_material
+  - height
+  - length
   - pattern
   - pom_pom_trim_backing_tape_material
   - ribbon_trim_backing_type
+  - trim_length
+  - width
   return_reasons:
   - size
   - color
@@ -3689,11 +4204,15 @@
   - color
   - craft_project_type
   - embellishment/trim_material
+  - height
+  - length
   - pattern
   - ribbon_trim_backing_type
   - ric_rac_wave_size
   - trim_elasticity
   - trim_finish
+  - trim_length
+  - width
   return_reasons:
   - size
   - color
@@ -3711,10 +4230,14 @@
   - color
   - craft_project_type
   - embellishment/trim_material
+  - height
+  - length
   - pattern
+  - ribbon_length
   - ribbon_sheen_level
   - ribbon_trim_backing_type
   - satin_ribbon_face_type
+  - width
   return_reasons:
   - size
   - color
@@ -3732,9 +4255,13 @@
   - color
   - craft_project_type
   - embellishment/trim_material
+  - height
+  - length
   - pattern
   - ribbon_trim_backing_type
   - trim_application_method
+  - trim_length
+  - width
   return_reasons:
   - size
   - color
@@ -3752,10 +4279,16 @@
   - color
   - craft_project_type
   - embellishment/trim_material
+  - height
+  - length
   - pattern
   - ribbon_trim_backing_type
+  - tassel_drop_length
+  - tassel_spacing
   - tassel_trim_header_type
   - tassel_trim_use_case
+  - trim_length
+  - width
   return_reasons:
   - size
   - color
@@ -3773,8 +4306,12 @@
   - color
   - craft_project_type
   - embellishment/trim_material
+  - height
+  - length
   - pattern
+  - ribbon_length
   - ribbon_trim_backing_type
+  - width
   return_reasons:
   - size
   - color
@@ -3798,8 +4335,12 @@
   - craft_project_type
   - glitter_application_method
   - glitter_effect_type
+  - height
+  - length
   - pattern
   - sequin/glitter_shape
+  - sequin_size
+  - width
   return_reasons:
   - size
   - color
@@ -3818,7 +4359,10 @@
   - craft_project_type
   - glitter_effect_type
   - glitter_shape
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3838,7 +4382,10 @@
   - glitter_effect_type
   - glitter_glue_base_solvent_type
   - glitter_shape
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - style
@@ -3857,7 +4404,10 @@
   - glitter_effect_type
   - glitter_shape
   - glitter_use_suitability
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3878,7 +4428,10 @@
   - glitter_effect_type
   - glitter_opacity_coverage
   - glitter_shape
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3897,9 +4450,12 @@
   - craft_project_type
   - cup_type
   - glitter_effect_type
+  - height
+  - length
   - pattern
   - sequin_application_method
   - sequin_shape
+  - width
   return_reasons:
   - size
   - color
@@ -3921,10 +4477,13 @@
   attributes:
   - color
   - embellishment/trim_material
+  - height
   - label_fold_type
   - label_text_type
   - labeling_project_type
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3944,10 +4503,13 @@
   - care_label_symbol_system
   - color
   - embellishment/trim_material
+  - height
   - label_fold_type
   - label_text_type
   - labeling_project_type
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3965,13 +4527,16 @@
   - color
   - custom_label_content_type
   - embellishment/trim_material
+  - height
   - label_edge_type
   - label_finish
   - label_fold_type
   - label_text_type
   - labeling_project_type
+  - length
   - pattern
   - sew_in_label_placement
+  - width
   return_reasons:
   - size
   - color
@@ -3988,13 +4553,16 @@
   attributes:
   - color
   - embellishment/trim_material
+  - height
   - label_fold_type
   - label_text_type
   - labeling_project_type
+  - length
   - logo_label_compatible_fabric_weight
   - logo_label_edge_finish
   - logo_label_print_production_method
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4013,11 +4581,14 @@
   - care_durability
   - color
   - embellishment/trim_material
+  - height
   - label_fold_type
   - label_text_type
   - labeling_project_type
+  - length
   - name_label_text_template
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4034,13 +4605,16 @@
   attributes:
   - color
   - embellishment/trim_material
+  - height
   - label_finish_edge_style
   - label_fold_type
   - label_text_type
   - labeling_project_type
+  - length
   - pattern
   - size_system
   - text_color
+  - width
   return_reasons:
   - size
   - color
@@ -4058,7 +4632,10 @@
   - color
   - embossing_project_type
   - finish
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -4074,7 +4651,10 @@
   - ae-2-1-2-10-2
   - ae-2-1-2-10-3
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - weight
@@ -4088,12 +4668,17 @@
   name: Batting & Stuffing
   children: []
   attributes:
+  - batting_and_stuffing_coverage_area
   - batting_stuffing_form_factor
   - batting_stuffing_loft_level
   - batting_stuffing_thermal_insulation_level
+  - batting_stuffing_weight_per_area
   - filling/padding_project_type
+  - height
+  - length
   - material
   - thickness_type
+  - width
   return_reasons:
   - color
   - weight
@@ -4108,7 +4693,11 @@
   children: []
   attributes:
   - filling/padding_project_type
+  - height
+  - length
   - material
+  - weight
+  - width
   return_reasons:
   - color
   - weight
@@ -4123,9 +4712,13 @@
   children: []
   attributes:
   - filling/padding_project_type
+  - height
+  - length
+  - loft_uncompressed_thickness
   - material
   - pillow_form_size
   - pillow_shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -4140,9 +4733,12 @@
   attributes:
   - color
   - craft/sculpting_project_type
+  - height
   - leather/vinyl_texture
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -4182,6 +4778,7 @@
   - clay_modeling_dough_base_material
   - clay_modeling_dough_curing_method
   - color
+  - package_size
   - package_type
   - pattern
   - recommended_age_group
@@ -4206,9 +4803,11 @@
   - clay_modeling_dough_curing_method
   - clay_texture
   - color
+  - package_size
   - package_type
   - pattern
   - recommended_age_group
+  - weight
   return_reasons:
   - color
   - changed_my_mind
@@ -4228,9 +4827,11 @@
   - clay_texture
   - color
   - dried_surface_finish
+  - package_size
   - package_type
   - pattern
   - recommended_age_group
+  - weight
   return_reasons:
   - color
   - changed_my_mind
@@ -4249,9 +4850,11 @@
   - color
   - finish_after_baking
   - oven_bake_clay_formulation
+  - package_size
   - package_type
   - pattern
   - recommended_age_group
+  - weight
   return_reasons:
   - color
   - changed_my_mind
@@ -4268,11 +4871,13 @@
   - clay_modeling_dough_curing_method
   - clay_texture
   - color
+  - package_size
   - package_type
   - pattern
   - polymer_clay_firmness_level
   - polymer_clay_translucency
   - recommended_age_group
+  - weight
   return_reasons:
   - color
   - changed_my_mind
@@ -4289,10 +4894,14 @@
   - clay_modeling_dough_curing_method
   - clay_texture
   - color
+  - cure_time
+  - package_size
   - package_type
   - pattern
   - recommended_age_group
+  - sculpting_clay_bake_cure_temperature
   - sculpting_clay_base_type
+  - weight
   return_reasons:
   - color
   - changed_my_mind
@@ -4310,11 +4919,13 @@
   - clay_paintability
   - clay_texture
   - color
+  - package_size
   - package_type
   - pattern
   - recommended_age_group
   - self_hardening_clay_finish
   - self_hardening_clay_water_resistance_after_curing
+  - weight
   return_reasons:
   - color
   - changed_my_mind
@@ -4332,9 +4943,11 @@
   - color
   - modeling_dough_base_material
   - modeling_dough_features
+  - package_size
   - package_type
   - pattern
   - recommended_age_group
+  - weight
   return_reasons:
   - color
   - changed_my_mind
@@ -4368,6 +4981,8 @@
   - ae-2-1-2-12-3-2
   attributes:
   - color
+  - height
+  - length
   - package_type
   - pattern
   - plaster_gauze_finish
@@ -4375,6 +4990,7 @@
   - plaster_gauze_weave_density
   - pottery/sculpting_project_type
   - recommended_age_group
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -4388,6 +5004,8 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - package_type
   - pattern
   - plaster_gauze_finish
@@ -4395,6 +5013,7 @@
   - plaster_gauze_weave_density
   - pottery/sculpting_project_type
   - recommended_age_group
+  - width
   return_reasons:
   - size
   - color
@@ -4409,6 +5028,8 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - package_type
   - pattern
   - plaster_gauze_finish
@@ -4416,6 +5037,7 @@
   - plaster_gauze_weave_density
   - pottery/sculpting_project_type
   - recommended_age_group
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -4437,6 +5059,7 @@
   - recommended_age_group
   - slip_texture
   - viscosity_thickness
+  - volume
   return_reasons:
   - color
   - changed_my_mind
@@ -4454,10 +5077,13 @@
   - ae-2-1-2-14-4
   attributes:
   - color
+  - height
+  - length
   - pattern
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - color
   - pattern
@@ -4478,11 +5104,14 @@
   - canvas_compatible_media
   - canvas_material
   - color
+  - height
+  - length
   - paper_size
   - pattern
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4502,6 +5131,8 @@
   attributes:
   - color
   - fabric_cut_format
+  - height
+  - length
   - material
   - needlecraft_fabric_composition
   - needlecraft_stitching_coverage
@@ -4511,6 +5142,7 @@
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4528,6 +5160,8 @@
   - aida_cloth_pre_cut_format
   - color
   - fabric_cut_format
+  - height
+  - length
   - needlecraft_fabric_composition
   - needlecraft_stitching_coverage
   - number_of_needlecraft_fabrics
@@ -4536,6 +5170,7 @@
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4553,6 +5188,8 @@
   - evenweave_fabric_finish_treatment
   - evenweave_fabric_package_format
   - fabric_cut_format
+  - height
+  - length
   - needlecraft_fabric_color_family
   - needlecraft_fabric_composition
   - needlecraft_stitching_coverage
@@ -4562,6 +5199,7 @@
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4578,6 +5216,9 @@
   - color
   - dye_type_needlecraft_fabric
   - fabric_cut_format
+  - fabric_piece_size
+  - height
+  - length
   - needlecraft_fabric_composition
   - needlecraft_fabric_weave_type
   - needlecraft_stitching_coverage
@@ -4587,6 +5228,7 @@
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4631,6 +5273,8 @@
   - canvas_texture
   - color
   - edge_finish
+  - height
+  - length
   - painting_canvas_material
   - painting_surface_priming_type
   - paper_size
@@ -4639,6 +5283,7 @@
   - suitable_for_paint_type
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4658,6 +5303,8 @@
   - canvas_texture
   - color
   - edge_finish
+  - height
+  - length
   - painting_canvas_material
   - painting_surface_priming_type
   - paper_size
@@ -4666,6 +5313,7 @@
   - suitable_for_paint_type
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4681,10 +5329,13 @@
   attributes:
   - canvas_finish
   - canvas_mounting_format
+  - canvas_roll_core_diameter
   - canvas_texture
   - canvas_weave_type
   - color
   - edge_finish
+  - height
+  - length
   - painting_canvas_material
   - painting_surface_priming_type
   - paper_size
@@ -4693,6 +5344,7 @@
   - suitable_for_paint_type
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4711,6 +5363,8 @@
   - canvas_texture
   - color
   - edge_finish
+  - height
+  - length
   - painting_canvas_material
   - painting_surface_priming_type
   - paper_size
@@ -4720,6 +5374,7 @@
   - suitable_for_paint_type
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4737,12 +5392,15 @@
   - ae-2-1-2-14-1-3-3
   attributes:
   - color
+  - height
+  - length
   - number_of_plastic_canvas_meshes
   - paper_size
   - pattern
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4757,6 +5415,8 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - number_of_plastic_canvas_meshes
   - paper_size
   - pattern
@@ -4765,6 +5425,7 @@
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4779,12 +5440,16 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - number_of_plastic_canvas_meshes
   - paper_size
   - pattern
+  - plastic_canvas_hole_size
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4799,14 +5464,18 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - number_of_canvas_meshes
   - number_of_plastic_canvas_meshes
   - paper_size
   - pattern
   - plastic_canvas_sheet_finish
+  - sheet_thickness
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4836,12 +5505,15 @@
   - fabric_end_use
   - fabric_opacity_level
   - fabric_stretch_level
+  - height
+  - length
   - material_treatment
   - mesh_type
   - pattern
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4862,10 +5534,13 @@
   - fabric_end_use
   - fabric_opacity_level
   - fabric_stretch_level
+  - height
+  - length
   - pattern
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4886,12 +5561,15 @@
   - fabric_end_use
   - fabric_opacity_level
   - fabric_stretch_level
+  - height
+  - length
   - material_treatment
   - mesh_type
   - pattern
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4916,11 +5594,14 @@
   - fabric_end_use
   - fabric_opacity_level
   - fabric_stretch_level
+  - height
+  - length
   - pattern
   - stretch_level
   - textile_finish_treatment
   - twill_direction
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4944,10 +5625,13 @@
   - fabric_weight_class
   - flannel_brushing_finish
   - flannel_use_type
+  - height
+  - length
   - pattern
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4968,11 +5652,14 @@
   - fabric_opacity_level
   - fabric_stretch_level
   - fleece_finish_surface
+  - height
   - intended_use_fleece_fabric
+  - length
   - pattern
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -4993,12 +5680,15 @@
   - fabric_intended_use
   - fabric_opacity_level
   - fabric_stretch_level
+  - height
+  - length
   - linen_finish_treatment
   - linen_weave_type
   - pattern
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -5019,12 +5709,16 @@
   - fabric_opacity_level
   - fabric_selling_format
   - fabric_stretch_level
+  - height
+  - length
   - organza_finish_sheen
   - organza_transparency_level
   - pattern
   - stretch_level
   - textile_finish_treatment
+  - usable_fabric_width
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -5039,16 +5733,21 @@
   name: Satin
   children: []
   attributes:
+  - bolt_roll_length
   - care_instructions
   - color
   - fabric_end_use
   - fabric_opacity_level
   - fabric_stretch_level
   - fabric_use_case
+  - fabric_width_selvage_to_selvage
+  - height
+  - length
   - pattern
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -5069,12 +5768,16 @@
   - fabric_finish
   - fabric_opacity_level
   - fabric_stretch_level
+  - height
+  - length
   - pattern
   - silk_fiber_type
   - stretch_level
   - textile_finish_treatment
+  - usable_fabric_width
   - water_resistance_level
   - weave_type
+  - width
   return_reasons:
   - size
   - color
@@ -5094,10 +5797,13 @@
   - fabric_end_use
   - fabric_opacity_level
   - fabric_stretch_level
+  - height
+  - length
   - pattern
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -5117,13 +5823,16 @@
   - care_instructions
   - color
   - fabric_structure
+  - height
   - interfacing_application_area
   - interfacing_color_family
   - interfacing_stiffness_level
+  - length
   - pattern
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -5141,13 +5850,16 @@
   - care_instructions
   - color
   - fabric_structure
+  - height
   - interfacing_application_area
   - interfacing_color_family
   - interfacing_stiffness_level
+  - length
   - pattern
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -5165,15 +5877,18 @@
   - care_instructions
   - color
   - fabric_structure
+  - height
   - interfacing_application_area
   - interfacing_color_family
   - interfacing_selling_format
   - interfacing_stiffness_level
+  - length
   - pattern
   - sew_in_interfacing_elasticity
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -5195,11 +5910,14 @@
   - care_instructions
   - color
   - compatible_printer
+  - height
+  - length
   - paper_size
   - pattern
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -5218,12 +5936,15 @@
   - care_instructions
   - color
   - compatible_printer
+  - height
+  - length
   - paper_size
   - pattern
   - printable_canvas_intended_use
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -5243,12 +5964,15 @@
   - compatible_printer
   - cotton_weave_type
   - fabric_backing_type
+  - height
+  - length
   - paper_size
   - pattern
   - printable_fabric_format
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -5267,11 +5991,15 @@
   - care_instructions
   - color
   - compatible_printer
+  - height
+  - length
   - paper_size
   - pattern
+  - silk_weight_momme
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -5289,6 +6017,8 @@
   - care_instructions
   - color
   - compatible_printer
+  - height
+  - length
   - paper_size
   - pattern
   - stretch_level
@@ -5296,6 +6026,7 @@
   - transfer_application_method
   - transfer_peel_temperature
   - water_resistance_level
+  - width
   return_reasons:
   - size
   - color
@@ -5313,6 +6044,7 @@
   - ae-2-1-2-17-2
   - ae-2-1-2-17-3
   attributes:
+  - flash_point
   - olfactory_arts_material_form
   return_reasons:
   - scent
@@ -5335,6 +6067,7 @@
   - candle_dye_form
   - candle_fragrance_form
   - color
+  - flash_point
   - olfactory_arts_material_form
   - pattern
   return_reasons:
@@ -5358,7 +6091,9 @@
   attributes:
   - candle_dye_form
   - color
+  - flash_point
   - olfactory_arts_material_form
+  - package_size
   - pattern
   - scent
   - wax_blend_composition
@@ -5379,7 +6114,9 @@
   attributes:
   - candle_dye_form
   - color
+  - flash_point
   - olfactory_arts_material_form
+  - package_size
   - pattern
   - scent
   - wax_blend_composition
@@ -5401,9 +6138,12 @@
   - candle_dye_form
   - color
   - compatible_gel_wax_additives
+  - flash_point
   - gel_wax_density_grade
+  - gel_wax_melt_temperature
   - gel_wax_transparency_level
   - olfactory_arts_material_form
+  - package_size
   - pattern
   - recommended_container_type
   - scent
@@ -5426,7 +6166,9 @@
   - candle_dye_form
   - color
   - crystalline_finish_style
+  - flash_point
   - olfactory_arts_material_form
+  - package_size
   - palm_wax_blend_readiness
   - palm_wax_form
   - pattern
@@ -5449,10 +6191,13 @@
   attributes:
   - candle_dye_form
   - color
+  - flash_point
   - olfactory_arts_material_form
+  - package_size
   - pattern
   - scent
   - wax_blend_composition
+  - wax_melt_point_temperature
   - wax_physical_form
   - wax_recommended_candle_application
   return_reasons:
@@ -5470,7 +6215,9 @@
   attributes:
   - candle_dye_form
   - color
+  - flash_point
   - olfactory_arts_material_form
+  - package_size
   - pattern
   - scent
   - wax_blend_composition
@@ -5491,6 +6238,7 @@
   attributes:
   - candle_dye_form
   - color
+  - flash_point
   - olfactory_arts_material_form
   - pattern
   - scent
@@ -5510,6 +6258,7 @@
   attributes:
   - candle_dye_form
   - color
+  - flash_point
   - olfactory_arts_material_form
   - pattern
   - scent
@@ -5531,8 +6280,12 @@
   attributes:
   - accessory_size
   - candle_dye_form
+  - flash_point
+  - height
+  - length
   - material
   - olfactory_arts_material_form
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5549,9 +6302,15 @@
   - accessory_size
   - candle_dye_form
   - compatible_wick_series
+  - flash_point
+  - height
+  - length
   - material
   - olfactory_arts_material_form
   - wick_tab_crimp_type
+  - wick_tab_neck_height
+  - wick_tab_neck_inner_diameter
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5567,11 +6326,16 @@
   attributes:
   - accessory_size
   - candle_dye_form
+  - flash_point
+  - height
+  - length
   - material
   - olfactory_arts_material_form
   - recommended_candle_format
   - self_adhesive_backing_format
+  - wick_hole_diameter
   - wick_tab_shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5590,9 +6354,14 @@
   - ae-2-1-2-17-1-3-4
   attributes:
   - candle_dye_form
+  - flash_point
+  - height
+  - length
   - material
   - olfactory_arts_material_form
   - wick_construction_type
+  - wick_tab_size
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5607,10 +6376,16 @@
   children: []
   attributes:
   - candle_dye_form
+  - flash_point
+  - height
+  - length
   - material
   - olfactory_arts_material_form
   - wick_construction_type
   - wick_core_type
+  - wick_diameter
+  - wick_tab_size
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5626,10 +6401,17 @@
   attributes:
   - accessory_size
   - candle_dye_form
+  - flash_point
+  - height
+  - length
   - material
   - olfactory_arts_material_form
+  - tab_neck_height
   - wick_construction_type
+  - wick_length
   - wick_tab_material
+  - wick_tab_size
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5644,9 +6426,11 @@
   children: []
   attributes:
   - candle_dye_form
+  - flash_point
   - material
   - olfactory_arts_material_form
   - wick_construction_type
+  - wick_tab_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -5659,9 +6443,11 @@
   children: []
   attributes:
   - candle_dye_form
+  - flash_point
   - material
   - olfactory_arts_material_form
   - wick_construction_type
+  - wick_tab_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -5676,6 +6462,7 @@
   - candle_dye_form
   - candle_fragrance_form
   - color
+  - flash_point
   - olfactory_arts_material_form
   - pattern
   return_reasons:
@@ -5692,6 +6479,7 @@
   - candle_dye_form
   - candle_fragrance_form
   - color
+  - flash_point
   - olfactory_arts_material_form
   - pattern
   return_reasons:
@@ -5708,6 +6496,7 @@
   - candle_dye_form
   - candle_fragrance_form
   - color
+  - flash_point
   - olfactory_arts_material_form
   - pattern
   return_reasons:
@@ -5724,6 +6513,7 @@
   - ae-2-1-2-17-2-2
   attributes:
   - extraction_method
+  - flash_point
   - olfactory_arts_material_form
   - perfumery_ingredient_carrier_solvent
   - perfumery_ingredient_form
@@ -5741,6 +6531,7 @@
   children: []
   attributes:
   - extraction_method
+  - flash_point
   - ingredient_pathway
   - ingredient_physical_form
   - olfactory_arts_material_form
@@ -5764,9 +6555,11 @@
   children: []
   attributes:
   - extraction_method
+  - flash_point
   - fragrance_level
   - olfactory_arts_material_form
   - perfumery_base_carrier_type
+  - perfumery_base_flash_point
   - perfumery_base_intended_application
   - perfumery_ingredient_carrier_solvent
   - perfumery_ingredient_form
@@ -5783,6 +6576,7 @@
   name: Incense Making Materials
   children: []
   attributes:
+  - flash_point
   - olfactory_arts_material_form
   return_reasons:
   - changed_my_mind
@@ -5821,7 +6615,10 @@
   name: Craft Knife Blades
   children: []
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -5840,6 +6637,9 @@
   - care_instructions
   - carry_options
   - cover_features
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -5856,7 +6656,10 @@
   attributes:
   - accessory_size
   - extension_table_features
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5869,11 +6672,14 @@
   name: Sewing Machine Feet
   children: []
   attributes:
+  - height
+  - length
   - lumber/wood_type
   - material
   - presser_foot_attachment_method
   - sewing_foot_type
   - sewing_machine_shank_type
+  - width
   - wood_finish
   return_reasons:
   - incompatible
@@ -5887,8 +6693,11 @@
   name: Sewing Machine Replacement Parts
   children: []
   attributes:
+  - height
+  - length
   - material
   - sewing_machine_part_category
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -5922,8 +6731,11 @@
   attributes:
   - compatible_spinning_wheel_drive_system
   - drive_band_material_type
+  - height
+  - length
   - material
   - spinning_oil_application_area
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5938,8 +6750,11 @@
   children: []
   attributes:
   - compatible_spinning_wheel_drive_system
+  - height
+  - length
   - material
   - mounting_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5954,7 +6769,10 @@
   attributes:
   - bobbin_winder_winding_direction
   - compatible_spinning_wheel_drive_system
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5967,9 +6785,14 @@
   name: Bobbins
   children: []
   attributes:
+  - bobbin_core_diameter
+  - bobbin_shaft_bore_diameter
   - compatible_spinning_wheel_drive_system
+  - height
+  - length
   - material
   - spinning_wheel_drive_system
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -5985,10 +6808,14 @@
   - brake_band_form
   - brake_band_material_type
   - brake_band_style
+  - brake_band_thickness
   - compatible_spinning_wheel_drive_system
   - fastener_type
+  - height
   - included_components
+  - length
   - material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6004,7 +6831,10 @@
   - compatible_spinning_wheel_drive_system
   - drive_band_cross_section_shape
   - drive_band_join_type
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6019,7 +6849,12 @@
   attributes:
   - color
   - compatible_spinning_wheel_drive_system
+  - drive_wheel_hub_bore_diameter
+  - height
+  - length
   - pattern
+  - spinning_wheel_drive_wheel_diameter
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6035,7 +6870,10 @@
   - compatible_spinning_wheel_drive_system
   - flyer_hook_mounting_method
   - flyer_hook_orientation
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6051,8 +6889,11 @@
   - compatible_spinning_wheel_drive_system
   - flyer_kit_finish_coating
   - flyer_kit_included_components
+  - height
+  - length
   - material
   - tension_system
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6066,8 +6907,13 @@
   children: []
   attributes:
   - compatible_spinning_wheel_drive_system
+  - height
+  - lazy_kate_rod_dowel_diameter
+  - lazy_kate_rod_usable_length
   - lazy_kate_tension_control_type
+  - length
   - material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6081,7 +6927,10 @@
   children: []
   attributes:
   - compatible_spinning_wheel_drive_system
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6095,7 +6944,10 @@
   children: []
   attributes:
   - compatible_spinning_wheel_drive_system
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6109,8 +6961,11 @@
   children: []
   attributes:
   - compatible_spinning_wheel_drive_system
+  - height
+  - length
   - material
   - mounting_attachment_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6125,9 +6980,14 @@
   attributes:
   - circumference_adjustment_mechanism
   - compatible_spinning_wheel_drive_system
+  - height
+  - length
   - material
+  - minimum_skein_circumference
   - skein_winder_bearing_bushing_type
   - skein_winder_drive_type
+  - skein_winder_maximum_skein_circumference
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6141,8 +7001,11 @@
   children: []
   attributes:
   - compatible_spinning_wheel_drive_system
+  - height
+  - length
   - material
   - spinner_control_card_design_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6160,6 +7023,7 @@
   - spinning_oil_application_tool
   - spinning_oil_features
   - spinning_wheel_part_application
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6173,7 +7037,10 @@
   children: []
   attributes:
   - compatible_spinning_wheel_drive_system
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6187,7 +7054,10 @@
   children: []
   attributes:
   - compatible_spinning_wheel_drive_system
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6202,8 +7072,12 @@
   attributes:
   - compatible_spinning_wheel_drive_system
   - compatible_whorl_drive_band_type
+  - height
+  - length
   - material
+  - whorl_diameter
   - whorl_mounting_interface
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6216,10 +7090,16 @@
   name: Yarn Swifts
   children: []
   attributes:
+  - clamp_opening
   - compatible_spinning_wheel_drive_system
+  - height
+  - length
   - material
+  - minimum_skein_circumference
+  - width
   - yarn_swift_adjustability
   - yarn_swift_bearing_type
+  - yarn_swift_maximum_skein_circumference
   return_reasons:
   - size
   - changed_my_mind
@@ -6233,10 +7113,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - stamp_block_features
   - stamp_block_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6295,7 +7178,10 @@
   - blocking_mat_features
   - blocking_mat_surface_markings
   - compatible_pin_type
+  - height
+  - length
   - shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6314,7 +7200,10 @@
   - blocking_mat_grid_unit
   - blocking_mat_surface_markings
   - compatible_pin_type
+  - height
+  - length
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -6333,7 +7222,10 @@
   - blocking_mat_features
   - blocking_mat_surface_markings
   - compatible_pin_type
+  - height
+  - length
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -6355,6 +7247,9 @@
   attributes:
   - blocking_wire_end_cap_type
   - blocking_wire_set_includes
+  - height
+  - length
+  - width
   - wire/rope_material
   - wire_thickness
   return_reasons:
@@ -6373,7 +7268,10 @@
   - blocking_wire_end_cap_type
   - blocking_wire_set_includes
   - ends_style_blocking_wires
+  - height
+  - length
   - suitable_for_craft_type
+  - width
   - wire/rope_material
   - wire_thickness
   return_reasons:
@@ -6390,6 +7288,9 @@
   attributes:
   - blocking_wire_end_cap_type
   - blocking_wire_set_includes
+  - height
+  - length
+  - width
   - wire/rope_material
   - wire_thickness
   return_reasons:
@@ -6407,7 +7308,10 @@
   - blocking_wire_end_cap_type
   - blocking_wire_set_includes
   - blocking_wire_usage
+  - height
   - included_accessories
+  - length
+  - width
   - wire/rope_material
   - wire_thickness
   return_reasons:
@@ -6424,6 +7328,9 @@
   attributes:
   - blocking_wire_end_cap_type
   - blocking_wire_set_includes
+  - height
+  - length
+  - width
   - wire/rope_material
   - wire_thickness
   return_reasons:
@@ -6440,6 +7347,9 @@
   attributes:
   - blocking_wire_end_cap_type
   - blocking_wire_set_includes
+  - height
+  - length
+  - width
   - wire/rope_material
   - wire_thickness
   return_reasons:
@@ -6457,6 +7367,9 @@
   - art/crafting_tool_material
   - blocking_wire_end_cap_type
   - blocking_wire_set_includes
+  - height
+  - length
+  - width
   - wire_thickness
   return_reasons:
   - size
@@ -6496,8 +7409,11 @@
   - ae-2-1-4-3-1-8
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - palette_knife_flexibility
   - palette_knife_shape
+  - width
   return_reasons:
   - size
   - color
@@ -6513,8 +7429,11 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - palette_knife_flexibility
   - palette_knife_shape
+  - width
   return_reasons:
   - size
   - color
@@ -6530,8 +7449,11 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - palette_knife_flexibility
   - palette_knife_shape
+  - width
   return_reasons:
   - size
   - color
@@ -6547,8 +7469,11 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - palette_knife_flexibility
   - palette_knife_shape
+  - width
   return_reasons:
   - size
   - color
@@ -6564,8 +7489,11 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - palette_knife_flexibility
   - palette_knife_shape
+  - width
   return_reasons:
   - size
   - color
@@ -6581,8 +7509,11 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - palette_knife_flexibility
   - palette_knife_shape
+  - width
   return_reasons:
   - size
   - color
@@ -6598,9 +7529,12 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - palette_knife_blade_edge_profile
   - palette_knife_flexibility
   - palette_knife_shape
+  - width
   return_reasons:
   - size
   - color
@@ -6616,8 +7550,11 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - palette_knife_flexibility
   - palette_knife_shape
+  - width
   return_reasons:
   - size
   - color
@@ -6633,8 +7570,11 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - palette_knife_flexibility
   - palette_knife_shape
+  - width
   return_reasons:
   - size
   - color
@@ -6650,10 +7590,14 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - palette_design
   - palette_surface_finish
+  - palette_thickness
   - shape
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -6700,7 +7644,10 @@
   attributes:
   - blade_material
   - handle_material
+  - height
+  - length
   - scissor_blade_type
+  - width
   return_reasons:
   - size
   - color
@@ -6716,7 +7663,10 @@
   attributes:
   - blade_material
   - handle_material
+  - height
+  - length
   - scissor_blade_type
+  - width
   return_reasons:
   - size
   - color
@@ -6733,8 +7683,11 @@
   - blade_material
   - handle_ergonomics
   - handle_material
+  - height
+  - length
   - scissor_blade_type
   - scissors_application
+  - width
   return_reasons:
   - size
   - color
@@ -6751,8 +7704,11 @@
   - blade_material
   - cutting_application
   - handle_material
+  - height
+  - length
   - pivot_adjustability
   - scissor_blade_type
+  - width
   return_reasons:
   - size
   - color
@@ -6768,7 +7724,10 @@
   attributes:
   - blade_material
   - handle_material
+  - height
+  - length
   - scissor_blade_type
+  - width
   return_reasons:
   - size
   - color
@@ -6786,7 +7745,10 @@
   - color
   - craft_cutter/embosser_type
   - craft_cutter_embosser_machine_operation
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6805,6 +7767,9 @@
   - compatible_blade_system
   - craft_knife_design
   - handle_material
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -6822,7 +7787,11 @@
   attributes:
   - art/crafting_tool_material
   - color
+  - height
+  - length
   - pattern
+  - scoring_groove_spacing
+  - width
   return_reasons:
   - size
   - color
@@ -6840,6 +7809,9 @@
   - art/crafting_tool_material
   - craft_scoring_board_included_accessories
   - craft_scoring_board_measurement_system
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -6855,6 +7827,9 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -6870,6 +7845,9 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -6888,6 +7866,10 @@
   attributes:
   - art/crafting_tool_material
   - art_crafting_tool_tip_style
+  - embossing_tip_size
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -6904,6 +7886,11 @@
   - art/crafting_tool_material
   - art_crafting_tool_tip_style
   - embossing_pen_ink_color
+  - embossing_tip_size
+  - height
+  - ink_dry_time
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -6920,6 +7907,10 @@
   - art/crafting_tool_material
   - art_crafting_tool_tip_style
   - embossing_stylus_tip_shape
+  - embossing_tip_size
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -6936,7 +7927,10 @@
   - art/crafting_tool_material
   - battery_size
   - battery_type
+  - height
+  - length
   - seam_ripper_tip_style
+  - width
   return_reasons:
   - size
   - color
@@ -6955,6 +7949,9 @@
   - ae-2-1-4-4-8-4
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -6969,8 +7966,11 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - pendant_cutter_safety_features
   - pendant_cutter_wear_method
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -6984,7 +7984,10 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - snip_cutter_spring_mechanism
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -6998,10 +8001,13 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - thread_cutter_form_factor
   - thread_cutter_mechanism
   - thread_cutter_safety_features
   - thread_cutter_usage_application
+  - width
   return_reasons:
   - size
   - color
@@ -7016,7 +8022,10 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - safety_features
+  - width
   - yarn_cutter_physical_style
   return_reasons:
   - size
@@ -7036,6 +8045,9 @@
   - battery_type
   - craft_decoration_maker_accessories_included
   - craft_decoration_maker_type
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -7064,7 +8076,10 @@
   attributes:
   - color
   - construction
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7083,7 +8098,10 @@
   - brush_size
   - color
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7099,7 +8117,10 @@
   attributes:
   - accessory_size
   - art/crafting_tool_material
+  - height
   - ink_application_technique
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7116,7 +8137,12 @@
   - craft_project_type
   - decorative_stamp_design
   - decorative_stamp_form_factor
+  - height
+  - impression_height
+  - impression_width
+  - length
   - mounting_style
+  - width
   return_reasons:
   - size
   - style
@@ -7133,6 +8159,9 @@
   - ae-2-1-4-6-4-2
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7148,8 +8177,11 @@
   - art/crafting_tool_material
   - beam_material
   - drafting_compass_fine_adjustment_mechanism
+  - height
+  - length
   - marking_tip_type
   - scale_units
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7165,6 +8197,9 @@
   - art/crafting_tool_material
   - drafting_compass_adjustment_mechanism
   - drafting_compass_lead_holder_type
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7178,8 +8213,11 @@
   children: []
   attributes:
   - craft_project_type
+  - height
+  - length
   - material
   - squeegee_blade_design
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7196,8 +8234,12 @@
   attributes:
   - color
   - compatible_stencil_media_format
+  - height
+  - length
+  - maximum_stencil_width
   - pattern
   - stencil_machine_consumable_type
+  - width
   return_reasons:
   - size
   - weight
@@ -7212,11 +8254,18 @@
   name: Electric Stencil Machines
   children: []
   attributes:
+  - amperage
   - color
   - compatible_stencil_material
   - compatible_stencil_media_format
+  - height
+  - length
+  - maximum_stencil_width
   - pattern
+  - power_consumption_typical
   - stencil_machine_consumable_type
+  - voltage
+  - width
   return_reasons:
   - size
   - weight
@@ -7233,8 +8282,12 @@
   attributes:
   - color
   - compatible_stencil_media_format
+  - height
+  - length
+  - maximum_stencil_width
   - pattern
   - stencil_machine_consumable_type
+  - width
   return_reasons:
   - size
   - weight
@@ -7251,9 +8304,12 @@
   attributes:
   - art/crafting_tool_material
   - color
+  - height
+  - length
   - pattern
   - stencil/cut_shape
   - suitable_for_crafting_material
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7271,7 +8327,10 @@
   - ae-2-1-4-6-8-3
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - stitch_marker_and_counter_style
+  - width
   return_reasons:
   - size
   - color
@@ -7286,7 +8345,11 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
+  - maximum_stitch_yarn_thickness_supported
   - stitch_marker_and_counter_style
+  - width
   return_reasons:
   - size
   - color
@@ -7301,9 +8364,12 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
   - knitting_marker_counter_type
+  - length
   - row_counter_format
   - stitch_marker_and_counter_style
+  - width
   return_reasons:
   - size
   - color
@@ -7318,10 +8384,13 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - number_of_digits
   - row_counter_mechanism
   - row_counter_mounting_method
   - stitch_marker_and_counter_style
+  - width
   return_reasons:
   - size
   - color
@@ -7339,6 +8408,9 @@
   - ae-2-1-4-6-9-3
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -7353,8 +8425,11 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - ruler_edge_type
   - ruler_marking_style
+  - width
   return_reasons:
   - size
   - color
@@ -7369,9 +8444,12 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - quilting_ruler_markings
   - quilting_ruler_non_slip_feature
   - quilting_ruler_transparency
+  - width
   return_reasons:
   - size
   - color
@@ -7387,8 +8465,11 @@
   attributes:
   - art/crafting_tool_material
   - graduation_increment
+  - height
+  - length
   - seam_gauge_scale_type
   - seam_gauge_slider_material
+  - width
   return_reasons:
   - size
   - color
@@ -7403,8 +8484,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - temperature_control_type
+  - width
   return_reasons:
   - size
   - color
@@ -7452,6 +8536,9 @@
   - cutting_mat_grid_style
   - cutting_mat_intended_use
   - grid_unit
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7467,6 +8554,9 @@
   - accessory_size
   - art/crafting_tool_material
   - dress_form_features
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7483,7 +8573,10 @@
   - art/crafting_tool_material
   - crafting_mat/pad_features
   - felting_pad_surface_material
+  - height
   - intended_technique
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7502,8 +8595,11 @@
   - ae-2-1-4-10-5
   attributes:
   - crafting_frame/stretcher_features
+  - height
+  - length
   - material
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -7520,8 +8616,11 @@
   - canvas_stretcher_assembly_type
   - canvas_stretcher_corner_joint_type
   - crafting_stretcher_features
+  - height
+  - length
   - material
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7541,8 +8640,11 @@
   - cross_stitch_frame_included_components
   - cross_stitch_frame_type
   - frame_adjustability
+  - height
+  - length
   - material
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -7559,9 +8661,13 @@
   attributes:
   - clamping_closure_type
   - crafting_hoop_features
+  - diameter
   - embroidery_hoop_type
+  - height
+  - length
   - material
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7576,12 +8682,16 @@
   children: []
   attributes:
   - crafting_frame_features
+  - height
+  - length
   - material
   - needlepoint_frame_canvas_attachment_method
   - needlepoint_frame_compatible_stand_type
   - needlepoint_frame_contents
+  - needlepoint_frame_roller_length
   - needlepoint_frame_tension_adjustment_type
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7597,10 +8707,14 @@
   attributes:
   - compatible_machine_type
   - crafting_frame_features
+  - height
+  - length
   - material
   - maximum_quilt_size_supported
   - number_of_quilting_frame_rails
+  - quilting_width_capacity
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -7616,12 +8730,16 @@
   children: []
   attributes:
   - accessory_size
+  - compatible_glue_stick_diameter
   - glue_gun_features
   - glue_gun_nozzle_style
   - glue_gun_operation
   - glue_gun_technology
+  - height
+  - length
   - power_source
   - temperature
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7637,9 +8755,12 @@
   attributes:
   - battery_size
   - battery_type
+  - height
+  - length
   - light_source
   - lighting_features
   - paper_size
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7672,8 +8793,11 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
   - hook_grip_design
   - hook_size
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -7695,8 +8819,11 @@
   - ae-2-1-4-13-2-6
   attributes:
   - hand_sewing_needle_point_type
+  - height
+  - length
   - needle_eye_type
   - needle_size
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7710,9 +8837,13 @@
   children: []
   attributes:
   - beading_needle_flexibility
+  - compatible_bead_hole_size
   - hand_sewing_needle_point_type
+  - height
+  - length
   - needle_eye_type
   - needle_size
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7726,8 +8857,11 @@
   children: []
   attributes:
   - hand_sewing_needle_point_type
+  - height
+  - length
   - needle_eye_type
   - needle_size
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7741,9 +8875,12 @@
   children: []
   attributes:
   - hand_sewing_needle_point_type
+  - height
+  - length
   - needle_eye_type
   - needle_size
   - point_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7757,8 +8894,11 @@
   children: []
   attributes:
   - hand_sewing_needle_point_type
+  - height
+  - length
   - needle_eye_type
   - needle_size
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7772,8 +8912,11 @@
   children: []
   attributes:
   - hand_sewing_needle_point_type
+  - height
+  - length
   - needle_eye_type
   - needle_size
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7787,8 +8930,11 @@
   children: []
   attributes:
   - hand_sewing_needle_point_type
+  - height
+  - length
   - needle_eye_type
   - needle_size
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7804,8 +8950,12 @@
   - ae-2-1-4-13-3-2
   - ae-2-1-4-13-3-3
   attributes:
+  - height
+  - length
   - lumber/wood_type
   - material
+  - needle_diameter
+  - width
   return_reasons:
   - size
   - length
@@ -7822,10 +8972,15 @@
   attributes:
   - circular_knitting_needle_cable_type
   - circular_knitting_needles_tip_material
+  - height
   - knitting_needle_tip_style
+  - length
   - lumber/wood_type
   - material
+  - needle_diameter
   - needle_size_system
+  - tip_length
+  - width
   return_reasons:
   - size
   - length
@@ -7841,8 +8996,12 @@
   children: []
   attributes:
   - double_pointed_needle_point_style
+  - height
+  - length
   - material
+  - needle_diameter
   - surface_finish
+  - width
   return_reasons:
   - size
   - length
@@ -7857,7 +9016,11 @@
   name: Single-Pointed Knitting Needles
   children: []
   attributes:
+  - height
+  - length
   - material
+  - needle_diameter
+  - width
   return_reasons:
   - size
   - length
@@ -7873,7 +9036,10 @@
   children: []
   attributes:
   - accessory_size
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7886,10 +9052,13 @@
   name: Sewing Machine Needles
   children: []
   attributes:
+  - height
+  - length
   - needle_size
   - sewing_machine_needle_point_type
   - sewing_machine_needle_system
   - sewing_machine_needle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7904,7 +9073,10 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - pin_size
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -7917,10 +9089,15 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - diameter
+  - height
+  - length
+  - pin_length
   - straight_pin_application
   - straight_pin_finish
   - straight_pin_head_material
   - straight_pin_head_shape
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -7954,9 +9131,12 @@
   name: Felting Needles & Machines
   children: []
   attributes:
+  - height
+  - length
   - needle_felting_needle_profile
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7975,10 +9155,13 @@
   - ae-2-1-4-16-2-4
   attributes:
   - accessory_size
+  - height
+  - length
   - loom_finish
   - material
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7992,10 +9175,13 @@
   children: []
   attributes:
   - accessory_size
+  - height
+  - length
   - loom_finish
   - material
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8009,11 +9195,14 @@
   children: []
   attributes:
   - accessory_size
+  - height
   - lap_hand_loom_accessories_included
+  - length
   - loom_finish
   - material
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8027,10 +9216,13 @@
   children: []
   attributes:
   - accessory_size
+  - height
+  - length
   - loom_finish
   - material
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8044,6 +9236,8 @@
   children: []
   attributes:
   - accessory_size
+  - height
+  - length
   - loom_finish
   - material
   - tapestry_loom_loom_format
@@ -8051,6 +9245,7 @@
   - tapestry_loom_tensioning_system
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8067,11 +9262,14 @@
   - ae-2-1-4-16-3-3
   - ae-2-1-4-16-3-4
   attributes:
+  - height
+  - length
   - loom_folding_portability_design_type
   - loom_tension_adjustment_method
   - material
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - width
   return_reasons:
   - size
   - weight
@@ -8087,6 +9285,8 @@
   attributes:
   - back_beam_type
   - brake_type
+  - height
+  - length
   - loom_folding_portability_design_type
   - loom_tension_adjustment_method
   - loom_tie_up_system
@@ -8094,6 +9294,7 @@
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
   - warp_beam_type
+  - width
   return_reasons:
   - size
   - weight
@@ -8107,6 +9308,8 @@
   name: Floor Mechanical Looms
   children: []
   attributes:
+  - height
+  - length
   - loom_folding_portability_design_type
   - loom_tension_adjustment_method
   - material
@@ -8114,6 +9317,7 @@
   - mechanical_loom_weaving_type
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - width
   return_reasons:
   - size
   - weight
@@ -8127,11 +9331,14 @@
   name: Jack Mechanical Looms
   children: []
   attributes:
+  - height
+  - length
   - loom_folding_portability_design_type
   - loom_tension_adjustment_method
   - material
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - width
   return_reasons:
   - size
   - weight
@@ -8145,6 +9352,8 @@
   name: Table Mechanical Looms
   children: []
   attributes:
+  - height
+  - length
   - loom_accessories_included
   - loom_folding_portability_design_type
   - loom_frame_folding_design
@@ -8152,6 +9361,7 @@
   - material
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - width
   return_reasons:
   - size
   - weight
@@ -8173,9 +9383,16 @@
   - battery_type
   - bobbin_system
   - compatible_needle_system
+  - height
+  - length
+  - maximum_stitch_length
+  - maximum_stitch_width
+  - presser_foot_lift_height
   - stitch_types
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - throat_space
+  - width
   return_reasons:
   - size
   - weight
@@ -8191,12 +9408,19 @@
   attributes:
   - bobbin_loading_type
   - compatible_needle_system
+  - height
+  - length
+  - maximum_stitch_length
+  - maximum_stitch_width
+  - presser_foot_lift_height
   - sewing_machine_bobbin_class
   - sewing_machine_buttonhole_type
   - sewing_machine_display_type
   - stitch_types
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - throat_space
+  - width
   return_reasons:
   - size
   - weight
@@ -8212,9 +9436,17 @@
   attributes:
   - compatible_needle_system
   - embroidery_machine_bobbin_type
+  - embroidery_machine_maximum_embroidery_area
+  - height
+  - length
+  - maximum_stitch_length
+  - maximum_stitch_width
+  - presser_foot_lift_height
   - stitch_types
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - throat_space
+  - width
   return_reasons:
   - size
   - weight
@@ -8230,9 +9462,16 @@
   attributes:
   - compatible_needle_system
   - compatible_presser_foot
+  - height
+  - length
+  - maximum_stitch_length
+  - maximum_stitch_width
+  - presser_foot_lift_height
   - stitch_types
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - throat_space
+  - width
   return_reasons:
   - size
   - color
@@ -8248,13 +9487,20 @@
   children: []
   attributes:
   - compatible_needle_system
+  - height
   - knife_system
+  - length
+  - maximum_stitch_length
+  - maximum_stitch_width
+  - presser_foot_lift_height
   - serger_stitch_functions
   - serger_thread_count
   - stitch_types
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
   - threading_system
+  - throat_space
+  - width
   return_reasons:
   - size
   - weight
@@ -8272,9 +9518,12 @@
   - ae-2-1-4-16-5-3
   - ae-2-1-4-16-5-4
   attributes:
+  - height
+  - length
   - material
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - width
   return_reasons:
   - size
   - weight
@@ -8288,10 +9537,14 @@
   name: Double Drive Spinning Wheels
   children: []
   attributes:
+  - height
+  - length
   - material
+  - spinning_wheel_orifice_height
   - spinning_wheel_tension_adjustment_type
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - width
   return_reasons:
   - size
   - color
@@ -8306,11 +9559,17 @@
   name: Electric Spinning Wheels
   children: []
   attributes:
+  - amperage
   - electric_spinning_wheel_speed_control_type
+  - height
+  - length
   - material
+  - power_consumption_typical
   - spinning_wheel_brake_tension_system_type
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - voltage
+  - width
   return_reasons:
   - size
   - weight
@@ -8325,11 +9584,15 @@
   children: []
   attributes:
   - flyer_orifice_type
+  - height
+  - length
   - material
+  - spinning_wheel_bobbin_weight
   - spinning_wheel_hook_system
   - spinning_wheel_portability_foldability
   - textile_craft_machine_features
   - textile_craft_machine_operation_type
+  - width
   return_reasons:
   - size
   - color
@@ -8344,6 +9607,8 @@
   name: Travel Spinning Wheels
   children: []
   attributes:
+  - height
+  - length
   - material
   - spinning_wheel_drive_system
   - tension_system
@@ -8351,6 +9616,7 @@
   - textile_craft_machine_operation_type
   - travel_spinning_wheel_assembly_required
   - travel_spinning_wheel_portability_features
+  - width
   return_reasons:
   - size
   - color
@@ -8368,6 +9634,9 @@
   - ae-2-1-4-17-2
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8382,8 +9651,11 @@
   attributes:
   - accessory_size
   - art/crafting_tool_material
+  - height
+  - length
   - needle_pushing_surface_type
   - textile_craft_machine_features
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8398,7 +9670,10 @@
   attributes:
   - accessory_size
   - art/crafting_tool_material
+  - height
+  - length
   - textile_craft_machine_features
+  - width
   return_reasons:
   - size
   - color
@@ -8421,7 +9696,11 @@
   - ae-2-1-4-18-8
   attributes:
   - compatible_thread_yarn_tool
+  - height
+  - length
   - material
+  - spindle_whorl_weight
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8441,6 +9720,10 @@
   attributes:
   - bristle_material
   - brush_material
+  - height
+  - length
+  - spindle_whorl_weight
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8454,6 +9737,10 @@
   children: []
   attributes:
   - brush_material
+  - height
+  - length
+  - spindle_whorl_weight
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8466,10 +9753,15 @@
   name: Drum Carders
   children: []
   attributes:
+  - carding_width
   - compatible_fiber_type
   - drive_type
   - drum_carder_accessories_included
+  - height
+  - length
   - material
+  - spindle_whorl_weight
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8482,8 +9774,14 @@
   name: Flick Carders
   children: []
   attributes:
+  - carding_surface_width
   - compatible_fiber_type
+  - height
+  - length
   - material
+  - pin_gauge
+  - spindle_whorl_weight
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8496,7 +9794,11 @@
   name: Hand Carders
   children: []
   attributes:
+  - height
+  - length
   - material
+  - spindle_whorl_weight
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8510,8 +9812,13 @@
   children: []
   attributes:
   - carding_surface_pin_material
+  - height
+  - length
   - material
+  - spindle_whorl_weight
   - teasing_tool_style
+  - width
+  - working_area_length
   return_reasons:
   - size
   - changed_my_mind
@@ -8528,10 +9835,15 @@
   - ae-2-1-4-18-2-3
   attributes:
   - accessory_size
+  - hand_spindle_weight
+  - height
+  - length
   - material
   - spindle_bearing_surface_material
   - spindle_hook_type
   - spindle_whorl_position
+  - spindle_whorl_weight
+  - width
   return_reasons:
   - size
   - color
@@ -8548,10 +9860,16 @@
   attributes:
   - accessory_size
   - drop_spindle_whorl_position
+  - hand_spindle_weight
+  - height
+  - length
   - material
   - spindle_bearing_surface_material
   - spindle_finish
   - spindle_hook_type
+  - spindle_whorl_weight
+  - whorl_diameter
+  - width
   return_reasons:
   - size
   - color
@@ -8567,12 +9885,17 @@
   children: []
   attributes:
   - accessory_size
+  - hand_spindle_weight
+  - height
+  - length
   - material
   - spindle_bearing_surface_material
   - spindle_bearing_type
   - spindle_hook_type
   - spindle_support_method
   - spindle_tip_style
+  - spindle_whorl_weight
+  - width
   return_reasons:
   - size
   - color
@@ -8588,9 +9911,14 @@
   children: []
   attributes:
   - accessory_size
+  - hand_spindle_weight
+  - height
+  - length
   - material
   - spindle_bearing_surface_material
   - spindle_hook_type
+  - spindle_whorl_weight
+  - width
   return_reasons:
   - size
   - color
@@ -8608,9 +9936,13 @@
   - ae-2-1-4-18-3-2
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - needle_threader_compatible_needle_type
   - needle_threader_mechanism_type
   - needle_threader_packaging_type
+  - spindle_whorl_weight
+  - width
   return_reasons:
   - size
   - color
@@ -8628,10 +9960,14 @@
   - battery_size
   - battery_type
   - compatible_thread
+  - height
+  - length
   - needle_threader_compatible_needle_type
   - needle_threader_mechanism_type
   - needle_threader_packaging_type
   - replacement_parts_availability
+  - spindle_whorl_weight
+  - width
   return_reasons:
   - size
   - color
@@ -8647,10 +9983,14 @@
   children: []
   attributes:
   - art/crafting_tool_material
+  - height
+  - length
   - needle_threader_compatible_needle_type
   - needle_threader_mechanism_type
   - needle_threader_packaging_type
+  - spindle_whorl_weight
   - threader_intended_use
+  - width
   return_reasons:
   - size
   - color
@@ -8669,9 +10009,13 @@
   - ae-2-1-4-18-4-3
   - ae-2-1-4-18-4-4
   attributes:
+  - height
+  - length
   - material
+  - spindle_whorl_weight
   - thread_yarn_guide_mounting_attachment_style
   - thread_yarn_guide_tension_control
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8684,9 +10028,13 @@
   name: Finger Guides
   children: []
   attributes:
+  - height
+  - length
   - material
+  - spindle_whorl_weight
   - thread_yarn_guide_mounting_attachment_style
   - thread_yarn_guide_tension_control
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8699,10 +10047,14 @@
   name: Thimble Guides
   children: []
   attributes:
+  - height
+  - length
   - material
+  - spindle_whorl_weight
   - thimble_guide_size
   - thread_yarn_guide_mounting_attachment_style
   - thread_yarn_guide_tension_control
+  - width
   - worn_on_finger
   return_reasons:
   - size
@@ -8717,9 +10069,13 @@
   name: Wire Guides
   children: []
   attributes:
+  - height
+  - length
   - material
+  - spindle_whorl_weight
   - thread_yarn_guide_mounting_attachment_style
   - thread_yarn_guide_tension_control
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8733,10 +10089,14 @@
   name: Yarn Guides
   children: []
   attributes:
+  - height
   - intended_craft
+  - length
   - material
+  - spindle_whorl_weight
   - thread_yarn_guide_mounting_attachment_style
   - thread_yarn_guide_tension_control
+  - width
   - yarn_guide_style
   return_reasons:
   - size
@@ -8752,7 +10112,11 @@
   attributes:
   - accessory_size
   - art/crafting_tool_material
+  - height
+  - length
+  - spindle_whorl_weight
   - spool_form_factor
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8767,7 +10131,11 @@
   - ae-2-1-4-18-6-1
   - ae-2-1-4-18-6-2
   attributes:
+  - height
+  - length
   - material
+  - spindle_whorl_weight
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8780,9 +10148,18 @@
   name: Electric Winders
   children: []
   attributes:
+  - amperage
   - electric_winder_accessories_included
+  - height
+  - length
   - material
+  - maximum_spool_bobbin_diameter_supported
+  - maximum_spool_bobbin_width_supported
+  - power_consumption_typical
+  - spindle_whorl_weight
   - supported_spool_bobbin_types
+  - voltage
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8796,7 +10173,11 @@
   name: Handheld Winders
   children: []
   attributes:
+  - height
+  - length
   - material
+  - spindle_whorl_weight
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8815,7 +10196,11 @@
   - ae-2-1-4-18-7-4
   attributes:
   - compatible_loom_type
+  - height
+  - length
   - material
+  - spindle_whorl_weight
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8830,9 +10215,13 @@
   attributes:
   - compatible_loom
   - compatible_loom_type
+  - height
+  - length
   - material
+  - spindle_whorl_weight
   - weaving_beater_edge_type
   - weaving_beater_style
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8847,7 +10236,12 @@
   children: []
   attributes:
   - compatible_loom_type
+  - height
+  - length
   - material
+  - spindle_whorl_weight
+  - weaving_beater_edge_width
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8862,8 +10256,13 @@
   children: []
   attributes:
   - compatible_loom_type
+  - height
+  - length
   - material
   - reed_dent_material
+  - spindle_whorl_weight
+  - weaving_width
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8878,7 +10277,11 @@
   children: []
   attributes:
   - compatible_loom_type
+  - height
+  - length
   - material
+  - spindle_whorl_weight
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8897,8 +10300,12 @@
   - ae-2-1-4-18-8-4
   attributes:
   - bobbin_type
+  - height
+  - length
   - material
+  - spindle_whorl_weight
   - weaving_shuttle_use_case
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8915,9 +10322,13 @@
   - bobbin_type
   - compatible_boat_weaving_shuttle_loom
   - compatible_bobbin_type
+  - height
+  - length
   - material
+  - spindle_whorl_weight
   - tension_mechanism
   - weaving_shuttle_use_case
+  - width
   - winding_method
   return_reasons:
   - size
@@ -8933,10 +10344,16 @@
   children: []
   attributes:
   - bobbin_type
+  - compatible_bobbin_diameter
+  - compatible_weaving_shuttle_bobbin_length
+  - height
+  - length
   - material
+  - spindle_whorl_weight
   - tension_control_type
   - weaving_shuttle_tip_style
   - weaving_shuttle_use_case
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8951,8 +10368,12 @@
   children: []
   attributes:
   - bobbin_type
+  - height
+  - length
   - material
+  - spindle_whorl_weight
   - weaving_shuttle_use_case
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8967,8 +10388,12 @@
   children: []
   attributes:
   - bobbin_type
+  - height
+  - length
   - material
+  - spindle_whorl_weight
   - weaving_shuttle_use_case
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9166,9 +10591,12 @@
   attributes:
   - color
   - craft_organizer_storage_features
+  - height
+  - length
   - material
   - number_of_compartments
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -9189,8 +10617,11 @@
   attributes:
   - accessory_size
   - craft_organizer_storage_features
+  - height
+  - length
   - material
   - number_of_compartments
+  - width
   return_reasons:
   - size
   - color
@@ -9207,9 +10638,12 @@
   - accessory_size
   - compatible_hook_size
   - craft_organizer_storage_features
+  - height
   - hook_organizer_style
+  - length
   - material
   - number_of_compartments
+  - width
   return_reasons:
   - size
   - color
@@ -9228,8 +10662,11 @@
   - bag/case_material
   - compatible_needle_size
   - craft_organizer_storage_features
+  - height
+  - length
   - needle_case_format
   - number_of_compartments
+  - width
   return_reasons:
   - size
   - color
@@ -9246,11 +10683,14 @@
   attributes:
   - accessory_size
   - craft_organizer_storage_features
+  - height
+  - length
   - material
   - needle_holder_features
   - needle_holder_mounting_attachment_method
   - needle_holder_style
   - number_of_compartments
+  - width
   return_reasons:
   - size
   - color
@@ -9267,10 +10707,13 @@
   attributes:
   - accessory_size
   - craft_organizer_storage_features
+  - height
+  - length
   - material
   - number_of_compartments
   - pin_cushion_attachment_style
   - pin_cushion_features
+  - width
   return_reasons:
   - size
   - color
@@ -9290,9 +10733,12 @@
   attributes:
   - accessory_size
   - craft_organizer_storage_features
+  - height
+  - length
   - material
   - number_of_compartments
   - sewing_kit_components_included
+  - width
   return_reasons:
   - size
   - color
@@ -9309,9 +10755,12 @@
   attributes:
   - accessory_size
   - craft_organizer_storage_features
+  - height
+  - length
   - lumber/wood_type
   - material
   - number_of_compartments
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -9329,8 +10778,11 @@
   attributes:
   - accessory_size
   - craft_organizer_storage_features
+  - height
+  - length
   - material
   - number_of_compartments
+  - width
   return_reasons:
   - size
   - color
@@ -9347,8 +10799,11 @@
   attributes:
   - accessory_size
   - craft_organizer_storage_features
+  - height
+  - length
   - material
   - number_of_compartments
+  - width
   return_reasons:
   - size
   - color
@@ -9369,9 +10824,12 @@
   attributes:
   - accessory_size
   - craft_organizer_storage_features
+  - height
+  - length
   - material
   - number_of_compartments
   - thread_yarn_organizer_features
+  - width
   return_reasons:
   - size
   - color
@@ -9388,8 +10846,11 @@
   - accessory_size
   - compatible_thread_spool_format
   - craft_organizer_storage_features
+  - height
+  - length
   - material
   - number_of_compartments
+  - width
   return_reasons:
   - size
   - color
@@ -9405,10 +10866,14 @@
   attributes:
   - accessory_size
   - craft_organizer_storage_features
+  - height
+  - length
   - lumber/wood_type
   - material
   - number_of_compartments
   - thread_rack_compatible_spool_type
+  - thread_rack_peg_length
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -9426,7 +10891,10 @@
   - accessory_size
   - bag/case_material
   - craft_organizer_storage_features
+  - height
+  - length
   - number_of_compartments
+  - width
   return_reasons:
   - size
   - color
@@ -9443,9 +10911,12 @@
   attributes:
   - accessory_size
   - craft_organizer_storage_features
+  - height
   - intended_yarn_form
+  - length
   - material
   - number_of_compartments
+  - width
   return_reasons:
   - size
   - color
@@ -9462,8 +10933,11 @@
   attributes:
   - accessory_size
   - craft_organizer_storage_features
+  - height
+  - length
   - material
   - number_of_compartments
+  - width
   return_reasons:
   - size
   - color
@@ -9518,9 +10992,13 @@
   - ae-2-1-6-5
   attributes:
   - color
+  - finished_item_size
+  - height
+  - length
   - mold/cut_shape
   - mold_material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -9541,9 +11019,13 @@
   - beading_pattern_bead_size
   - beading_pattern_chart_format
   - beading_pattern_stitch_technique
+  - finished_item_size
+  - height
+  - length
   - mold_material
   - pattern_distribution_format
   - skill_level
+  - width
   return_reasons:
   - size
   - style
@@ -9562,11 +11044,15 @@
   - beading_pattern_bead_size
   - beading_pattern_chart_format
   - beading_pattern_stitch_technique
+  - finished_item_size
+  - height
+  - length
   - mold_material
   - needle_requirement_beading_pattern
   - pattern_distribution_format
   - skill_level
   - thread_cord_type_beading_pattern
+  - width
   return_reasons:
   - size
   - style
@@ -9585,9 +11071,14 @@
   - beading_pattern_chart_format
   - beading_pattern_stitch_technique
   - beading_technique_stitch
+  - finished_item_size
+  - finished_project_width
+  - height
+  - length
   - mold_material
   - pattern_distribution_format
   - skill_level
+  - width
   return_reasons:
   - size
   - style
@@ -9603,10 +11094,14 @@
   children: []
   attributes:
   - color
+  - finished_item_size
+  - height
+  - length
   - material
   - mold_material
   - mold_shape
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -9622,9 +11117,14 @@
   - ae-2-1-6-3-1
   - ae-2-1-6-3-2
   attributes:
+  - felting_mold_cavity_depth
   - felting_mold_intended_use
+  - finished_item_size
+  - height
+  - length
   - mold_material
   - mold_shape
+  - width
   return_reasons:
   - size
   - style
@@ -9639,8 +11139,12 @@
   children: []
   attributes:
   - felting_mold_intended_use
+  - finished_item_size
+  - height
+  - length
   - mold_material
   - mold_shape
+  - width
   return_reasons:
   - size
   - style
@@ -9656,8 +11160,12 @@
   children: []
   attributes:
   - felting_mold_intended_use
+  - finished_item_size
+  - height
+  - length
   - mold_material
   - mold_shape
+  - width
   return_reasons:
   - size
   - style
@@ -9677,10 +11185,14 @@
   - ae-2-1-6-4-4
   - ae-2-1-6-4-5
   attributes:
+  - finished_item_size
+  - height
+  - length
   - license_usage_terms
   - mold_material
   - pattern_distribution_format
   - skill_level
+  - width
   return_reasons:
   - size
   - style
@@ -9699,10 +11211,14 @@
   - cross_stitch_chart_symbol_type
   - cross_stitch_finishing_type
   - cross_stitch_pattern_technique
+  - finished_item_size
+  - height
+  - length
   - license_usage_terms
   - mold_material
   - pattern_distribution_format
   - skill_level
+  - width
   return_reasons:
   - size
   - style
@@ -9717,12 +11233,17 @@
   name: Embroidery Patterns
   children: []
   attributes:
+  - finished_item_size
+  - height
   - included_materials
+  - length
   - license_usage_terms
   - mold_material
   - pattern_distribution_format
+  - recommended_hoop_size
   - skill_level
   - transfer_method
+  - width
   return_reasons:
   - size
   - style
@@ -9737,6 +11258,9 @@
   name: Needlepoint Patterns
   children: []
   attributes:
+  - finished_item_size
+  - height
+  - length
   - license_usage_terms
   - mold_material
   - needlepoint_canvas_mesh_count
@@ -9744,6 +11268,7 @@
   - needlepoint_project_type
   - pattern_distribution_format
   - skill_level
+  - width
   return_reasons:
   - size
   - style
@@ -9758,6 +11283,7 @@
   name: Knitting Patterns
   children: []
   attributes:
+  - finished_item_size
   - license_usage_terms
   - mold_material
   - pattern_distribution_format
@@ -9775,6 +11301,7 @@
   name: Crochet Patterns
   children: []
   attributes:
+  - finished_item_size
   - license_usage_terms
   - mold_material
   - pattern_distribution_format
@@ -9796,12 +11323,16 @@
   - ae-2-1-6-5-3
   - ae-2-1-6-5-4
   attributes:
+  - finished_item_size
+  - height
+  - length
   - mold_material
   - pattern_distribution_format
   - sewing_pattern_notions_required
   - sewing_pattern_recommended_fabric
   - sewing_pattern_size_range
   - skill_level
+  - width
   return_reasons:
   - size
   - style
@@ -9817,6 +11348,9 @@
   children: []
   attributes:
   - color
+  - finished_item_size
+  - height
+  - length
   - mold_material
   - pattern
   - pattern_distribution_format
@@ -9826,6 +11360,7 @@
   - sewing_pattern_recommended_fabric
   - sewing_pattern_size_range
   - skill_level
+  - width
   return_reasons:
   - size
   - style
@@ -9840,14 +11375,19 @@
   name: Clothing Sewing Patterns
   children: []
   attributes:
+  - finished_item_size
   - garment_pattern_type
+  - height
+  - length
   - mold_material
   - pattern_distribution_format
   - pattern_sizing_system
+  - required_yardage
   - sewing_pattern_notions_required
   - sewing_pattern_recommended_fabric
   - sewing_pattern_size_range
   - skill_level
+  - width
   return_reasons:
   - size
   - style
@@ -9862,7 +11402,10 @@
   name: Home Decor Sewing Patterns
   children: []
   attributes:
+  - finished_item_size
+  - height
   - home_decor_sewing_pattern_project_type
+  - length
   - mold_material
   - pattern_distribution_format
   - recommended_fabric_weight
@@ -9871,6 +11414,7 @@
   - sewing_pattern_size_range
   - skill_level
   - tiling_format
+  - width
   return_reasons:
   - size
   - style
@@ -10022,6 +11566,7 @@
   - ae-2-2-2-1
   - ae-2-2-2-2
   attributes:
+  - coin_weight
   - condition
   - construction
   - embellishment/trim_material
@@ -10049,10 +11594,14 @@
   - banknote_material
   - banknote_security_features
   - banknote_serial_number_type
+  - coin_weight
   - condition
   - country
   - denomination
   - grading_service
+  - height
+  - length
+  - width
   return_reasons:
   - condition
   - changed_my_mind
@@ -10071,16 +11620,21 @@
   - coin_grade_numismatic
   - coin_material
   - coin_strike_or_finish
+  - coin_weight
   - condition
   - construction
   - country
   - denomination
   - embellishment/trim_material
   - grading_service
+  - height
   - jewelry_material
+  - length
   - material_origin
   - product_classification
   - product_use
+  - weight
+  - width
   return_reasons:
   - condition
   - changed_my_mind
@@ -10094,16 +11648,23 @@
   children: []
   attributes:
   - certification_service
+  - coin_diameter
   - coin_grade_numismatic
   - coin_material
   - coin_strike_or_finish
+  - coin_thickness
+  - coin_weight
   - condition
   - country
   - denomination
   - grading_scale
   - grading_service
+  - height
+  - length
   - mint_mark
   - purity_unit
+  - weight
+  - width
   return_reasons:
   - condition
   - edition
@@ -10120,6 +11681,7 @@
   - coin_grade_numismatic
   - coin_material
   - coin_strike_or_finish
+  - coin_weight
   - commemorative_coin_finish
   - commemorative_coin_mint_mark
   - commemorative_subject
@@ -10129,10 +11691,14 @@
   - denomination
   - embellishment/trim_material
   - grading_service
+  - height
   - jewelry_material
+  - length
   - material_origin
   - product_classification
   - product_use
+  - weight
+  - width
   return_reasons:
   - condition
   - edition
@@ -10150,10 +11716,15 @@
   - coin_material
   - coin_strike_or_finish
   - coin_strike_type
+  - coin_weight
   - condition
   - country
   - denomination
   - grading_service
+  - height
+  - length
+  - weight
+  - width
   return_reasons:
   - condition
   - edition
@@ -10294,13 +11865,17 @@
   - ae-2-2-4-1-4
   - ae-2-2-4-1-5
   attributes:
+  - barrel_length
   - collectible_gun_accessories_included
   - collectible_gun_firing_mechanism
   - condition
   - era
   - gun_action_type
   - gun_operational_status
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - condition
   - edition
@@ -10315,13 +11890,17 @@
   children: []
   attributes:
   - antique_gun_ignition_system
+  - barrel_length
   - collectible_gun_firing_mechanism
   - condition
   - era
   - gun_action_type
   - gun_operational_status
   - gun_type
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - style
   - condition
@@ -10336,13 +11915,17 @@
   name: Handguns
   children: []
   attributes:
+  - barrel_length
   - collectible_gun_firing_mechanism
   - condition
   - era
   - gun_action_type
   - gun_operational_status
   - handgun_grip_material
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - style
   - condition
@@ -10357,15 +11940,19 @@
   name: Replica Guns
   children: []
   attributes:
+  - barrel_length
   - collectible_gun_firing_mechanism
   - condition
   - era
   - gun_action_type
   - gun_operational_status
+  - height
+  - length
   - material
   - replica_gun_action_type
   - replica_gun_firing_mechanism
   - replica_gun_moving_parts
+  - width
   return_reasons:
   - style
   - condition
@@ -10380,16 +11967,21 @@
   name: Rifles
   children: []
   attributes:
+  - barrel_length
   - collectible_gun_firing_mechanism
   - condition
   - era
   - gun_action_type
   - gun_operational_status
+  - height
+  - length
   - material
   - rifle_action_type
+  - rifle_barrel_length
   - rifle_finish
   - rifle_magazine_type
   - rifle_stock_material
+  - width
   return_reasons:
   - condition
   - edition
@@ -10403,16 +11995,20 @@
   name: Shotguns
   children: []
   attributes:
+  - barrel_length
   - collectible_gun_firing_mechanism
   - condition
   - era
   - gun_action_type
   - gun_operational_status
+  - height
+  - length
   - material
   - shotgun_action_type
   - shotgun_choke_type
   - shotgun_gauge
   - shotgun_stock_material
+  - width
   return_reasons:
   - style
   - condition
@@ -10434,11 +12030,15 @@
   - ae-2-2-4-2-6
   attributes:
   - blade_material
+  - blade_thickness
   - condition
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - sheath_type
   - tang_type
+  - width
   return_reasons:
   - condition
   - edition
@@ -10453,12 +12053,16 @@
   children: []
   attributes:
   - blade_material
+  - blade_thickness
   - collectible_knife_blade_finish
   - condition
   - handle_material
+  - height
+  - length
   - sheath_material
   - sheath_type
   - tang_type
+  - width
   return_reasons:
   - style
   - condition
@@ -10474,10 +12078,15 @@
   children: []
   attributes:
   - blade_material
+  - blade_thickness
   - condition
   - handle_material
+  - height
+  - length
+  - overall_length
   - sheath_type
   - tang_type
+  - width
   return_reasons:
   - color
   - style
@@ -10494,10 +12103,14 @@
   children: []
   attributes:
   - blade_material
+  - blade_thickness
   - condition
   - handle_material
+  - height
+  - length
   - sheath_type
   - tang_type
+  - width
   return_reasons:
   - style
   - condition
@@ -10513,10 +12126,14 @@
   children: []
   attributes:
   - blade_material
+  - blade_thickness
   - condition
   - handle_material
+  - height
+  - length
   - sheath_type
   - tang_type
+  - width
   return_reasons:
   - color
   - style
@@ -10533,12 +12150,16 @@
   children: []
   attributes:
   - blade_material
+  - blade_thickness
   - condition
   - handle_material
+  - height
   - knife_lock_mechanism
+  - length
   - pocket_knife_opening_mechanism
   - sheath_type
   - tang_type
+  - width
   return_reasons:
   - size
   - style
@@ -10555,11 +12176,15 @@
   children: []
   attributes:
   - blade_material
+  - blade_thickness
   - condition
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - sheath_type
   - tang_type
+  - width
   return_reasons:
   - style
   - condition
@@ -10579,10 +12204,15 @@
   - ae-2-2-4-3-4
   - ae-2-2-4-3-5
   attributes:
+  - blade_length
   - blade_material
+  - blade_width
   - condition
   - handle_material
+  - height
+  - length
   - sword_scabbard_material
+  - width
   return_reasons:
   - color
   - condition
@@ -10597,12 +12227,17 @@
   name: European Collectible Swords
   children: []
   attributes:
+  - blade_length
   - blade_material
+  - blade_width
   - condition
   - european_sword_historical_period
   - european_sword_pattern_type
   - handle_material
+  - height
+  - length
   - sword_scabbard_material
+  - width
   return_reasons:
   - size
   - style
@@ -10618,11 +12253,16 @@
   name: Fantasy Collectible Swords
   children: []
   attributes:
+  - blade_length
   - blade_material
+  - blade_width
   - condition
   - handle_material
+  - height
+  - length
   - scabbard_material
   - sword_scabbard_material
+  - width
   return_reasons:
   - size
   - style
@@ -10638,10 +12278,15 @@
   name: Historical Collectible Swords
   children: []
   attributes:
+  - blade_length
   - blade_material
+  - blade_width
   - condition
   - handle_material
+  - height
+  - length
   - sword_scabbard_material
+  - width
   return_reasons:
   - style
   - condition
@@ -10656,10 +12301,15 @@
   name: Movie Replica Collectible Swords
   children: []
   attributes:
+  - blade_length
   - blade_material
+  - blade_width
   - condition
   - handle_material
+  - height
+  - length
   - sword_scabbard_material
+  - width
   return_reasons:
   - size
   - style
@@ -10675,10 +12325,15 @@
   name: Samurai Collectible Swords
   children: []
   attributes:
+  - blade_length
   - blade_material
+  - blade_width
   - condition
   - handle_material
+  - height
+  - length
   - sword_scabbard_material
+  - width
   return_reasons:
   - size
   - condition
@@ -10695,9 +12350,12 @@
   attributes:
   - accessory_size
   - condition
+  - height
+  - length
   - lumber/wood_type
   - material
   - stand/display_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -10721,10 +12379,13 @@
   - condition
   - country
   - denomination
+  - height
+  - length
   - postage_stamp_features
   - printing_method
   - rarity
   - stamp_theme
+  - width
   return_reasons:
   - condition
   - edition
@@ -10741,10 +12402,13 @@
   - condition
   - country
   - denomination
+  - height
+  - length
   - postage_stamp_features
   - printing_method
   - rarity
   - stamp_theme
+  - width
   return_reasons:
   - condition
   - changed_my_mind
@@ -10761,12 +12425,15 @@
   - country
   - denomination
   - gum_condition
+  - height
+  - length
   - postage_stamp_features
   - postage_stamp_format
   - postmark_type
   - printing_method
   - rarity
   - stamp_theme
+  - width
   return_reasons:
   - condition
   - changed_my_mind
@@ -10785,10 +12452,13 @@
   - first_day_cover_cachet_type
   - first_day_cover_cancellation_type
   - first_day_cover_set_type
+  - height
+  - length
   - postage_stamp_features
   - printing_method
   - rarity
   - stamp_theme
+  - width
   return_reasons:
   - condition
   - changed_my_mind
@@ -10804,10 +12474,13 @@
   - condition
   - country
   - denomination
+  - height
+  - length
   - postage_stamp_features
   - printing_method
   - rarity
   - stamp_theme
+  - width
   return_reasons:
   - condition
   - changed_my_mind
@@ -10823,10 +12496,13 @@
   - condition
   - country
   - denomination
+  - height
+  - length
   - postage_stamp_features
   - printing_method
   - rarity
   - stamp_theme
+  - width
   return_reasons:
   - condition
   - changed_my_mind
@@ -10850,6 +12526,8 @@
   - fluorescence_under_uv
   - fossil_type
   - geological_era
+  - height
+  - length
   - luster
   - mineral_class
   - pattern
@@ -10857,6 +12535,7 @@
   - rock_composition
   - rock_formation
   - specimen_presentation
+  - width
   return_reasons:
   - color
   - condition
@@ -10881,12 +12560,15 @@
   - fossil_type
   - geological_era
   - geological_period
+  - height
+  - length
   - luster
   - mineral_class
   - rarity
   - rock_composition
   - rock_formation
   - specimen_presentation
+  - width
   return_reasons:
   - color
   - condition
@@ -10914,7 +12596,9 @@
   - gemstone_cut_style
   - gemstone_treatment_status
   - geological_era
+  - height
   - jewelry_material
+  - length
   - luster
   - material_origin
   - mineral_class
@@ -10925,6 +12609,7 @@
   - rock_composition
   - rock_formation
   - specimen_presentation
+  - width
   return_reasons:
   - color
   - condition
@@ -10946,6 +12631,8 @@
   - fluorescence_under_uv
   - fossil_type
   - geological_era
+  - height
+  - length
   - luster
   - mineral_class
   - pattern
@@ -10953,6 +12640,7 @@
   - rock_composition
   - rock_formation
   - specimen_presentation
+  - width
   return_reasons:
   - color
   - condition
@@ -10974,6 +12662,8 @@
   - fluorescence_under_uv
   - fossil_type
   - geological_era
+  - height
+  - length
   - luster
   - mineral_class
   - pattern
@@ -10981,6 +12671,7 @@
   - rock_composition
   - rock_formation
   - specimen_presentation
+  - width
   return_reasons:
   - color
   - condition
@@ -10998,10 +12689,13 @@
   - color
   - compatible_model_system_train_scale
   - condition
+  - height
+  - length
   - material
   - pattern
   - scale_model_accessory_type
   - scale_model_theme
+  - width
   return_reasons:
   - size
   - scale
@@ -11034,14 +12728,17 @@
   - condition
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
   - kit_construction_type
+  - length
   - lumber/wood_type
   - pattern
   - recommended_age_group
   - scale_model_assembly_status
   - scale_model_material
   - skill_level
+  - width
   - wood_finish
   return_reasons:
   - color
@@ -11058,10 +12755,13 @@
   children: []
   attributes:
   - condition
+  - height
   - kit_construction_type
+  - length
   - scale_model_assembly_status
   - scale_model_material
   - skill_level
+  - width
   return_reasons:
   - color
   - scale
@@ -11079,10 +12779,13 @@
   attributes:
   - bus_model_type
   - condition
+  - height
   - kit_construction_type
+  - length
   - scale_model_assembly_status
   - scale_model_material
   - skill_level
+  - width
   return_reasons:
   - color
   - scale
@@ -11099,11 +12802,14 @@
   children: []
   attributes:
   - condition
+  - height
   - kit_construction_type
+  - length
   - scale_model_assembly_status
   - scale_model_car_features
   - scale_model_material
   - skill_level
+  - width
   return_reasons:
   - color
   - scale
@@ -11121,10 +12827,13 @@
   attributes:
   - articulation_features
   - condition
+  - height
   - kit_construction_type
+  - length
   - scale_model_assembly_status
   - scale_model_material
   - skill_level
+  - width
   return_reasons:
   - color
   - condition
@@ -11143,11 +12852,15 @@
   - condition
   - coupler_system
   - decoder_interface_socket_type
+  - height
   - kit_construction_type
+  - length
   - locomotive_wheel_arrangement_whyte_notation
+  - minimum_curve_radius
   - scale_model_assembly_status
   - scale_model_material
   - skill_level
+  - width
   return_reasons:
   - color
   - condition
@@ -11164,12 +12877,15 @@
   children: []
   attributes:
   - condition
+  - height
   - kit_construction_type
+  - length
   - scale_model_assembly_status
   - scale_model_material
   - scale_model_paint_status
   - scale_model_rotor_configuration
   - skill_level
+  - width
   return_reasons:
   - color
   - scale
@@ -11187,12 +12903,15 @@
   attributes:
   - condition
   - figure_finish_type
+  - height
   - horse_model_breed
   - kit_construction_type
+  - length
   - scale_model_assembly_status
   - scale_model_material
   - scale_model_pose
   - skill_level
+  - width
   return_reasons:
   - color
   - scale
@@ -11210,10 +12929,13 @@
   - battery_size
   - battery_type
   - condition
+  - height
   - kit_construction_type
+  - length
   - scale_model_assembly_status
   - scale_model_material
   - skill_level
+  - width
   return_reasons:
   - color
   - scale
@@ -11230,10 +12952,13 @@
   children: []
   attributes:
   - condition
+  - height
   - kit_construction_type
+  - length
   - scale_model_assembly_status
   - scale_model_material
   - skill_level
+  - width
   return_reasons:
   - color
   - condition
@@ -11250,10 +12975,14 @@
   children: []
   attributes:
   - condition
+  - height
   - kit_construction_type
+  - length
+  - overall_length
   - scale_model_assembly_status
   - scale_model_material
   - skill_level
+  - width
   return_reasons:
   - color
   - scale
@@ -11270,10 +12999,13 @@
   children: []
   attributes:
   - condition
+  - height
   - kit_construction_type
+  - length
   - scale_model_assembly_status
   - scale_model_material
   - skill_level
+  - width
   return_reasons:
   - color
   - scale
@@ -11290,12 +13022,15 @@
   children: []
   attributes:
   - condition
+  - height
   - kit_construction_type
+  - length
   - scale_model_assembly_status
   - scale_model_kit_components_included
   - scale_model_material
   - skill_level
   - tank_model_scale
+  - width
   return_reasons:
   - color
   - scale
@@ -11312,7 +13047,9 @@
   children: []
   attributes:
   - condition
+  - height
   - kit_construction_type
+  - length
   - locomotive_prototype_power_type
   - model_train_power_pickup_method
   - model_train_track_gauge
@@ -11320,6 +13057,7 @@
   - scale_model_assembly_status
   - scale_model_material
   - skill_level
+  - width
   return_reasons:
   - color
   - scale
@@ -11336,12 +13074,15 @@
   children: []
   attributes:
   - condition
+  - height
   - kit_construction_type
+  - length
   - scale_model_assembly_status
   - scale_model_material
   - scale_model_truck_era
   - scale_model_truck_propulsion_type
   - skill_level
+  - width
   return_reasons:
   - color
   - scale
@@ -11357,8 +13098,11 @@
   children: []
   attributes:
   - accessory_size
+  - height
+  - length
   - material
   - seal_stamp_design
+  - width
   return_reasons:
   - size
   - color
@@ -11427,8 +13171,11 @@
   - banner_hanging_hardware_type
   - banner_shape
   - condition
+  - height
+  - length
   - sport
   - sports_logo
+  - width
   return_reasons:
   - size
   - color
@@ -11468,9 +13215,12 @@
   attributes:
   - condition
   - figurine_scale
+  - height
+  - length
   - lumber/wood_type
   - sport
   - sports_logo
+  - width
   - wood_finish
   return_reasons:
   - color
@@ -11487,8 +13237,11 @@
   children: []
   attributes:
   - condition
+  - height
+  - length
   - sport
   - sports_logo
+  - width
   return_reasons:
   - size
   - color
@@ -11527,6 +13280,8 @@
   attributes:
   - accessory_size
   - age_group
+  - brim_depth
+  - circumference
   - color
   - condition
   - fabric
@@ -11607,13 +13362,16 @@
   - condition
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
   - keychain_attachment_type
   - keychain_style
+  - length
   - licensed_sports_property
   - pattern
   - sport
   - sports_logo
+  - width
   return_reasons:
   - color
   - style
@@ -11633,13 +13391,16 @@
   - condition
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - pattern
   - pin_backing_type
   - pin_size
   - pin_type
   - sport
   - sports_logo
+  - width
   return_reasons:
   - color
   - condition
@@ -11655,8 +13416,11 @@
   children: []
   attributes:
   - condition
+  - height
+  - length
   - sport
   - sports_logo
+  - width
   return_reasons:
   - size
   - color
@@ -11677,6 +13441,7 @@
   - condition
   - fabric
   - pattern
+  - scarf_length_end_to_end
   - sport
   - sports_logo
   - target_gender
@@ -11746,9 +13511,12 @@
   children: []
   attributes:
   - condition
+  - height
+  - length
   - sport
   - sports_logo
   - wall_decal_style
+  - width
   return_reasons:
   - size
   - color
@@ -11766,11 +13534,14 @@
   - art_style
   - color
   - condition
+  - height
+  - length
   - material
   - pattern
   - vintage_advertisement_decade
   - vintage_advertisement_format
   - vintage_advertisement_subject_category
+  - width
   return_reasons:
   - size
   - condition
@@ -11838,6 +13609,7 @@
   - malt_color_rating_system
   - malt_form
   - malt_treatment
+  - package_size
   - potential_extract
   - smoked_malt_smoking_material
   return_reasons:
@@ -11863,6 +13635,7 @@
   - malt_color_rating_system
   - malt_form
   - malt_treatment
+  - package_size
   - potential_extract
   return_reasons:
   - taste
@@ -11888,6 +13661,7 @@
   - malt_intended_use
   - malt_treatment
   - modification_level
+  - package_size
   - potential_extract
   return_reasons:
   - color
@@ -11911,6 +13685,7 @@
   - malt_color_rating_system
   - malt_form
   - malt_treatment
+  - package_size
   - potential_extract
   - roasted_malt_processing_type
   return_reasons:
@@ -11936,6 +13711,7 @@
   - malt_form
   - malt_treatment
   - malt_usage_purpose
+  - package_size
   - potential_extract
   - specialty_malt_name_type
   return_reasons:
@@ -11955,9 +13731,13 @@
   - bottle_neck_finish_closure_size
   - bottle_style
   - color
+  - diameter
   - equipment_contact_material_brew_wine
   - glass_tint
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -12065,6 +13845,7 @@
   name: Fruit Wine Making Supplies
   children: []
   attributes:
+  - batch_yield_volume
   - equipment_contact_material_brew_wine
   - fruit_variety
   - grape_variety
@@ -12091,6 +13872,7 @@
   - oak_product_form
   - oak_toast_level
   - region
+  - target_batch_volume
   - wine_additive_type
   - wine_making_ingredient_type
   - wine_making_stage
@@ -12192,10 +13974,13 @@
   attributes:
   - accessory_size
   - color
+  - height
   - juggling_prop_set_size
+  - length
   - material
   - pattern
   - weight_type
+  - width
   return_reasons:
   - size
   - color
@@ -12214,11 +13999,14 @@
   - color
   - contact_juggling_ball_fill_type
   - contact_juggling_ball_transparency
+  - height
   - juggling_prop_set_size
+  - length
   - material
   - pattern
   - surface_finish
   - weight_type
+  - width
   return_reasons:
   - size
   - color
@@ -12234,13 +14022,18 @@
   children: []
   attributes:
   - accessory_size
+  - center_stick_diameter
   - color
+  - devil_stick_weight
+  - height
   - juggling_prop_set_size
+  - length
   - material
   - pattern
   - set_components
   - surface_coating_or_wrap
   - weight_type
+  - width
   return_reasons:
   - size
   - color
@@ -12258,10 +14051,14 @@
   - accessory_size
   - color
   - diabolo_axle_system
+  - diabolo_cup_width
+  - height
   - juggling_prop_set_size
+  - length
   - material
   - pattern
   - weight_type
+  - width
   return_reasons:
   - size
   - color
@@ -12278,10 +14075,13 @@
   attributes:
   - accessory_size
   - color
+  - height
   - juggling_prop_set_size
+  - length
   - material
   - pattern
   - weight_type
+  - width
   return_reasons:
   - size
   - color
@@ -12298,12 +14098,15 @@
   attributes:
   - accessory_size
   - color
+  - height
   - juggling_club_construction_type
   - juggling_club_core_material
   - juggling_prop_set_size
+  - length
   - material
   - pattern
   - weight_type
+  - width
   return_reasons:
   - size
   - color
@@ -12320,11 +14123,14 @@
   attributes:
   - accessory_size
   - color
+  - height
   - juggling_prop_set_size
   - juggling_ring_edge_style
+  - length
   - material
   - pattern
   - weight_type
+  - width
   return_reasons:
   - size
   - color
@@ -12341,7 +14147,9 @@
   attributes:
   - accessory_size
   - color
+  - height
   - juggling_prop_set_size
+  - length
   - material
   - pattern
   - poi_handle_type
@@ -12349,6 +14157,7 @@
   - poi_tether_type
   - poi_type
   - weight_type
+  - width
   return_reasons:
   - size
   - color
@@ -12364,8 +14173,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - skill_level
+  - width
   return_reasons:
   - size
   - color
@@ -12385,10 +14197,13 @@
   - ae-2-6-4
   attributes:
   - color
+  - height
+  - length
   - model_making_kit_items_included
   - model_making_product_type
   - pattern
   - skill_level
+  - width
   return_reasons:
   - color
   - scale
@@ -12409,6 +14224,8 @@
   attributes:
   - battery_size
   - battery_type
+  - height
+  - length
   - material
   - model_making_kit_items_included
   - model_making_product_type
@@ -12417,8 +14234,10 @@
   - model_rocket_propellant_type
   - model_rocket_recommended_launch_rod_or_rail_size
   - model_rocket_recovery_method
+  - motor_mount_diameter
   - skill_level
   - stages_supported
+  - width
   return_reasons:
   - size
   - color
@@ -12434,6 +14253,8 @@
   name: High-Power Rockets
   children: []
   attributes:
+  - height
+  - length
   - material
   - model_making_kit_items_included
   - model_making_product_type
@@ -12443,6 +14264,7 @@
   - model_rocket_recovery_method
   - skill_level
   - stages_supported
+  - width
   return_reasons:
   - size
   - color
@@ -12458,9 +14280,13 @@
   name: Multi-Stage Rockets
   children: []
   attributes:
+  - estimated_max_altitude
+  - height
+  - length
   - material
   - model_making_kit_items_included
   - model_making_product_type
+  - model_rocket_body_tube_diameter
   - model_rocket_kit_contents
   - model_rocket_power_source_required
   - model_rocket_propellant_type
@@ -12469,6 +14295,7 @@
   - recommended_motor_impulse_class
   - skill_level
   - stages_supported
+  - width
   return_reasons:
   - size
   - color
@@ -12484,6 +14311,8 @@
   name: Single-Stage Rockets
   children: []
   attributes:
+  - height
+  - length
   - material
   - model_making_kit_items_included
   - model_making_product_type
@@ -12494,6 +14323,7 @@
   - model_rocket_recovery_method
   - skill_level
   - stages_supported
+  - width
   return_reasons:
   - size
   - color
@@ -12509,6 +14339,8 @@
   name: Water Rockets
   children: []
   attributes:
+  - height
+  - length
   - material
   - model_making_kit_items_included
   - model_making_product_type
@@ -12521,6 +14353,7 @@
   - water_rocket_kit_items_included
   - water_rocket_propulsion_type
   - water_rocket_recovery_system
+  - width
   return_reasons:
   - color
   - difficulty_level
@@ -12535,6 +14368,8 @@
   name: Model Train Accessories
   children: []
   attributes:
+  - height
+  - length
   - model_making_kit_items_included
   - model_making_product_type
   - model_train_accessory_electrical_connection_type
@@ -12542,6 +14377,7 @@
   - model_train_gauge
   - model_train_theme
   - skill_level
+  - width
   return_reasons:
   - color
   - scale
@@ -12563,6 +14399,8 @@
   attributes:
   - battery_size
   - battery_type
+  - height
+  - length
   - model_control_technology
   - model_making_kit_items_included
   - model_making_product_type
@@ -12571,6 +14409,7 @@
   - model_train_scale
   - model_train_sound_features
   - skill_level
+  - width
   return_reasons:
   - color
   - scale
@@ -12585,6 +14424,8 @@
   name: Diesel Locomotives
   children: []
   attributes:
+  - height
+  - length
   - model_control_technology
   - model_making_kit_items_included
   - model_making_product_type
@@ -12593,6 +14434,7 @@
   - model_train_scale
   - model_train_sound_features
   - skill_level
+  - width
   return_reasons:
   - color
   - scale
@@ -12607,6 +14449,9 @@
   name: Electric Locomotives
   children: []
   attributes:
+  - amperage
+  - height
+  - length
   - model_control_technology
   - model_making_kit_items_included
   - model_making_product_type
@@ -12614,7 +14459,10 @@
   - model_train_lighting_features
   - model_train_scale
   - model_train_sound_features
+  - power_consumption_typical
   - skill_level
+  - voltage
+  - width
   return_reasons:
   - color
   - scale
@@ -12629,6 +14477,8 @@
   name: Freight Trains
   children: []
   attributes:
+  - height
+  - length
   - model_control_technology
   - model_making_kit_items_included
   - model_making_product_type
@@ -12637,6 +14487,7 @@
   - model_train_scale
   - model_train_sound_features
   - skill_level
+  - width
   return_reasons:
   - color
   - scale
@@ -12651,6 +14502,8 @@
   name: Passenger Trains
   children: []
   attributes:
+  - height
+  - length
   - model_control_technology
   - model_making_kit_items_included
   - model_making_product_type
@@ -12660,6 +14513,7 @@
   - model_train_sound_features
   - passenger_car_type
   - skill_level
+  - width
   return_reasons:
   - color
   - scale
@@ -12674,6 +14528,8 @@
   name: Steam Locomotives
   children: []
   attributes:
+  - height
+  - length
   - model_control_technology
   - model_making_kit_items_included
   - model_making_product_type
@@ -12683,6 +14539,7 @@
   - model_train_sound_features
   - skill_level
   - wheel_arrangement
+  - width
   return_reasons:
   - color
   - scale
@@ -12700,6 +14557,8 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - model_making_kit_items_included
   - model_making_product_type
   - pattern
@@ -12708,6 +14567,7 @@
   - scale_model_kit_type
   - scale_model_material
   - skill_level
+  - width
   return_reasons:
   - color
   - scale
@@ -12799,7 +14659,10 @@
   - brass_instrument_care_kit_purpose
   - brass_lubricant_application_area
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -12820,6 +14683,9 @@
   - cleaner_sanitizer_intended_area
   - cleaning_formula
   - compatible_brass_instrument
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12834,11 +14700,15 @@
   attributes:
   - bore_cleaner_format
   - bore_cleaner_safe_for_finish
+  - bore_cleaner_volume
   - brass_cleaning_tool_type
   - brass_lubricant_application_area
   - cleaner_sanitizer_intended_area
   - cleaning_formula
   - compatible_brass_instrument
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12858,7 +14728,11 @@
   - cleaning_formula
   - compatible_brass_instrument
   - compatible_finish_type
+  - drying_time
   - formulation_type
+  - height
+  - length
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -12877,7 +14751,10 @@
   - cleaning_formula
   - compatible_brass_instrument
   - compatible_brass_instrument_finish
+  - height
+  - length
   - slide_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12895,6 +14772,9 @@
   - cleaner_sanitizer_intended_area
   - cleaning_formula
   - compatible_brass_instrument
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12910,6 +14790,9 @@
   - brass_cleaning_tool_type
   - brass_lubricant_application_area
   - compatible_brass_instrument
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12928,7 +14811,10 @@
   attributes:
   - brass_cleaning_tool_type
   - brass_lubricant_application_area
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12945,7 +14831,10 @@
   - bell_guard_coverage_area
   - brass_cleaning_tool_type
   - brass_lubricant_application_area
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12960,7 +14849,10 @@
   attributes:
   - brass_cleaning_tool_type
   - brass_lubricant_application_area
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12975,7 +14867,10 @@
   attributes:
   - brass_cleaning_tool_type
   - brass_lubricant_application_area
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12990,8 +14885,11 @@
   attributes:
   - brass_cleaning_tool_type
   - brass_lubricant_application_area
+  - height
   - instrument_accessory_material
+  - length
   - valve_guard_coverage_area
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -13013,6 +14911,7 @@
   - compatible_valve_type
   - dispenser_type
   - lubricant_form
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -13029,8 +14928,11 @@
   - brass_lubricant_application_area
   - brass_polishing_cloth_abrasiveness_level
   - color
+  - height
   - instrument_accessory_material
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -13044,10 +14946,16 @@
   children: []
   attributes:
   - bag/case_material
+  - brass_instrument_case_interior_height_depth
+  - brass_instrument_case_interior_width
   - brass_instrument_case_shell_material
+  - case_interior_length
   - case_lining_material
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -13064,8 +14972,13 @@
   attributes:
   - brass_mouthpiece_backbore
   - brass_mouthpiece_cup_depth
+  - brass_mouthpiece_throat_size
   - compatible_brass_instrument
+  - height
+  - length
   - mouthpiece_shank_size
+  - rim_diameter
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13084,9 +14997,12 @@
   - ae-2-7-1-4-4
   - ae-2-7-1-4-5
   attributes:
+  - height
   - instrument_accessory_material
+  - length
   - mute_attenuation_level
   - mute_finish
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -13102,9 +15018,13 @@
   children: []
   attributes:
   - adjustable_cup_mutes
+  - cup_mute_depth
+  - height
   - instrument_accessory_material
+  - length
   - mute_attenuation_level
   - mute_finish
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -13118,9 +15038,12 @@
   name: Harmon Mutes
   children: []
   attributes:
+  - height
   - instrument_accessory_material
+  - length
   - mute_attenuation_level
   - mute_finish
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -13134,10 +15057,13 @@
   name: Plunger Mutes
   children: []
   attributes:
+  - height
   - instrument_accessory_material
+  - length
   - mute_attenuation_level
   - mute_finish
   - plunger_mute_handle_type
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -13152,12 +15078,15 @@
   children: []
   attributes:
   - airflow_resistance_level
+  - height
   - instrument_accessory_material
+  - length
   - mute_attenuation_level
   - mute_finish
   - practice_mute_audio_output
   - practice_mute_intonation_impact
   - practice_mute_venting_valve_type
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -13171,10 +15100,14 @@
   name: Straight Mutes
   children: []
   attributes:
+  - height
   - instrument_accessory_material
+  - length
   - mute_attenuation_level
   - mute_cork_padding_material
   - mute_finish
+  - mute_weight
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -13190,6 +15123,9 @@
   attributes:
   - brass_instrument_replacement_part_type
   - compatible_brass_instrument
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13205,8 +15141,11 @@
   - ae-2-7-1-6-1
   - ae-2-7-1-6-2
   attributes:
+  - height
   - instrument_accessory_material
   - instrument_support_type
+  - length
+  - width
   return_reasons:
   - size
   - style
@@ -13248,8 +15187,12 @@
   children: []
   attributes:
   - baton_grip_design
+  - diameter
+  - height
   - instrument_accessory_material
+  - length
   - tip_material
+  - width
   return_reasons:
   - length
   - weight
@@ -13267,12 +15210,15 @@
   - battery_size
   - battery_type
   - display_technology
+  - height
+  - length
   - power_source
   - transposition_modes
   - tuner_design
   - tuner_input_method
   - tuning_modes
   - tuning_range
+  - width
   return_reasons:
   - battery_life
   - incompatible
@@ -13291,11 +15237,14 @@
   - battery_type
   - beat_subdivisions
   - display_technology
+  - height
+  - length
   - metronome_display_style
   - metronome_output_method
   - power_source
   - sound_options
   - time_signatures
+  - width
   return_reasons:
   - size
   - color
@@ -13310,10 +15259,13 @@
   children: []
   attributes:
   - frame_material
+  - height
   - height_adjustment
+  - length
   - seat_cushioning
   - seat_shape
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -13329,11 +15281,14 @@
   children: []
   attributes:
   - compatible_instrument
+  - height
   - instrument_accessory_material
+  - length
   - lyre/flip_folder_attachment_type
   - lyre_flip_folder_mounting_location
   - orientation
   - page_size
+  - width
   return_reasons:
   - size
   - color
@@ -13352,7 +15307,10 @@
   - ae-2-7-7-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13372,6 +15330,9 @@
   - bag/case_storage_features
   - care_instructions
   - carry_options
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13384,8 +15345,12 @@
   name: Music Stand Lights
   children: []
   attributes:
+  - gooseneck_length
+  - height
+  - length
   - light_source
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13404,8 +15369,11 @@
   - ae-2-7-7-3-4
   attributes:
   - accessory_size
+  - height
   - instrument_accessory_material
+  - length
   - sheet_music_clip_padding_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -13422,8 +15390,11 @@
   - clamp_sheet_music_clip_features
   - clip_color
   - compatible_mounting_surface
+  - height
   - instrument_accessory_material
+  - length
   - sheet_music_clip_padding_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13437,8 +15408,12 @@
   children: []
   attributes:
   - accessory_size
+  - elastic_band_width
+  - height
   - instrument_accessory_material
+  - length
   - sheet_music_clip_padding_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13452,8 +15427,11 @@
   children: []
   attributes:
   - accessory_size
+  - height
   - instrument_accessory_material
+  - length
   - sheet_music_clip_padding_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13467,10 +15445,13 @@
   children: []
   attributes:
   - accessory_size
+  - height
   - instrument_accessory_material
+  - length
   - sheet_music_clip_padding_material
   - sheet_music_clip_spring_tension_level
   - sheet_music_clip_use_environment
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13483,11 +15464,17 @@
   name: Music Stands
   children: []
   attributes:
+  - desk_lip_depth
   - desk_size
+  - height
   - instrument_accessory_material
+  - length
   - music_stand_design
+  - music_stand_desk_height
   - music_stand_desk_tilt_adjustment
+  - music_stand_desk_width
   - music_stand_intended_use
+  - width
   return_reasons:
   - size
   - style
@@ -13509,7 +15496,10 @@
   - ae-2-7-9-6
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13523,8 +15513,13 @@
   name: Musical Instrument Amplifier Cabinets
   children: []
   attributes:
+  - height
   - instrument_accessory_material
+  - length
+  - power
   - speaker_configuration
+  - speaker_driver_diameter
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13543,10 +15538,15 @@
   - bag/case_storage_features
   - care_instructions
   - carry_options
+  - case_padding_thickness
   - closure_type
   - compatible_amplifier
   - compatible_amplifier_fit_method
   - cover_features
+  - height
+  - interior_width
+  - length
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13560,10 +15560,14 @@
   name: Musical Instrument Amplifier Footswitches
   children: []
   attributes:
+  - cable_length
   - compatible_amplifier
   - control_functions
   - footswitch_action_style
   - footswitch_power_source
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -13577,10 +15581,13 @@
   children: []
   attributes:
   - color
+  - height
   - instrument_accessory_material
   - knob_function
   - knob_style
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -13595,9 +15602,12 @@
   attributes:
   - color
   - compatible_electric/acoustic_instrument
+  - height
   - instrument_accessory_material
+  - length
   - music_stand_design
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13611,11 +15621,14 @@
   children: []
   attributes:
   - amplifier_tube_function
+  - height
+  - length
   - power_source
   - tube_base_type
   - tube_component
   - tube_configuration
   - tube_matching_grade
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -13632,8 +15645,12 @@
   - ae-2-7-10-3
   - ae-2-7-10-4
   attributes:
+  - height
   - input/output_ports
+  - length
+  - power_output_typical
   - sound_controls
+  - width
   return_reasons:
   - size
   - color
@@ -13651,8 +15668,12 @@
   - acoustic_amplifier_feedback_control_features
   - battery_size
   - battery_type
+  - height
   - input/output_ports
+  - length
+  - power_output_typical
   - sound_controls
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13668,8 +15689,12 @@
   attributes:
   - battery_size
   - battery_type
+  - height
   - input/output_ports
+  - length
+  - power_output_typical
   - sound_controls
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13685,8 +15710,12 @@
   attributes:
   - battery_size
   - battery_type
+  - height
   - input/output_ports
+  - length
+  - power_output_typical
   - sound_controls
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13700,10 +15729,14 @@
   name: Keyboard Amplifiers
   children: []
   attributes:
+  - height
   - input/output_ports
   - keyboard_amplifier_inputs
   - keyboard_amplifier_output_types
+  - length
+  - power_output_typical
   - sound_controls
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13720,7 +15753,10 @@
   - ae-2-7-11-2
   - ae-2-7-11-3
   attributes:
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13745,8 +15781,11 @@
   - care_instructions
   - carry_options
   - compatible_keyboard_configuration
+  - height
   - keyboard_case_handle_type
+  - length
   - rolling_case_wheel_configuration
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13763,11 +15802,17 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - bag_case_interior_height
+  - bag_case_interior_length
+  - bag_case_interior_width
   - care_instructions
   - carry_options
   - compatible_keyboard_configuration
+  - height
   - keyboard_case_handle_type
+  - length
   - rolling_case_wheel_configuration
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13787,11 +15832,18 @@
   - care_instructions
   - carry_options
   - compatible_keyboard_configuration
+  - height
+  - interior_width
+  - keyboard_case_empty_weight
   - keyboard_case_handle_type
+  - keyboard_case_interior_height
+  - keyboard_case_interior_length
   - keyboard_case_interior_padding_type
   - keyboard_case_protection_level
   - keyboard_case_wheel_type
+  - length
   - rolling_case_wheel_configuration
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13811,10 +15863,13 @@
   - care_instructions
   - carry_options
   - compatible_keyboard_configuration
+  - height
   - keyboard_case_handle_type
+  - length
   - musical_keyboard_case_fit_type
   - rolling_case_wheel_configuration
   - water_resistance_rating_case_protection_level
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13834,8 +15889,11 @@
   - care_instructions
   - carry_options
   - compatible_keyboard_configuration
+  - height
   - keyboard_case_handle_type
+  - length
   - rolling_case_wheel_configuration
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13854,8 +15912,11 @@
   - ae-2-7-11-2-5
   attributes:
   - compatible_keyboard_configuration
+  - height
   - instrument_accessory_material
+  - length
   - mount/stand_features
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13869,9 +15930,12 @@
   children: []
   attributes:
   - compatible_keyboard_configuration
+  - height
   - instrument_accessory_material
+  - length
   - lumber/wood_type
   - mount/stand_features
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -13886,8 +15950,11 @@
   children: []
   attributes:
   - compatible_keyboard_configuration
+  - height
   - instrument_accessory_material
+  - length
   - mount/stand_features
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13901,9 +15968,12 @@
   children: []
   attributes:
   - compatible_keyboard_configuration
+  - height
   - instrument_accessory_material
+  - length
   - mount/stand_features
   - tubing_shape
+  - width
   return_reasons:
   - size
   - weight
@@ -13918,8 +15988,11 @@
   children: []
   attributes:
   - compatible_keyboard_configuration
+  - height
   - instrument_accessory_material
+  - length
   - mount/stand_features
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13933,10 +16006,15 @@
   children: []
   attributes:
   - compatible_keyboard_configuration
+  - height
   - instrument_accessory_material
+  - keyboard_stand_crossbar_depth
   - keyboard_stand_tier_type
   - keyboard_stand_tiers
+  - length
   - mount/stand_features
+  - stand_weight
+  - width
   return_reasons:
   - size
   - weight
@@ -13954,10 +16032,13 @@
   attributes:
   - compatible_pedal_instrument_type
   - connection_method
+  - height
   - instrument_accessory_material
   - keyboard_pedal_connector_type
+  - length
   - pedal_polarity
   - sustain_pedal_switch_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13973,10 +16054,13 @@
   attributes:
   - connection_method
   - damper_pedal_style
+  - height
   - instrument_accessory_material
   - keyboard_pedal_connector_type
+  - length
   - pedal_polarity
   - sustain_pedal_switch_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -13990,12 +16074,15 @@
   children: []
   attributes:
   - connection_method
+  - height
   - instrument_accessory_material
   - keyboard_pedal_connector_type
+  - length
   - non_slip_base_features
   - pedal_polarity
   - sustain_pedal_form_factor
   - sustain_pedal_switch_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14020,7 +16107,10 @@
   - ae-2-7-12-11
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -14041,7 +16131,11 @@
   - color
   - compatible_percussion_instrument
   - cymbal_drum_case_wheel_configuration
+  - diameter
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14060,7 +16154,11 @@
   - color
   - compatible_percussion_instrument
   - cymbal_drum_case_wheel_configuration
+  - diameter
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14077,7 +16175,11 @@
   - color
   - compatible_percussion_instrument
   - cymbal_drum_case_wheel_configuration
+  - diameter
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14095,8 +16197,12 @@
   - compatible_cymbal_size
   - compatible_percussion_instrument
   - cymbal_drum_case_wheel_configuration
+  - diameter
+  - height
+  - length
   - pattern
   - percussion_case_style
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14112,7 +16218,11 @@
   - ae-2-7-12-2-2
   attributes:
   - drum_hardware_material
+  - height
+  - length
   - mute_coverage_type
+  - mute_thickness
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -14129,8 +16239,12 @@
   attributes:
   - damping_level
   - drum_hardware_material
+  - height
+  - length
   - mute_attachment_method
   - mute_coverage_type
+  - mute_thickness
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -14147,7 +16261,11 @@
   - damping_level
   - drum_hardware_material
   - drum_mute_material
+  - height
+  - length
   - mute_coverage_type
+  - mute_thickness
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -14172,8 +16290,12 @@
   - drum_head_hoop_rim_material
   - drum_head_ply_count
   - drum_head_position
+  - drum_head_size
   - drum_head_surface_finish
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -14189,6 +16311,7 @@
   children: []
   attributes:
   - bass_drum_head_built_in_muffling
+  - bass_drum_head_collar_depth
   - bass_drum_head_surface_finish
   - bass_drum_head_type
   - color
@@ -14199,9 +16322,14 @@
   - drum_head_hoop_rim_material
   - drum_head_ply_count
   - drum_head_position
+  - drum_head_size
   - drum_head_surface_finish
   - head_side
+  - height
+  - length
   - pattern
+  - port_diameter
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -14227,8 +16355,12 @@
   - drum_head_ply_count
   - drum_head_position
   - drum_head_reinforcement_type
+  - drum_head_size
   - drum_head_surface_finish
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -14244,6 +16376,7 @@
   attributes:
   - color
   - drum_hardware_material
+  - drum_head_collar_depth
   - drum_head_collar_type
   - drum_head_damping_control
   - drum_head_film_material
@@ -14251,8 +16384,12 @@
   - drum_head_muffling_feature
   - drum_head_ply_count
   - drum_head_position
+  - drum_head_size
   - drum_head_surface_finish
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -14270,6 +16407,9 @@
   - compatible_percussion_instrument
   - drum_key_drive_type
   - drum_key_handle_style
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14287,6 +16427,9 @@
   - drum_key_drive_type
   - drum_key_handle_style
   - handle_grip_type
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14318,8 +16461,12 @@
   children: []
   attributes:
   - bass_drum_beater_head_shape
+  - bass_drum_beater_weight
   - beater_head_size
   - drum_hardware_material
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14337,9 +16484,13 @@
   - ae-2-7-12-5-2-4
   - ae-2-7-12-5-2-5
   attributes:
+  - compatible_tube_diameter
   - cymbal_arm_style
   - drum_hardware_material
   - drum_mount_clamp_type
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14352,12 +16503,16 @@
   name: Clamps
   children: []
   attributes:
+  - compatible_tube_diameter
   - cymbal_arm_style
   - drum_clamp_locking_mechanism
   - drum_clamp_mount_interface
   - drum_clamp_type
   - drum_hardware_material
   - drum_mount_clamp_type
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14370,11 +16525,16 @@
   name: Cymbal Arms
   children: []
   attributes:
+  - compatible_tube_diameter
+  - cymbal_arm_length
   - cymbal_arm_mounting_interface
   - cymbal_arm_rotation_positioning_features
   - cymbal_arm_style
   - drum_hardware_material
   - drum_mount_clamp_type
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14387,10 +16547,15 @@
   name: Multi-Clamps
   children: []
   attributes:
+  - clamp_rod_diameter
+  - compatible_tube_diameter
   - cymbal_arm_style
   - drum_hardware_material
   - drum_mount_clamp_type
   - drum_multi_clamp_clamp_type
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14403,10 +16568,15 @@
   name: Rack Systems
   children: []
   attributes:
+  - compatible_tube_diameter
   - cymbal_arm_style
   - drum_hardware_material
   - drum_mount_clamp_type
+  - drum_rack_tube_diameter
+  - height
+  - length
   - rack_system_configuration
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14419,12 +16589,16 @@
   name: Tom Mounts
   children: []
   attributes:
+  - compatible_tube_diameter
   - cymbal_arm_style
   - drum_mount_clamp_type
+  - height
+  - length
   - mount_material
   - tom_mount_adjustment_features
   - tom_mount_components_included
   - tom_mount_mounting_position
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14451,7 +16625,11 @@
   - drum_pedal_baseplate_type
   - drum_pedal_cam_type
   - drum_pedal_clamp_type
+  - drum_pedal_footboard_length
   - footboard_type
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14470,8 +16648,12 @@
   - drum_pedal_accessories_included
   - drum_pedal_baseplate_type
   - drum_pedal_clamp_type
+  - drum_pedal_footboard_length
   - drum_pedal_intended_use
   - footboard_type
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14489,10 +16671,15 @@
   - drum_hardware_material
   - drum_pedal_accessories_included
   - drum_pedal_baseplate_type
+  - drum_pedal_beater_shaft_length
   - drum_pedal_chain_configuration
   - drum_pedal_chain_type
   - drum_pedal_clamp_type
+  - drum_pedal_footboard_length
   - footboard_type
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14512,8 +16699,12 @@
   - drum_pedal_accessories_included
   - drum_pedal_baseplate_type
   - drum_pedal_clamp_type
+  - drum_pedal_footboard_length
   - drum_pedal_spring_adjustment_method
   - footboard_type
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14534,8 +16725,12 @@
   - drum_pedal_accessories_included
   - drum_pedal_baseplate_type
   - drum_pedal_clamp_type
+  - drum_pedal_footboard_length
   - drum_pedal_spring_type
   - footboard_type
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14555,7 +16750,11 @@
   - drum_pedal_baseplate_type
   - drum_pedal_bearing_type
   - drum_pedal_clamp_type
+  - drum_pedal_footboard_length
   - footboard_type
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14575,6 +16774,7 @@
   - drum_pedal_baseplate_type
   - drum_pedal_cam_type
   - drum_pedal_clamp_type
+  - drum_pedal_footboard_length
   - footboard_type
   return_reasons:
   - changed_my_mind
@@ -14594,6 +16794,7 @@
   - drum_pedal_baseplate_type
   - drum_pedal_cam_type
   - drum_pedal_clamp_type
+  - drum_pedal_footboard_length
   - footboard_type
   return_reasons:
   - changed_my_mind
@@ -14609,7 +16810,10 @@
   - ae-2-7-12-6-2
   attributes:
   - brush_material
+  - height
+  - length
   - mounting_method
+  - width
   return_reasons:
   - size
   - incompatible
@@ -14630,8 +16834,12 @@
   - care_instructions
   - carry_options
   - closure_type
+  - height
+  - length
+  - maximum_stick_length
   - mounting_attachment_method
   - mounting_method
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14671,7 +16879,10 @@
   - drumstick_model
   - drumstick_taper
   - grip_texture
+  - height
+  - length
   - percussion_tip_shape
+  - width
   return_reasons:
   - size
   - weight
@@ -14688,9 +16899,13 @@
   attributes:
   - bristle_stiffness
   - brush_material
+  - drum_brush_bristle_wire_length
   - drumstick_model
   - grip_texture
+  - height
+  - length
   - percussion_tip_shape
+  - width
   return_reasons:
   - length
   - weight
@@ -14707,7 +16922,10 @@
   - drum_hardware_material
   - drumstick_model
   - grip_texture
+  - height
+  - length
   - percussion_tip_shape
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -14728,10 +16946,13 @@
   - electronic_drum_module_audio_interface_functionality
   - electronic_drum_module_metronome_features
   - electronic_drum_module_sample_import_support
+  - height
   - input/output_ports
+  - length
   - midi_connectivity
   - sound_effects
   - trigger_input_connector
+  - width
   return_reasons:
   - size
   - incompatible
@@ -14748,10 +16969,13 @@
   - electronic_drum_module_audio_interface_functionality
   - electronic_drum_module_metronome_features
   - electronic_drum_module_power_source
+  - height
   - input/output_ports
+  - length
   - midi_connectivity
   - sound_effects
   - trigger_input_connector
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14766,12 +16990,15 @@
   attributes:
   - electronic_drum_module_audio_interface_functionality
   - electronic_drum_module_metronome_features
+  - height
   - input/output_ports
+  - length
   - midi_connectivity
   - sound_effects
   - sound_expansion_method
   - sound_module_sound_library_focus
   - trigger_input_connector
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14786,13 +17013,16 @@
   attributes:
   - electronic_drum_module_audio_interface_functionality
   - electronic_drum_module_metronome_features
+  - height
   - input/output_ports
+  - length
   - midi_connectivity
   - midi_output_type
   - sound_effects
   - trigger_input_connector
   - trigger_input_connector_type
   - trigger_input_zone_support
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14807,7 +17037,10 @@
   - ae-2-7-12-9-1
   - ae-2-7-12-9-2
   attributes:
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - size
   - incompatible
@@ -14829,6 +17062,11 @@
   - care_instructions
   - carry_options
   - closure_type
+  - height
+  - interior_length
+  - internal_height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14846,9 +17084,12 @@
   - ae-2-7-12-9-2-4
   attributes:
   - compatible_percussion_instrument
+  - height
+  - length
   - mount/stand_features
   - mount_material
   - orientation
+  - width
   return_reasons:
   - size
   - weight
@@ -14864,9 +17105,12 @@
   attributes:
   - compatible_percussion_instrument
   - hand_percussion_mount_attachment_mechanism
+  - height
+  - length
   - mount/stand_features
   - mount_material
   - orientation
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14880,9 +17124,12 @@
   children: []
   attributes:
   - compatible_percussion_instrument
+  - height
   - instrument_accessory_material
+  - length
   - mount/stand_features
   - orientation
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14896,9 +17143,12 @@
   children: []
   attributes:
   - compatible_percussion_instrument
+  - height
+  - length
   - mount/stand_features
   - mount_material
   - orientation
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14912,9 +17162,12 @@
   children: []
   attributes:
   - compatible_percussion_instrument
+  - height
   - instrument_accessory_material
+  - length
   - mount/stand_features
   - orientation
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14929,10 +17182,13 @@
   attributes:
   - grip_texture
   - handle_material
+  - height
+  - length
   - mallet_material
   - percussion_mallet_handle_grip_style
   - percussion_mallet_head_construction
   - percussion_tip_shape
+  - width
   return_reasons:
   - size
   - weight
@@ -14950,9 +17206,12 @@
   - ae-2-7-12-11-1
   attributes:
   - compatible_percussion_instrument
+  - height
   - instrument_accessory_material
+  - length
   - mount/stand_features
   - percussion_stand_design
+  - width
   return_reasons:
   - size
   - incompatible
@@ -14967,8 +17226,11 @@
   children: []
   attributes:
   - compatible_percussion_instrument
+  - height
   - instrument_accessory_material
+  - length
   - mount/stand_features
+  - width
   return_reasons:
   - size
   - weight
@@ -14986,7 +17248,10 @@
   - ae-2-7-13-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -15036,10 +17301,13 @@
   - battery_type
   - color
   - compatible_string_instrument
+  - height
+  - length
   - output_level
   - pattern
   - pickup_mounting_type
   - pickup_type
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -15062,9 +17330,12 @@
   - compatible_capo_fretboard_radius
   - compatible_capo_number_of_strings
   - compatible_string_instrument
+  - height
   - instrument_accessory_material
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15085,8 +17356,11 @@
   - compatible_capo_number_of_strings
   - compatible_string_instrument
   - fretboard_radius_fit
+  - height
   - instrument_accessory_material
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15106,10 +17380,13 @@
   - compatible_fingerboard_radius
   - compatible_neck_profile_width
   - compatible_string_instrument
+  - height
   - instrument_accessory_material
+  - length
   - partial_capo_covered_strings
   - pattern
   - string_coverage
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15128,8 +17405,12 @@
   - compatible_capo_fretboard_radius
   - compatible_capo_number_of_strings
   - compatible_string_instrument
+  - height
   - instrument_accessory_material
+  - length
+  - maximum_fretboard_width_supported
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15148,8 +17429,12 @@
   - compatible_capo_fretboard_radius
   - compatible_capo_number_of_strings
   - compatible_string_instrument
+  - height
   - instrument_accessory_material
+  - length
+  - maximum_compatible_neck_width
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15166,6 +17451,8 @@
   - battery_type
   - color
   - compatible_string_instrument
+  - height
+  - length
   - magnet_type
   - output_level
   - pattern
@@ -15175,6 +17462,7 @@
   - pickup_position
   - pickup_string_spacing
   - pickup_type
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -15197,9 +17485,15 @@
   - color
   - compatible_guitar_body_shape
   - compatible_string_instrument
+  - guitar_case_internal_depth
+  - guitar_case_internal_length
+  - guitar_case_internal_width
   - guitar_case_style
+  - height
+  - length
   - number_of_guitar_slots
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -15215,8 +17509,12 @@
   - compatible_string_instrument
   - guitar_bridge_system_type
   - guitar_fitting/part_type
+  - guitar_fitting_part_mounting_hole_spacing
   - guitar_tuning_peg_mounting_style
+  - height
   - instrument_part_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15236,9 +17534,12 @@
   - battery_type
   - compatible_string_instrument
   - guitar_humidifier_placement
+  - height
   - humidifier_design
   - humidifying_medium
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15256,10 +17557,14 @@
   - compatible_guitar_case
   - compatible_string_instrument
   - guitar_humidifier_placement
+  - height
   - humidifier_design
   - humidifier_refill_medium_type
   - humidifying_medium
   - instrument_accessory_material
+  - internal_fit_dimensions
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15274,9 +17579,12 @@
   attributes:
   - compatible_string_instrument
   - guitar_humidifier_placement
+  - height
   - humidifier_design
   - humidifying_medium
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15291,12 +17599,15 @@
   attributes:
   - compatible_string_instrument
   - guitar_humidifier_placement
+  - height
   - humidifier_design
   - humidifier_features
   - humidifier_refill_method
   - humidifying_medium
   - instrument_accessory_material
+  - length
   - target_relative_humidity_rh
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15314,11 +17625,14 @@
   attributes:
   - color
   - grip_texture
+  - height
   - instrument_accessory_material
+  - length
   - pattern
   - pick_design
   - pick_grip_aid
   - thickness_type
+  - width
   return_reasons:
   - size
   - color
@@ -15340,11 +17654,14 @@
   - finger_pick_size
   - finger_pick_wear_location
   - grip_texture
+  - height
   - instrument_accessory_material
+  - length
   - pattern
   - pick_design
   - pick_grip_aid
   - thickness_type
+  - width
   return_reasons:
   - size
   - color
@@ -15361,12 +17678,15 @@
   attributes:
   - color
   - grip_texture
+  - height
   - instrument_accessory_material
+  - length
   - pattern
   - pick_design
   - pick_grip_aid
   - thickness_type
   - tip_shape
+  - width
   return_reasons:
   - size
   - color
@@ -15404,9 +17724,12 @@
   - compatible_string_instrument
   - guitar_slide_finish
   - guitar_slide_style
+  - height
   - instrument_accessory_material
+  - length
   - pattern
   - slide_intended_finger
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -15422,10 +17745,13 @@
   - color
   - compatible_string_instrument
   - guitar_stand_type
+  - height
   - instrument_accessory_material
+  - length
   - mount/stand_features
   - music_stand_design
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -15442,10 +17768,15 @@
   - guitar_strap_attachment_type
   - guitar_strap_end_material
   - guitar_strap_features
+  - height
   - instrument_accessory_material
+  - length
+  - padding_thickness
   - pattern
   - strap_design
+  - strap_maximum_length
   - strap_padding
+  - width
   return_reasons:
   - size
   - color
@@ -15463,6 +17794,9 @@
   - ae-2-7-13-1-11-2
   attributes:
   - compatible_string_instrument
+  - height
+  - length
+  - width
   - winder_features
   return_reasons:
   - incompatible
@@ -15476,11 +17810,17 @@
   name: Electric String Winders
   children: []
   attributes:
+  - amperage
   - battery_size
   - battery_type
   - compatible_string_instrument
   - compatible_winder_head_bit
+  - height
   - included_accessories
+  - length
+  - power_consumption_typical
+  - voltage
+  - width
   - winder_features
   - winding_speed_control_type
   return_reasons:
@@ -15496,6 +17836,9 @@
   children: []
   attributes:
   - compatible_string_instrument
+  - height
+  - length
+  - width
   - winder_features
   return_reasons:
   - incompatible
@@ -15516,8 +17859,11 @@
   - guitar_string_coating
   - guitar_string_set_gauge_category
   - guitar_string_winding_type
+  - height
   - instrument_string_material
+  - length
   - string_end_type
+  - width
   return_reasons:
   - gauge
   - incompatible
@@ -15536,10 +17882,13 @@
   - guitar_string_coating
   - guitar_string_gauge_type
   - guitar_string_set_gauge_category
+  - height
   - instrument_string_material
+  - length
   - packaging_format
   - string_end_type
   - string_set_type
+  - width
   - winding_type
   return_reasons:
   - gauge
@@ -15559,8 +17908,11 @@
   - core_type_bass_strings
   - guitar_string_coating
   - guitar_string_set_gauge_category
+  - height
   - instrument_string_material
+  - length
   - string_end_type
+  - width
   - winding_type
   return_reasons:
   - gauge
@@ -15582,8 +17934,11 @@
   - compatible_classical_guitar_string_scale_length
   - guitar_string_coating
   - guitar_string_set_gauge_category
+  - height
   - instrument_string_material
+  - length
   - string_end_type
+  - width
   return_reasons:
   - gauge
   - sound_quality
@@ -15601,9 +17956,12 @@
   - compatible_scale_length
   - guitar_string_coating
   - guitar_string_set_gauge_category
+  - height
   - instrument_string_material
+  - length
   - string_core_shape
   - string_end_type
+  - width
   return_reasons:
   - gauge
   - sound_quality
@@ -15618,12 +17976,20 @@
   name: Guitar Tuning Pegs
   children: []
   attributes:
+  - compatible_headstock_thickness
   - compatible_string_instrument
+  - guitar_tuning_peg_bushing_outer_diameter
   - guitar_tuning_peg_button_shape
   - guitar_tuning_peg_configuration
+  - guitar_tuning_peg_post_height
   - guitar_tuning_peg_shaft_type
   - guitar_tuning_peg_style
+  - height
   - instrument/accessory_finish
+  - length
+  - mounting_screw_hole_spacing
+  - tuning_peg_post_diameter
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15696,6 +18062,9 @@
   - carry_options
   - closure_type
   - compatible_orchestral_string_instrument
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -15717,6 +18086,9 @@
   - carry_options
   - closure_type
   - compatible_orchestral_string_instrument
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15738,6 +18110,9 @@
   - carry_options
   - closure_type
   - compatible_orchestral_string_instrument
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15759,6 +18134,9 @@
   - carry_options
   - closure_type
   - compatible_orchestral_string_instrument
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15777,7 +18155,10 @@
   - bow_winding_material
   - compatible_orchestral_string_instrument
   - frog_material
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15799,7 +18180,10 @@
   - closure_type
   - color
   - compatible_orchestral_string_instrument
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -15814,11 +18198,14 @@
   children: []
   attributes:
   - compatible_orchestral_string_instrument
+  - height
   - instrument/accessory_finish
   - instrument_part_material
   - instrument_part_mounting_method
+  - length
   - orchestral_string_instrument_fitting_part_type
   - orchestral_string_instrument_part_position
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15832,8 +18219,12 @@
   children: []
   attributes:
   - compatible_orchestral_string_instrument
+  - height
   - instrument_accessory_material
+  - length
+  - mute_weight
   - orchestral_string_instrument_mute_type
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -15851,9 +18242,12 @@
   - battery_type
   - color
   - compatible_orchestral_string_instrument
+  - height
+  - length
   - pattern
   - pickup_design
   - pickup_type
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -15868,9 +18262,12 @@
   children: []
   attributes:
   - compatible_orchestral_string_instrument
+  - height
   - instrument_accessory_material
+  - length
   - music_stand_design
   - stand_padding_material
+  - width
   return_reasons:
   - size
   - weight
@@ -15885,13 +18282,16 @@
   children: []
   attributes:
   - compatible_orchestral_string_instrument
+  - height
   - instrument_string_material
+  - length
   - orchestral_string_core_material
   - orchestral_string_end_type
   - orchestral_string_included_strings
   - orchestral_string_winding_material
   - string_set_type
   - tension
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -15926,12 +18326,14 @@
   children: []
   attributes:
   - instrument_accessory_material
+  - net_rosin_weight
   - package_type
   - rosin_dust_level
   - rosin_form
   - rosin_formula_additives
   - rosin_grade
   - rosin_hardness
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15945,7 +18347,10 @@
   children: []
   attributes:
   - accessory_size
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -15963,6 +18368,7 @@
   attributes:
   - application_method
   - ingredient_origin
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15979,6 +18385,7 @@
   - compatible_wood
   - ingredient_origin
   - polish_formulation
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15997,6 +18404,7 @@
   - compatible_string_instrument_finish
   - ingredient_origin
   - polish_purpose
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16013,6 +18421,7 @@
   - ingredient_origin
   - varnish_formulation_base
   - varnish_transparency_tint
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16060,7 +18469,10 @@
   - ae-2-7-14-1-6
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -16075,7 +18487,10 @@
   children:
   - ae-2-7-14-1-1-1
   attributes:
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16088,9 +18503,13 @@
   name: Bassoon Swabs
   children: []
   attributes:
+  - height
+  - length
+  - swab_head_diameter
   - swab_intended_bassoon_section
   - swab_material
   - swab_weight_style
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16108,11 +18527,17 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_case_carrying_style
+  - bassoon_case_interior_height
+  - bassoon_case_interior_length
+  - bassoon_case_interior_width
   - bassoon_case_shell_type
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16127,7 +18552,10 @@
   - ae-2-7-14-1-3-1
   - ae-2-7-14-1-3-2
   attributes:
+  - height
   - instrument_part_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16141,7 +18569,12 @@
   children: []
   attributes:
   - bassoon_bocal_system
+  - bassoon_bocal_tenon_diameter
+  - bassoon_bocal_tip_opening_diameter
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16154,7 +18587,10 @@
   name: Bassoon Small Parts
   children: []
   attributes:
+  - height
   - instrument_part_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16171,8 +18607,11 @@
   - ae-2-7-14-1-4-3
   - ae-2-7-14-1-4-4
   attributes:
+  - height
   - instrument_accessory_material
+  - length
   - reed_strength
+  - width
   return_reasons:
   - strength
   - changed_my_mind
@@ -16185,9 +18624,15 @@
   name: Filed Reeds
   children: []
   attributes:
+  - bassoon_reed_length
   - bassoon_reed_thread_color
+  - bassoon_reed_tip_opening
+  - bassoon_reed_width
+  - height
   - instrument_accessory_material
+  - length
   - reed_strength
+  - width
   return_reasons:
   - strength
   - changed_my_mind
@@ -16201,9 +18646,13 @@
   children: []
   attributes:
   - bassoon_reed_scrape_style
+  - bassoon_reed_staple_length
   - bassoon_reed_type
+  - height
   - instrument_accessory_material
+  - length
   - reed_strength
+  - width
   return_reasons:
   - strength
   - changed_my_mind
@@ -16216,8 +18665,11 @@
   name: Machine-Made Reeds
   children: []
   attributes:
+  - height
   - instrument_accessory_material
+  - length
   - reed_strength
+  - width
   return_reasons:
   - strength
   - changed_my_mind
@@ -16230,8 +18682,11 @@
   name: Unfiled Reeds
   children: []
   attributes:
+  - height
   - instrument_accessory_material
+  - length
   - reed_strength
+  - width
   return_reasons:
   - strength
   - changed_my_mind
@@ -16244,9 +18699,12 @@
   name: Bassoon Stands
   children: []
   attributes:
+  - height
   - instrument_accessory_material
+  - length
   - mount/stand_features
   - music_stand_design
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16260,11 +18718,14 @@
   children: []
   attributes:
   - color
+  - height
   - instrument_accessory_material
   - instrument_support_type
+  - length
   - padding_level
   - pattern
   - player_size_range
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16285,7 +18746,10 @@
   - ae-2-7-14-2-7
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -16303,7 +18767,10 @@
   - ae-2-7-14-2-1-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16317,6 +18784,9 @@
   children: []
   attributes:
   - clarinet_care_kit_intended_use
+  - height
+  - length
+  - width
   - woodwind_care_items_included
   return_reasons:
   - changed_my_mind
@@ -16330,8 +18800,11 @@
   children: []
   attributes:
   - color
+  - height
   - instrument_accessory_material
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16344,7 +18817,10 @@
   name: Clarinet Swabs
   children: []
   attributes:
+  - height
+  - length
   - swab_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16363,8 +18839,14 @@
   - bag/case_storage_features
   - care_instructions
   - carry_options
+  - clarinet_case_interior_height
+  - clarinet_case_interior_length
+  - clarinet_case_interior_width
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16381,7 +18863,10 @@
   - ae-2-7-14-2-3-3
   attributes:
   - compatible_clarinet_type
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16396,8 +18881,11 @@
   attributes:
   - clarinet_cap_style
   - compatible_clarinet_type
+  - height
   - instrument_accessory_material
+  - length
   - ligature_plating_or_finish
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16411,9 +18899,12 @@
   children: []
   attributes:
   - compatible_clarinet_type
+  - height
   - instrument_accessory_material
+  - length
   - ligature_reed_contact_style
   - ligature_tension_adjustment_mechanism
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16428,9 +18919,12 @@
   attributes:
   - compatible_clarinet_type
   - compatible_reed_cut
+  - height
   - instrument_accessory_material
+  - length
   - ligature_screw_position_relative_to_reed
   - ligature_tightening_mechanism_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16448,7 +18942,10 @@
   - ae-2-7-14-2-4-4
   attributes:
   - compatible_clarinet_type
+  - height
   - instrument_part_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16462,7 +18959,10 @@
   children: []
   attributes:
   - compatible_clarinet_type
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16478,11 +18978,16 @@
   - ae-2-7-14-2-4-2-2
   attributes:
   - clarinet_bell_acoustic_design
+  - clarinet_bell_opening_diameter
   - clarinet_bell_ring_material
+  - clarinet_bell_throat_tenon_diameter
   - compatible_clarinet_type
+  - height
   - instrument/accessory_finish
   - instrument_accessory_material
+  - length
   - lumber/wood_type
+  - width
   - wood_finish
   return_reasons:
   - incompatible
@@ -16498,11 +19003,17 @@
   attributes:
   - clarinet_bell_acoustic_design
   - clarinet_bell_adjustment_mechanism
+  - clarinet_bell_opening_diameter
   - clarinet_bell_ring_material
+  - clarinet_bell_throat_tenon_diameter
   - clarinet_bell_tuning_effect
+  - clarinet_bell_weight
   - compatible_clarinet_type
+  - height
   - instrument/accessory_finish
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - size
   - incompatible
@@ -16517,10 +19028,15 @@
   children: []
   attributes:
   - clarinet_bell_acoustic_design
+  - clarinet_bell_opening_diameter
   - clarinet_bell_ring_material
+  - clarinet_bell_throat_tenon_diameter
   - compatible_clarinet_type
+  - height
   - instrument/accessory_finish
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - size
   - incompatible
@@ -16543,10 +19059,13 @@
   - compatible_clarinet_mouthpiece_ligature
   - compatible_clarinet_type
   - compatible_mouthpiece_patch
+  - height
   - instrument_accessory_material
+  - length
   - mouthpiece_facing_length
   - pattern
   - tip_opening
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16560,7 +19079,10 @@
   children: []
   attributes:
   - compatible_clarinet_type
+  - height
   - instrument_part_material
+  - length
+  - width
   - woodwind_small_part_type
   return_reasons:
   - incompatible
@@ -16575,9 +19097,12 @@
   children: []
   attributes:
   - compatible_clarinet_type
+  - height
   - instrument_accessory_material
+  - length
   - music_stand_design
   - protective_contact_padding_material
+  - width
   return_reasons:
   - size
   - weight
@@ -16593,8 +19118,11 @@
   attributes:
   - clarinet_reed_cut
   - clarinet_reed_material_type
+  - height
   - instrument_accessory_material
+  - length
   - reed_strength
+  - width
   return_reasons:
   - strength
   - changed_my_mind
@@ -16608,10 +19136,13 @@
   children: []
   attributes:
   - compatible_clarinet_type
+  - height
   - instrument_accessory_material
   - instrument_support_type
+  - length
   - strap_attachment_hardware
   - support_padding
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16629,7 +19160,10 @@
   - ae-2-7-14-3-4
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -16647,7 +19181,10 @@
   - ae-2-7-14-3-1-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16660,6 +19197,10 @@
   name: Flute Care Kits
   children: []
   attributes:
+  - cleaning_rod_length
+  - height
+  - length
+  - width
   - woodwind_care_items_included
   return_reasons:
   - changed_my_mind
@@ -16673,7 +19214,10 @@
   children: []
   attributes:
   - flute_cleaning_rod_tip_type
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16686,8 +19230,12 @@
   name: Flute Swabs
   children: []
   attributes:
+  - height
   - instrument_cleaning_swab_form_factor
+  - length
+  - swab_length
   - swab_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16707,6 +19255,10 @@
   - care_instructions
   - carry_options
   - flute_case_capacity
+  - flute_case_interior_length
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16721,7 +19273,10 @@
   - ae-2-7-14-3-3-1
   - ae-2-7-14-3-3-2
   attributes:
+  - height
   - instrument_part_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16739,8 +19294,13 @@
   - embouchure_hole_shape
   - headjoint_crown_style
   - headjoint_pitch_standard
+  - headjoint_wall_thickness
+  - height
   - instrument_accessory_material
+  - length
   - lip_plate_material
+  - tenon_diameter
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16756,8 +19316,13 @@
   - embouchure_hole_shape
   - headjoint_crown_style
   - headjoint_pitch_standard
+  - headjoint_wall_thickness
+  - height
   - instrument_accessory_material
+  - length
   - lip_plate_material
+  - tenon_diameter
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16774,8 +19339,13 @@
   - flute_headjoint_cork_type
   - headjoint_crown_style
   - headjoint_pitch_standard
+  - headjoint_wall_thickness
+  - height
   - instrument_accessory_material
+  - length
   - lip_plate_material
+  - tenon_diameter
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16789,7 +19359,10 @@
   children: []
   attributes:
   - compatible_flute_type
+  - height
   - instrument_part_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16803,7 +19376,10 @@
   children: []
   attributes:
   - compatible_flute_type
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - size
   - weight
@@ -16821,8 +19397,11 @@
   attributes:
   - battery_size
   - battery_type
+  - height
   - instrument_accessory_material
+  - length
   - lumber/wood_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -16843,7 +19422,10 @@
   - bag/case_storage_features
   - care_instructions
   - carry_options
+  - height
+  - length
   - protection_level
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16859,7 +19441,10 @@
   - ae-2-7-14-4-2-2
   attributes:
   - compatible_harmonica_type
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16873,9 +19458,12 @@
   children: []
   attributes:
   - compatible_harmonica_type
+  - height
   - instrument_accessory_material
+  - length
   - lumber/wood_type
   - material
+  - width
   - wood_finish
   return_reasons:
   - incompatible
@@ -16890,7 +19478,10 @@
   children: []
   attributes:
   - compatible_harmonica_type
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16910,7 +19501,10 @@
   - ae-2-7-14-5-6
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -16927,7 +19521,10 @@
   - ae-2-7-14-5-1-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16940,7 +19537,10 @@
   name: Oboe Care Kits
   children: []
   attributes:
+  - height
   - kit_pouch_case_type
+  - length
+  - width
   - woodwind_care_items_included
   return_reasons:
   - changed_my_mind
@@ -16953,9 +19553,13 @@
   name: Oboe Swabs
   children: []
   attributes:
+  - height
+  - length
   - oboe_swab_style
+  - swab_cord_length
   - swab_material
   - swab_weight_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16974,10 +19578,16 @@
   - bag/case_storage_features
   - care_instructions
   - carry_options
+  - height
+  - length
   - oboe_case_capacity
   - oboe_case_carry_configuration
   - oboe_case_design
+  - oboe_case_interior_height
+  - oboe_case_interior_length
+  - oboe_case_interior_width
   - oboe_case_internal_fit_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16992,7 +19602,10 @@
   - ae-2-7-14-5-3-1
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -17006,7 +19619,10 @@
   children: []
   attributes:
   - compatible_oboe_type
+  - height
   - instrument_part_material
+  - length
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17022,7 +19638,10 @@
   attributes:
   - compatible_oboe_type
   - contact_surface_material
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -17035,8 +19654,11 @@
   name: Oboe Reeds
   children: []
   attributes:
+  - height
   - instrument_accessory_material
+  - length
   - reed_strength
+  - width
   return_reasons:
   - strength
   - changed_my_mind
@@ -17050,8 +19672,11 @@
   children: []
   attributes:
   - compatible_oboe_type
+  - height
   - instrument_accessory_material
+  - length
   - oboe_strap_padding
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -17069,7 +19694,10 @@
   attributes:
   - color
   - compatible_recorder_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17085,7 +19713,10 @@
   attributes:
   - color
   - compatible_recorder_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -17106,7 +19737,10 @@
   - carry_options
   - compatible_recorder_size
   - compatible_recorder_type
+  - height
+  - length
   - recorder_case_shell_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -17120,7 +19754,10 @@
   children: []
   attributes:
   - compatible_recorder_type
+  - height
   - instrument_part_material
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -17141,7 +19778,10 @@
   - ae-2-7-14-7-7
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17159,7 +19799,10 @@
   - ae-2-7-14-7-1-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -17172,7 +19815,10 @@
   name: Saxophone Care Kits
   children: []
   attributes:
+  - height
   - kit_format
+  - length
+  - width
   - woodwind_care_items_included
   return_reasons:
   - changed_my_mind
@@ -17186,8 +19832,12 @@
   children: []
   attributes:
   - compatible_saxophone_type
+  - height
   - instrument_accessory_material
+  - length
+  - pad_saver_diameter
   - pad_saver_style
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17202,10 +19852,14 @@
   children: []
   attributes:
   - cord_material
+  - height
+  - length
   - pull_through_weight_material
   - saxophone_swab_application_area
+  - saxophone_swab_length
   - swab_material
   - swab_style
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -17224,6 +19878,9 @@
   - bag/case_storage_features
   - care_instructions
   - carry_options
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -17238,9 +19895,12 @@
   attributes:
   - cap_attachment_style
   - compatible_saxophone_type
+  - height
   - instrument/accessory_finish
+  - length
   - ligature_and_cap_component_type
   - ligature_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -17260,9 +19920,12 @@
   - battery_type
   - color
   - compatible_saxophone_size
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - incompatible
@@ -17285,9 +19948,13 @@
   - compatible_reed_type
   - compatible_saxophone_size
   - facing_length
+  - height
   - instrument_accessory_material
+  - length
+  - mouthpiece_tip_opening
   - saxophone_mouthpiece_baffle_type
   - tip_opening
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17305,9 +19972,13 @@
   - compatible_reed_type
   - compatible_saxophone_size
   - facing_length
+  - height
   - instrument_accessory_material
+  - length
+  - mouthpiece_tip_opening
   - saxophone_mouthpiece_baffle_type
   - tip_opening
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17325,9 +19996,13 @@
   - compatible_reed_type
   - compatible_saxophone_size
   - facing_length
+  - height
   - instrument_accessory_material
+  - length
+  - mouthpiece_tip_opening
   - saxophone_mouthpiece_baffle_type
   - tip_opening
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17345,14 +20020,19 @@
   - compatible_reed_type
   - compatible_saxophone_size
   - facing_length
+  - height
   - instrument_accessory_material
+  - length
+  - mouthpiece_tip_opening
   - saxophone_mouthpiece_baffle_type
   - soprano_saxophone_mouthpiece_baffle_type
   - soprano_saxophone_mouthpiece_chamber_size
   - soprano_saxophone_mouthpiece_finish
   - soprano_saxophone_mouthpiece_included_accessories
+  - soprano_saxophone_mouthpiece_table_length
   - soprano_saxophone_mouthpiece_tonal_character
   - tip_opening
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17370,9 +20050,13 @@
   - compatible_reed_type
   - compatible_saxophone_size
   - facing_length
+  - height
   - instrument_accessory_material
+  - length
+  - mouthpiece_tip_opening
   - saxophone_mouthpiece_baffle_type
   - tip_opening
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17391,6 +20075,7 @@
   - compatible_saxophone_size
   - facing_length
   - instrument_accessory_material
+  - mouthpiece_tip_opening
   - saxophone_mouthpiece_baffle_type
   - tip_opening
   return_reasons:
@@ -17405,7 +20090,11 @@
   children: []
   attributes:
   - compatible_saxophone_size
+  - height
   - instrument_accessory_material
+  - length
+  - saxophone_neck_bore_diameter
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17420,9 +20109,12 @@
   children: []
   attributes:
   - compatible_saxophone_size
+  - height
   - instrument_part_material
+  - length
   - saxophone_small_part_thread_size
   - spring_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17436,7 +20128,10 @@
   name: Saxophone Pegs & Stands
   children: []
   attributes:
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -17449,11 +20144,14 @@
   name: Saxophone Reeds
   children: []
   attributes:
+  - height
   - instrument_accessory_material
+  - length
   - reed_strength
   - saxophone_reed_cut
   - saxophone_reed_material_type
   - saxophone_reed_strength_scale
+  - width
   return_reasons:
   - strength
   - changed_my_mind
@@ -17466,7 +20164,10 @@
   name: Saxophone Straps & Supports
   children: []
   attributes:
+  - height
   - instrument_accessory_material
+  - length
+  - width
   return_reasons:
   - size
   - weight
@@ -17483,6 +20184,7 @@
   attributes:
   - cork_grease_base_material
   - cork_grease_form
+  - volume
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -17495,7 +20197,10 @@
   children: []
   attributes:
   - cloth_thickness
+  - height
   - instrument_accessory_material
+  - length
+  - width
   - woodwind_polishing_cloth_intended_use
   return_reasons:
   - changed_my_mind
@@ -17509,6 +20214,9 @@
   children: []
   attributes:
   - bag/case_material
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -17523,6 +20231,9 @@
   attributes:
   - blade_material
   - handle_material
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -17543,7 +20254,10 @@
   - ae-2-8-7
   - ae-2-8-8
   attributes:
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17559,7 +20273,10 @@
   - ae-2-8-1-2
   attributes:
   - free_reed_instrument_orientation
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - color
   - sound_quality
@@ -17576,7 +20293,10 @@
   - accordion_tuning
   - bass_button_configuration
   - free_reed_instrument_orientation
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - color
   - sound_quality
@@ -17592,7 +20312,10 @@
   attributes:
   - concertina_button_configuration
   - free_reed_instrument_orientation
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - color
   - sound_quality
@@ -17615,8 +20338,11 @@
   - bagpipes_playing_mode
   - chanter_type
   - finger_hole_configuration
+  - height
   - instrument_material
+  - length
   - reed_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17639,9 +20365,12 @@
   - great_highland_bagpipes_blowpipe_valve_type
   - great_highland_bagpipes_drone_configuration
   - great_highland_bagpipes_mounting_material
+  - height
   - instrument_material
+  - length
   - reed_type
   - reeds_included
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17659,9 +20388,12 @@
   - bagpipes_playing_mode
   - chanter_type
   - finger_hole_configuration
+  - height
   - instrument_material
   - irish_warpipe_set_configuration
+  - length
   - reed_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17679,8 +20411,11 @@
   - bellows_orientation
   - chanter_type
   - finger_hole_configuration
+  - height
   - instrument_material
+  - length
   - reed_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17698,11 +20433,14 @@
   - blowpipe_valve_type
   - chanter_type
   - finger_hole_configuration
+  - height
   - instrument_material
+  - length
   - reed_type
   - scottish_smallpipes_bag_material
   - scottish_smallpipes_drone_tuning_configuration
   - scottish_smallpipes_reed_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17720,11 +20458,14 @@
   - bellows_material
   - chanter_type
   - finger_hole_configuration
+  - height
   - instrument_material
+  - length
   - reed_type
   - uilleann_pipes_bag_material
   - uilleann_pipes_handedness
   - uilleann_pipes_set_configuration
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17743,8 +20484,13 @@
   - ae-2-8-3-5
   - ae-2-8-3-6
   attributes:
+  - bell_diameter
+  - bore_size
   - brass_instrument_valve_configuration
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17760,11 +20506,16 @@
   - ae-2-8-3-1-2
   - ae-2-8-3-1-3
   attributes:
+  - bell_diameter
   - bell_size
+  - bore_size
   - brass_instrument_valve_configuration
+  - height
   - instrument_material
   - intended_use
+  - length
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17777,11 +20528,16 @@
   name: Alto Horns
   children: []
   attributes:
+  - bell_diameter
   - bell_size
+  - bore_size
   - brass_instrument_valve_configuration
+  - height
   - instrument_material
+  - length
   - mouthpiece_shank_type
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17794,12 +20550,17 @@
   name: Baritone Horns
   children: []
   attributes:
+  - bell_diameter
   - bell_size
+  - bore_size
   - brass_instrument_valve_configuration
+  - height
   - included_accessories
   - instrument_material
+  - length
   - mouthpiece_shank_type
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17812,11 +20573,16 @@
   name: Mellophones
   children: []
   attributes:
+  - bell_diameter
   - bell_size
+  - bore_size
   - brass_instrument_valve_configuration
   - compatible_mouthpiece_type
+  - height
   - instrument_material
+  - length
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17829,12 +20595,17 @@
   name: Euphoniums
   children: []
   attributes:
+  - bell_diameter
   - bell_size
+  - bore_size
   - brass_instrument_valve_configuration
   - euphonium_included_accessories
   - euphonium_valve_configuration
+  - height
   - instrument_material
+  - length
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17849,13 +20620,18 @@
   - ae-2-8-3-3-1
   - ae-2-8-3-3-2
   attributes:
+  - bell_diameter
   - bell_size
+  - bore_size
   - brass_instrument_valve_configuration
   - french_horn_bell_type
   - french_horn_included_accessories
   - french_horn_wrap_type
+  - height
   - instrument_material
+  - length
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17868,7 +20644,9 @@
   name: Double French Horns
   children: []
   attributes:
+  - bell_diameter
   - bell_size
+  - bore_size
   - brass_instrument_valve_configuration
   - french_horn_bell_construction
   - french_horn_bell_material
@@ -17876,8 +20654,11 @@
   - french_horn_included_accessories
   - french_horn_leadpipe_material
   - french_horn_wrap_type
+  - height
   - instrument_material
+  - length
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17890,14 +20671,19 @@
   name: Single French Horns
   children: []
   attributes:
+  - bell_diameter
   - bell_size
+  - bore_size
   - brass_instrument_valve_configuration
   - french_horn_bell_type
   - french_horn_finish
   - french_horn_included_accessories
   - french_horn_wrap_type
+  - height
   - instrument_material
+  - length
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17912,10 +20698,15 @@
   - ae-2-8-3-4-1
   - ae-2-8-3-4-2
   attributes:
+  - bell_diameter
   - bell_size
+  - bore_size
   - brass_instrument_valve_configuration
+  - height
   - instrument_material
+  - length
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17930,12 +20721,17 @@
   attributes:
   - bass_trombone_slide_material
   - bass_trombone_valve_wrap_style
+  - bell_diameter
   - bell_size
+  - bore_size
   - brass_instrument_valve_configuration
   - handslide_bore_type
+  - height
   - instrument_material
+  - length
   - tuning_pitch
   - valve_configuration
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17948,13 +20744,18 @@
   name: Tenor Trombones
   children: []
   attributes:
+  - bell_diameter
   - bell_size
+  - bore_size
   - brass_instrument_valve_configuration
+  - height
   - instrument_material
+  - length
   - mouthpiece_shank_size
   - tenor_trombone_slide_type
   - tenor_trombone_valve_configuration
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17970,10 +20771,15 @@
   - ae-2-8-3-5-2
   - ae-2-8-3-5-3
   attributes:
+  - bell_diameter
   - bell_size
+  - bore_size
   - brass_instrument_valve_configuration
+  - height
   - instrument_material
+  - length
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -17986,11 +20792,16 @@
   name: Cornets
   children: []
   attributes:
+  - bell_diameter
   - bell_size
+  - bore_size
   - brass_instrument_valve_configuration
   - cornet_mouthpiece_shank_type
+  - height
   - instrument_material
+  - length
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -18003,14 +20814,19 @@
   name: Flugelhorns
   children: []
   attributes:
+  - bell_diameter
   - bell_material
   - bell_size
+  - bore_size
   - brass_instrument_valve_configuration
   - flugelhorn_leadpipe_material
   - flugelhorn_trigger_type
+  - height
   - instrument_material
+  - length
   - mouthpiece_shank_receiver_size
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -18023,12 +20839,17 @@
   name: Trumpets
   children: []
   attributes:
+  - bell_diameter
   - bell_size
+  - bore_size
   - brass_instrument_valve_configuration
+  - height
   - instrument_material
+  - length
   - trumpet_bell_material
   - trumpet_leadpipe_material
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -18042,11 +20863,16 @@
   children:
   - ae-2-8-3-6-1
   attributes:
+  - bell_diameter
   - bell_size
+  - bore_size
   - brass_instrument_valve_configuration
+  - height
   - instrument_material
+  - length
   - tuba_leadpipe_material
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -18059,11 +20885,17 @@
   name: Sousaphones
   children: []
   attributes:
+  - bell_diameter
   - bell_size
+  - bore_size
   - brass_instrument_valve_configuration
+  - height
   - instrument_material
+  - length
+  - sousaphone_weight
   - tuba_leadpipe_material
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -18082,7 +20914,10 @@
   attributes:
   - battery_size
   - battery_type
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18100,7 +20935,12 @@
   attributes:
   - battery_size
   - battery_type
+  - height
   - instrument_material
+  - length
+  - memory_capacity
+  - sampling_rate
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18114,8 +20954,13 @@
   name: Drum Samplers
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
+  - memory_capacity
+  - sampling_rate
   - storage_media_and_transfer_methods_supported
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18133,7 +20978,13 @@
   - audio_outputs
   - groove_sampler_onboard_effects
   - groove_sampler_storage_expansion_type
+  - groove_sampler_weight
+  - height
   - instrument_material
+  - length
+  - memory_capacity
+  - sampling_rate
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18152,8 +21003,11 @@
   - aftertouch_support
   - battery_size
   - battery_type
+  - height
   - instrument_material
   - interface_type
+  - length
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18168,8 +21022,11 @@
   children: []
   attributes:
   - aftertouch_support
+  - height
   - instrument_material
   - interface_type
+  - length
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18185,10 +21042,13 @@
   attributes:
   - aftertouch_support
   - compatible_host_platform
+  - height
   - instrument_material
   - interface_type
+  - length
   - pad_controller_additional_control
   - pad_controller_performance_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18207,10 +21067,13 @@
   attributes:
   - battery_size
   - battery_type
+  - height
   - instrument_material
   - interface_type
   - keyboard_key_type
   - keyboard_power_supply_type
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18227,10 +21090,13 @@
   attributes:
   - battery_size
   - battery_type
+  - height
   - instrument_material
   - interface_type
   - keyboard_key_type
   - keyboard_power_supply_type
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18245,10 +21111,13 @@
   name: Stage Pianos
   children: []
   attributes:
+  - height
   - instrument_material
   - interface_type
   - keyboard_key_type
   - keyboard_power_supply_type
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18265,10 +21134,14 @@
   attributes:
   - battery_size
   - battery_type
+  - height
   - instrument_material
   - interface_type
   - keyboard_key_type
   - keyboard_power_supply_type
+  - keyboard_weight
+  - length
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18289,10 +21162,13 @@
   - battery_size
   - battery_type
   - control_voltage_or_gate_connectivity
+  - height
   - instrument_material
+  - length
   - polyphony
   - synthesis_method
   - synthesizer_form_factor
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18309,11 +21185,14 @@
   - analog_synthesizer_cv_gate_i_o
   - analog_synthesizer_keybed_configuration
   - control_voltage_or_gate_connectivity
+  - height
   - instrument_material
+  - length
   - polyphony
   - sound_synthesizer_patch_memory
   - synthesis_method
   - synthesizer_form_factor
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18328,10 +21207,13 @@
   children: []
   attributes:
   - control_voltage_or_gate_connectivity
+  - height
   - instrument_material
+  - length
   - polyphony
   - synthesis_method
   - synthesizer_form_factor
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18346,10 +21228,13 @@
   children: []
   attributes:
   - control_voltage_or_gate_connectivity
+  - height
   - instrument_material
+  - length
   - polyphony
   - synthesis_method
   - synthesizer_form_factor
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18364,11 +21249,14 @@
   children: []
   attributes:
   - control_voltage_or_gate_connectivity
+  - height
   - instrument_material
+  - length
   - polyphony
   - synthesis_method
   - synthesizer_form_factor
   - virtual_analog_synthesizer_form_factor
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18393,7 +21281,10 @@
   - ae-2-8-5-10
   - ae-2-8-5-11
   attributes:
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18412,8 +21303,12 @@
   - bass_drum_head_configuration
   - bass_drum_hoop_material
   - bass_drum_mounting_style
+  - diameter
+  - height
   - instrument_material
+  - length
   - shell_construction
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18431,8 +21326,12 @@
   - bass_drum_hoop_material
   - bass_drum_mounting_style
   - concert_bass_drum_mounting_stand_type
+  - diameter
+  - height
   - instrument_material
+  - length
   - shell_construction
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18449,9 +21348,14 @@
   - bass_drum_head_configuration
   - bass_drum_hoop_material
   - bass_drum_mounting_style
+  - diameter
   - drum_head_type
+  - height
   - instrument_material
+  - length
+  - marching_bass_drum_weight
   - shell_construction
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18475,8 +21379,15 @@
   - ae-2-8-5-2-9
   - ae-2-8-5-2-10
   attributes:
+  - cymbal_bell_size
+  - cymbal_thickness
   - cymbal_weight_class
+  - diameter
+  - height
   - instrument_material
+  - length
+  - mounting_hole_diameter
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18492,8 +21403,15 @@
   attributes:
   - china_cymbal_edge_shape
   - china_cymbal_sound_character
+  - cymbal_bell_size
+  - cymbal_thickness
   - cymbal_weight_class
+  - diameter
+  - height
   - instrument_material
+  - length
+  - mounting_hole_diameter
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18509,8 +21427,15 @@
   attributes:
   - crash_cymbal_profile
   - crash_cymbal_sound_character
+  - cymbal_bell_size
+  - cymbal_thickness
   - cymbal_weight_class
+  - diameter
+  - height
   - instrument_material
+  - length
+  - mounting_hole_diameter
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18524,8 +21449,15 @@
   name: Ride Cymbals
   children: []
   attributes:
+  - cymbal_bell_size
+  - cymbal_thickness
   - cymbal_weight_class
+  - diameter
+  - height
   - instrument_material
+  - length
+  - mounting_hole_diameter
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18539,9 +21471,16 @@
   name: Sizzle Cymbals
   children: []
   attributes:
+  - cymbal_bell_size
+  - cymbal_thickness
   - cymbal_weight_class
+  - diameter
+  - height
   - instrument_material
+  - length
+  - mounting_hole_diameter
   - sizzle_mechanism
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18555,8 +21494,15 @@
   name: Splash Cymbals
   children: []
   attributes:
+  - cymbal_bell_size
+  - cymbal_thickness
   - cymbal_weight_class
+  - diameter
+  - height
   - instrument_material
+  - length
+  - mounting_hole_diameter
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18571,13 +21517,20 @@
   children: []
   attributes:
   - cymbal_application
+  - cymbal_bell_size
   - cymbal_hammering_style
   - cymbal_lathing
   - cymbal_sound_character
   - cymbal_sustain
+  - cymbal_thickness
   - cymbal_volume_level
   - cymbal_weight_class
+  - diameter
+  - height
   - instrument_material
+  - length
+  - mounting_hole_diameter
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18591,8 +21544,11 @@
   name: Crash/Ride Cymbals
   children: []
   attributes:
+  - cymbal_bell_size
+  - cymbal_thickness
   - cymbal_weight_class
   - instrument_material
+  - mounting_hole_diameter
   - profile_shape
   return_reasons:
   - changed_my_mind
@@ -18605,8 +21561,11 @@
   name: Bell Cymbals
   children: []
   attributes:
+  - cymbal_bell_size
+  - cymbal_thickness
   - cymbal_weight_class
   - instrument_material
+  - mounting_hole_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -18618,8 +21577,11 @@
   name: Stack Cymbals
   children: []
   attributes:
+  - cymbal_bell_size
+  - cymbal_thickness
   - cymbal_weight_class
   - instrument_material
+  - mounting_hole_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -18631,8 +21593,11 @@
   name: Hi-Hat Cymbals
   children: []
   attributes:
+  - cymbal_bell_size
+  - cymbal_thickness
   - cymbal_weight_class
   - instrument_material
+  - mounting_hole_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -18659,8 +21624,11 @@
   - drum_kit_included_items
   - drum_kit_portability
   - drum_shell_material
+  - height
   - instrument_material
+  - length
   - lumber/wood_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -18678,12 +21646,16 @@
   attributes:
   - acoustic_drum_kit_components_included
   - drum_configuration
+  - drum_kit_bass_drum_diameter
   - drum_kit_included_items
   - drum_kit_portability
   - drum_kit_shell_construction_features
   - drum_shell_material
   - drum_shell_wood_species
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -18698,11 +21670,16 @@
   name: Bass Drum Kits
   children: []
   attributes:
+  - bass_drum_depth
+  - bass_drum_diameter
   - drum_configuration
   - drum_kit_included_items
   - drum_kit_portability
   - drum_shell_material
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -18722,7 +21699,10 @@
   - drum_kit_included_items
   - drum_kit_portability
   - drum_shell_material
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18740,7 +21720,10 @@
   - drum_kit_included_items
   - drum_kit_portability
   - drum_shell_material
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -18759,7 +21742,10 @@
   - drum_kit_included_items
   - drum_kit_portability
   - drum_shell_material
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -18779,7 +21765,11 @@
   - drum_kit_included_items
   - drum_kit_portability
   - drum_shell_material
+  - height
   - instrument_material
+  - length
+  - snare_drum_diameter
+  - width
   return_reasons:
   - size
   - color
@@ -18800,7 +21790,10 @@
   - drum_kit_included_items
   - drum_kit_portability
   - drum_shell_material
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18819,7 +21812,11 @@
   - drum_kit_included_items
   - drum_kit_portability
   - drum_shell_material
+  - height
   - instrument_material
+  - length
+  - rack_tom_diameters
+  - width
   return_reasons:
   - size
   - color
@@ -18838,7 +21835,10 @@
   - drum_kit_included_items
   - drum_kit_portability
   - drum_shell_material
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -18893,8 +21893,11 @@
   - ae-2-8-5-4-3
   attributes:
   - electronic_drum_components
+  - height
   - instrument_material
   - interface_type
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18912,8 +21915,11 @@
   - cymbal_type
   - electronic_cymbal_trigger_zones
   - electronic_drum_components
+  - height
   - instrument_material
   - interface_type
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18929,8 +21935,11 @@
   children: []
   attributes:
   - electronic_drum_components
+  - height
   - instrument_material
   - interface_type
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18949,8 +21958,11 @@
   - drum_pad_triggering_zones
   - electronic_drum_components
   - electronic_drum_pad_playing_surface_type
+  - height
   - instrument_material
   - interface_type
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18969,7 +21981,10 @@
   - ae-2-8-5-5-3
   - ae-2-8-5-5-4
   attributes:
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18983,7 +21998,10 @@
   name: Glockenspiels
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -18997,7 +22015,10 @@
   name: Metallophones
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19011,12 +22032,15 @@
   name: Vibraphones
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
   - vibraphone_bar_material
   - vibraphone_motor_type
   - vibraphone_range_octaves
   - vibraphone_resonator_tube_material
   - vibraphone_tuning_standard
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19030,7 +22054,10 @@
   name: Xylophones
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
+  - width
   - xylophone_range_octaves
   - xylophone_resonator_type
   return_reasons:
@@ -19049,7 +22076,11 @@
   - ae-2-8-5-6-2
   - ae-2-8-5-6-3
   attributes:
+  - diameter
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19063,9 +22094,13 @@
   name: Opera Gongs
   children: []
   attributes:
+  - diameter
   - gong_profile_type
+  - height
   - included_accessories
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19079,9 +22114,15 @@
   name: Tam-Tams
   children: []
   attributes:
+  - diameter
+  - height
   - instrument_material
+  - length
   - tam_tam_construction_style
   - tam_tam_items_included
+  - tam_tam_playing_area_diameter
+  - tam_tam_thickness
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19095,7 +22136,11 @@
   name: Wind Gongs
   children: []
   attributes:
+  - diameter
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19125,7 +22170,10 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19147,7 +22195,10 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -19167,7 +22218,10 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -19184,7 +22238,10 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -19201,7 +22258,10 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -19219,11 +22279,15 @@
   attributes:
   - cymbal_playing_style_genre
   - cymbal_set_configuration
+  - diameter
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -19237,11 +22301,15 @@
   children: []
   attributes:
   - cymbal_playing_style_genre
+  - diameter
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -19255,13 +22323,17 @@
   children: []
   attributes:
   - cymbal_playing_style_genre
+  - diameter
   - grip_type
   - hand_cymbal_set_configuration
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -19275,14 +22347,19 @@
   children: []
   attributes:
   - cymbal_playing_style_genre
+  - diameter
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   - zill_playing_style
   - zill_strap_material
   - zills_strap_adjustability
+  - zills_weight
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -19306,9 +22383,12 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_dimensions_unit_context
   - instrument_material
+  - length
   - material
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -19322,12 +22402,16 @@
   children: []
   attributes:
   - chime_sound_character
+  - chime_tube_bar_length
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_dimensions_unit_context
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -19344,8 +22428,11 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_dimensions_unit_context
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -19358,13 +22445,17 @@
   name: Orchestra Chimes
   children: []
   attributes:
+  - chime_tube_diameter
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_dimensions_unit_context
   - instrument_material
+  - length
   - portability_frame_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -19381,8 +22472,12 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_dimensions_unit_context
   - instrument_material
+  - length
+  - tube_diameter
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -19406,7 +22501,10 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19423,12 +22521,16 @@
   attributes:
   - bongo_center_block_material
   - bongo_shell_material
+  - diameter
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - tuning_mechanism
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19445,12 +22547,16 @@
   - bongo_center_block_material
   - bongo_shell_material
   - bongo_tuning_system
+  - diameter
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - tuning_mechanism
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19475,8 +22581,11 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - playing_surface_material
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19498,8 +22607,11 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - playing_surface_material
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19518,13 +22630,17 @@
   - cajon_corner_control_system
   - cajon_corner_edge_design
   - cajon_snare_system_type
+  - cajon_weight
   - flamenco_cajon_snare_system
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - playing_surface_material
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19548,9 +22664,13 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - instrument_playing_surface_thickness
+  - length
   - playing_surface_material
   - sound_port_type
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19569,11 +22689,15 @@
   attributes:
   - conga_head_tensioning_system
   - conga_set_included_drum_types
+  - diameter
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19589,11 +22713,15 @@
   attributes:
   - conga_head_tensioning_system
   - conga_set_included_drum_types
+  - diameter
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19609,13 +22737,17 @@
   attributes:
   - conga_head_tensioning_system
   - conga_set_included_drum_types
+  - diameter
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
   - head_material
+  - height
   - instrument_material
+  - length
   - quinto_tuning_system
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19631,11 +22763,15 @@
   attributes:
   - conga_head_tensioning_system
   - conga_set_included_drum_types
+  - diameter
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19652,13 +22788,17 @@
   - ae-2-8-5-7-4-4-2
   - ae-2-8-5-7-4-4-3
   attributes:
+  - diameter
   - frame_drum_jingle_configuration
   - frame_drum_tuning_system
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19673,13 +22813,18 @@
   children: []
   attributes:
   - bodhr_n_head_material
+  - bodhr_n_shell_depth
   - bodhr_n_tuning_system_type
+  - diameter
   - frame_drum_tuning_system
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19693,12 +22838,16 @@
   name: Dafs
   children: []
   attributes:
+  - diameter
   - frame_drum_tuning_system
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19712,15 +22861,20 @@
   name: Tars
   children: []
   attributes:
+  - diameter
   - frame_drum_tuning_system
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - tar_head_material
   - tar_playing_style
+  - tar_rim_depth
   - tar_tuning_system
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19737,14 +22891,18 @@
   - ae-2-8-5-7-4-5-2
   - ae-2-8-5-7-4-5-3
   attributes:
+  - diameter
   - goblet_drum_playing_style
   - hand_drum_head_material
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - tuning_system
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19761,14 +22919,18 @@
   - darbuka_accessories_included
   - darbuka_body_finish_type
   - darbuka_head_material
+  - diameter
   - goblet_drum_playing_style
   - hand_drum_head_material
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - tuning_system
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19782,6 +22944,7 @@
   name: Djembes
   children: []
   attributes:
+  - diameter
   - djembe_shell_construction
   - djembe_tuning_system
   - goblet_drum_playing_style
@@ -19790,9 +22953,12 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - rope_material
   - tuning_system
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19806,6 +22972,7 @@
   name: Doumbeks
   children: []
   attributes:
+  - diameter
   - doumbek_accessories_included
   - doumbek_head_material
   - doumbek_head_type
@@ -19817,9 +22984,12 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - shell_finish
   - tuning_system
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19836,13 +23006,17 @@
   - ae-2-8-5-7-4-6-2
   - ae-2-8-5-7-4-6-3
   attributes:
+  - diameter
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - tabla_included_components
   - tabla_tonal_pitch_range_bayan
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19858,13 +23032,17 @@
   attributes:
   - bayan_included_accessories
   - bayan_tuning_system_type
+  - diameter
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - tabla_included_components
   - tabla_tonal_pitch_range_bayan
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19881,15 +23059,19 @@
   - dayan_head_material
   - dayan_strap_material
   - dayan_syahi_type
+  - diameter
   - gatta_tabla_tuning_block_material
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - included_accessories
   - instrument_material
+  - length
   - tabla_included_components
   - tabla_tonal_pitch_range_bayan
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19903,14 +23085,18 @@
   name: Tabla Sets
   children: []
   attributes:
+  - diameter
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - tabla_included_components
   - tabla_set_pieces_included
   - tabla_tonal_pitch_range_bayan
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19932,10 +23118,13 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - talking_drum_accessories_included
   - talking_drum_cord_material
   - talking_drum_tuning_mechanism
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19956,10 +23145,13 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - talking_drum_accessories_included
   - talking_drum_cord_material
   - talking_drum_tuning_mechanism
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -19979,11 +23171,14 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - talking_drum_accessories_included
   - talking_drum_cord_material
   - talking_drum_tuning_mechanism
   - tuning_mechanism
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -20002,11 +23197,14 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - talking_drum_accessories_included
   - talking_drum_cord_material
   - talking_drum_tuning_mechanism
   - tension_pitch_modulation_system
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -20025,8 +23223,11 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - musical_block_pitch_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20050,7 +23251,10 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20066,12 +23270,16 @@
   - accessory_size
   - cowbell_beater_type
   - cowbell_mounting_method
+  - cowbell_mouth_opening_width
   - cowbell_sound_character
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20087,12 +23295,16 @@
   - accessory_size
   - cowbell_beater_type
   - cowbell_mounting_method
+  - cowbell_opening_size
   - cowbell_sound_character
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20113,7 +23325,10 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20133,9 +23348,12 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - included_accessories
   - instrument_material
+  - length
   - scraping_surface_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20154,9 +23372,12 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - included_accessories
   - instrument_material
+  - length
   - scraping_surface_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20173,11 +23394,15 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - included_accessories
   - instrument_material
+  - length
+  - musical_ratchet_handle_length
   - musical_ratchet_sound_character
   - ratchet_mounting_style
   - scraping_surface_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20195,12 +23420,15 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - included_accessories
   - included_scraper_implement_type
   - instrument_material
+  - length
   - musical_scraper_groove_surface_material
   - musical_scraper_type
   - scraping_surface_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20222,8 +23450,11 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - shaker_fill_material
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20242,7 +23473,10 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20260,9 +23494,12 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - pitch_range
   - shaker_shell_material
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20280,7 +23517,10 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20298,11 +23538,14 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - rainstick_construction_type
   - rainstick_fill_material
   - rainstick_playing_technique
   - rainstick_sound_character
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20315,13 +23558,18 @@
   name: Musical Triangles
   children: []
   attributes:
+  - diameter
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - size_designation
+  - triangle_striker_length
   - triangle_striker_material
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20337,13 +23585,17 @@
   - ae-2-8-5-7-10-2
   - ae-2-8-5-7-10-3
   attributes:
+  - diameter
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - tambourine_head_material
   - tambourine_jingle_material
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20356,15 +23608,19 @@
   name: Handheld Tambourines
   children: []
   attributes:
+  - diameter
   - grip_features
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - tambourine_frame_style
   - tambourine_jingle_material
   - tambourine_tuning_mechanism
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20377,13 +23633,17 @@
   name: Headless Tambourines
   children: []
   attributes:
+  - diameter
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - tambourine_jingle_configuration
   - tambourine_jingle_material
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20396,13 +23656,17 @@
   name: Jingle Ring Tambourines
   children: []
   attributes:
+  - diameter
   - hand_percussion_mounting_handling
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
+  - length
   - tambourine_jingle_material
   - tambourine_mounting_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20421,9 +23685,12 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
   - instrument_playing_technique
   - instrument_size_class
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20440,11 +23707,14 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - instrument_material
   - instrument_playing_technique
   - instrument_size_class
+  - length
   - playing_method
   - rattle_element_material
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20461,13 +23731,16 @@
   - hand_percussion_playing_method
   - hand_percussion_set_configuration
   - hand_percussion_size_class
+  - height
   - included_accessories
   - instrument_material
   - instrument_playing_technique
   - instrument_size_class
+  - length
   - slapstick_handle_type
   - slapstick_playing_surface_material
   - sound_character
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20480,9 +23753,13 @@
   name: Hi-Hats
   children: []
   attributes:
+  - diameter
+  - height
   - hi_hat_pair_type
   - hi_hat_sound_character
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -20496,12 +23773,16 @@
   name: Practice Pads
   children: []
   attributes:
+  - diameter
+  - height
   - instrument_material
+  - length
   - playing_surface_type
   - practice_pad_features
   - practice_pad_mounting_style
   - practice_pad_rebound_level
   - practice_pad_surface_configuration
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -20520,13 +23801,17 @@
   - ae-2-8-5-10-4
   - ae-2-8-5-10-5
   attributes:
+  - diameter
+  - height
   - instrument_material
+  - length
   - lumber/wood_type
   - snare_drum_bearing_edge_profile
   - snare_drum_finish_type
   - snare_drum_hoop_type
   - snare_drum_mounting_type
   - snare_drum_strainer_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -20541,14 +23826,19 @@
   name: Metal Snare Drums
   children: []
   attributes:
+  - diameter
+  - height
   - instrument_material
+  - length
   - snare_drum_bearing_edge_profile
+  - snare_drum_depth
   - snare_drum_finish_type
   - snare_drum_hoop_type
   - snare_drum_mounting_type
   - snare_drum_shell_material
   - snare_drum_strainer_mechanism
   - snare_drum_strainer_type
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -20562,12 +23852,16 @@
   name: Piccolo Snare Drums
   children: []
   attributes:
+  - diameter
+  - height
   - instrument_material
+  - length
   - snare_drum_bearing_edge_profile
   - snare_drum_finish_type
   - snare_drum_hoop_type
   - snare_drum_mounting_type
   - snare_drum_strainer_type
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -20581,7 +23875,10 @@
   name: Wood Snare Drums
   children: []
   attributes:
+  - diameter
+  - height
   - instrument_material
+  - length
   - snare_drum_bearing_edge_profile
   - snare_drum_finish_type
   - snare_drum_hoop_type
@@ -20589,6 +23886,7 @@
   - snare_drum_strainer_type
   - snare_hoop_type
   - snare_throw_off_type
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -20642,8 +23940,13 @@
   - ae-2-8-5-11-1
   - ae-2-8-5-11-2
   attributes:
+  - diameter
+  - height
   - instrument_material
+  - length
+  - tom_tom_depth
   - tom_tom_design
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -20657,8 +23960,13 @@
   name: Concert Tom-Toms
   children: []
   attributes:
+  - diameter
   - drum_head_included
+  - height
   - instrument_material
+  - length
+  - tom_tom_depth
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -20672,9 +23980,15 @@
   name: Octobans
   children: []
   attributes:
+  - diameter
   - drumhead_type
+  - height
   - instrument_material
+  - length
   - octoban_mounting_system_type
+  - octoban_shell_depth
+  - tom_tom_depth
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -20694,12 +24008,15 @@
   attributes:
   - battery_size
   - battery_type
+  - height
   - instrument_material
   - interface_type
   - keyboard_action
+  - length
   - piano_additional_features
   - piano_pedals
   - piano_size
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20717,12 +24034,15 @@
   - acoustic_piano_plate_frame_material
   - acoustic_piano_soundboard_material
   - concert_pitch_standard
+  - height
   - instrument_material
   - interface_type
   - keyboard_action
+  - length
   - piano_additional_features
   - piano_pedals
   - piano_size
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20735,12 +24055,15 @@
   name: Electric Pianos
   children: []
   attributes:
+  - height
   - instrument_material
   - interface_type
   - keyboard_action
+  - length
   - piano_additional_features
   - piano_pedals
   - piano_size
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20754,13 +24077,16 @@
   children: []
   attributes:
   - grand_piano_soundboard_material
+  - height
   - instrument_material
   - interface_type
   - keyboard_action
+  - length
   - lid_support_positions
   - piano_additional_features
   - piano_pedals
   - piano_size
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20773,13 +24099,16 @@
   name: Upright Pianos
   children: []
   attributes:
+  - height
   - instrument_material
   - interface_type
   - keyboard_action
+  - length
   - piano_additional_features
   - piano_pedals
   - piano_size
   - upright_piano_power_source
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20803,7 +24132,10 @@
   attributes:
   - battery_size
   - battery_type
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -20820,9 +24152,12 @@
   - ae-2-8-7-1-2
   attributes:
   - electronics_power_source
+  - height
   - instrument_bow_material
   - instrument_material
+  - length
   - string_instrument_size
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -20837,9 +24172,12 @@
   children: []
   attributes:
   - electronics_power_source
+  - height
   - instrument_bow_material
   - instrument_material
+  - length
   - string_instrument_size
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -20855,10 +24193,13 @@
   attributes:
   - electric_instrument_output_connection_type
   - electronics_power_source
+  - height
   - included_accessories
   - instrument_bow_material
   - instrument_material
+  - length
   - string_instrument_size
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -20881,15 +24222,18 @@
   - fingerboard_material
   - fingerboard_pattern
   - guitar_size
+  - height
   - instrument_color
   - instrument_material
   - instrument_pattern
   - instrument_string_color
   - instrument_string_material
   - instrument_string_pattern
+  - length
   - neck_color
   - neck_material
   - neck_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -20911,15 +24255,19 @@
   - fingerboard_material
   - fingerboard_pattern
   - guitar_size
+  - height
   - instrument_color
   - instrument_material
   - instrument_pattern
   - instrument_string_color
   - instrument_string_material
   - instrument_string_pattern
+  - length
   - neck_color
   - neck_material
   - neck_pattern
+  - nut_width
+  - width
   return_reasons:
   - size
   - color
@@ -20940,15 +24288,18 @@
   - fingerboard_material
   - fingerboard_pattern
   - guitar_size
+  - height
   - instrument_color
   - instrument_material
   - instrument_pattern
   - instrument_string_color
   - instrument_string_material
   - instrument_string_pattern
+  - length
   - neck_color
   - neck_material
   - neck_pattern
+  - width
   return_reasons:
   - color
   - sound_quality
@@ -20970,16 +24321,19 @@
   - fingerboard_pattern
   - guitar_body_finish_type
   - guitar_size
+  - height
   - instrument_color
   - instrument_material
   - instrument_pattern
   - instrument_string_color
   - instrument_string_material
   - instrument_string_pattern
+  - length
   - neck_color
   - neck_material
   - neck_pattern
   - top_soundboard_material
+  - width
   return_reasons:
   - size
   - color
@@ -21002,16 +24356,19 @@
   - fingerboard_material
   - fingerboard_pattern
   - guitar_size
+  - height
   - instrument_color
   - instrument_material
   - instrument_pattern
   - instrument_string_color
   - instrument_string_material
   - instrument_string_pattern
+  - length
   - neck_color
   - neck_material
   - neck_pattern
   - pickup_configuration
+  - width
   return_reasons:
   - size
   - color
@@ -21033,8 +24390,11 @@
   - harp_action_type
   - harp_finish
   - harp_size
+  - height
   - instrument_material
+  - length
   - soundboard_material
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -21051,9 +24411,12 @@
   - harp_action_type
   - harp_finish
   - harp_size
+  - height
   - instrument_material
+  - length
   - lever_type
   - soundboard_material
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -21070,8 +24433,11 @@
   - harp_action_type
   - harp_finish
   - harp_size
+  - height
   - instrument_material
+  - length
   - soundboard_material
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -21088,8 +24454,11 @@
   - harp_action_type
   - harp_finish
   - harp_size
+  - height
   - instrument_material
+  - length
   - soundboard_material
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -21107,8 +24476,11 @@
   - harp_finish
   - harp_included_accessories
   - harp_size
+  - height
   - instrument_material
+  - length
   - soundboard_material
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -21124,10 +24496,13 @@
   - ae-2-8-7-4-1
   - ae-2-8-7-4-2
   attributes:
+  - height
   - instrument_bow_material
   - instrument_material
+  - length
   - string_instrument_size
   - upright_bass_pickup_system
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -21141,10 +24516,13 @@
   name: Bass Violins
   children: []
   attributes:
+  - height
   - instrument_bow_material
   - instrument_material
+  - length
   - string_instrument_size
   - upright_bass_pickup_system
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -21159,11 +24537,14 @@
   children: []
   attributes:
   - body_material
+  - height
   - included_accessories
   - instrument_bow_material
   - instrument_material
+  - length
   - string_instrument_size
   - upright_bass_pickup_system
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -21177,9 +24558,13 @@
   name: Violas
   children: []
   attributes:
+  - height
   - instrument_bow_material
   - instrument_material
+  - length
   - pickup_and_preamp_configuration
+  - viola_body_length
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -21195,9 +24580,12 @@
   attributes:
   - battery_size
   - battery_type
+  - height
   - instrument_bow_material
   - instrument_material
+  - length
   - string_instrument_size
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -21256,6 +24644,7 @@
   attributes:
   - banjo_head_type
   - banjo_pickup_configuration
+  - banjo_rim_diameter
   - banjo_tone_ring_type
   - banjo_tuning_machine_type
   - included_accessories
@@ -21400,6 +24789,7 @@
   - instrument_string_color
   - instrument_string_material
   - instrument_string_pattern
+  - scale_length
   - ukulele_body_shape
   - ukulele_electronics_configuration
   - ukulele_string_re_entrant_tuning
@@ -21425,6 +24815,7 @@
   - instrument_string_color
   - instrument_string_material
   - instrument_string_pattern
+  - scale_length
   - ukulele_body_shape
   - ukulele_construction_type
   - ukulele_electronics_configuration
@@ -21449,6 +24840,7 @@
   - instrument_string_color
   - instrument_string_material
   - instrument_string_pattern
+  - scale_length
   - ukulele_back_and_sides_wood
   - ukulele_body_cutaway
   - ukulele_body_shape
@@ -21479,6 +24871,7 @@
   - instrument_string_color
   - instrument_string_material
   - instrument_string_pattern
+  - scale_length
   - ukulele_body_shape
   - ukulele_electronics_configuration
   - ukulele_string_re_entrant_tuning
@@ -21502,6 +24895,7 @@
   - instrument_string_color
   - instrument_string_material
   - instrument_string_pattern
+  - scale_length
   - ukulele_body_shape
   - ukulele_electronics_configuration
   - ukulele_string_re_entrant_tuning
@@ -21525,6 +24919,7 @@
   - instrument_string_color
   - instrument_string_material
   - instrument_string_pattern
+  - scale_length
   - ukulele_body_shape
   - ukulele_electronics_configuration
   - ukulele_string_re_entrant_tuning
@@ -21552,6 +24947,7 @@
   - instrument_string_color
   - instrument_string_material
   - instrument_string_pattern
+  - scale_length
   - ukulele_body_shape
   - ukulele_electronics_configuration
   - ukulele_string_re_entrant_tuning
@@ -21576,6 +24972,7 @@
   - instrument_string_color
   - instrument_string_material
   - instrument_string_pattern
+  - scale_length
   - ukulele_body_shape
   - ukulele_electronics_configuration
   - ukulele_string_re_entrant_tuning
@@ -21608,7 +25005,10 @@
   - ae-2-8-8-14
   - ae-2-8-8-15
   attributes:
+  - height
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -21625,8 +25025,11 @@
   - ae-2-8-8-1-3
   attributes:
   - bassoon_model_level
+  - height
   - instrument/accessory_finish
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -21644,8 +25047,11 @@
   - bassoon_performance_level
   - bocal_material
   - bore_type
+  - height
   - instrument/accessory_finish
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -21661,9 +25067,13 @@
   - bassoon_keywork_material
   - bassoon_model_level
   - bassoon_system
+  - height
   - instrument/accessory_finish
   - instrument_level
   - instrument_material
+  - instrument_weight
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -21677,8 +25087,11 @@
   children: []
   attributes:
   - bassoon_model_level
+  - height
   - instrument/accessory_finish
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -21699,9 +25112,12 @@
   - ae-2-8-8-2-7
   attributes:
   - clarinet_key_system
+  - height
   - instrument/accessory_finish
   - instrument_material
+  - length
   - mouthpiece
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -21714,13 +25130,17 @@
   name: A Clarinets
   children: []
   attributes:
+  - clarinet_barrel_length
   - clarinet_body_type
   - clarinet_key_system
   - clarinet_keywork_plating
+  - height
   - instrument/accessory_finish
   - instrument_material
   - instrument_parts_included
+  - length
   - mouthpiece
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -21737,9 +25157,12 @@
   - clarinet_key_system
   - clarinet_keywork_material
   - clarinet_thumb_rest_type
+  - height
   - instrument/accessory_finish
   - instrument_material
+  - length
   - mouthpiece
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -21755,9 +25178,12 @@
   - bass_clarinet_body_material
   - bass_clarinet_lowest_written_note
   - clarinet_key_system
+  - height
   - instrument/accessory_finish
   - instrument_material
+  - length
   - mouthpiece
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -21772,9 +25198,12 @@
   attributes:
   - clarinet_included_accessories
   - clarinet_key_system
+  - height
   - instrument/accessory_finish
   - instrument_material
+  - length
   - mouthpiece
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -21790,9 +25219,12 @@
   - clarinet_key_system
   - contra_alto_clarinet_body_configuration
   - contra_alto_clarinet_lowest_note_extension
+  - height
   - instrument/accessory_finish
   - instrument_material
+  - length
   - mouthpiece
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -21810,9 +25242,12 @@
   - contra_bass_clarinet_bell_type
   - contra_bass_clarinet_bore_type
   - contra_bass_clarinet_lowest_written_note
+  - height
   - instrument/accessory_finish
   - instrument_material
+  - length
   - mouthpiece
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -21827,9 +25262,12 @@
   attributes:
   - clarinet_key_system
   - eb_clarinet_body_type
+  - height
   - instrument/accessory_finish
   - instrument_material
+  - length
   - mouthpiece
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -21855,9 +25293,12 @@
   - flute_offset_g
   - flute_wall_thickness
   - headjoint_cut
+  - height
   - instrument/accessory_finish
   - instrument_material
+  - length
   - lumber/wood_type
+  - width
   - wood_finish
   return_reasons:
   - sound_quality
@@ -21876,8 +25317,11 @@
   - flute_offset_g
   - flute_wall_thickness
   - headjoint_cut
+  - height
   - instrument/accessory_finish
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -21895,8 +25339,11 @@
   - flute_offset_g
   - flute_wall_thickness
   - headjoint_cut
+  - height
   - instrument/accessory_finish
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -21914,8 +25361,11 @@
   - flute_offset_g
   - flute_wall_thickness
   - headjoint_cut
+  - height
   - instrument/accessory_finish
   - instrument_material
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -21933,10 +25383,13 @@
   - flute_offset_g
   - flute_wall_thickness
   - headjoint_cut
+  - height
   - instrument/accessory_finish
   - instrument_material
+  - length
   - piccolo_key_system
   - piccolo_keywork_features
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -21998,8 +25451,12 @@
   - ae-2-8-8-4-4
   attributes:
   - color
+  - flutophone_tuning_pitch_reference
+  - height
   - instrument_material
+  - length
   - pattern
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22013,8 +25470,12 @@
   children: []
   attributes:
   - color
+  - flutophone_tuning_pitch_reference
+  - height
   - instrument_material
+  - length
   - pattern
+  - width
   - woodwind_body_construction
   return_reasons:
   - sound_quality
@@ -22029,8 +25490,12 @@
   children: []
   attributes:
   - color
+  - flutophone_tuning_pitch_reference
+  - height
   - instrument_material
+  - length
   - pattern
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22044,8 +25509,12 @@
   children: []
   attributes:
   - color
+  - flutophone_tuning_pitch_reference
+  - height
   - instrument_material
+  - length
   - pattern
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22059,9 +25528,15 @@
   children: []
   attributes:
   - color
+  - flutophone_tuning_pitch_reference
+  - height
   - instrument_material
+  - length
   - pattern
+  - tenor_flutophone_body_length
   - tenor_flutophone_fingering_system
+  - tenor_flutophone_weight
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22085,8 +25560,11 @@
   - harmonica_cover_plate_material
   - harmonica_finish
   - harmonica_reed_plate_material
+  - height
   - instrument_material
+  - length
   - mouthpiece_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22103,12 +25581,16 @@
   - bass_harmonica_mouthpiece_style
   - bass_harmonica_reed_material
   - bass_harmonica_tuning_system
+  - bass_harmonica_weight
   - harmonica_comb_material
   - harmonica_cover_plate_material
   - harmonica_finish
   - harmonica_reed_plate_material
+  - height
   - instrument_material
+  - length
   - mouthpiece_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22126,8 +25608,11 @@
   - harmonica_cover_plate_material
   - harmonica_finish
   - harmonica_reed_plate_material
+  - height
   - instrument_material
+  - length
   - mouthpiece_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22144,8 +25629,11 @@
   - harmonica_cover_plate_material
   - harmonica_finish
   - harmonica_reed_plate_material
+  - height
   - instrument_material
+  - length
   - mouthpiece_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22165,8 +25653,11 @@
   - harmonica_finish
   - harmonica_included_accessories
   - harmonica_reed_plate_material
+  - height
   - instrument_material
+  - length
   - mouthpiece_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22183,10 +25674,13 @@
   - harmonica_cover_plate_material
   - harmonica_finish
   - harmonica_reed_plate_material
+  - height
   - instrument_material
+  - length
   - mouthpiece_type
   - octave_harmonica_cover_plate_material
   - octave_harmonica_tuning_system
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22206,8 +25700,11 @@
   - harmonica_reed_plate_material
   - harmonica_system_type
   - harmonica_tuning_system
+  - height
   - instrument_material
+  - length
   - mouthpiece_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22224,8 +25721,11 @@
   - harmonica_cover_plate_material
   - harmonica_finish
   - harmonica_reed_plate_material
+  - height
   - instrument_material
+  - length
   - mouthpiece_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22241,8 +25741,11 @@
   - ae-2-8-8-6-2
   attributes:
   - accessory_size
+  - height
   - instrument_material
   - jew_harp_accessories_included
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22256,10 +25759,13 @@
   children: []
   attributes:
   - accessory_size
+  - height
   - instrument_material
   - jew_harp_accessories_included
   - jew_s_harp_frame_style
   - jew_s_harp_tongue_profile
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22273,8 +25779,11 @@
   children: []
   attributes:
   - accessory_size
+  - height
   - instrument_material
   - jew_harp_accessories_included
+  - length
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22290,10 +25799,13 @@
   - ae-2-8-8-7-2
   attributes:
   - color
+  - height
   - instrument_material
+  - length
   - melodica_mouthpiece_configuration
   - melodica_style
   - pattern
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22307,7 +25819,9 @@
   children: []
   attributes:
   - color
+  - height
   - instrument_material
+  - length
   - melodica_included_accessories
   - melodica_key_color_scheme
   - melodica_mouthpiece_configuration
@@ -22315,6 +25829,7 @@
   - melodica_size_class
   - melodica_style
   - pattern
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22328,13 +25843,16 @@
   children: []
   attributes:
   - color
+  - height
   - instrument_material
+  - length
   - melodica_accessory_set_included
   - melodica_air_chamber_material
   - melodica_mouthpiece_configuration
   - melodica_reed_plate_material
   - melodica_style
   - pattern
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22350,9 +25868,13 @@
   - ae-2-8-8-8-2
   - ae-2-8-8-8-3
   attributes:
+  - height
   - instrument_material
+  - length
   - musical_key
+  - pipe_inner_diameter_musical_instrument_pipe
   - pipe_instrument_voicing_sound_production_method
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22365,9 +25887,12 @@
   name: Organs
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
   - musical_key
   - pipe_instrument_voicing_sound_production_method
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22380,10 +25905,13 @@
   name: Pan Flutes
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
   - musical_key
   - pan_flute_tuning_standard
   - pipe_instrument_voicing_sound_production_method
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22396,9 +25924,12 @@
   name: Reed Pipes
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
   - musical_key
   - pipe_instrument_voicing_sound_production_method
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22413,8 +25944,11 @@
   - ae-2-8-8-9-1
   - ae-2-8-8-9-2
   attributes:
+  - height
   - instrument_material
+  - length
   - oboe_key_system
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22427,8 +25961,11 @@
   name: English Horns
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
   - oboe_key_system
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22441,9 +25978,12 @@
   name: Oboes
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
   - oboe_key_system
   - oboe_keywork_plating
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22459,8 +25999,11 @@
   - ae-2-8-8-10-2
   - ae-2-8-8-10-3
   attributes:
+  - height
   - instrument_material
+  - length
   - ocarina_style
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22473,9 +26016,13 @@
   name: Inline Ocarinas
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
   - ocarina_chamber_count
   - ocarina_style
+  - ocarina_tuning_reference
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22488,9 +26035,12 @@
   name: Pendant Ocarinas
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
   - ocarina_fingering_system
   - ocarina_style
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22503,10 +26053,13 @@
   name: Transverse Ocarinas
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
   - ocarina_accessories_included
   - ocarina_finish_type
   - ocarina_style
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22526,12 +26079,15 @@
   - ae-2-8-8-11-6
   - ae-2-8-8-11-7
   attributes:
+  - height
   - instrument_material
+  - length
   - recorder_fingering_system
   - recorder_joint_configuration
   - recorder_keywork
   - recorder_pitch_standard_a4
   - recorder_thumb_hole_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22544,7 +26100,9 @@
   name: Alto Recorders
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
   - recorder_fingering_system
   - recorder_finish
   - recorder_hole_type
@@ -22552,6 +26110,7 @@
   - recorder_joint_style
   - recorder_pitch_standard_a4
   - recorder_thumb_hole_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22567,12 +26126,15 @@
   - bass_recorder_bocal_type
   - bass_recorder_included_accessories
   - bass_recorder_keywork_material
+  - height
   - instrument_material
+  - length
   - recorder_bore_type
   - recorder_fingering_system
   - recorder_joint_configuration
   - recorder_pitch_standard_a4
   - recorder_thumb_hole_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22585,12 +26147,16 @@
   name: Contrabass Recorders
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
   - recorder_bore_design
   - recorder_fingering_system
   - recorder_joint_configuration
   - recorder_pitch_standard_a4
   - recorder_thumb_hole_type
+  - recorder_total_weight
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22603,13 +26169,16 @@
   name: Great Bass Recorders
   children: []
   attributes:
+  - height
   - instrument_key
   - instrument_material
+  - length
   - recorder_accessories_included
   - recorder_fingering_system
   - recorder_joint_configuration
   - recorder_pitch_standard_a4
   - recorder_thumb_hole_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22622,11 +26191,14 @@
   name: Sopranino Recorders
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
   - recorder_fingering_system
   - recorder_joint_configuration
   - recorder_pitch_standard_a4
   - recorder_thumb_hole_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22639,13 +26211,16 @@
   name: Soprano Recorders
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
   - pitch_standard
   - recorder_fingering_system
   - recorder_joint_configuration
   - recorder_mouthpiece_type
   - recorder_pitch_standard_a4
   - recorder_thumb_hole_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22658,12 +26233,15 @@
   name: Tenor Recorders
   children: []
   attributes:
+  - height
   - instrument_material
+  - length
   - recorder_fingering_system
   - recorder_joint_configuration
   - recorder_pitch_standard_a4
   - recorder_thumb_hole_type
   - tenor_recorder_joint_type
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22682,13 +26260,16 @@
   - ae-2-8-8-12-5
   attributes:
   - extended_saxophone_range
+  - height
   - instrument/accessory_finish
   - instrument_material
   - keywork_finish
+  - length
   - neck_configuration
   - saxophone_body_finish
   - saxophone_package_contents
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22702,9 +26283,11 @@
   children: []
   attributes:
   - extended_saxophone_range
+  - height
   - instrument/accessory_finish
   - instrument_material
   - keywork_finish
+  - length
   - neck_configuration
   - saxophone_body_finish
   - saxophone_construction_style
@@ -22712,6 +26295,7 @@
   - saxophone_key_touch_material
   - saxophone_package_contents
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22725,13 +26309,16 @@
   children: []
   attributes:
   - extended_saxophone_range
+  - height
   - instrument/accessory_finish
   - instrument_material
   - keywork_finish
+  - length
   - neck_configuration
   - saxophone_body_finish
   - saxophone_package_contents
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22745,11 +26332,13 @@
   children: []
   attributes:
   - extended_saxophone_range
+  - height
   - included_case_type
   - included_items_woodwind_instrument
   - instrument/accessory_finish
   - instrument_material
   - keywork_finish
+  - length
   - neck_configuration
   - saxophone_body_finish
   - saxophone_body_type
@@ -22757,6 +26346,7 @@
   - saxophone_neck_type
   - saxophone_package_contents
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22770,14 +26360,17 @@
   children: []
   attributes:
   - extended_saxophone_range
+  - height
   - instrument/accessory_finish
   - instrument_material
   - keywork_finish
+  - length
   - neck_configuration
   - saxophone_body_finish
   - saxophone_package_contents
   - soprano_saxophone_body_style
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22791,15 +26384,19 @@
   children: []
   attributes:
   - extended_saxophone_range
+  - height
   - instrument/accessory_finish
   - instrument_material
   - keywork_finish
+  - length
   - neck_configuration
   - saxophone_body_finish
   - saxophone_package_contents
   - tenor_saxophone_key_system
   - tenor_saxophone_pad_material
+  - tenor_saxophone_weight
   - tuning_pitch
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22818,9 +26415,12 @@
   - ae-2-8-8-13-5
   attributes:
   - color
+  - height
   - instrument_material
+  - length
   - pattern
   - tin_whistle_included_accessories
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22834,9 +26434,12 @@
   children: []
   attributes:
   - color
+  - height
   - instrument_material
+  - length
   - pattern
   - tin_whistle_included_accessories
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22850,11 +26453,14 @@
   children: []
   attributes:
   - color
+  - height
   - instrument_material
+  - length
   - pattern
   - tin_whistle_body_material
   - tin_whistle_bore_type
   - tin_whistle_included_accessories
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22868,9 +26474,12 @@
   children: []
   attributes:
   - color
+  - height
   - instrument_material
+  - length
   - pattern
   - tin_whistle_included_accessories
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22884,10 +26493,13 @@
   children: []
   attributes:
   - color
+  - height
   - instrument_material
+  - length
   - pattern
   - tin_whistle_included_accessories
   - whistle_head_material
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22901,9 +26513,12 @@
   children: []
   attributes:
   - color
+  - height
   - instrument_material
+  - length
   - pattern
   - tin_whistle_included_accessories
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22919,8 +26534,11 @@
   - ae-2-8-8-14-2
   attributes:
   - accessory_size
+  - height
   - instrument_material
+  - length
   - musical_key
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22934,9 +26552,12 @@
   children: []
   attributes:
   - accessory_size
+  - height
   - instrument_material
+  - length
   - musical_key
   - train_whistle_intended_use
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22950,9 +26571,12 @@
   children: []
   attributes:
   - accessory_size
+  - height
   - instrument_material
+  - length
   - musical_key
   - train_whistle_sound_character
+  - width
   return_reasons:
   - sound_quality
   - changed_my_mind
@@ -22967,6 +26591,7 @@
   attributes:
   - accessory_size
   - didgeridoo_construction_type
+  - didgeridoo_length
   - instrument/accessory_finish
   - instrument_material
   - mouthpiece_type
@@ -23025,9 +26650,12 @@
   attributes:
   - attachment_options
   - color
+  - height
   - item_style
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -23044,9 +26672,12 @@
   attributes:
   - color
   - corsage/boutonniere_design
+  - height
+  - length
   - material_treatment
   - pattern
   - plant_material
+  - width
   return_reasons:
   - size
   - color
@@ -23145,6 +26776,7 @@
   - color
   - flower_care_instructions
   - material_treatment
+  - orchid_flower_size
   - pattern
   - plant_material
   - stem_length
@@ -23171,6 +26803,7 @@
   - plant_material
   - rose_bloom_stage
   - rose_grade
+  - rose_head_diameter
   - stem_length
   return_reasons:
   - size
@@ -23236,8 +26869,11 @@
   - ae-3-1-5-5
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -23255,9 +26891,13 @@
   - accessory_size
   - bag/case_material
   - color
+  - gift_bag_gusset_depth
   - gift_bag_handle_design
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -23280,11 +26920,14 @@
   - gift_box_tin_insert_type
   - gift_box_tin_sustainability_features
   - gift_box_tin_window_type
+  - height
   - jewelry_material
+  - length
   - lumber/wood_type
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -23301,9 +26944,12 @@
   attributes:
   - color
   - construction
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -23321,8 +26967,11 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -23339,8 +26988,11 @@
   attributes:
   - color
   - embellishment/trim_material
+  - height
+  - length
   - material
   - pattern
+  - width
   - wrapping_occasion
   - wrapping_paper_features
   return_reasons:
@@ -23365,11 +27017,14 @@
   - card_size
   - celebration_type
   - color
+  - height
   - item_style
+  - length
   - material_treatment
   - pattern
   - personalization_design
   - plant_material
+  - width
   return_reasons:
   - size
   - color
@@ -23390,13 +27045,16 @@
   - celebration_type
   - color
   - embellishment/trim_material
+  - height
   - inside_message_type
   - item_style
+  - length
   - material
   - pattern
   - personalization_design
   - recipient_relationship
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -23414,9 +27072,12 @@
   - card_size
   - celebration_type
   - color
+  - height
   - item_style
+  - length
   - pattern
   - personalization_design
+  - width
   return_reasons:
   - size
   - color
@@ -23433,8 +27094,11 @@
   attributes:
   - card_size
   - celebration_type
+  - height
   - item_style
+  - length
   - personalization_design
+  - width
   return_reasons:
   - size
   - color
@@ -23498,7 +27162,10 @@
   attributes:
   - advice_card_prompt_type
   - card_size
+  - height
   - item_style
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -23513,6 +27180,7 @@
   name: Balloon Kits
   children: []
   attributes:
+  - balloon_kit_diameter
   - balloon_kit_finish
   - balloon_kit_items_included
   - balloon_kit_material
@@ -23520,7 +27188,10 @@
   - battery_type
   - celebration_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -23540,8 +27211,11 @@
   - celebration_type
   - color
   - compatible_inflation_gas
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -23562,7 +27236,10 @@
   - battery_type
   - celebration_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -23579,7 +27256,10 @@
   - birthday_candle_design
   - birthday_candle_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -23602,7 +27282,10 @@
   - chair_sash_finish
   - color
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -23621,7 +27304,10 @@
   - chair_sash_finish
   - color
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -23640,7 +27326,10 @@
   - chair_sash_finish
   - color
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -23659,8 +27348,11 @@
   - chair_sash_finish
   - color
   - fabric
+  - height
+  - length
   - pattern
   - ruffle_style
+  - width
   return_reasons:
   - size
   - color
@@ -23679,7 +27371,10 @@
   - chair_sash_finish
   - color
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -23742,6 +27437,7 @@
   - cocktail_decoration_design
   - cocktail_decoration_material
   - cocktail_napkin_features
+  - cocktail_napkin_unfolded_size
   - color
   - disposable_compostable_claim
   - napkin_ply
@@ -23761,6 +27457,7 @@
   attributes:
   - cocktail_decoration_design
   - cocktail_decoration_material
+  - cocktail_pick_length
   - cocktail_pick_tip_style
   - cocktail_pick_top_handle_style
   - color
@@ -23799,6 +27496,7 @@
   attributes:
   - cocktail_decoration_design
   - cocktail_decoration_material
+  - cocktail_umbrella_canopy_diameter
   - cocktail_umbrella_handle_pick_material
   - color
   - disposable_compostable_claim
@@ -23818,6 +27516,7 @@
   attributes:
   - color
   - confetti_format
+  - confetti_piece_size
   - embellishment/trim_material
   - material_treatment
   - pattern
@@ -23838,7 +27537,10 @@
   - accessory_size
   - color
   - decoration_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -23855,6 +27557,9 @@
   - game_components
   - game_difficulty
   - game_name
+  - height
+  - length
+  - width
   return_reasons:
   - difficulty_level
   - changed_my_mind
@@ -23870,10 +27575,13 @@
   - accessory_size
   - color
   - embellishment/trim_material
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - straw/stirrer_design
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -23889,8 +27597,11 @@
   children: []
   attributes:
   - envelope_seal_design
+  - height
+  - length
   - material
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -23905,9 +27616,12 @@
   children: []
   attributes:
   - celebration_type
+  - height
   - item_style
+  - length
   - paper_size
   - program_format
+  - width
   return_reasons:
   - size
   - color
@@ -23926,7 +27640,10 @@
   - ae-3-2-14-3
   attributes:
   - accessory_size
+  - height
+  - length
   - noise_intensity
+  - width
   return_reasons:
   - size
   - color
@@ -23941,7 +27658,10 @@
   children: []
   attributes:
   - accessory_size
+  - height
+  - length
   - noise_intensity
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -23958,7 +27678,10 @@
   - firework_assortment_launch_type
   - firework_assortment_types_included
   - firework_effect_types
+  - height
+  - length
   - noise_intensity
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -23972,9 +27695,14 @@
   children: []
   attributes:
   - accessory_size
+  - firework_burn_duration
+  - firework_fountain_height
   - firework_ignition_method
   - firework_visual_intensity_level
+  - height
+  - length
   - noise_intensity
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -23988,8 +27716,11 @@
   children: []
   attributes:
   - decoration_material
+  - height
   - inflatable_decoration_items_included
   - inflatable_decoration_type
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -24007,9 +27738,12 @@
   - card_format
   - celebration_type
   - embellishment/trim_material
+  - height
   - invitation_personalization_design
   - invitation_printing_coverage
   - item_style
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -24030,8 +27764,11 @@
   - ae-3-2-17-5
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -24045,10 +27782,14 @@
   name: Blowouts
   children: []
   attributes:
+  - blowout_extension_length
   - color
+  - height
+  - length
   - material
   - mouthpiece_material
   - pattern
+  - width
   return_reasons:
   - color
   - style
@@ -24063,8 +27804,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - style
@@ -24079,8 +27823,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - style
@@ -24095,10 +27842,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - party_horn_mouthpiece_type
   - party_horn_style
   - pattern
+  - width
   return_reasons:
   - color
   - style
@@ -24115,10 +27865,13 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - material
   - pattern
   - whistle_light_features
   - whistle_sound_style
+  - width
   return_reasons:
   - color
   - style
@@ -24134,11 +27887,14 @@
   attributes:
   - celebration_type
   - color
+  - height
+  - length
   - lumber/wood_type
   - material
   - party_favor_type
   - pattern
   - theme
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -24156,8 +27912,12 @@
   - age_group
   - color
   - game_difficulty
+  - game_setup_time
+  - height
+  - length
   - party_game_format
   - pattern
+  - width
   return_reasons:
   - difficulty_level
   - changed_my_mind
@@ -24173,7 +27933,10 @@
   - age_group
   - color
   - hat_style
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -24194,7 +27957,11 @@
   - ae-3-2-21-5
   attributes:
   - color
+  - height
+  - length
+  - party_streamer_curtain_coverage_area
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -24210,7 +27977,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - party_streamer_curtain_coverage_area
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -24226,7 +27997,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - party_streamer_curtain_coverage_area
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -24243,7 +28018,11 @@
   attributes:
   - color
   - foil_curtain_mounting_method
+  - height
+  - length
+  - party_streamer_curtain_coverage_area
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -24262,7 +28041,11 @@
   - fringe_curtain_finish
   - fringe_curtain_material
   - fringe_curtain_use_location
+  - height
+  - length
+  - party_streamer_curtain_coverage_area
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -24280,10 +28063,14 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - material_treatment
+  - party_streamer_curtain_coverage_area
   - pattern
   - plant_material
+  - width
   return_reasons:
   - size
   - color
@@ -24300,8 +28087,11 @@
   attributes:
   - celebration_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -24318,11 +28108,14 @@
   attributes:
   - accessory_size
   - celebration_type
+  - height
+  - length
   - material
   - pi_ata_filler_type_included
   - pi_ata_hanging_method
   - pi_ata_opening_type
   - pinata_design
+  - width
   return_reasons:
   - size
   - color
@@ -24341,9 +28134,12 @@
   - celebration_type
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - material
   - place_card_holder_closure_mechanism
+  - width
   return_reasons:
   - size
   - color
@@ -24360,9 +28156,12 @@
   attributes:
   - card_design
   - celebration_type
+  - height
+  - length
   - material
   - place_card_orientation
   - place_card_printing_status
+  - width
   return_reasons:
   - size
   - color
@@ -24379,7 +28178,10 @@
   attributes:
   - card_design
   - celebration_type
+  - height
+  - length
   - response_fields_included
+  - width
   return_reasons:
   - size
   - color
@@ -24395,7 +28197,10 @@
   children: []
   attributes:
   - accessory_size
+  - height
+  - length
   - sparkler_shape
+  - width
   return_reasons:
   - size
   - color
@@ -24411,9 +28216,14 @@
   attributes:
   - card_box_holder_type
   - celebration_type
+  - height
   - item_style
+  - length
   - material
   - personalization_type
+  - slot_length
+  - slot_width
+  - width
   return_reasons:
   - size
   - color
@@ -24438,6 +28248,7 @@
   - spray_string_recommended_surface
   - spray_string_scent
   - spray_string_suitable_age_group
+  - volume
   return_reasons:
   - color
   - changed_my_mind
@@ -24474,11 +28285,14 @@
   - accessory_size
   - disco_ball_mirror_tile_material
   - disco_ball_mirror_tile_size
+  - height
+  - length
   - light_source
   - material
   - mounting_type
   - power_source
   - reflective_finish
+  - width
   return_reasons:
   - size
   - color
@@ -24495,7 +28309,11 @@
   - battery_size
   - battery_type
   - fluid_type
+  - height
+  - length
+  - power_rating
   - sfx_control_technology
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24516,7 +28334,11 @@
   - battery_type
   - compatible_special_effects_device
   - connection_method
+  - height
+  - length
+  - power_rating
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24533,8 +28355,12 @@
   - connection_method
   - dmx_output_connector_type
   - form_factor
+  - height
+  - length
   - lighting_control_protocols_supported
+  - power_rating
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24549,9 +28375,13 @@
   attributes:
   - compatible_special_effects_device
   - connection_method
+  - height
+  - length
+  - power_rating
   - power_source
   - sound_sensitivity_control
   - special_effects_output_interface
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24566,8 +28396,12 @@
   attributes:
   - compatible_special_effects_device
   - connection_method
+  - height
+  - length
+  - power_rating
   - power_source
   - timer_operating_modes
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24581,11 +28415,14 @@
   children: []
   attributes:
   - compatible_special_effects_device
+  - height
+  - length
   - light_stand_style
   - load_capacity
   - material
   - mounting_type
   - special_effects_stand_stability_features
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -24608,11 +28445,15 @@
   - battery_size
   - battery_type
   - compatible_special_effects_lighting_features
+  - height
+  - length
   - light_color
   - light_pattern
   - mounting_type
+  - power_rating
   - power_source
   - sfx_control_technology
+  - width
   return_reasons:
   - size
   - color
@@ -24630,12 +28471,16 @@
   - compatible_special_effects_lighting_features
   - gobo_format
   - gobo_rotation
+  - height
+  - length
   - light_color
   - light_pattern
   - mounting_type
+  - power_rating
   - power_source
   - sfx_control_technology
   - wheel_type
+  - width
   return_reasons:
   - size
   - color
@@ -24651,13 +28496,18 @@
   children: []
   attributes:
   - compatible_special_effects_lighting_features
+  - height
+  - laser_output_power
   - laser_safety_class
+  - length
   - light_color
   - light_pattern
   - mounting_type
   - operating_modes
+  - power_rating
   - power_source
   - sfx_control_technology
+  - width
   return_reasons:
   - size
   - color
@@ -24675,11 +28525,15 @@
   - battery_size
   - battery_type
   - compatible_special_effects_lighting_features
+  - height
+  - length
   - light_color
   - light_pattern
   - mounting_type
+  - power_rating
   - power_source
   - sfx_control_technology
+  - width
   return_reasons:
   - size
   - color
@@ -24695,11 +28549,15 @@
   children: []
   attributes:
   - compatible_special_effects_lighting_features
+  - height
+  - length
   - light_color
   - light_pattern
   - mounting_type
+  - power_rating
   - power_source
   - sfx_control_technology
+  - width
   return_reasons:
   - size
   - color
@@ -24715,11 +28573,15 @@
   children: []
   attributes:
   - compatible_special_effects_lighting_features
+  - height
+  - length
   - light_color
   - light_pattern
   - mounting_type
+  - power_rating
   - power_source
   - sfx_control_technology
+  - width
   return_reasons:
   - size
   - color
@@ -24743,6 +28605,9 @@
   - award_material
   - award_mounting_display_type
   - award_occasion
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -24764,7 +28629,10 @@
   - certificate_border_style
   - certificate_personalization_type
   - foil_color
+  - height
+  - length
   - lumber/wood_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -24789,8 +28657,11 @@
   - award_occasion
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - material
+  - width
   return_reasons:
   - size
   - color
@@ -24808,9 +28679,12 @@
   - award_customization_included
   - award_material
   - award_occasion
+  - height
+  - length
   - material
   - pin_attachment_type
   - pin_face_customization_method
+  - width
   return_reasons:
   - size
   - color
@@ -24830,8 +28704,11 @@
   - award_occasion
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - material
+  - width
   return_reasons:
   - size
   - color
@@ -24851,10 +28728,13 @@
   - award_occasion
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - material
   - medal_attachment_style
   - medal_packaging
+  - width
   return_reasons:
   - size
   - color
@@ -24872,10 +28752,13 @@
   - award_customization_included
   - award_material
   - award_occasion
+  - height
+  - length
   - material
   - medal_award_level
   - medal_finish
   - ribbon_style
+  - width
   return_reasons:
   - size
   - color
@@ -24894,8 +28777,13 @@
   - award_material
   - award_occasion
   - award_plaque_plate_material
+  - award_plaque_plate_size
+  - engraving_plate_size
+  - height
+  - length
   - lumber/wood_type
   - material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -24918,7 +28806,10 @@
   - award_material
   - award_occasion
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -24942,7 +28833,10 @@
   - award_ribbon_material
   - award_ribbon_placement_title
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -24962,8 +28856,11 @@
   - award_material
   - award_occasion
   - color
+  - height
+  - length
   - pattern
   - rosette_center_type
+  - width
   return_reasons:
   - size
   - color
@@ -24987,9 +28884,12 @@
   - construction
   - embellishment/trim_material
   - engraving
+  - height
   - jewelry_material
+  - length
   - material
   - trophy_design
+  - width
   return_reasons:
   - size
   - color

--- a/data/categories/ap_animals_pet_supplies.yml
+++ b/data/categories/ap_animals_pet_supplies.yml
@@ -116,9 +116,11 @@
   attributes:
   - color
   - height
+  - length
   - lumber/wood_type
   - material
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -134,8 +136,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -152,7 +157,10 @@
   - ap-2-1-1-2-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -167,7 +175,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -182,7 +193,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -197,7 +211,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -214,8 +231,11 @@
   - accessory_size
   - bird_cage/stand_design
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -232,6 +252,7 @@
   attributes:
   - bird_food_form
   - bird_food_ingredients
+  - package_size
   - suitable_for_bird_type
   return_reasons:
   - animal_refused
@@ -246,8 +267,11 @@
   name: Bird Gyms & Playstands
   children: []
   attributes:
+  - height
+  - length
   - lumber/wood_type
   - suitable_for_bird_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -264,8 +288,11 @@
   - ap-2-1-5-1
   - ap-2-1-5-2
   attributes:
+  - height
+  - length
   - lumber/wood_type
   - suitable_for_bird_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -280,7 +307,10 @@
   name: Ladders & Steps
   children: []
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - incompatible
@@ -294,8 +324,11 @@
   name: Swings & Perches
   children: []
   attributes:
+  - height
+  - length
   - lumber/wood_type
   - material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -320,8 +353,11 @@
   attributes:
   - battery_size
   - battery_type
+  - height
+  - length
   - lumber/wood_type
   - toy/game_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -336,7 +372,10 @@
   name: Balls & Fetch Toys
   children: []
   attributes:
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -350,7 +389,10 @@
   name: Bells & Beads
   children: []
   attributes:
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -366,8 +408,11 @@
   attributes:
   - battery_size
   - battery_type
+  - height
+  - length
   - lumber/wood_type
   - toy/game_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -384,8 +429,11 @@
   attributes:
   - battery_size
   - battery_type
+  - height
+  - length
   - lumber/wood_type
   - toy/game_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -400,7 +448,10 @@
   name: Mirrors
   children: []
   attributes:
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -414,7 +465,10 @@
   name: Puzzles & Interactive Toys
   children: []
   attributes:
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -428,7 +482,10 @@
   name: Ropes & Knots
   children: []
   attributes:
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -442,7 +499,10 @@
   name: Tunnels & Tubes
   children: []
   attributes:
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -457,6 +517,7 @@
   children: []
   attributes:
   - bird_treat_type
+  - package_size
   - package_type
   - pet_supply_product_form
   - suitable_for_bird_type
@@ -495,6 +556,7 @@
   - ap-2-2-1-2
   attributes:
   - cat_age_group
+  - package_size
   - package_type
   - pet_dietary_requirements
   - pet_food_flavor
@@ -514,6 +576,7 @@
   children: []
   attributes:
   - cat_age_group
+  - package_size
   - package_type
   - pet_dietary_requirements
   - pet_food_flavor
@@ -533,6 +596,7 @@
   children: []
   attributes:
   - cat_age_group
+  - package_size
   - package_type
   - pet_dietary_requirements
   - pet_food_flavor
@@ -560,8 +624,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -579,8 +646,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -598,7 +668,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -615,8 +688,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -634,7 +710,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -651,7 +730,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -668,7 +750,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -685,7 +770,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -701,7 +789,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -720,7 +811,10 @@
   - ap-2-2-4-3
   attributes:
   - cat_litter_formula
+  - height
+  - length
   - lumber/wood_type
+  - width
   - wood_finish
   return_reasons:
   - scent
@@ -736,8 +830,11 @@
   children: []
   attributes:
   - care_instructions
+  - height
+  - length
   - liner_features
   - usage_type
+  - width
   return_reasons:
   - size
   - scent
@@ -753,8 +850,11 @@
   attributes:
   - care_instructions
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - texture
@@ -769,8 +869,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -799,10 +902,13 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - material_treatment
   - pattern
   - plant_material
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -816,7 +922,10 @@
   name: Balls & Chasers
   children: []
   attributes:
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -832,9 +941,12 @@
   attributes:
   - battery_size
   - battery_type
+  - height
+  - length
   - material_treatment
   - plant_material
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -848,7 +960,10 @@
   name: Chew Toys
   children: []
   attributes:
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -862,7 +977,10 @@
   name: Feathers & Teasers
   children: []
   attributes:
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -878,7 +996,10 @@
   attributes:
   - battery_size
   - battery_type
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -894,7 +1015,10 @@
   attributes:
   - battery_size
   - battery_type
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -908,7 +1032,10 @@
   name: Puzzles & Treat-Dispensing Toys
   children: []
   attributes:
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -922,7 +1049,10 @@
   name: Squeakies
   children: []
   attributes:
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -937,8 +1067,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -952,7 +1085,10 @@
   name: Tunnels
   children: []
   attributes:
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -966,7 +1102,10 @@
   name: Wands
   children: []
   attributes:
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - size
   - length
@@ -982,6 +1121,7 @@
   attributes:
   - cat_age_group
   - material_treatment
+  - package_size
   - package_type
   - pet_dietary_requirements
   - pet_food_flavor
@@ -1027,9 +1167,12 @@
   attributes:
   - accessory_size
   - care_instructions
+  - height
+  - length
   - liner_features
   - material
   - usage_type
+  - width
   return_reasons:
   - size
   - absorbency
@@ -1049,9 +1192,12 @@
   - diaper_features
   - dog_diaper_size
   - dog_diaper_type
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - absorbency
@@ -1068,6 +1214,7 @@
   - ap-2-3-3-2
   attributes:
   - dog_age_group
+  - package_size
   - package_type
   - pet_dietary_requirements
   - pet_food_flavor
@@ -1088,6 +1235,7 @@
   children: []
   attributes:
   - dog_age_group
+  - package_size
   - package_type
   - pet_dietary_requirements
   - pet_food_flavor
@@ -1107,6 +1255,7 @@
   children: []
   attributes:
   - dog_age_group
+  - package_size
   - package_type
   - pet_dietary_requirements
   - pet_food_flavor
@@ -1128,9 +1277,12 @@
   attributes:
   - color
   - dog_house_features
+  - height
+  - length
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -1145,7 +1297,10 @@
   name: Dog Kennel & Run Accessories
   children: []
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - color
@@ -1167,8 +1322,11 @@
   attributes:
   - color
   - dog_kennel/run_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1185,8 +1343,11 @@
   attributes:
   - color
   - dog_pen_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1202,9 +1363,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1221,8 +1385,11 @@
   attributes:
   - color
   - dog_kennel_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1239,8 +1406,11 @@
   attributes:
   - color
   - dog_kennel_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1257,8 +1427,11 @@
   attributes:
   - color
   - dog_kennel_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1278,9 +1451,12 @@
   - color
   - dog_age_group
   - dog_toy_type
+  - height
+  - length
   - pattern
   - suitable_for_breed_size
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1297,7 +1473,12 @@
   - control_technology
   - dog_age_group
   - exercise_machine_features
+  - height
+  - length
+  - maximum_load_capacity
+  - maximum_speed
   - suitable_for_breed_size
+  - width
   return_reasons:
   - size
   - capacity
@@ -1312,6 +1493,7 @@
   children: []
   attributes:
   - dog_age_group
+  - package_size
   - package_type
   - pet_dietary_requirements
   - pet_food_flavor
@@ -1368,8 +1550,11 @@
   - ap-2-4-1-5
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -1385,8 +1570,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -1402,8 +1590,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -1419,8 +1610,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -1436,8 +1630,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -1453,8 +1650,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -1477,8 +1677,11 @@
   - accessory_size
   - color
   - compatible_aquarium
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1496,8 +1699,11 @@
   - accessory_size
   - color
   - compatible_aquarium
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1515,8 +1721,11 @@
   - accessory_size
   - color
   - compatible_aquarium
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1534,8 +1743,11 @@
   - accessory_size
   - color
   - compatible_aquarium
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1553,8 +1765,11 @@
   - accessory_size
   - color
   - compatible_aquarium
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1572,8 +1787,11 @@
   - accessory_size
   - color
   - compatible_aquarium
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1612,6 +1830,9 @@
   children: []
   attributes:
   - compatible_aquarium
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1641,6 +1862,9 @@
   children: []
   attributes:
   - compatible_aquarium
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -1656,6 +1880,9 @@
   children: []
   attributes:
   - compatible_aquarium
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1669,6 +1896,9 @@
   children: []
   attributes:
   - compatible_aquarium
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -1682,6 +1912,9 @@
   children: []
   attributes:
   - compatible_aquarium
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -1696,6 +1929,9 @@
   children: []
   attributes:
   - compatible_aquarium
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - length
@@ -1710,6 +1946,9 @@
   children: []
   attributes:
   - compatible_aquarium
+  - height
+  - length
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1756,7 +1995,10 @@
   - accessory_size
   - color
   - decoration_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1774,7 +2016,10 @@
   - accessory_size
   - color
   - decoration_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1810,6 +2055,7 @@
   - accessory_size
   - color
   - decoration_material
+  - package_size
   - pattern
   return_reasons:
   - color
@@ -1829,9 +2075,12 @@
   - accessory_size
   - color
   - decoration_material
+  - height
+  - length
   - material_treatment
   - pattern
   - plant_material
+  - width
   return_reasons:
   - size
   - color
@@ -1849,7 +2098,10 @@
   - accessory_size
   - color
   - decoration_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1867,9 +2119,12 @@
   - accessory_size
   - color
   - decoration_material
+  - height
+  - length
   - lumber/wood_type
   - material_treatment
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -1888,10 +2143,13 @@
   - accessory_size
   - color
   - decoration_material
+  - height
+  - length
   - lumber/wood_type
   - material_treatment
   - pattern
   - plant_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -1910,7 +2168,10 @@
   - accessory_size
   - color
   - decoration_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1932,8 +2193,14 @@
   attributes:
   - aquarium_filter_features
   - filter_type
+  - flow_rate
+  - height
+  - length
+  - power
   - power_source
   - suitable_for_water_type
+  - voltage
+  - width
   return_reasons:
   - size
   - capacity
@@ -1949,8 +2216,14 @@
   children: []
   attributes:
   - aquarium_filter_features
+  - flow_rate
+  - height
+  - length
+  - power
   - power_source
   - suitable_for_water_type
+  - voltage
+  - width
   return_reasons:
   - size
   - capacity
@@ -1966,8 +2239,14 @@
   children: []
   attributes:
   - aquarium_filter_features
+  - flow_rate
+  - height
+  - length
+  - power
   - power_source
   - suitable_for_water_type
+  - voltage
+  - width
   return_reasons:
   - size
   - capacity
@@ -1983,8 +2262,14 @@
   children: []
   attributes:
   - aquarium_filter_features
+  - flow_rate
+  - height
+  - length
+  - power
   - power_source
   - suitable_for_water_type
+  - voltage
+  - width
   return_reasons:
   - size
   - capacity
@@ -2000,8 +2285,14 @@
   children: []
   attributes:
   - aquarium_filter_features
+  - flow_rate
+  - height
+  - length
+  - power
   - power_source
   - suitable_for_water_type
+  - voltage
+  - width
   return_reasons:
   - size
   - capacity
@@ -2017,8 +2308,14 @@
   children: []
   attributes:
   - aquarium_filter_features
+  - flow_rate
+  - height
+  - length
+  - power
   - power_source
   - suitable_for_water_type
+  - voltage
+  - width
   return_reasons:
   - size
   - capacity
@@ -2038,7 +2335,11 @@
   - ap-2-4-6-4
   attributes:
   - color
+  - handle_length
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -2054,7 +2355,11 @@
   children: []
   attributes:
   - color
+  - handle_length
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -2069,7 +2374,11 @@
   children: []
   attributes:
   - color
+  - handle_length
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -2084,7 +2393,11 @@
   children: []
   attributes:
   - color
+  - handle_length
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -2099,7 +2412,11 @@
   children: []
   attributes:
   - color
+  - handle_length
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -2122,6 +2439,7 @@
   attributes:
   - color
   - gravel/substrate_material
+  - package_size
   - pattern
   - substrate_features
   return_reasons:
@@ -2141,6 +2459,7 @@
   attributes:
   - color
   - material_treatment
+  - package_size
   - pattern
   - plant_material
   - substrate_features
@@ -2159,6 +2478,7 @@
   children: []
   attributes:
   - color
+  - package_size
   - pattern
   - substrate_features
   return_reasons:
@@ -2176,6 +2496,7 @@
   children: []
   attributes:
   - color
+  - package_size
   - pattern
   - substrate_features
   return_reasons:
@@ -2193,6 +2514,7 @@
   children: []
   attributes:
   - color
+  - package_size
   - pattern
   - substrate_features
   return_reasons:
@@ -2210,6 +2532,7 @@
   children: []
   attributes:
   - color
+  - package_size
   - pattern
   - substrate_features
   return_reasons:
@@ -2227,6 +2550,7 @@
   children: []
   attributes:
   - color
+  - package_size
   - pattern
   - substrate_features
   return_reasons:
@@ -2244,6 +2568,7 @@
   children: []
   attributes:
   - color
+  - package_size
   - pattern
   - substrate_features
   return_reasons:
@@ -2261,9 +2586,15 @@
   children: []
   attributes:
   - aquarium_light_spectrum
+  - height
+  - length
   - light_source
   - lighting_features
+  - maximum_tank_rim_size
+  - power
   - power_source
+  - voltage
+  - width
   return_reasons:
   - size
   - color
@@ -2279,7 +2610,11 @@
   children: []
   attributes:
   - aquarium_overflow_box_design
+  - flow_rate
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - capacity
@@ -2299,9 +2634,13 @@
   - ap-2-4-10-4
   attributes:
   - color
+  - height
+  - length
   - lumber/wood_type
   - material
+  - maximum_load_capacity
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2319,9 +2658,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lumber/wood_type
   - material
+  - maximum_load_capacity
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2339,9 +2682,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lumber/wood_type
   - material
+  - maximum_load_capacity
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2359,8 +2706,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2377,8 +2728,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2396,8 +2751,11 @@
   - ap-2-4-11-1
   - ap-2-4-11-2
   attributes:
+  - height
+  - length
   - power_source
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2411,8 +2769,11 @@
   name: Analog Temperature Controllers
   children: []
   attributes:
+  - height
+  - length
   - power_source
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2426,8 +2787,11 @@
   name: Digital Temperature Controllers
   children: []
   attributes:
+  - height
+  - length
   - power_source
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2568,7 +2932,11 @@
 - id: ap-2-4-13
   name: Aquariums
   children: []
-  attributes: []
+  attributes:
+  - height
+  - length
+  - volume
+  - width
   return_reasons:
   - size
   - color
@@ -2588,6 +2956,7 @@
   - ap-2-4-14-3
   - ap-2-4-14-4
   attributes:
+  - package_size
   - suitable_for_water_type
   return_reasons:
   - incompatible
@@ -2601,6 +2970,7 @@
   name: Granular Fertilizers
   children: []
   attributes:
+  - package_size
   - suitable_for_water_type
   return_reasons:
   - incompatible
@@ -2614,6 +2984,7 @@
   name: Liquid Fertilizers
   children: []
   attributes:
+  - package_size
   - suitable_for_water_type
   return_reasons:
   - incompatible
@@ -2627,6 +2998,7 @@
   name: Powder Fertilizers
   children: []
   attributes:
+  - package_size
   - suitable_for_water_type
   return_reasons:
   - incompatible
@@ -2640,6 +3012,7 @@
   name: Tablet Fertilizers
   children: []
   attributes:
+  - package_size
   - suitable_for_water_type
   return_reasons:
   - incompatible
@@ -2655,6 +3028,10 @@
   attributes:
   - battery_size
   - battery_type
+  - capacity
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -2680,6 +3057,7 @@
   - ap-2-4-16-9
   attributes:
   - fish_type
+  - package_size
   - package_type
   - pet_food_flavor
   - pet_supply_product_form
@@ -2698,6 +3076,7 @@
   children: []
   attributes:
   - fish_type
+  - package_size
   - package_type
   - pet_food_flavor
   - suitable_for_fish_type
@@ -2714,6 +3093,7 @@
   children: []
   attributes:
   - fish_type
+  - package_size
   - package_type
   - pet_food_flavor
   - suitable_for_fish_type
@@ -2730,6 +3110,7 @@
   children: []
   attributes:
   - fish_type
+  - package_size
   - package_type
   - pet_food_flavor
   - suitable_for_fish_type
@@ -2746,6 +3127,7 @@
   children: []
   attributes:
   - fish_type
+  - package_size
   - package_type
   - pet_food_flavor
   - suitable_for_fish_type
@@ -2762,6 +3144,7 @@
   children: []
   attributes:
   - fish_type
+  - package_size
   - package_type
   - pet_food_flavor
   - suitable_for_fish_type
@@ -2778,6 +3161,7 @@
   children: []
   attributes:
   - fish_type
+  - package_size
   - package_type
   - pet_food_flavor
   - suitable_for_fish_type
@@ -2794,6 +3178,7 @@
   children: []
   attributes:
   - fish_type
+  - package_size
   - package_type
   - pet_food_flavor
   - suitable_for_fish_type
@@ -2810,6 +3195,7 @@
   children: []
   attributes:
   - fish_type
+  - package_size
   - package_type
   - pet_food_flavor
   - suitable_for_fish_type
@@ -2826,6 +3212,7 @@
   children: []
   attributes:
   - fish_type
+  - package_size
   - package_type
   - pet_food_flavor
   - suitable_for_fish_type
@@ -2851,8 +3238,11 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2868,8 +3258,11 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2885,8 +3278,11 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2903,8 +3299,11 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2920,8 +3319,11 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2937,8 +3339,11 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2954,8 +3359,11 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2971,8 +3379,11 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2988,8 +3399,11 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3170,7 +3584,9 @@
   attributes:
   - accessory_size
   - animal_type
+  - brim_depth
   - care_instructions
+  - circumference
   - color
   - fabric
   - pattern
@@ -3405,7 +3821,10 @@
   name: Pet Apparel Hangers
   children: []
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - color
@@ -3421,9 +3840,12 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - pattern
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -3455,11 +3877,14 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_bedding_features
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -3478,11 +3903,14 @@
   - animal_type
   - basket_material
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - pet_bedding_features
   - shape
   - suitable_space
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -3502,11 +3930,14 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_bedding_features
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -3525,11 +3956,14 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_bedding_features
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -3548,11 +3982,14 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_bedding_features
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -3571,11 +4008,14 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_bedding_features
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -3594,11 +4034,14 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_bedding_features
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -3617,11 +4060,14 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_bedding_features
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -3640,11 +4086,14 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_bedding_features
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -3663,11 +4112,14 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - pattern
   - pet_bedding_features
   - shape
   - suitable_space
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -3686,11 +4138,14 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_bedding_features
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -3709,11 +4164,14 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_bedding_features
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -3732,11 +4190,14 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_bedding_features
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -3755,11 +4216,14 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_bedding_features
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -3778,8 +4242,11 @@
   - ap-2-10-2
   - ap-2-10-3
   attributes:
+  - height
+  - length
   - material
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -3794,8 +4261,11 @@
   name: Collar Bells
   children: []
   attributes:
+  - height
+  - length
   - material
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -3810,8 +4280,11 @@
   name: Collar Charms
   children: []
   attributes:
+  - height
+  - length
   - material
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -3826,8 +4299,11 @@
   name: ID Tag Charms
   children: []
   attributes:
+  - height
+  - length
   - material
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -3846,6 +4322,9 @@
   - ap-2-11-3
   attributes:
   - connectivity_technology
+  - height
+  - length
+  - width
   return_reasons:
   - battery_life
   - incompatible
@@ -3861,7 +4340,10 @@
   attributes:
   - connectivity_technology
   - glucose_meter_features
+  - height
+  - length
   - pet_monitor_items_included
+  - width
   return_reasons:
   - battery_life
   - incompatible
@@ -3876,6 +4358,9 @@
   children: []
   attributes:
   - connectivity_technology
+  - height
+  - length
+  - width
   return_reasons:
   - battery_life
   - incompatible
@@ -3892,7 +4377,10 @@
   - battery_size
   - battery_type
   - connectivity_technology
+  - height
+  - length
   - pet_thermometer_design
+  - width
   return_reasons:
   - battery_life
   - incompatible
@@ -3906,7 +4394,10 @@
   name: Pet Bowl Mats
   children: []
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - color
@@ -3921,7 +4412,10 @@
   name: Pet Bowl Stands
   children: []
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - color
@@ -3945,9 +4439,13 @@
   - ap-2-14-8
   attributes:
   - animal_type
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3965,9 +4463,13 @@
   - animal_type
   - battery_size
   - battery_type
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3983,10 +4485,14 @@
   children: []
   attributes:
   - animal_type
+  - capacity
   - color
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -4003,9 +4509,13 @@
   children: []
   attributes:
   - animal_type
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4021,9 +4531,13 @@
   children: []
   attributes:
   - animal_type
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4039,9 +4553,13 @@
   children: []
   attributes:
   - animal_type
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4057,9 +4575,13 @@
   children: []
   attributes:
   - animal_type
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4075,9 +4597,13 @@
   children: []
   attributes:
   - animal_type
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - capacity
@@ -4094,9 +4620,13 @@
   - animal_type
   - battery_size
   - battery_type
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - capacity
@@ -4110,7 +4640,10 @@
   name: Pet Carrier & Crate Accessories
   children: []
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4136,8 +4669,12 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4153,7 +4690,11 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
+  - width
   return_reasons:
   - size
   - color
@@ -4170,7 +4711,11 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
+  - width
   return_reasons:
   - size
   - color
@@ -4187,7 +4732,11 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
+  - width
   return_reasons:
   - size
   - color
@@ -4204,6 +4753,10 @@
   attributes:
   - animal_type
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
+  - width
   return_reasons:
   - size
   - color
@@ -4219,7 +4772,11 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
+  - width
   return_reasons:
   - size
   - color
@@ -4235,7 +4792,11 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
+  - width
   return_reasons:
   - size
   - color
@@ -4252,7 +4813,11 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
+  - width
   return_reasons:
   - size
   - color
@@ -4268,7 +4833,11 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
+  - width
   return_reasons:
   - size
   - color
@@ -4285,7 +4854,11 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
+  - width
   return_reasons:
   - size
   - color
@@ -4302,7 +4875,11 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
+  - width
   return_reasons:
   - size
   - color
@@ -4330,9 +4907,12 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -4349,9 +4929,12 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -4368,9 +4951,12 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -4387,9 +4973,12 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -4407,9 +4996,12 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -4429,9 +5021,12 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -4448,9 +5043,12 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -4467,9 +5065,12 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -4487,9 +5088,12 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -4506,9 +5110,12 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -4525,9 +5132,12 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -4550,8 +5160,11 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4570,7 +5183,10 @@
   - battery_type
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4586,9 +5202,12 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -4605,8 +5224,11 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4623,7 +5245,10 @@
   - animal_type
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4639,8 +5264,11 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -4655,8 +5283,11 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4670,7 +5301,10 @@
   name: Pet Door Accessories
   children: []
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4693,7 +5327,10 @@
   - animal_type
   - color
   - door_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4711,7 +5348,10 @@
   - animal_type
   - color
   - door_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4730,7 +5370,10 @@
   - animal_type
   - color
   - door_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4748,7 +5391,10 @@
   - animal_type
   - color
   - door_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4766,7 +5412,10 @@
   - animal_type
   - color
   - door_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4784,7 +5433,10 @@
   - animal_type
   - color
   - door_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4807,6 +5459,7 @@
   attributes:
   - animal_type
   - pet_supply_product_form
+  - volume
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -4834,6 +5487,7 @@
   attributes:
   - animal_type
   - pet_supply_product_form
+  - volume
   return_reasons:
   - animal_refused
   - changed_my_mind
@@ -4848,6 +5502,7 @@
   attributes:
   - animal_type
   - pet_supply_product_form
+  - volume
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -4861,6 +5516,7 @@
   attributes:
   - animal_type
   - pet_supply_product_form
+  - volume
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -4874,6 +5530,7 @@
   attributes:
   - animal_type
   - pet_supply_product_form
+  - volume
   return_reasons:
   - animal_refused
   - changed_my_mind
@@ -4888,6 +5545,7 @@
   attributes:
   - animal_type
   - pet_supply_product_form
+  - volume
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -4904,6 +5562,9 @@
   attributes:
   - accessory_size
   - first_aid_kit_components
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -4918,6 +5579,9 @@
   attributes:
   - accessory_size
   - first_aid_kit_components
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -4932,6 +5596,9 @@
   attributes:
   - accessory_size
   - first_aid_kit_components
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -4946,6 +5613,9 @@
   attributes:
   - accessory_size
   - first_aid_kit_components
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -4979,7 +5649,10 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
   - pet_supply_product_form
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -4994,6 +5667,7 @@
   attributes:
   - animal_type
   - pet_supply_product_form
+  - volume
   return_reasons:
   - capacity
   - changed_my_mind
@@ -5008,6 +5682,7 @@
   attributes:
   - animal_type
   - pet_supply_product_form
+  - volume
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -5022,6 +5697,7 @@
   - alcohol/solvent_content
   - animal_type
   - pet_supply_product_form
+  - volume
   return_reasons:
   - capacity
   - changed_my_mind
@@ -5035,7 +5711,10 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
   - pet_supply_product_form
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5077,7 +5756,11 @@
   - ap-2-24-2
   - ap-2-24-3
   attributes:
+  - capacity
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - color
@@ -5092,7 +5775,11 @@
   name: Can Covers
   children: []
   attributes:
+  - capacity
   - food_storage_material
+  - height
+  - length
+  - width
   return_reasons:
   - color
   - capacity
@@ -5106,7 +5793,11 @@
   name: Food Storage Bins
   children: []
   attributes:
+  - capacity
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - color
   - capacity
@@ -5120,7 +5811,11 @@
   name: Food Storage Containers
   children: []
   attributes:
+  - capacity
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - color
   - capacity
@@ -5134,7 +5829,10 @@
   name: Pet Food Scoops
   children: []
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -5180,7 +5878,10 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5194,6 +5895,9 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5207,6 +5911,9 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5220,6 +5927,9 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5248,6 +5958,9 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5261,6 +5974,9 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5279,6 +5995,7 @@
   attributes:
   - alcohol/solvent_content
   - pet_supply_product_form
+  - volume
   return_reasons:
   - capacity
   - changed_my_mind
@@ -5293,6 +6010,7 @@
   attributes:
   - alcohol/solvent_content
   - pet_supply_product_form
+  - volume
   return_reasons:
   - capacity
   - changed_my_mind
@@ -5307,6 +6025,7 @@
   attributes:
   - alcohol/solvent_content
   - pet_supply_product_form
+  - volume
   return_reasons:
   - capacity
   - changed_my_mind
@@ -5321,6 +6040,7 @@
   attributes:
   - alcohol/solvent_content
   - pet_supply_product_form
+  - volume
   return_reasons:
   - capacity
   - changed_my_mind
@@ -5335,6 +6055,7 @@
   attributes:
   - alcohol/solvent_content
   - pet_supply_product_form
+  - volume
   return_reasons:
   - capacity
   - changed_my_mind
@@ -5355,7 +6076,10 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -5371,7 +6095,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5386,7 +6113,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -5404,7 +6134,10 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -5421,7 +6154,10 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -5438,7 +6174,10 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -5453,10 +6192,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_hair_dryer_design
   - pet_hair_dryer_speed_settings
+  - width
   return_reasons:
   - size
   - color
@@ -5472,6 +6214,7 @@
   attributes:
   - color
   - pattern
+  - volume
   return_reasons:
   - color
   - changed_my_mind
@@ -5488,9 +6231,12 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - pet_nail_tool_type
+  - width
   return_reasons:
   - size
   - color
@@ -5509,6 +6255,7 @@
   attributes:
   - animal_type
   - constitutive_ingredients
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -5523,6 +6270,7 @@
   attributes:
   - animal_type
   - constitutive_ingredients
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -5537,6 +6285,7 @@
   attributes:
   - animal_type
   - constitutive_ingredients
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -5551,6 +6300,7 @@
   attributes:
   - animal_type
   - constitutive_ingredients
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -5696,7 +6446,10 @@
   name: Pet Heating Pad Accessories
   children: []
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5712,8 +6465,11 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - temperature
@@ -5734,9 +6490,12 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -5753,8 +6512,11 @@
   attributes:
   - accessory_size
   - animal_type
+  - height
+  - length
   - material
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -5771,8 +6533,11 @@
   attributes:
   - accessory_size
   - animal_type
+  - height
+  - length
   - material
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -5790,8 +6555,11 @@
   attributes:
   - accessory_size
   - animal_type
+  - height
+  - length
   - material
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -5808,8 +6576,11 @@
   attributes:
   - accessory_size
   - animal_type
+  - height
+  - length
   - material
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - color
@@ -5825,7 +6596,10 @@
   name: Pet Leash Extensions
   children: []
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - length
   - incompatible
@@ -5847,10 +6621,13 @@
   attributes:
   - animal_type
   - color
+  - height
   - leash_design
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - color
   - length
@@ -5867,10 +6644,13 @@
   attributes:
   - animal_type
   - color
+  - height
   - leash_design
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - color
   - length
@@ -5887,10 +6667,13 @@
   attributes:
   - animal_type
   - color
+  - height
   - leash_design
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - color
   - length
@@ -5907,10 +6690,13 @@
   attributes:
   - animal_type
   - color
+  - height
   - leash_design
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - color
   - length
@@ -5927,10 +6713,13 @@
   attributes:
   - animal_type
   - color
+  - height
   - leash_design
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - color
   - length
@@ -5947,10 +6736,13 @@
   attributes:
   - animal_type
   - color
+  - height
   - leash_design
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - color
   - length
@@ -5967,10 +6759,13 @@
   attributes:
   - animal_type
   - color
+  - height
   - leash_design
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - color
   - length
@@ -5987,8 +6782,11 @@
   attributes:
   - accessory_size
   - animal_type
+  - height
+  - length
   - pet_control_accessory_features
   - pet_medical_collar_design
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6001,8 +6799,10 @@
   name: Pet Medical Tape & Bandages
   children: []
   attributes:
+  - length
   - medical_tape_material
   - pet_medical_supply_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6135,9 +6935,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_control_accessory_features
+  - width
   return_reasons:
   - size
   - style
@@ -6190,6 +6993,7 @@
   attributes:
   - animal_type
   - pet_food_flavor
+  - volume
   return_reasons:
   - animal_refused
   - changed_my_mind
@@ -6204,6 +7008,7 @@
   attributes:
   - animal_type
   - pet_food_flavor
+  - volume
   return_reasons:
   - animal_refused
   - changed_my_mind
@@ -6246,6 +7051,7 @@
   attributes:
   - animal_type
   - pet_food_flavor
+  - volume
   return_reasons:
   - animal_refused
   - changed_my_mind
@@ -6274,6 +7080,7 @@
   attributes:
   - animal_type
   - pet_food_flavor
+  - volume
   return_reasons:
   - animal_refused
   - changed_my_mind
@@ -6293,9 +7100,13 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - stroller_features
+  - width
   return_reasons:
   - size
   - color
@@ -6311,9 +7122,13 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - stroller_features
+  - width
   return_reasons:
   - size
   - color
@@ -6330,9 +7145,13 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - stroller_features
+  - width
   return_reasons:
   - size
   - color
@@ -6349,9 +7168,13 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - stroller_features
+  - width
   return_reasons:
   - size
   - color
@@ -6368,9 +7191,13 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - stroller_features
+  - width
   return_reasons:
   - size
   - color
@@ -6387,9 +7214,13 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - stroller_features
+  - width
   return_reasons:
   - size
   - color
@@ -6408,6 +7239,7 @@
   - product_certifications_standards
   - skin_care_features
   - spf_level
+  - volume
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -6441,9 +7273,12 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_trainer_type
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -6461,9 +7296,12 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_pad_features
+  - width
   return_reasons:
   - size
   - color
@@ -6480,9 +7318,12 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_pad_features
+  - width
   return_reasons:
   - size
   - color
@@ -6499,9 +7340,12 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_pad_features
+  - width
   return_reasons:
   - size
   - color
@@ -6518,9 +7362,12 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_pad_features
+  - width
   return_reasons:
   - size
   - color
@@ -6537,9 +7384,12 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - pet_pad_features
+  - width
   return_reasons:
   - size
   - capacity
@@ -6559,6 +7409,7 @@
   - pattern
   - pet_spray/solution_type
   - pet_supply_product_form
+  - volume
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -6629,6 +7480,7 @@
   - pet_dietary_preferences
   - pet_food_flavor
   - pet_supply_product_form
+  - volume
   return_reasons:
   - animal_refused
   - changed_my_mind
@@ -6749,8 +7601,11 @@
   - ap-2-43-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6765,7 +7620,10 @@
   name: Flashlight Dispensers
   children: []
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - color
@@ -6782,7 +7640,10 @@
   name: Standard Dispensers & Holders
   children: []
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - color
@@ -6797,7 +7658,10 @@
   name: Storage Dispensers
   children: []
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - color
@@ -6815,6 +7679,9 @@
   attributes:
   - accessory_size
   - disposable/reusable_bag_features
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - scent
@@ -6834,8 +7701,11 @@
   - ap-2-45-4
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6852,8 +7722,11 @@
   attributes:
   - color
   - disposable_bag_material
+  - height
+  - length
   - pattern
   - waste_bag_features
+  - width
   return_reasons:
   - size
   - color
@@ -6869,8 +7742,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6886,8 +7762,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6904,8 +7783,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6939,6 +7821,7 @@
   children: []
   attributes:
   - animal_type
+  - package_size
   - pet_supply_product_form
   - reptile/amphibian_food_form
   return_reasons:
@@ -6956,9 +7839,12 @@
   attributes:
   - accessory_size
   - animal_type
+  - height
+  - length
   - material
   - material_treatment
   - plant_material
+  - width
   return_reasons:
   - size
   - color
@@ -6976,11 +7862,17 @@
   - animal_type
   - battery_size
   - battery_type
+  - height
+  - length
   - light_color
   - light_pattern
   - lighting_features
   - material
+  - maximum_tank_rim_size
+  - power
   - reptile/amphibian_habitat_supply_type
+  - voltage
+  - width
   return_reasons:
   - size
   - color
@@ -7002,7 +7894,10 @@
   - accessory_size
   - animal_type
   - habitat_material
+  - height
+  - length
   - lumber/wood_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -7021,6 +7916,9 @@
   - accessory_size
   - animal_type
   - habitat_material
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -7039,6 +7937,9 @@
   - accessory_size
   - animal_type
   - habitat_material
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - capacity
@@ -7056,8 +7957,11 @@
   - accessory_size
   - animal_type
   - habitat_material
+  - height
+  - length
   - material_treatment
   - plant_material
+  - width
   return_reasons:
   - size
   - color
@@ -7076,6 +7980,9 @@
   - accessory_size
   - animal_type
   - habitat_material
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -7094,6 +8001,7 @@
   - color
   - material
   - material_treatment
+  - package_size
   - pattern
   - plant_material
   return_reasons:
@@ -7130,6 +8038,7 @@
   attributes:
   - animal_type
   - color
+  - package_size
   - pattern
   return_reasons:
   - size
@@ -7147,6 +8056,7 @@
   children: []
   attributes:
   - animal_type
+  - package_size
   - package_type
   - pet_food_flavor
   - small_animal_dietary_requirements
@@ -7166,8 +8076,11 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
   - lumber/wood_type
   - material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -7184,8 +8097,11 @@
   children: []
   attributes:
   - animal_type
+  - height
+  - length
   - material
   - small_animal_habitat/cage_type
+  - width
   return_reasons:
   - size
   - color
@@ -7207,6 +8123,7 @@
   - ap-2-47-5-6
   attributes:
   - animal_type
+  - package_size
   - pet_food_flavor
   return_reasons:
   - dietary_requirements
@@ -7222,6 +8139,7 @@
   children: []
   attributes:
   - animal_type
+  - package_size
   - pet_food_flavor
   return_reasons:
   - animal_refused
@@ -7237,6 +8155,7 @@
   children: []
   attributes:
   - animal_type
+  - package_size
   - pet_food_flavor
   return_reasons:
   - dietary_requirements
@@ -7252,6 +8171,7 @@
   children: []
   attributes:
   - animal_type
+  - package_size
   - pet_food_flavor
   return_reasons:
   - dietary_requirements
@@ -7267,6 +8187,7 @@
   children: []
   attributes:
   - animal_type
+  - package_size
   - pet_food_flavor
   return_reasons:
   - animal_refused
@@ -7282,6 +8203,7 @@
   children: []
   attributes:
   - animal_type
+  - package_size
   - pet_food_flavor
   return_reasons:
   - dietary_requirements
@@ -7297,6 +8219,7 @@
   children: []
   attributes:
   - animal_type
+  - package_size
   - pet_food_flavor
   return_reasons:
   - animal_refused
@@ -7318,8 +8241,11 @@
   attributes:
   - color
   - compatible_vehicle
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7336,8 +8262,11 @@
   attributes:
   - color
   - compatible_vehicle
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7354,8 +8283,11 @@
   attributes:
   - color
   - compatible_vehicle
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7372,8 +8304,11 @@
   attributes:
   - color
   - compatible_vehicle
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7390,8 +8325,11 @@
   attributes:
   - color
   - compatible_vehicle
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7408,8 +8346,11 @@
   attributes:
   - color
   - compatible_vehicle
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7426,9 +8367,13 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - incompatible

--- a/data/categories/bi_business_industrial.yml
+++ b/data/categories/bi_business_industrial.yml
@@ -63,10 +63,13 @@
   attributes:
   - color
   - fold_type
+  - height
+  - length
   - orientation
   - paper_finish
   - paper_size
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -84,8 +87,11 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -103,8 +109,11 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -121,8 +130,11 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -140,8 +152,11 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -159,8 +174,11 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -193,9 +211,14 @@
   - display_recommended_use
   - display_resolution
   - display_technology
+  - height
+  - length
   - operating_system
   - pattern
+  - power_consumption_typical
+  - screen_size
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -216,10 +239,15 @@
   - display_recommended_use
   - display_resolution
   - display_technology
+  - height
+  - length
   - operating_system
   - pattern
+  - power_consumption_typical
+  - screen_size
   - suitable_space
   - trade_show_display_features
+  - width
   return_reasons:
   - size
   - color
@@ -238,8 +266,11 @@
   - color
   - display_recommended_use
   - features
+  - height
+  - length
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -260,10 +291,15 @@
   - display_recommended_use
   - display_resolution
   - display_technology
+  - height
+  - length
   - operating_system
   - pattern
+  - power_consumption_typical
+  - screen_size
   - suitable_space
   - trade_show_display_features
+  - width
   return_reasons:
   - size
   - weight
@@ -285,10 +321,15 @@
   - display_recommended_use
   - display_resolution
   - display_technology
+  - height
+  - length
   - operating_system
   - pattern
+  - power_consumption_typical
+  - screen_size
   - suitable_space
   - trade_show_display_features
+  - width
   return_reasons:
   - size
   - weight
@@ -308,10 +349,15 @@
   - display_recommended_use
   - display_resolution
   - display_technology
+  - height
+  - length
   - operating_system
   - pattern
+  - power_consumption_typical
+  - screen_size
   - suitable_space
   - trade_show_display_features
+  - width
   return_reasons:
   - size
   - weight
@@ -331,10 +377,15 @@
   - display_recommended_use
   - display_resolution
   - display_technology
+  - height
+  - length
   - operating_system
   - pattern
+  - power_consumption_typical
+  - screen_size
   - suitable_space
   - trade_show_display_features
+  - width
   return_reasons:
   - size
   - color
@@ -354,10 +405,15 @@
   - display_recommended_use
   - display_resolution
   - display_technology
+  - height
+  - length
   - operating_system
   - pattern
+  - power_consumption_typical
+  - screen_size
   - suitable_space
   - trade_show_display_features
+  - width
   return_reasons:
   - size
   - color
@@ -378,10 +434,15 @@
   - display_recommended_use
   - display_resolution
   - display_technology
+  - height
+  - length
   - operating_system
   - pattern
+  - power_consumption_typical
+  - screen_size
   - suitable_space
   - trade_show_display_features
+  - width
   return_reasons:
   - size
   - color
@@ -402,10 +463,15 @@
   - display_recommended_use
   - display_resolution
   - display_technology
+  - height
+  - length
   - operating_system
   - pattern
+  - power_consumption_typical
+  - screen_size
   - suitable_space
   - trade_show_display_features
+  - width
   return_reasons:
   - size
   - color
@@ -423,9 +489,12 @@
   attributes:
   - color
   - display_recommended_use
+  - height
+  - length
   - pattern
   - suitable_space
   - trade_show_display_features
+  - width
   return_reasons:
   - size
   - color
@@ -445,8 +514,11 @@
   - battery_type
   - color
   - display_recommended_use
+  - height
+  - length
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - color
   - weight
@@ -465,11 +537,16 @@
   - display_recommended_use
   - display_resolution
   - display_technology
+  - height
+  - length
   - operating_system
   - pattern
+  - power_consumption_typical
+  - screen_size
   - suitable_space
   - totem_design
   - trade_show_display_features
+  - width
   return_reasons:
   - size
   - color
@@ -488,8 +565,11 @@
   - color
   - display_recommended_use
   - features
+  - height
+  - length
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -544,10 +624,13 @@
   attributes:
   - color
   - egg_turning
+  - height
   - humidity_control_method
+  - length
   - pattern
   - power_source
   - suitable_for_egg_type
+  - width
   return_reasons:
   - size
   - capacity
@@ -570,6 +653,7 @@
   - animal_feed_form
   - color
   - livestock_food_ingredients
+  - package_size
   - pattern
   return_reasons:
   - dietary_requirements
@@ -587,6 +671,7 @@
   - color
   - ingredient_category
   - livestock_food_ingredients
+  - package_size
   - pattern
   return_reasons:
   - dietary_requirements
@@ -605,6 +690,7 @@
   - color
   - ingredient_category
   - livestock_food_ingredients
+  - package_size
   - pattern
   return_reasons:
   - dietary_requirements
@@ -622,6 +708,7 @@
   - color
   - ingredient_category
   - livestock_food_ingredients
+  - package_size
   - pattern
   return_reasons:
   - dietary_requirements
@@ -639,6 +726,7 @@
   - color
   - ingredient_category
   - livestock_food_ingredients
+  - package_size
   - pattern
   return_reasons:
   - dietary_requirements
@@ -656,6 +744,7 @@
   - color
   - ingredient_category
   - livestock_food_ingredients
+  - package_size
   - pattern
   - pig_feed_stage
   return_reasons:
@@ -673,9 +762,13 @@
   - bi-2-1-3-2
   attributes:
   - animal_type
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -690,10 +783,14 @@
   children: []
   attributes:
   - animal_type
+  - capacity
   - color
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -709,9 +806,13 @@
   children: []
   attributes:
   - animal_type
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -727,9 +828,12 @@
   - accessory_size
   - animal_type
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_animal_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -1120,8 +1224,12 @@
   - color
   - communication_protocols
   - controller_design
+  - height
+  - length
+  - memory_capacity
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1137,8 +1245,12 @@
   - color
   - communication_protocols
   - controller_design
+  - height
+  - length
+  - memory_capacity
   - pattern
   - power_source
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -1155,8 +1267,12 @@
   - color
   - communication_protocols
   - controller_design
+  - height
+  - length
+  - memory_capacity
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1172,8 +1288,12 @@
   - color
   - communication_protocols
   - controller_design
+  - height
+  - length
+  - memory_capacity
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1189,8 +1309,12 @@
   - color
   - communication_protocols
   - controller_design
+  - height
+  - length
+  - memory_capacity
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1206,9 +1330,13 @@
   - color
   - communication_protocols
   - controller_design
+  - height
+  - length
+  - memory_capacity
   - pattern
   - phase_type
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1224,7 +1352,12 @@
   - color
   - control_method
   - controller_drive_type
+  - height
+  - input_voltage
+  - length
   - pattern
+  - power_rating
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1260,9 +1393,13 @@
   attributes:
   - color
   - connectivity_technology
+  - distance_range
   - features
+  - height
+  - length
   - pattern
   - surverying_accessories_included
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1277,9 +1414,13 @@
   attributes:
   - color
   - connectivity_technology
+  - distance_range
   - features
+  - height
+  - length
   - pattern
   - surverying_accessories_included
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1294,9 +1435,13 @@
   attributes:
   - color
   - connectivity_technology
+  - distance_range
   - features
+  - height
+  - length
   - pattern
   - surverying_accessories_included
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1311,9 +1456,13 @@
   attributes:
   - color
   - connectivity_technology
+  - distance_range
   - features
+  - height
+  - length
   - pattern
   - surverying_accessories_included
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1329,9 +1478,12 @@
   - bi-4-2-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - traffic_control_device_features
+  - width
   return_reasons:
   - size
   - color
@@ -1346,9 +1498,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - traffic_control_device_features
+  - width
   return_reasons:
   - size
   - color
@@ -1363,9 +1518,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - traffic_control_device_features
+  - width
   return_reasons:
   - size
   - color
@@ -1415,7 +1573,10 @@
   - bi-5-1-5
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - shade
   - consistency
@@ -1431,7 +1592,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - consistency
   - shade
@@ -1446,7 +1610,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - consistency
   - shade
@@ -1461,7 +1628,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - consistency
   - shade
@@ -1476,7 +1646,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - consistency
   - shade
@@ -1496,8 +1669,11 @@
   - bi-5-2-5
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1513,8 +1689,11 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -1528,10 +1707,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mirror_handle_design
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -1546,8 +1728,11 @@
   attributes:
   - color
   - dentistry_items_included
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -1562,9 +1747,12 @@
   attributes:
   - attachment_type
   - color
+  - height
+  - length
   - material
   - pattern
   - prophy_cup_design
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1580,8 +1768,11 @@
   attributes:
   - attachment_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1598,8 +1789,12 @@
   - color
   - dental_paste_flavor
   - grit_type
+  - height
+  - length
   - package_type
   - pattern
+  - volume
+  - width
   return_reasons:
   - flavor
   - grit
@@ -1619,8 +1814,11 @@
   - bi-6-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1639,7 +1837,10 @@
   - color
   - costume_theme
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1655,10 +1856,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - prop_theme
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -1677,9 +1881,12 @@
   - bi-6-3-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -1695,9 +1902,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -1714,8 +1924,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -1731,9 +1944,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -1750,7 +1966,10 @@
   - bi-7-1
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -1765,8 +1984,11 @@
   - bullion_form
   - color
   - country
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -1812,8 +2034,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1828,8 +2053,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1845,8 +2073,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1862,8 +2093,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -1877,8 +2111,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - lid_size
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1894,8 +2132,11 @@
   - bi-8-6-1
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -1909,8 +2150,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1931,7 +2175,10 @@
   attributes:
   - color
   - disposable_tableware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -1945,9 +2192,13 @@
   children: []
   attributes:
   - color
+  - diameter
   - disposable_tableware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -1963,9 +2214,14 @@
   name: Disposable Cups
   children: []
   attributes:
+  - capacity
   - color
+  - diameter
   - disposable_tableware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - capacity
@@ -1985,8 +2241,11 @@
   attributes:
   - color
   - disposable_tableware_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - color
@@ -2003,7 +2262,10 @@
   attributes:
   - color
   - disposable_tableware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - quantity
@@ -2019,8 +2281,11 @@
   attributes:
   - color
   - disposable_tableware_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - color
@@ -2037,8 +2302,11 @@
   attributes:
   - color
   - disposable_tableware_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - color
@@ -2054,9 +2322,13 @@
   children: []
   attributes:
   - color
+  - diameter
   - disposable_tableware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -2073,8 +2345,11 @@
   attributes:
   - basket_material
   - color
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2090,10 +2365,13 @@
   - furniture/fixture_color
   - furniture/fixture_material
   - furniture/fixture_pattern
+  - height
+  - length
   - shape
   - shelf_color
   - shelf_material
   - shelf_pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -2108,7 +2386,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -2124,8 +2405,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -2141,8 +2425,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -2158,8 +2445,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -2175,8 +2465,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2190,9 +2483,13 @@
   name: Take-Out Containers
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2207,10 +2504,15 @@
   attributes:
   - bottom_surface_material
   - burner_material
+  - capacity
   - color
+  - height
+  - length
   - lid_material
   - pattern
+  - power
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -2229,8 +2531,11 @@
   - bi-8-17-3
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -2246,8 +2551,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -2261,8 +2569,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -2276,8 +2587,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -2310,8 +2624,11 @@
   - bi-9-1-1
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2326,8 +2643,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2404,7 +2724,10 @@
   - accessory_size
   - color
   - gear_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - fit
@@ -2439,7 +2762,10 @@
   - accessory_size
   - color
   - gear_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -2459,8 +2785,12 @@
   - bi-9-3-3
   attributes:
   - color
+  - handle_length
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2476,8 +2806,12 @@
   attributes:
   - blade_material
   - handle_color
+  - handle_length
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -2492,9 +2826,14 @@
   children: []
   attributes:
   - handle_color
+  - handle_length
   - handle_material
   - handle_pattern
+  - height
   - jaw_material
+  - jaw_opening
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2510,7 +2849,10 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - scale_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2547,7 +2889,10 @@
   - color
   - cover_features
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2564,8 +2909,11 @@
   attributes:
   - chair_features
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -2587,8 +2935,11 @@
   attributes:
   - chair_features
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -2605,8 +2956,11 @@
   attributes:
   - chair_features
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -2623,8 +2977,11 @@
   attributes:
   - chair_features
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -2642,8 +2999,11 @@
   attributes:
   - chair_features
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -2660,8 +3020,11 @@
   attributes:
   - chair_features
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -2712,7 +3075,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2728,7 +3094,10 @@
   attributes:
   - bulldozer_blade_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2745,8 +3114,12 @@
   - chair_features
   - chipper_technology
   - color
+  - height
+  - length
+  - maximum_cutting_diameter
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2761,7 +3134,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -2778,7 +3154,10 @@
   attributes:
   - color
   - discharge_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -2798,7 +3177,10 @@
   - bi-11-6-4
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2813,7 +3195,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2827,7 +3212,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2841,7 +3229,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2855,7 +3246,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2875,7 +3269,10 @@
   attributes:
   - color
   - drive_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2891,7 +3288,10 @@
   attributes:
   - color
   - drive_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2906,7 +3306,10 @@
   attributes:
   - color
   - drive_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2921,7 +3324,10 @@
   attributes:
   - color
   - drive_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2936,7 +3342,10 @@
   attributes:
   - color
   - drive_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2951,7 +3360,10 @@
   attributes:
   - color
   - drive_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2964,8 +3376,12 @@
   name: Motor Graders
   children: []
   attributes:
+  - blade_size
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2982,7 +3398,10 @@
   - bi-11-9-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2997,7 +3416,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -3011,7 +3433,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -3028,7 +3453,10 @@
   - bi-11-10-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -3044,7 +3472,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -3059,7 +3490,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -3074,7 +3508,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -3089,7 +3526,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -3114,7 +3554,11 @@
   attributes:
   - color
   - drive_type
+  - height
+  - horsepower
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -3131,9 +3575,13 @@
   - color
   - engine_type
   - fuel_supply
+  - height
+  - horsepower
   - item_condition
+  - length
   - pattern
   - tractor_accessories_included
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -3150,9 +3598,13 @@
   - drive_type
   - engine_type
   - fuel_supply
+  - height
+  - horsepower
   - item_condition
+  - length
   - pattern
   - tractor_accessories_included
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -3169,9 +3621,13 @@
   - drive_type
   - engine_type
   - fuel_supply
+  - height
+  - horsepower
   - item_condition
+  - length
   - pattern
   - tractor_accessories_included
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -3188,9 +3644,13 @@
   - drive_type
   - engine_type
   - fuel_supply
+  - height
+  - horsepower
   - item_condition
+  - length
   - pattern
   - tractor_accessories_included
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -3282,7 +3742,12 @@
   - bi-11-13-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - trench_depth
+  - trench_width
+  - width
   return_reasons:
   - size
   - incompatible
@@ -3297,7 +3762,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - trench_depth
+  - trench_width
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -3311,7 +3781,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - trench_depth
+  - trench_width
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -3325,7 +3800,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -3344,7 +3822,10 @@
   - bi-11-15-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -3360,7 +3841,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -3375,7 +3859,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -3390,7 +3877,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -3404,9 +3894,13 @@
   name: Yard Scrapers
   children: []
   attributes:
+  - blade_size
   - color
+  - height
+  - length
   - pattern
   - propulsion_type
+  - width
   return_reasons:
   - size
   - capacity
@@ -3762,8 +4256,11 @@
   attributes:
   - color
   - counter_shape
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3784,8 +4281,11 @@
   - bi-12-1-2-5
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3802,8 +4302,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3820,8 +4323,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - rack_design
+  - width
   return_reasons:
   - size
   - color
@@ -3837,8 +4343,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3854,9 +4363,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3872,8 +4384,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3891,7 +4406,10 @@
   - bi-12-2-1
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3910,7 +4428,10 @@
   - bell_sound
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3926,8 +4447,11 @@
   - bi-12-3-1
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3944,8 +4468,11 @@
   attributes:
   - color
   - counter_shape
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3982,9 +4509,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lock_type
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -4003,9 +4533,12 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - shelf_color
   - shelf_material
   - shelf_pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4021,8 +4554,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -4039,9 +4575,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lock_type
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4059,8 +4598,11 @@
   - bi-14-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4075,8 +4617,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4091,8 +4636,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4107,8 +4655,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -4125,8 +4676,11 @@
   - bi-15-4
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -4140,8 +4694,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -4157,8 +4714,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -4174,8 +4734,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4214,8 +4777,11 @@
   attributes:
   - color
   - handcuff_lock_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - lock_type
@@ -4231,8 +4797,11 @@
   attributes:
   - color
   - handcuff_lock_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - lock_type
@@ -4248,8 +4817,11 @@
   attributes:
   - color
   - handcuff_lock_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -4266,8 +4838,11 @@
   attributes:
   - color
   - handcuff_lock_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - lock_type
@@ -4283,8 +4858,11 @@
   attributes:
   - color
   - handcuff_lock_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - lock_type
@@ -4300,8 +4878,11 @@
   attributes:
   - color
   - handcuff_lock_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - lock_type
@@ -4321,9 +4902,12 @@
   - color
   - detector_sensitivity
   - frequency_type
+  - height
+  - length
   - metal_detector_features
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - battery_life
@@ -4342,9 +4926,12 @@
   - color
   - detector_sensitivity
   - frequency_type
+  - height
+  - length
   - metal_detector_features
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - battery_life
@@ -4363,9 +4950,12 @@
   - color
   - detector_sensitivity
   - frequency_type
+  - height
+  - length
   - metal_detector_features
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - battery_life
@@ -4382,9 +4972,12 @@
   - color
   - detector_sensitivity
   - frequency_type
+  - height
+  - length
   - metal_detector_features
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - battery_life
@@ -4422,7 +5015,10 @@
   attributes:
   - automation
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -4439,7 +5035,10 @@
   attributes:
   - automation
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -4455,7 +5054,10 @@
   attributes:
   - automation
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -4470,7 +5072,10 @@
   attributes:
   - automation
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -4485,7 +5090,10 @@
   attributes:
   - automation
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -4500,7 +5108,10 @@
   attributes:
   - automation
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -4539,7 +5150,10 @@
   - bi-18-1-5
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4556,7 +5170,10 @@
   attributes:
   - color
   - conveyor_operation
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4572,7 +5189,10 @@
   attributes:
   - color
   - conveyor_operation
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4588,7 +5208,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4603,8 +5226,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - pneumatic_conveyor_operation
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4620,7 +5246,10 @@
   attributes:
   - color
   - conveyor_operation
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4662,8 +5291,11 @@
   - bi-18-2-1-5
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4678,8 +5310,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4694,8 +5329,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4710,8 +5348,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4726,8 +5367,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4742,8 +5386,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4762,8 +5409,11 @@
   - bi-18-2-2-4
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4778,8 +5428,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4794,8 +5447,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4812,8 +5468,11 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4828,8 +5487,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4850,10 +5512,14 @@
   - bi-18-2-3-6
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - power
   - power_source
   - suitable_for_vehicle_type
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4868,10 +5534,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - power
   - power_source
   - suitable_for_vehicle_type
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4886,10 +5556,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - power
   - power_source
   - suitable_for_vehicle_type
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4904,10 +5578,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - power
   - power_source
   - suitable_for_vehicle_type
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4922,10 +5600,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - power
   - power_source
   - suitable_for_vehicle_type
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4940,10 +5622,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - power
   - power_source
   - suitable_for_vehicle_type
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4958,10 +5644,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - power
   - power_source
   - suitable_for_vehicle_type
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4980,7 +5670,10 @@
   - bi-18-2-4-5
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4996,7 +5689,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5012,7 +5708,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5028,7 +5727,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5044,7 +5746,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5062,8 +5767,13 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - input_voltage
+  - length
   - pattern
+  - power
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5083,8 +5793,11 @@
   - bi-18-3-4
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5100,8 +5813,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5116,8 +5832,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5132,8 +5851,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5148,8 +5870,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5190,8 +5915,13 @@
   children: []
   attributes:
   - color
+  - curtain_drop
+  - curtain_width
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -5210,8 +5940,11 @@
   - bi-19-2-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -5227,8 +5960,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -5243,8 +5979,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -5260,8 +5999,11 @@
   attributes:
   - bedding_size
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -5300,9 +6042,14 @@
   children: []
   attributes:
   - color
+  - energy_selection_adult_mode
+  - energy_selection_child_mode
   - external_defibrillator_features
+  - height
+  - length
   - operating_mode
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5317,7 +6064,10 @@
   attributes:
   - color
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -5339,8 +6089,11 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5354,7 +6107,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5368,7 +6124,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5382,9 +6141,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - tuning_fork_design
   - tuning_fork_frequency
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5398,7 +6160,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5414,8 +6179,11 @@
   - bi-19-4-4-4
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5431,9 +6199,12 @@
   attributes:
   - color
   - compatible_patient_profile
+  - height
+  - length
   - material
   - pattern
   - stretcher/gurney_intended_use
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5449,9 +6220,12 @@
   attributes:
   - color
   - compatible_patient_profile
+  - height
+  - length
   - material
   - pattern
   - stretcher/gurney_intended_use
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5467,9 +6241,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5487,8 +6264,11 @@
   - bi-19-4-6-4
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5505,8 +6285,11 @@
   - color
   - compatible_patient_profile
   - equipment_operation
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5523,8 +6306,11 @@
   - color
   - compatible_patient_profile
   - equipment_operation
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5541,8 +6327,11 @@
   - color
   - compatible_patient_profile
   - equipment_operation
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5558,9 +6347,12 @@
   - bi-19-4-7-1
   attributes:
   - color
+  - height
+  - length
   - pattern
   - stethoscope_design
   - stethoscope_technology
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5574,9 +6366,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - stethoscope_design
   - stethoscope_technology
+  - width
   return_reasons:
   - size
   - color
@@ -5595,7 +6390,10 @@
   - bi-19-4-8-4
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5610,7 +6408,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5625,7 +6426,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5640,7 +6444,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5657,7 +6464,10 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5675,8 +6485,11 @@
   - bi-19-4-9-3
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5690,8 +6503,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5705,8 +6521,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5720,8 +6539,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5759,7 +6581,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5776,7 +6601,10 @@
   - chiropractic_table_design
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5793,7 +6621,10 @@
   - chiropractic_table_design
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5831,7 +6662,10 @@
   - color
   - compatible_patient_profile
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5848,7 +6682,10 @@
   - color
   - compatible_patient_profile
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5865,7 +6702,10 @@
   - color
   - compatible_patient_profile
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5884,7 +6724,10 @@
   - color
   - compatible_patient_profile
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5901,7 +6744,10 @@
   - color
   - compatible_patient_profile
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5918,7 +6764,10 @@
   - color
   - compatible_patient_profile
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5937,7 +6786,10 @@
   attributes:
   - bedding_size
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5951,10 +6803,16 @@
   name: Full-Electric Beds
   children: []
   attributes:
+  - amperage
   - bedding_size
   - color
   - compatible_patient_profile
+  - height
+  - length
   - pattern
+  - power_consumption_typical
+  - voltage
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5971,7 +6829,10 @@
   - bedding_size
   - color
   - compatible_patient_profile
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5985,9 +6846,15 @@
   name: Semi-Electric Beds
   children: []
   attributes:
+  - amperage
   - bedding_size
   - color
+  - height
+  - length
   - pattern
+  - power_consumption_typical
+  - voltage
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -6005,8 +6872,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -6022,8 +6892,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -6039,8 +6912,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -6079,7 +6955,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -6095,7 +6974,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -6111,7 +6993,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -6127,7 +7012,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -6143,7 +7031,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -6160,7 +7051,10 @@
   - cart_design
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -6179,8 +7073,11 @@
   attributes:
   - color
   - compatible_patient_profile
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -6196,8 +7093,11 @@
   attributes:
   - color
   - compatible_patient_profile
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -6213,8 +7113,11 @@
   attributes:
   - color
   - compatible_patient_profile
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -6251,8 +7154,11 @@
   - bi-19-6-1-4
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6266,8 +7172,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6281,8 +7190,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6296,8 +7208,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6311,8 +7226,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6326,12 +7244,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - product_sterility
   - scalpel_blade_material
   - scalpel_blade_number
   - scalpel_blade_shape
   - usage_type
+  - width
   return_reasons:
   - size
   - shape
@@ -6347,6 +7268,8 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - product_sterility
   - scalpel_blade_material
@@ -6354,6 +7277,7 @@
   - scalpel_blade_shape
   - scalpel_handle_number
   - usage_type
+  - width
   return_reasons:
   - size
   - shape
@@ -6388,7 +7312,10 @@
   - bi-19-6-4-1-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - gauge
   - changed_my_mind
@@ -6402,7 +7329,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - gauge
   - changed_my_mind
@@ -6416,7 +7346,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - gauge
   - changed_my_mind
@@ -6430,7 +7363,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - gauge
   - changed_my_mind
@@ -6446,7 +7382,10 @@
   - bi-19-6-4-2-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - gauge
   - changed_my_mind
@@ -6460,7 +7399,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - gauge
   - changed_my_mind
@@ -6474,7 +7416,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - gauge
   - changed_my_mind
@@ -6526,8 +7471,11 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6544,12 +7492,15 @@
   - bi-19-7-3-3
   attributes:
   - color
+  - height
+  - length
   - medical_syringe_purpose
   - needle_gauge
   - needle_housing_material
   - pattern
   - tip_design
   - usage_type
+  - width
   return_reasons:
   - capacity
   - gauge
@@ -6565,12 +7516,16 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - medical_syringe_purpose
   - needle_gauge
   - needle_housing_material
   - pattern
+  - syringe_size
   - tip_design
   - usage_type
+  - width
   return_reasons:
   - capacity
   - gauge
@@ -6586,12 +7541,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - medical_syringe_purpose
   - needle_gauge
   - needle_housing_material
   - pattern
   - tip_design
   - usage_type
+  - width
   return_reasons:
   - gauge
   - incompatible
@@ -6606,12 +7564,16 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - medical_syringe_purpose
   - needle_gauge
   - needle_housing_material
   - pattern
+  - syringe_size
   - tip_design
   - usage_type
+  - width
   return_reasons:
   - capacity
   - gauge
@@ -6632,7 +7594,10 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -6648,7 +7613,10 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - caused_irritation
   - residue
@@ -6664,7 +7632,10 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -6680,7 +7651,10 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -6696,7 +7670,10 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - flange_size
   - adhesive_strength
@@ -6714,8 +7691,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6753,7 +7733,10 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6768,7 +7751,10 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6783,7 +7769,10 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6798,7 +7787,10 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6813,7 +7805,10 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -6967,8 +7962,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6985,9 +7983,12 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - material
   - pattern
   - product_sterility
+  - width
   return_reasons:
   - size
   - material
@@ -7043,8 +8044,13 @@
   - bi-20-1-1-4
   attributes:
   - color
+  - crusher_output_size
+  - feed_size
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -7059,8 +8065,13 @@
   children: []
   attributes:
   - color
+  - crusher_output_size
+  - feed_size
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -7075,8 +8086,13 @@
   children: []
   attributes:
   - color
+  - crusher_output_size
+  - feed_size
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -7091,8 +8107,13 @@
   children: []
   attributes:
   - color
+  - crusher_output_size
+  - feed_size
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -7107,8 +8128,13 @@
   children: []
   attributes:
   - color
+  - crusher_output_size
+  - feed_size
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -7125,8 +8151,11 @@
   - color
   - drilling_method
   - drilling_rig_orientation
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -7141,8 +8170,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7195,10 +8227,13 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - needle_gauge
   - needle_material
   - pattern
+  - width
   return_reasons:
   - gauge
   - incompatible
@@ -7213,9 +8248,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - needle_gauge
   - needle_material
   - pattern
+  - width
   return_reasons:
   - gauge
   - incompatible
@@ -7230,9 +8268,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - needle_gauge
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7265,8 +8306,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7281,7 +8325,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - volume
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -7300,9 +8348,12 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7317,9 +8368,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7335,9 +8389,12 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7352,9 +8409,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7373,9 +8433,12 @@
   - bi-21-2-4-4
   attributes:
   - color
+  - height
+  - length
   - needle_gauge
   - needle_material
   - pattern
+  - width
   return_reasons:
   - gauge
   - incompatible
@@ -7390,9 +8453,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - needle_gauge
   - needle_material
   - pattern
+  - width
   return_reasons:
   - gauge
   - incompatible
@@ -7407,9 +8473,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - needle_gauge
   - needle_material
   - pattern
+  - width
   return_reasons:
   - gauge
   - incompatible
@@ -7424,9 +8493,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - needle_gauge
   - needle_material
   - pattern
+  - width
   return_reasons:
   - gauge
   - incompatible
@@ -7441,9 +8513,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - needle_gauge
   - needle_material
   - pattern
+  - width
   return_reasons:
   - gauge
   - incompatible
@@ -7485,8 +8560,11 @@
   - bi-22-1-4
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7503,8 +8581,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7521,8 +8602,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7539,8 +8623,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7557,8 +8644,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7579,9 +8669,12 @@
   - bi-22-2-4
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - target_gender
+  - width
   return_reasons:
   - size
   - color
@@ -7597,9 +8690,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - target_gender
+  - width
   return_reasons:
   - size
   - color
@@ -7615,9 +8711,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - target_gender
+  - width
   return_reasons:
   - size
   - color
@@ -7633,9 +8732,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - target_gender
+  - width
   return_reasons:
   - size
   - color
@@ -7651,9 +8753,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - target_gender
+  - width
   return_reasons:
   - size
   - color
@@ -7673,8 +8778,11 @@
   - bi-22-3-4
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7690,8 +8798,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7707,8 +8818,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7725,8 +8839,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7742,8 +8859,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7782,10 +8902,13 @@
   attributes:
   - color
   - currencies_supported
+  - height
+  - length
   - pattern
   - portability
   - power_source
   - verification_technology
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7821,9 +8944,12 @@
   - bi-22-4-2-1-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - portability
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7838,9 +8964,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - portability
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7855,9 +8984,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - portability
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7874,8 +9006,11 @@
   - battery_type
   - color
   - connectivity_technology
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7892,9 +9027,15 @@
   - connectivity_technology
   - display_resolution
   - display_technology
+  - height
+  - length
   - pad_display_profile
   - pattern
   - portability
+  - screen_size
+  - width
+  - working_area_height
+  - working_area_width
   return_reasons:
   - size
   - changed_my_mind
@@ -7910,7 +9051,10 @@
   - bi-22-4-3-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7925,8 +9069,11 @@
   attributes:
   - color
   - connectivity_technology
+  - height
+  - length
   - pattern
   - terminal_operation
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7940,9 +9087,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - mounting_type
   - operating_system
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7957,8 +9107,11 @@
   attributes:
   - color
   - currency_type
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -7975,9 +9128,12 @@
   - color
   - currency_type
   - display_technology
+  - height
   - housing_material
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7992,8 +9148,11 @@
   attributes:
   - bag/case_material
   - color
+  - height
+  - length
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - capacity
@@ -8009,7 +9168,10 @@
   attributes:
   - color
   - currency_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8028,8 +9190,11 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - pattern
   - shopping_bag_material
+  - width
   return_reasons:
   - size
   - color
@@ -8045,8 +9210,11 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - pattern
   - shopping_bag_material
+  - width
   return_reasons:
   - size
   - color
@@ -8062,8 +9230,11 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - pattern
   - shopping_bag_material
+  - width
   return_reasons:
   - size
   - color
@@ -8079,8 +9250,11 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - pattern
   - shopping_bag_material
+  - width
   return_reasons:
   - size
   - color
@@ -8096,8 +9270,11 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - pattern
   - shopping_bag_material
+  - width
   return_reasons:
   - size
   - color
@@ -8112,7 +9289,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8127,9 +9307,12 @@
   attributes:
   - bag/case_material
   - color
+  - height
+  - length
   - lighting_features
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -8146,8 +9329,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -8249,7 +9435,10 @@
   - bi-23-2-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8263,7 +9452,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8277,7 +9469,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8400,8 +9595,14 @@
   children: []
   attributes:
   - autoclave_sterilization_method
+  - capacity
   - color
+  - height
+  - length
   - pattern
+  - power
+  - steam_pressure
+  - width
   return_reasons:
   - size
   - capacity
@@ -8416,8 +9617,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_spin_speed
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -8432,8 +9637,12 @@
   children: []
   attributes:
   - color
+  - height
+  - ice_production_rate
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -8447,9 +9656,13 @@
   name: Freeze-Drying Machines
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -8464,8 +9677,12 @@
   children: []
   attributes:
   - blending_type
+  - capacity
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -8480,8 +9697,11 @@
   children: []
   attributes:
   - color
+  - height
   - laboratory_freezer_design
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -8500,8 +9720,12 @@
   - bi-23-4-7-4
   attributes:
   - color
+  - diameter
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8515,8 +9739,12 @@
   children: []
   attributes:
   - color
+  - diameter
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8531,8 +9759,12 @@
   children: []
   attributes:
   - color
+  - diameter
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8546,8 +9778,12 @@
   children: []
   attributes:
   - color
+  - diameter
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8561,8 +9797,12 @@
   children: []
   attributes:
   - color
+  - diameter
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -8578,8 +9818,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8596,7 +9839,10 @@
   - bi-23-4-9-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -8611,7 +9857,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -8626,7 +9875,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -8641,7 +9893,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -8677,7 +9932,10 @@
   attributes:
   - camera_sensor_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8697,8 +9955,11 @@
   attributes:
   - color
   - eyepiece/adapter_material
+  - height
+  - length
   - magnification
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8714,8 +9975,11 @@
   attributes:
   - color
   - eyepiece/adapter_material
+  - height
+  - length
   - magnification
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8731,8 +9995,11 @@
   attributes:
   - color
   - eyepiece/adapter_material
+  - height
+  - length
   - magnification
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8748,8 +10015,11 @@
   attributes:
   - color
   - eyepiece/adapter_material
+  - height
+  - length
   - magnification
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8765,8 +10035,11 @@
   attributes:
   - color
   - eyepiece/adapter_material
+  - height
+  - length
   - magnification
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8783,11 +10056,19 @@
   - bi-23-4-10-3-2
   - bi-23-4-10-3-3
   attributes:
+  - clear_aperture
   - color
+  - diameter
+  - effective_focal_length_efl
+  - height
+  - length
   - magnification
   - maximum_magnification
   - minimum_magnification
   - pattern
+  - tube_length
+  - width
+  - working_distance
   return_reasons:
   - size
   - incompatible
@@ -8801,12 +10082,20 @@
   name: Achromatic Microscope Lenses
   children: []
   attributes:
+  - clear_aperture
   - color
+  - diameter
+  - effective_focal_length_efl
   - field_flatness
+  - height
+  - length
   - magnification
   - maximum_magnification
   - minimum_magnification
   - pattern
+  - tube_length
+  - width
+  - working_distance
   return_reasons:
   - size
   - incompatible
@@ -8820,12 +10109,20 @@
   name: Apochromatic Microscope Lenses
   children: []
   attributes:
+  - clear_aperture
   - color
+  - diameter
+  - effective_focal_length_efl
   - field_flatness
+  - height
+  - length
   - magnification
   - maximum_magnification
   - minimum_magnification
   - pattern
+  - tube_length
+  - width
+  - working_distance
   return_reasons:
   - size
   - incompatible
@@ -8839,12 +10136,20 @@
   name: Fluorite Microscope Lenses
   children: []
   attributes:
+  - clear_aperture
   - color
+  - diameter
+  - effective_focal_length_efl
   - field_flatness
+  - height
+  - length
   - magnification
   - maximum_magnification
   - minimum_magnification
   - pattern
+  - tube_length
+  - width
+  - working_distance
   return_reasons:
   - size
   - incompatible
@@ -8858,9 +10163,15 @@
   name: Microscope Replacement Bulbs
   children: []
   attributes:
+  - bulb_power
   - bulb_type
   - color
+  - height
+  - illuminance
+  - length
   - pattern
+  - voltage
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8879,8 +10190,12 @@
   - bi-23-4-10-5-4
   attributes:
   - color
+  - height
+  - length
   - microscope_slide_material
+  - microscope_slide_thickness
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8894,8 +10209,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - microscope_slide_material
+  - microscope_slide_thickness
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8909,8 +10228,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - microscope_slide_material
+  - microscope_slide_thickness
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8924,8 +10247,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - microscope_slide_material
+  - microscope_slide_thickness
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8939,8 +10266,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - microscope_slide_material
+  - microscope_slide_thickness
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8957,11 +10288,14 @@
   - bi-23-4-11-4
   attributes:
   - color
+  - height
   - illumination_technique
+  - length
   - magnification
   - maximum_magnification
   - microscope_features
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8977,11 +10311,14 @@
   - battery_size
   - battery_type
   - color
+  - height
   - illumination_technique
+  - length
   - magnification
   - maximum_magnification
   - microscope_features
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8995,11 +10332,14 @@
   children: []
   attributes:
   - color
+  - height
   - illumination_technique
+  - length
   - magnification
   - maximum_magnification
   - microscope_features
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9013,11 +10353,14 @@
   children: []
   attributes:
   - color
+  - height
   - illumination_technique
+  - length
   - magnification
   - maximum_magnification
   - microscope_features
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9034,7 +10377,10 @@
   - bi-23-4-12-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9048,7 +10394,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9062,7 +10411,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9076,7 +10428,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9092,7 +10447,10 @@
   - bi-23-4-13-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9107,7 +10465,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9122,7 +10483,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9141,7 +10505,10 @@
   - bi-23-4-14-4
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9155,7 +10522,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9169,7 +10539,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9183,7 +10556,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9197,7 +10573,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9211,8 +10590,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - preservation_type
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -9248,9 +10630,13 @@
   name: Beakers
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -9264,9 +10650,13 @@
   name: Graduated Cylinders
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -9284,9 +10674,13 @@
   - bi-23-6-3-3
   - bi-23-6-3-4
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -9300,9 +10694,13 @@
   name: Boiling Laboratory Flasks
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -9315,9 +10713,13 @@
   name: Buchner Laboratory Flasks
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -9331,9 +10733,13 @@
   name: Erlenmeyer Laboratory Flasks
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -9347,9 +10753,13 @@
   name: Volumetric Laboratory Flasks
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -9363,9 +10773,14 @@
   name: Petri Dishes
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - petri_dish_size
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9381,9 +10796,13 @@
   - bi-23-6-5-2
   - bi-23-6-5-3
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -9397,9 +10816,13 @@
   name: Graduated Pipettes
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -9413,9 +10836,13 @@
   name: Micropipettes
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -9429,9 +10856,13 @@
   name: Volumetric Pipettes
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -9445,8 +10876,11 @@
   children: []
   attributes:
   - color
+  - height
   - housing_material
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9459,9 +10893,13 @@
   name: Test Tubes
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9474,9 +10912,13 @@
   name: Wash Bottles
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - capacity
@@ -9521,11 +10963,14 @@
   - accessory_size
   - color
   - display_technology
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - portability
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -9544,9 +10989,13 @@
   - connectivity_technology
   - display_resolution
   - display_technology
+  - height
+  - length
   - pattern
   - portability
+  - screen_size
   - suitable_space
+  - width
   return_reasons:
   - size
   - brightness
@@ -9563,13 +11012,19 @@
   - bi-24-3-1
   - bi-24-3-2
   attributes:
+  - amperage
   - color
   - display_sign_design
   - display_technology
+  - height
+  - length
   - pattern
   - portability
+  - power_consumption_typical
   - power_source
   - suitable_space
+  - voltage
+  - width
   return_reasons:
   - size
   - color
@@ -9590,10 +11045,13 @@
   - color
   - display_sign_design
   - display_technology
+  - height
+  - length
   - pattern
   - portability
   - power_source
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -9613,10 +11071,13 @@
   - color
   - display_sign_design
   - display_technology
+  - height
+  - length
   - pattern
   - portability
   - power_source
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -9634,11 +11095,14 @@
   - color
   - display_technology
   - emergency/safety_sign_design
+  - height
+  - length
   - lighting_options
   - pattern
   - portability
   - power_source
   - suitable_space
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -9654,11 +11118,14 @@
   - color
   - display_technology
   - facility_sign_design
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - portability
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -9675,12 +11142,15 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - material
   - mounting_type
   - open/closed_sign_design
   - pattern
   - portability
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -9696,11 +11166,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mounting_type
   - parking_sign_design
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -9715,11 +11188,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - policy_sign_design
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -9735,12 +11211,15 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - portability
   - retail/sale_sign_design
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -9756,11 +11235,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - road_sign_design
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -9776,10 +11258,13 @@
   attributes:
   - color
   - emergency/safety_sign_design
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - warning_category
+  - width
   return_reasons:
   - size
   - color
@@ -9795,10 +11280,13 @@
   attributes:
   - color
   - emergency/safety_sign_design
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - warning_category
+  - width
   return_reasons:
   - size
   - color
@@ -9813,11 +11301,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - retail/sale_sign_design
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -9865,7 +11356,10 @@
   - bullet_protection_level
   - color
   - gear_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9884,7 +11378,10 @@
   attributes:
   - color
   - filtration_class
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - filtration_class
@@ -9901,7 +11398,10 @@
   attributes:
   - color
   - filtration_class
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - filtration_class
   - incompatible
@@ -9917,7 +11417,10 @@
   attributes:
   - color
   - filtration_class
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - filtration_class
   - incompatible
@@ -9933,7 +11436,10 @@
   attributes:
   - color
   - filtration_class
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - filtration_class
   - incompatible
@@ -9950,8 +11456,11 @@
   - color
   - gear_material
   - hardhat_class
+  - height
+  - length
   - pattern
   - protection_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9971,7 +11480,10 @@
   - color
   - gear_material
   - hazmat_suit_design
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9991,7 +11503,10 @@
   - accessory_size
   - color
   - gear_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10009,7 +11524,10 @@
   - accessory_size
   - color
   - gear_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10027,7 +11545,10 @@
   - accessory_size
   - color
   - gear_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10045,7 +11566,10 @@
   - accessory_size
   - color
   - gear_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10065,9 +11589,12 @@
   attributes:
   - frame_color
   - frame_pattern
+  - height
+  - length
   - lens_color
   - lens_pattern
   - protective_gear_features
+  - width
   return_reasons:
   - size
   - fit
@@ -10083,9 +11610,12 @@
   attributes:
   - frame_color
   - frame_pattern
+  - height
+  - length
   - lens_color
   - lens_pattern
   - protective_gear_features
+  - width
   return_reasons:
   - coverage
   - fit
@@ -10102,9 +11632,12 @@
   attributes:
   - frame_color
   - frame_pattern
+  - height
+  - length
   - lens_color
   - lens_pattern
   - protective_gear_features
+  - width
   return_reasons:
   - size
   - fit
@@ -10120,9 +11653,12 @@
   attributes:
   - frame_color
   - frame_pattern
+  - height
+  - length
   - lens_color
   - lens_pattern
   - protective_gear_features
+  - width
   return_reasons:
   - size
   - fit
@@ -10143,10 +11679,13 @@
   - accessory_size
   - color
   - gear_material
+  - height
+  - length
   - pattern
   - protective_mask_design
   - protective_mask_features
   - usage_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10167,9 +11706,12 @@
   - dust_mask_type
   - filtration_class
   - gear_material
+  - height
+  - length
   - pattern
   - protective_mask_features
   - usage_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10187,11 +11729,14 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - material
   - pattern
   - protective_mask_design
   - protective_mask_features
   - usage_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10211,10 +11756,13 @@
   - accessory_size
   - color
   - gear_material
+  - height
+  - length
   - pattern
   - protective_mask_design
   - protective_mask_features
   - usage_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10233,10 +11781,13 @@
   - accessory_size
   - color
   - gear_material
+  - height
+  - length
   - pattern
   - protective_mask_design
   - protective_mask_features
   - usage_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10350,7 +11901,10 @@
   - attachment_type
   - color
   - gear_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - fit
@@ -10365,11 +11919,15 @@
   children: []
   attributes:
   - color
+  - height
   - helmet_shade_design
+  - length
   - pattern
+  - reaction_time
   - viewing_area_height
   - viewing_area_width
   - welding_helmet_features
+  - width
   return_reasons:
   - size
   - field_of_view
@@ -10390,7 +11948,10 @@
   - accessory_size
   - color
   - gear_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10409,7 +11970,10 @@
   - accessory_size
   - color
   - gear_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10428,7 +11992,10 @@
   - accessory_size
   - color
   - gear_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10447,7 +12014,10 @@
   - accessory_size
   - color
   - gear_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10468,7 +12038,10 @@
   attributes:
   - color
   - gear_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - weight_capacity
@@ -10485,7 +12058,10 @@
   attributes:
   - color
   - gear_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - weight_capacity
@@ -10501,7 +12077,10 @@
   attributes:
   - color
   - gear_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - weight_capacity
@@ -10517,7 +12096,10 @@
   attributes:
   - color
   - gear_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - length

--- a/data/categories/bt_baby_toddler.yml
+++ b/data/categories/bt_baby_toddler.yml
@@ -54,10 +54,14 @@
   - bt-1-1-5
   attributes:
   - color
+  - height
   - infant_age_group
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -71,10 +75,14 @@
   children: []
   attributes:
   - color
+  - height
   - infant_age_group
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - difficult_to_clean
   - fit
@@ -89,10 +97,14 @@
   children: []
   attributes:
   - color
+  - height
   - infant_age_group
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - size
   - support
@@ -108,10 +120,14 @@
   children: []
   attributes:
   - color
+  - height
   - infant_age_group
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - size
   - support
@@ -127,10 +143,14 @@
   children: []
   attributes:
   - color
+  - height
   - infant_age_group
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - size
   - drainage
@@ -145,10 +165,14 @@
   children: []
   attributes:
   - color
+  - height
   - infant_age_group
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -163,9 +187,12 @@
   - bt-1-2-1
   attributes:
   - color
+  - height
   - infant_age_group
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - coverage
@@ -180,9 +207,12 @@
   children: []
   attributes:
   - color
+  - height
   - infant_age_group
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - flow_rate
   - capacity
@@ -201,11 +231,14 @@
   - care_instructions
   - color
   - gift_set_format
+  - height
   - infant_age_group
+  - length
   - material
   - pattern
   - personalization_options
   - target_gender
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -222,7 +255,10 @@
   - bt-3-4
   - bt-3-5
   attributes:
+  - height
   - infant_age_group
+  - length
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -237,9 +273,12 @@
   - baby_health_items_included
   - color
   - grooming_kit_format
+  - height
   - infant_age_group
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -252,9 +291,12 @@
   children: []
   attributes:
   - color
+  - height
   - infant_age_group
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - suction
   - tip_size
@@ -271,9 +313,12 @@
   - care_instructions
   - closure_type
   - color
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - grip
   - length
@@ -287,7 +332,10 @@
   name: Pacifier Wipes
   children: []
   attributes:
+  - height
+  - length
   - material
+  - width
   - wipe_fragrance
   return_reasons:
   - scent
@@ -304,10 +352,13 @@
   - bt-3-5-2
   attributes:
   - color
+  - height
   - infant_age_group
+  - length
   - material
   - pacifier/teether_design
   - pattern
+  - width
   return_reasons:
   - baby_refused
   - changed_my_mind
@@ -323,11 +374,14 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - infant_age_group
   - jewelry_material
+  - length
   - material
   - pacifier/teether_design
   - pattern
+  - width
   return_reasons:
   - baby_refused
   - changed_my_mind
@@ -342,10 +396,13 @@
   attributes:
   - accessory_size
   - color
+  - height
   - infant_age_group
+  - length
   - material
   - pacifier/teether_design
   - pattern
+  - width
   return_reasons:
   - baby_refused
   - changed_my_mind
@@ -364,9 +421,12 @@
   - bt-4-5
   - bt-4-6
   attributes:
+  - height
   - infant_age_group
+  - length
   - material
   - safety_certifications
+  - width
   return_reasons:
   - installation
   - incompatible
@@ -386,8 +446,11 @@
   - bt-4-1-5
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - installation
   - incompatible
@@ -403,9 +466,12 @@
   attributes:
   - color
   - door_stopper_design
+  - height
+  - length
   - material
   - pattern
   - safety_device_installation
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -419,9 +485,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - safety_device_installation
+  - width
   return_reasons:
   - width
   - height
@@ -437,10 +506,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - locking_mechanism
   - material
   - pattern
   - safety_device_installation
+  - width
   return_reasons:
   - installation
   - lock_type
@@ -456,9 +528,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - safety_device_installation
+  - width
   return_reasons:
   - installation
   - incompatible
@@ -473,9 +548,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - safety_device_installation
+  - width
   return_reasons:
   - installation
   - incompatible
@@ -492,7 +570,10 @@
   - bt-4-2-2
   - bt-4-2-3
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - width
   - height
@@ -510,9 +591,12 @@
   attributes:
   - color
   - gate_mounting_type
+  - height
+  - length
   - locking_mechanism
   - pattern
   - safety_device_installation
+  - width
   return_reasons:
   - width
   - installation
@@ -529,11 +613,14 @@
   attributes:
   - color
   - gate_mounting_type
+  - height
+  - length
   - locking_mechanism
   - material
   - opening_direction
   - pattern
   - safety_device_installation
+  - width
   return_reasons:
   - width
   - installation
@@ -550,10 +637,13 @@
   attributes:
   - color
   - gate_mounting_type
+  - height
+  - length
   - locking_mechanism
   - opening_mechanism
   - pattern
   - safety_device_installation
+  - width
   return_reasons:
   - width
   - installation
@@ -574,7 +664,11 @@
   - baby_monitor_features
   - connectivity_technology
   - display_color_mode
+  - height
+  - length
   - range_type
+  - signal_range
+  - width
   return_reasons:
   - range
   - video_quality
@@ -592,7 +686,11 @@
   - baby_monitor_features
   - connectivity_technology
   - display_color_mode
+  - height
+  - length
   - range_type
+  - signal_range
+  - width
   return_reasons:
   - range
   - video_quality
@@ -610,7 +708,11 @@
   - baby_monitor_features
   - connectivity_technology
   - display_color_mode
+  - height
+  - length
   - range_type
+  - signal_range
+  - width
   return_reasons:
   - range
   - sound_quality
@@ -627,7 +729,11 @@
   - baby_monitor_features
   - connectivity_technology
   - display_color_mode
+  - height
+  - length
   - range_type
+  - signal_range
+  - width
   return_reasons:
   - range
   - video_quality
@@ -644,7 +750,10 @@
   - bt-4-4-2
   - bt-4-4-3
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -662,9 +771,12 @@
   attributes:
   - closure_type
   - color
+  - height
   - infant_age_group
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -681,9 +793,12 @@
   attributes:
   - closure_type
   - color
+  - height
   - infant_age_group
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -698,9 +813,12 @@
   attributes:
   - closure_type
   - color
+  - height
   - infant_age_group
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - adjustability
@@ -720,10 +838,13 @@
   - bt-4-5-5
   attributes:
   - color
+  - height
+  - length
   - locking_mechanism
   - material
   - pattern
   - safety_device_installation
+  - width
   return_reasons:
   - closure
   - incompatible
@@ -738,10 +859,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - locking_mechanism
   - material
   - pattern
   - safety_device_installation
+  - width
   return_reasons:
   - installation
   - closure
@@ -758,10 +882,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - locking_mechanism
   - material
   - pattern
   - safety_device_installation
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -775,10 +902,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - locking_mechanism
   - material
   - pattern
   - safety_device_installation
+  - width
   return_reasons:
   - installation
   - closure
@@ -794,10 +924,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - locking_mechanism
   - material
   - pattern
   - safety_device_installation
+  - width
   return_reasons:
   - closure
   - changed_my_mind
@@ -811,10 +944,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - locking_mechanism
   - material
   - pattern
   - safety_device_installation
+  - width
   return_reasons:
   - installation
   - lock_type
@@ -832,9 +968,12 @@
   - bt-4-6-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - safety_rail_installation
+  - width
   return_reasons:
   - installation
   - incompatible
@@ -849,9 +988,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - safety_rail_installation
+  - width
   return_reasons:
   - installation
   - height
@@ -867,9 +1009,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - safety_rail_installation
+  - width
   return_reasons:
   - width
   - installation
@@ -899,10 +1044,13 @@
   - baby/toddler_equipment_safety_features
   - care_instructions
   - color
+  - height
   - infant_age_group
+  - length
   - material
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - size
   - color
@@ -922,8 +1070,11 @@
   - bt-5-1-5
   attributes:
   - color
+  - height
+  - length
   - pattern
   - toy/game_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -937,11 +1088,14 @@
   attributes:
   - color
   - developmental_features
+  - height
   - infant_age_group
   - language
+  - length
   - pattern
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - printing
   - changed_my_mind
@@ -956,11 +1110,14 @@
   attributes:
   - color
   - developmental_features
+  - height
   - infant_age_group
   - language
+  - length
   - pattern
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -974,11 +1131,14 @@
   attributes:
   - color
   - developmental_features
+  - height
   - infant_age_group
   - language
+  - length
   - pattern
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -992,11 +1152,14 @@
   attributes:
   - color
   - developmental_features
+  - height
   - infant_age_group
   - language
+  - length
   - pattern
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - language
   - battery_life
@@ -1015,11 +1178,14 @@
   - battery_type
   - color
   - developmental_features
+  - height
   - infant_age_group
   - language
+  - length
   - pattern
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - fit
   - changed_my_mind
@@ -1037,9 +1203,12 @@
   - bt-5-2-4
   attributes:
   - color
+  - height
   - infant_age_group
+  - length
   - pattern
   - toy/game_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -1053,10 +1222,13 @@
   attributes:
   - color
   - developmental_features
+  - height
   - infant_age_group
+  - length
   - pattern
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - height
   - weight_capacity
@@ -1074,10 +1246,13 @@
   - battery_type
   - color
   - developmental_features
+  - height
   - infant_age_group
+  - length
   - pattern
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - sound_quality
   - too_loud
@@ -1096,12 +1271,15 @@
   - battery_type
   - color
   - developmental_features
+  - height
   - infant_age_group
+  - length
   - material
   - pattern
   - product_certifications_standards
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - too_big
   - too_loud
@@ -1119,11 +1297,14 @@
   - battery_type
   - color
   - developmental_features
+  - height
   - infant_age_group
+  - length
   - material
   - pattern
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - too_big
   - texture
@@ -1141,8 +1322,11 @@
   - bt-5-3-2
   attributes:
   - color
+  - height
+  - length
   - pattern
   - toy/game_material
+  - width
   return_reasons:
   - color
   - head_support
@@ -1159,12 +1343,16 @@
   - baby_equipment_safety_features
   - color
   - developmental_features
+  - height
   - infant_age_group
+  - length
+  - maximum_load_capacity
   - motion
   - pattern
   - portability
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - head_support
   - changed_my_mind
@@ -1180,12 +1368,16 @@
   - baby_equipment_safety_features
   - color
   - developmental_features
+  - height
   - infant_age_group
+  - length
+  - maximum_load_capacity
   - motion
   - pattern
   - portability
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - color
   - weight_capacity
@@ -1202,8 +1394,11 @@
   - bt-5-4-2
   attributes:
   - color
+  - height
+  - length
   - pattern
   - toy/game_material
+  - width
   return_reasons:
   - support
   - changed_my_mind
@@ -1218,12 +1413,16 @@
   attributes:
   - color
   - developmental_features
+  - height
   - infant_age_group
+  - length
+  - maximum_load_capacity
   - motion
   - pattern
   - portability
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - size
   - support
@@ -1241,12 +1440,16 @@
   - battery_type
   - color
   - developmental_features
+  - height
   - infant_age_group
+  - length
+  - maximum_load_capacity
   - motion
   - pattern
   - portability
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - size
   - support
@@ -1264,7 +1467,10 @@
   - bt-5-5-2
   - bt-5-5-3
   attributes:
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - installation
   - height
@@ -1281,10 +1487,13 @@
   attributes:
   - color
   - developmental_features
+  - height
+  - length
   - mobile_mounting_type
   - pattern
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - installation
   - incompatible
@@ -1300,10 +1509,13 @@
   attributes:
   - color
   - developmental_features
+  - height
+  - length
   - mobile_mounting_type
   - pattern
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - installation
   - length
@@ -1322,10 +1534,13 @@
   - battery_type
   - color
   - developmental_features
+  - height
+  - length
   - mobile_mounting_type
   - pattern
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - installation
   - incompatible
@@ -1342,7 +1557,10 @@
   - bt-5-6-2
   - bt-5-6-3
   attributes:
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - color
   - installation
@@ -1359,12 +1577,15 @@
   - attachment_method
   - color
   - developmental_features
+  - height
   - infant_age_group
+  - length
   - mobile_movement
   - nursery_theme
   - pattern
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - color
   - height
@@ -1383,12 +1604,15 @@
   - attachment_method
   - color
   - developmental_features
+  - height
   - infant_age_group
+  - length
   - mobile_movement
   - nursery_theme
   - pattern
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - installation
   - sound_quality
@@ -1406,12 +1630,15 @@
   - attachment_method
   - color
   - developmental_features
+  - height
   - infant_age_group
+  - length
   - mobile_movement
   - nursery_theme
   - pattern
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - installation
   - changed_my_mind
@@ -1428,8 +1655,11 @@
   - bt-5-7-3
   attributes:
   - color
+  - height
+  - length
   - pattern
   - toy/game_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -1446,7 +1676,9 @@
   - battery_size
   - battery_type
   - color
+  - height
   - infant_age_group
+  - length
   - light_options
   - lighting_features
   - pattern
@@ -1454,6 +1686,7 @@
   - product_certifications_standards
   - soothing_sounds
   - toy/game_material
+  - width
   return_reasons:
   - brightness
   - changed_my_mind
@@ -1473,14 +1706,17 @@
   - construction
   - developmental_features
   - embellishment/trim_material
+  - height
   - infant_age_group
   - jewelry_material
+  - length
   - light_options
   - pattern
   - power_source
   - product_certifications_standards
   - soothing_sounds
   - toy/game_material
+  - width
   return_reasons:
   - size
   - softness
@@ -1500,13 +1736,16 @@
   - battery_type
   - color
   - developmental_features
+  - height
   - infant_age_group
+  - length
   - light_options
   - pattern
   - power_source
   - product_certifications_standards
   - soothing_sounds
   - toy/game_material
+  - width
   return_reasons:
   - sound_quality
   - too_loud
@@ -1523,7 +1762,10 @@
   - bt-5-8-1
   - bt-5-8-2
   attributes:
+  - height
+  - length
   - toy/game_material
+  - width
   return_reasons:
   - height
   - changed_my_mind
@@ -1538,11 +1780,18 @@
   attributes:
   - color
   - developmental_features
+  - height
+  - height_folded
   - infant_age_group
+  - length
+  - length_folded
+  - maximum_load_capacity
   - pattern
   - portability
   - product_certifications_standards
   - toy/game_material
+  - width
+  - width_folded
   return_reasons:
   - height
   - changed_my_mind
@@ -1557,11 +1806,15 @@
   attributes:
   - color
   - developmental_features
+  - height
   - infant_age_group
+  - length
+  - maximum_load_capacity
   - pattern
   - portability
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - height
   - weight_capacity
@@ -1578,7 +1831,10 @@
   - bt-5-9-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - padding
@@ -1596,11 +1852,14 @@
   attributes:
   - color
   - developmental_features
+  - height
+  - length
   - pattern
   - play_equipment_items_included
   - portability
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - size
   - padding
@@ -1617,12 +1876,15 @@
   attributes:
   - color
   - developmental_features
+  - height
   - infant_age_group
+  - length
   - pattern
   - play_equipment_items_included
   - portability
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - size
   - pattern
@@ -1640,13 +1902,16 @@
   attributes:
   - color
   - developmental_features
+  - height
   - infant_age_group
+  - length
   - pattern
   - play_equipment_items_included
   - play_yard_design_features
   - portability
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - size
   - weight
@@ -1662,10 +1927,13 @@
   attributes:
   - color
   - developmental_features
+  - height
   - infant_age_group
+  - length
   - pattern
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - height
   - weight
@@ -1681,10 +1949,13 @@
   attributes:
   - color
   - developmental_features
+  - height
   - infant_age_group
+  - length
   - pattern
   - product_certifications_standards
   - toy/game_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -1726,7 +1997,11 @@
   - bt-6-1-4
   attributes:
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - vehicle_fit
@@ -1746,8 +2021,12 @@
   - car_seat_installation
   - car_seat_orientation
   - color
+  - height
   - infant_age_group
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - vehicle_fit
   - installation
@@ -1765,10 +2044,17 @@
   - car_seat_orientation
   - color
   - folding_mechanism
+  - height
+  - height_folded
   - infant_age_group
+  - length
+  - length_folded
+  - maximum_load_capacity
   - pattern
   - stroller_features
   - stroller_wheel_type
+  - width
+  - width_folded
   return_reasons:
   - vehicle_fit
   - difficult_to_fold
@@ -1790,8 +2076,12 @@
   - car_seat_installation
   - car_seat_orientation
   - color
+  - height
   - infant_age_group
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - vehicle_fit
@@ -1812,8 +2102,12 @@
   - car_seat_installation
   - car_seat_orientation
   - color
+  - height
   - infant_age_group
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - installation
   - vehicle_fit
@@ -1835,7 +2129,11 @@
   - bt-6-2-5
   attributes:
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - comfort
@@ -1853,9 +2151,13 @@
   - carrying_positions
   - closure_type
   - color
+  - height
   - infant_age_group
+  - length
   - material
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - comfort
@@ -1873,9 +2175,13 @@
   - carrying_positions
   - closure_type
   - color
+  - height
   - infant_age_group
+  - length
   - material
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - comfort
@@ -1895,10 +2201,14 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - infant_age_group
   - jewelry_material
+  - length
   - material
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1917,9 +2227,13 @@
   - carrying_positions
   - closure_type
   - color
+  - height
   - infant_age_group
+  - length
   - material
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - comfort
@@ -1937,9 +2251,13 @@
   - carrying_positions
   - closure_type
   - color
+  - height
   - infant_age_group
+  - length
   - material
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -1963,7 +2281,11 @@
   - bt-6-3-6
   attributes:
   - color
+  - height_folded
+  - length_folded
+  - maximum_load_capacity
   - pattern
+  - width_folded
   return_reasons:
   - weight
   - changed_my_mind
@@ -1978,10 +2300,17 @@
   attributes:
   - color
   - folding_mechanism
+  - height
+  - height_folded
   - infant_age_group
+  - length
+  - length_folded
+  - maximum_load_capacity
   - pattern
   - stroller_features
   - stroller_wheel_type
+  - width
+  - width_folded
   return_reasons:
   - weight
   - too_bulky
@@ -1999,10 +2328,17 @@
   - color
   - double_stroller_configuration
   - folding_mechanism
+  - height
+  - height_folded
   - infant_age_group
+  - length
+  - length_folded
+  - maximum_load_capacity
   - pattern
   - stroller_features
   - stroller_wheel_type
+  - width
+  - width_folded
   return_reasons:
   - too_wide
   - weight
@@ -2019,10 +2355,17 @@
   attributes:
   - color
   - folding_mechanism
+  - height
+  - height_folded
   - infant_age_group
+  - length
+  - length_folded
+  - maximum_load_capacity
   - pattern
   - stroller_features
   - stroller_wheel_type
+  - width
+  - width_folded
   return_reasons:
   - weight
   - too_bulky
@@ -2040,10 +2383,17 @@
   attributes:
   - color
   - folding_mechanism
+  - height
+  - height_folded
   - infant_age_group
+  - length
+  - length_folded
+  - maximum_load_capacity
   - pattern
   - stroller_features
   - stroller_wheel_type
+  - width
+  - width_folded
   return_reasons:
   - weight
   - too_bulky
@@ -2061,10 +2411,17 @@
   attributes:
   - color
   - folding_mechanism
+  - height
+  - height_folded
   - infant_age_group
+  - length
+  - length_folded
+  - maximum_load_capacity
   - pattern
   - stroller_features
   - stroller_wheel_type
+  - width
+  - width_folded
   return_reasons:
   - weight
   - too_bulky
@@ -2081,10 +2438,17 @@
   attributes:
   - color
   - folding_mechanism
+  - height
+  - height_folded
   - infant_age_group
+  - length
+  - length_folded
+  - maximum_load_capacity
   - pattern
   - stroller_features
   - stroller_wheel_type
+  - width
+  - width_folded
   return_reasons:
   - weight
   - changed_my_mind
@@ -2104,9 +2468,12 @@
   attributes:
   - care_instructions
   - color
+  - height
   - infant_age_group
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2129,7 +2496,10 @@
   - bt-7-1-6
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -2148,7 +2518,10 @@
   - compatible_seat_type
   - cover_features
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - fit
@@ -2170,7 +2543,10 @@
   - compatible_seat_type
   - cover_features
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - warmth
   - incompatible
@@ -2189,8 +2565,11 @@
   - care_instructions
   - color
   - compatible_seat_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - field_of_view
   - changed_my_mind
@@ -2206,8 +2585,11 @@
   - care_instructions
   - color
   - compatible_seat_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -2225,8 +2607,11 @@
   - care_instructions
   - color
   - compatible_seat_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2248,7 +2633,10 @@
   - carry_options
   - color
   - compatible_seat_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2269,7 +2657,10 @@
   - bt-7-2-6
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2287,7 +2678,10 @@
   - compatible_baby_carrier_type
   - cover_features
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - absorbency
@@ -2307,7 +2701,10 @@
   - compatible_baby_carrier_type
   - cover_features
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2328,7 +2725,10 @@
   - compatible_baby_carrier_type
   - cover_features
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -2350,7 +2750,10 @@
   - carry_options
   - color
   - compatible_baby_carrier_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_small
   - incompatible
@@ -2368,7 +2771,10 @@
   - color
   - compatible_baby_carrier_type
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_bulky
   - incompatible
@@ -2386,7 +2792,10 @@
   - color
   - compatible_baby_carrier_type
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -2409,7 +2818,10 @@
   - bt-7-3-7
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2425,8 +2837,11 @@
   - care_instructions
   - color
   - compatible_stroller_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2444,7 +2859,10 @@
   - color
   - compatible_stroller_type
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_small
   - warmth
@@ -2462,8 +2880,11 @@
   - care_instructions
   - color
   - compatible_stroller_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2479,8 +2900,11 @@
   - care_instructions
   - color
   - compatible_stroller_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -2499,7 +2923,10 @@
   - compatible_stroller_type
   - cover_features
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - ventilation
   - incompatible
@@ -2517,7 +2944,10 @@
   - color
   - compatible_stroller_type
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -2539,7 +2969,10 @@
   - carry_options
   - color
   - compatible_stroller_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -2558,8 +2991,11 @@
   - color
   - compatible_baby_transport_type
   - fabric
+  - height
+  - length
   - liner_features
   - pattern
+  - width
   return_reasons:
   - warmth
   - incompatible
@@ -2578,7 +3014,10 @@
   - compatible_baby_chair_type
   - cover_features
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2592,8 +3031,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -2638,7 +3080,10 @@
   - bt-9-1-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   - wipe_dispenser/warmer_features
   return_reasons:
   - incompatible
@@ -2653,8 +3098,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   - wipe_dispenser_features
   return_reasons:
   - incompatible
@@ -2669,8 +3117,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   - wipe_warmer_features
   return_reasons:
   - warmth
@@ -2686,8 +3137,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   - wipe_dispenser_features
   return_reasons:
   - incompatible
@@ -2781,7 +3235,10 @@
   - bt-9-3-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2801,7 +3258,10 @@
   - color
   - cover_features
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - absorbency
   - fit
@@ -2819,7 +3279,10 @@
   - color
   - cover_features
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2839,7 +3302,10 @@
   - color
   - cover_features
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2860,7 +3326,10 @@
   attributes:
   - changing_mat/tray_features
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - water_resistance
@@ -2876,7 +3345,10 @@
   attributes:
   - changing_mat_features
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2892,7 +3364,11 @@
   attributes:
   - changing_tray_features
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2907,7 +3383,10 @@
   attributes:
   - care_instructions
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - water_resistance
@@ -2925,7 +3404,10 @@
   - bt-9-5-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2943,8 +3425,11 @@
   - color
   - diaper_kit_components
   - diaper_organizer_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -2960,8 +3445,11 @@
   - color
   - diaper_kit_components
   - diaper_organizer_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - too_bulky
   - capacity
@@ -2978,8 +3466,11 @@
   - color
   - diaper_kit_components
   - diaper_organizer_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - capacity
   - too_bulky
@@ -2997,7 +3488,10 @@
   - bt-9-6-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - absorbency
@@ -3013,9 +3507,12 @@
   attributes:
   - care_instructions
   - color
+  - height
+  - length
   - liner_features
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - absorbency
@@ -3031,9 +3528,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - liner_features
   - material
   - pattern
+  - width
   return_reasons:
   - absorbency
   - fit
@@ -3048,9 +3548,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - liner_features
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - absorbency
@@ -3069,7 +3572,10 @@
   - bt-9-7-4
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3086,8 +3592,11 @@
   attributes:
   - color
   - diaper_organizer_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3104,8 +3613,11 @@
   attributes:
   - color
   - diaper_organizer_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -3120,8 +3632,11 @@
   attributes:
   - color
   - diaper_organizer_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -3136,8 +3651,11 @@
   attributes:
   - color
   - diaper_organizer_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -3155,7 +3673,10 @@
   - bt-9-8-4
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - odor_control
   - incompatible
@@ -3172,7 +3693,10 @@
   - color
   - disposable_bag_features
   - disposable_bag_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - capacity
   - odor_control
@@ -3188,7 +3712,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - odor_control
   - scent
@@ -3206,9 +3733,12 @@
   - care_instructions
   - color
   - fabric
+  - height
+  - length
   - liner_features
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - odor_control
@@ -3225,8 +3755,11 @@
   attributes:
   - color
   - disposable_bag_features
+  - height
+  - length
   - pattern
   - waste_bag_material
+  - width
   return_reasons:
   - capacity
   - odor_control
@@ -3244,7 +3777,10 @@
   - bt-9-9-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - capacity
   - odor_control
@@ -3259,9 +3795,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - trash_can_features
+  - width
   return_reasons:
   - capacity
   - odor_control
@@ -3276,9 +3815,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - trash_can_features
+  - width
   return_reasons:
   - capacity
   - odor_control
@@ -3302,6 +3844,7 @@
   - product_certifications_standards
   - skin_care_features
   - treatment_texture
+  - volume
   return_reasons:
   - scent
   - texture
@@ -3321,6 +3864,7 @@
   - product_certifications_standards
   - skin_care_features
   - treatment_texture
+  - volume
   return_reasons:
   - scent
   - consistency
@@ -3341,6 +3885,7 @@
   - product_certifications_standards
   - skin_care_features
   - treatment_texture
+  - volume
   return_reasons:
   - scent
   - consistency
@@ -3361,6 +3906,7 @@
   - product_certifications_standards
   - skin_care_features
   - treatment_texture
+  - volume
   return_reasons:
   - scent
   - consistency
@@ -3381,6 +3927,7 @@
   - product_certifications_standards
   - skin_care_features
   - treatment_texture
+  - volume
   return_reasons:
   - scent
   - ingredients
@@ -3399,8 +3946,11 @@
   - closure_type
   - color
   - diaper_bag_material
+  - height
+  - length
   - pattern
   - wet_bag_features
+  - width
   return_reasons:
   - water_resistance
   - capacity
@@ -3422,8 +3972,11 @@
   - closure_type
   - color
   - diaper_bag_material
+  - height
+  - length
   - pattern
   - wet_bag_features
+  - width
   return_reasons:
   - water_resistance
   - capacity
@@ -3446,8 +3999,11 @@
   - closure_type
   - color
   - diaper_bag_material
+  - height
+  - length
   - pattern
   - wet_bag_features
+  - width
   return_reasons:
   - water_resistance
   - capacity
@@ -3619,7 +4175,9 @@
   - bt-10-1-4
   - bt-10-1-5
   - bt-10-1-6
-  attributes: []
+  attributes:
+  - energy_per_100_g
+  - energy_per_serving
   return_reasons:
   - taste
   - texture
@@ -3635,6 +4193,8 @@
   children: []
   attributes:
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flour/grain_type
   - infant_age_group
   return_reasons:
@@ -3652,6 +4212,8 @@
   - bt-10-1-2-1
   - bt-10-1-2-2
   attributes:
+  - energy_per_100_ml
+  - energy_per_serving
   - infant_age_group
   return_reasons:
   - taste
@@ -3670,6 +4232,8 @@
   attributes:
   - baby_drink_packaging
   - baby_food_flavor
+  - energy_per_100_ml
+  - energy_per_serving
   - infant_age_group
   return_reasons:
   - taste
@@ -3688,6 +4252,8 @@
   attributes:
   - baby_drink_packaging
   - baby_food_flavor
+  - energy_per_100_ml
+  - energy_per_serving
   - infant_age_group
   return_reasons:
   - taste
@@ -3704,7 +4270,10 @@
   children: []
   attributes:
   - baby_food_flavor
+  - energy_per_100_g
+  - energy_per_serving
   - infant_age_group
+  - net_weight
   return_reasons:
   - taste
   - texture
@@ -3723,6 +4292,8 @@
   - bt-10-1-4-3
   - bt-10-1-4-4
   attributes:
+  - energy_per_100_ml
+  - energy_per_serving
   - formula_level
   return_reasons:
   - taste
@@ -3739,7 +4310,10 @@
   children: []
   attributes:
   - baby_formula_format
+  - energy_per_100_ml
+  - energy_per_serving
   - formula_level
+  - net_weight
   return_reasons:
   - taste
   - dietary_requirements
@@ -3755,7 +4329,10 @@
   children: []
   attributes:
   - baby_formula_format
+  - energy_per_100_ml
+  - energy_per_serving
   - formula_level
+  - net_weight
   return_reasons:
   - taste
   - consistency
@@ -3771,7 +4348,10 @@
   children: []
   attributes:
   - baby_formula_format
+  - energy_per_100_ml
+  - energy_per_serving
   - formula_level
+  - net_weight
   return_reasons:
   - taste
   - consistency
@@ -3787,7 +4367,10 @@
   children: []
   attributes:
   - baby_formula_format
+  - energy_per_100_ml
+  - energy_per_serving
   - formula_level
+  - net_weight
   return_reasons:
   - taste
   - consistency
@@ -3805,6 +4388,8 @@
   - baby_snack_flavor
   - baby_snack_texture
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - infant_age_group
   return_reasons:
   - taste
@@ -3822,7 +4407,10 @@
   attributes:
   - baby_food_flavor
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - infant_age_group
+  - net_weight
   return_reasons:
   - taste
   - consistency
@@ -3842,9 +4430,12 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
   - power_source
   - timer_features
+  - width
   return_reasons:
   - color
   - too_loud
@@ -3861,9 +4452,12 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
   - power_source
   - timer_features
+  - width
   return_reasons:
   - color
   - too_loud
@@ -3881,9 +4475,12 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
   - power_source
   - timer_features
+  - width
   return_reasons:
   - brightness
   - battery_life
@@ -3902,6 +4499,9 @@
   - bt-10-6-2
   attributes:
   - bottle_warmer/sterilizer_features
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - capacity
@@ -3921,7 +4521,10 @@
   attributes:
   - color
   - compatible_baby_bottle_design
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - speed
   - temperature
@@ -3936,14 +4539,20 @@
   name: Electric Bottle Warmers
   children: []
   attributes:
+  - amperage
   - bottle_warmer_features
   - cleaning_instructions
   - color
   - compatible_baby_bottle_design
   - heating_method
   - heating_speed
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - temperature_control
+  - voltage
+  - width
   return_reasons:
   - speed
   - capacity
@@ -3967,8 +4576,11 @@
   - compatible_baby_bottle_design
   - heating_method
   - heating_speed
+  - height
+  - length
   - pattern
   - temperature_control
+  - width
   return_reasons:
   - capacity
   - speed
@@ -3986,7 +4598,10 @@
   - bt-10-6-2-1
   - bt-10-6-2-2
   - bt-10-6-2-3
-  attributes: []
+  attributes:
+  - height
+  - length
+  - width
   return_reasons:
   - capacity
   - speed
@@ -4001,12 +4616,18 @@
   name: Electric Steam Sterilizers
   children: []
   attributes:
+  - amperage
   - bottle_sterilizer_features
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - sterilization_cycle_time
   - sterilization_method
+  - voltage
+  - width
   return_reasons:
   - capacity
   - speed
@@ -4024,9 +4645,12 @@
   - bottle_sterilizer_features
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - sterilization_cycle_time
   - sterilization_method
+  - width
   return_reasons:
   - size
   - capacity
@@ -4044,9 +4668,12 @@
   - bottle_sterilizer_features
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - sterilization_cycle_time
   - sterilization_method
+  - width
   return_reasons:
   - capacity
   - speed
@@ -4060,12 +4687,16 @@
   name: Breast Milk Storage Containers
   children: []
   attributes:
+  - capacity
   - closure_type
   - color
+  - height
+  - length
   - material
   - pattern
   - sterilization_instructions
   - usage_type
+  - width
   return_reasons:
   - capacity
   - not_dishwasher_safe
@@ -4087,8 +4718,11 @@
   - bt-10-8-7
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -4103,8 +4737,11 @@
   attributes:
   - bag/case_material
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -4123,7 +4760,10 @@
   attributes:
   - brush_material
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - texture
@@ -4139,8 +4779,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - difficult_to_clean
@@ -4157,7 +4800,10 @@
   attributes:
   - color
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4175,8 +4821,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - length
   - material
@@ -4192,8 +4841,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - flow_rate
   - incompatible
@@ -4212,8 +4864,11 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - pump_accessories
+  - width
   return_reasons:
   - flange_size
   - suction
@@ -4227,14 +4882,20 @@
   name: Double Electric Breast Pumps
   children: []
   attributes:
+  - amperage
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - portability
+  - power_consumption_typical
   - power_source
   - pump_accessories
   - pump_speed_settings
   - suction_levels
+  - voltage
+  - width
   return_reasons:
   - size
   - flange_size
@@ -4250,16 +4911,22 @@
   name: Electric Breast Pumps
   children: []
   attributes:
+  - amperage
   - battery_size
   - battery_type
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - portability
+  - power_consumption_typical
   - power_source
   - pump_accessories
   - pump_speed_settings
   - suction_levels
+  - voltage
+  - width
   return_reasons:
   - size
   - flange_size
@@ -4277,8 +4944,11 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - pump_accessories
+  - width
   return_reasons:
   - flange_size
   - comfort
@@ -4296,8 +4966,11 @@
   - care_instructions
   - closure_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4316,8 +4989,11 @@
   - closure_type
   - color
   - fabric
+  - height
+  - length
   - nursing_cover_coverage
   - pattern
+  - width
   return_reasons:
   - coverage
   - material
@@ -4335,8 +5011,11 @@
   - bt-10-12-2
   - bt-10-12-3
   attributes:
+  - height
+  - length
   - material
   - nursing_pad_design
+  - width
   return_reasons:
   - size
   - absorbency
@@ -4351,8 +5030,11 @@
   name: Disposable Nursing Pads
   children: []
   attributes:
+  - height
+  - length
   - material
   - nursing_pad_design
+  - width
   return_reasons:
   - size
   - absorbency
@@ -4368,8 +5050,11 @@
   name: Reusable Nursing Pads
   children: []
   attributes:
+  - height
+  - length
   - material
   - nursing_pad_design
+  - width
   return_reasons:
   - size
   - absorbency
@@ -4384,8 +5069,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - comfort
@@ -4403,7 +5091,10 @@
   - color
   - cover_closure_design
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4421,9 +5112,12 @@
   attributes:
   - color
   - firmness
+  - height
+  - length
   - material
   - nursing_pillow_shape
   - pattern
+  - width
   return_reasons:
   - size
   - support
@@ -4549,7 +5243,10 @@
   - bt-10-16-5-1
   - bt-10-16-5-2
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - material
@@ -4564,11 +5261,15 @@
   name: Baby Bottle Liners
   children: []
   attributes:
+  - capacity
   - color
   - compatible_baby_bottle_design
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - capacity
   - material
@@ -4587,8 +5288,11 @@
   - bt-10-16-5-2-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -4607,10 +5311,13 @@
   - color
   - compatible_baby_bottle_design
   - flow_rate_type
+  - height
+  - length
   - material
   - nipple_shape
   - pattern
   - stage
+  - width
   return_reasons:
   - flow_rate
   - too_firm
@@ -4628,10 +5335,13 @@
   - color
   - compatible_baby_bottle_design
   - flow_rate_type
+  - height
+  - length
   - material
   - nipple_shape
   - pattern
   - stage
+  - width
   return_reasons:
   - flow_rate
   - incompatible
@@ -4648,10 +5358,13 @@
   - color
   - compatible_baby_bottle_design
   - flow_rate_type
+  - height
+  - length
   - material
   - nipple_shape
   - pattern
   - stage
+  - width
   return_reasons:
   - flow_rate
   - incompatible
@@ -4667,7 +5380,11 @@
   - bt-10-16-6-1
   - bt-10-16-6-2
   - bt-10-16-6-3
-  attributes: []
+  attributes:
+  - capacity
+  - height
+  - length
+  - width
   return_reasons:
   - capacity
   - flow_rate
@@ -4684,12 +5401,16 @@
   attributes:
   - bottle_design
   - bottle_material
+  - capacity
   - color
   - flow_rate_type
+  - height
+  - length
   - nipple_material
   - nipple_type
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - capacity
   - flow_rate
@@ -4706,12 +5427,16 @@
   attributes:
   - bottle_design
   - bottle_material
+  - capacity
   - color
   - flow_rate_type
+  - height
+  - length
   - nipple_material
   - nipple_type
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - capacity
   - flow_rate
@@ -4728,12 +5453,16 @@
   attributes:
   - bottle_design
   - bottle_material
+  - capacity
   - color
   - flow_rate_type
+  - height
+  - length
   - nipple_material
   - nipple_type
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - capacity
   - flow_rate
@@ -4753,8 +5482,11 @@
   - closure_type
   - color
   - cover_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4769,13 +5501,17 @@
   name: Sippy Cups
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
+  - height
+  - length
   - lid_type
   - material
   - pattern
   - product_certifications_standards
   - spout_type
+  - width
   return_reasons:
   - capacity
   - flow_rate
@@ -4794,9 +5530,12 @@
   - bt-11-2
   - bt-11-3
   attributes:
+  - height
   - infant_age_group
+  - length
   - material
   - safety_certifications
+  - width
   return_reasons:
   - size
   - comfort
@@ -4811,9 +5550,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - potty/toilet_seat_design
+  - width
   return_reasons:
   - size
   - color
@@ -4829,9 +5571,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - potty_training_kit_components
+  - width
   return_reasons:
   - size
   - color
@@ -4847,9 +5592,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - potty/toilet_seat_design
+  - width
   return_reasons:
   - size
   - height
@@ -4868,9 +5616,12 @@
   attributes:
   - care_instructions
   - color
+  - height
   - infant_age_group
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4887,8 +5638,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4906,8 +5660,11 @@
   attributes:
   - closure_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color

--- a/data/categories/co_cameras_optics.yml
+++ b/data/categories/co_cameras_optics.yml
@@ -47,8 +47,12 @@
   - co-1-1-3
   attributes:
   - cable_housing_material
+  - cable_length
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -64,8 +68,12 @@
   children: []
   attributes:
   - cable_housing_material
+  - cable_length
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -82,8 +90,12 @@
   children: []
   attributes:
   - cable_housing_material
+  - cable_length
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -100,8 +112,12 @@
   children: []
   attributes:
   - cable_housing_material
+  - cable_length
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -123,8 +139,15 @@
   - camera_lens_material
   - camera_lens_type
   - color
+  - focal_length_telephoto
+  - focal_length_wide
+  - height
+  - length
+  - maximum_aperture_telephoto
+  - maximum_aperture_wide
   - pattern
   - suitable_for_camera_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -140,10 +163,17 @@
   - camera_lens_material
   - camera_lens_type
   - color
+  - focal_length_telephoto
+  - focal_length_wide
   - focus_adjustment
   - focus_type
+  - height
+  - length
+  - maximum_aperture_telephoto
+  - maximum_aperture_wide
   - pattern
   - suitable_for_camera_type
+  - width
   return_reasons:
   - field_of_view
   - magnification
@@ -162,8 +192,15 @@
   - camera_lens_material
   - camera_lens_type
   - color
+  - focal_length_telephoto
+  - focal_length_wide
+  - height
+  - length
+  - maximum_aperture_telephoto
+  - maximum_aperture_wide
   - pattern
   - suitable_for_camera_type
+  - width
   return_reasons:
   - magnification
   - field_of_view
@@ -181,8 +218,15 @@
   - camera_lens_material
   - camera_lens_type
   - color
+  - focal_length_telephoto
+  - focal_length_wide
+  - height
+  - length
+  - maximum_aperture_telephoto
+  - maximum_aperture_wide
   - pattern
   - suitable_for_camera_type
+  - width
   return_reasons:
   - field_of_view
   - weight
@@ -205,8 +249,11 @@
   - co-1-3-6
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -221,8 +268,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -245,8 +295,11 @@
   - carry_options
   - carrying_type
   - color
+  - height
+  - length
   - lens_storage_type
   - pattern
+  - width
   return_reasons:
   - size
   - padding
@@ -263,9 +316,13 @@
   children: []
   attributes:
   - color
+  - compatible_lens_diameter
+  - height
+  - length
   - lens_cap_compatible_device
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -281,8 +338,11 @@
   attributes:
   - color
   - converter_functionality
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - magnification
   - weight
@@ -298,10 +358,14 @@
   children: []
   attributes:
   - color
+  - compatible_lens_diameter
+  - height
+  - length
   - lens_filter_effects
   - lens_filter_type
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -317,8 +381,12 @@
   children: []
   attributes:
   - color
+  - compatible_lens_diameter
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -374,8 +442,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -404,7 +475,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -427,7 +501,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -450,7 +527,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - padding
@@ -471,7 +551,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -494,7 +577,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - padding
@@ -515,7 +601,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -538,7 +627,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -561,7 +653,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -584,7 +679,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -607,7 +705,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - padding
@@ -622,8 +723,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -638,8 +742,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - resolution
   - connectivity
@@ -665,7 +772,10 @@
   - contrast
   - film_format
   - grain
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -683,7 +793,10 @@
   - contrast
   - film_format
   - grain
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -701,7 +814,10 @@
   - contrast
   - film_format
   - grain
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -719,7 +835,10 @@
   - contrast
   - film_format
   - grain
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -737,7 +856,10 @@
   - contrast
   - film_format
   - grain
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -755,7 +877,10 @@
   - contrast
   - film_format
   - grain
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -773,7 +898,10 @@
   - contrast
   - film_format
   - grain
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -789,8 +917,11 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -808,8 +939,11 @@
   - color
   - flash_modes
   - flash_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - brightness
@@ -827,8 +961,11 @@
   - camera_mounting_type
   - color
   - focus_device_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - installation
   - weight
@@ -847,8 +984,11 @@
   - camera_gear_type
   - camera_mounting_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - diameter
   - installation
@@ -872,8 +1012,11 @@
   attributes:
   - camera_mounting_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - weight
   - installation
@@ -890,8 +1033,11 @@
   attributes:
   - camera_mounting_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - weight
   - battery_life
@@ -908,8 +1054,11 @@
   attributes:
   - camera_mounting_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - weight
   - installation
@@ -926,8 +1075,11 @@
   attributes:
   - camera_mounting_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - weight
   - installation
@@ -944,8 +1096,11 @@
   attributes:
   - camera_mounting_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - weight
   - installation
@@ -962,8 +1117,11 @@
   attributes:
   - camera_mounting_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - installation
   - weight
@@ -980,8 +1138,11 @@
   attributes:
   - camera_mounting_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - installation
   - incompatible
@@ -999,8 +1160,11 @@
   - battery_type
   - camera_mounting_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - installation
   - length
@@ -1017,9 +1181,12 @@
   attributes:
   - camera_sensor_type
   - color
+  - height
   - image_sensor_size
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - resolution
   - low_light_performance
@@ -1041,8 +1208,15 @@
   attributes:
   - camera_lens_type
   - color
+  - focal_length_telephoto
+  - focal_length_wide
+  - height
+  - length
   - material
+  - maximum_aperture_telephoto
+  - maximum_aperture_wide
   - pattern
+  - width
   return_reasons:
   - range
   - weight
@@ -1059,8 +1233,15 @@
   attributes:
   - camera_lens_type
   - color
+  - focal_length_telephoto
+  - focal_length_wide
+  - height
+  - length
   - material
+  - maximum_aperture_telephoto
+  - maximum_aperture_wide
   - pattern
+  - width
   return_reasons:
   - range
   - weight
@@ -1077,8 +1258,15 @@
   attributes:
   - camera_lens_type
   - color
+  - focal_length_telephoto
+  - focal_length_wide
+  - height
+  - length
   - material
+  - maximum_aperture_telephoto
+  - maximum_aperture_wide
   - pattern
+  - width
   return_reasons:
   - range
   - weight
@@ -1095,8 +1283,15 @@
   attributes:
   - camera_lens_type
   - color
+  - focal_length_telephoto
+  - focal_length_wide
+  - height
+  - length
   - material
+  - maximum_aperture_telephoto
+  - maximum_aperture_wide
   - pattern
+  - width
   return_reasons:
   - range
   - weight
@@ -1113,8 +1308,15 @@
   attributes:
   - camera_lens_type
   - color
+  - focal_length_telephoto
+  - focal_length_wide
+  - height
+  - length
   - material
+  - maximum_aperture_telephoto
+  - maximum_aperture_wide
   - pattern
+  - width
   return_reasons:
   - range
   - weight
@@ -1132,8 +1334,15 @@
   attributes:
   - camera_lens_type
   - color
+  - focal_length_telephoto
+  - focal_length_wide
+  - height
+  - length
   - material
+  - maximum_aperture_telephoto
+  - maximum_aperture_wide
   - pattern
+  - width
   return_reasons:
   - range
   - weight
@@ -1152,10 +1361,14 @@
   - battery_type
   - camera_control_type
   - color
+  - height
+  - length
   - material
   - pattern
   - power_source
   - remote_technology
+  - signal_range
+  - width
   return_reasons:
   - range
   - connectivity
@@ -1173,8 +1386,11 @@
   attributes:
   - camera_button/knob_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -1189,9 +1405,13 @@
   children: []
   attributes:
   - color
+  - depth
+  - height
   - material
   - pattern
   - screen/display_design
+  - screen_size
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1205,9 +1425,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - silencer/blimp_type
+  - width
   return_reasons:
   - too_bulky
   - incompatible
@@ -1222,8 +1445,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - weight
   - installation
@@ -1247,9 +1473,12 @@
   - co-1-4-18-8
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_camera/optics_device
+  - width
   return_reasons:
   - color
   - length
@@ -1265,9 +1494,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_camera/optics_device
+  - width
   return_reasons:
   - color
   - length
@@ -1283,9 +1515,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_camera/optics_device
+  - width
   return_reasons:
   - color
   - length
@@ -1301,9 +1536,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_camera/optics_device
+  - width
   return_reasons:
   - color
   - length
@@ -1319,9 +1557,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_camera/optics_device
+  - width
   return_reasons:
   - color
   - length
@@ -1337,9 +1578,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_camera/optics_device
+  - width
   return_reasons:
   - color
   - length
@@ -1355,9 +1599,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_camera/optics_device
+  - width
   return_reasons:
   - color
   - length
@@ -1373,9 +1620,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_camera/optics_device
+  - width
   return_reasons:
   - color
   - length
@@ -1391,9 +1641,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_camera/optics_device
+  - width
   return_reasons:
   - color
   - length
@@ -1410,8 +1663,11 @@
   attributes:
   - camera_attachment
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - coverage
   - incompatible
@@ -1426,8 +1682,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - weight
   - adjustability
@@ -1444,10 +1703,14 @@
   attributes:
   - color
   - display_resolution
+  - height
+  - length
   - material
   - monitor_type
   - pattern
   - power_source
+  - screen_size
+  - width
   return_reasons:
   - brightness
   - resolution
@@ -1464,9 +1727,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - color
   - incompatible
@@ -1481,8 +1747,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - installation
   - incompatible
@@ -1499,8 +1768,11 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - water_resistance
   - weight
@@ -1517,11 +1789,14 @@
   attributes:
   - camera_mounting_type
   - color
+  - height
+  - length
   - light_design
   - lighting_features
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - brightness
   - light_spectrum
@@ -1559,8 +1834,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1590,7 +1868,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -1615,7 +1896,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -1638,7 +1922,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -1661,7 +1948,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -1684,7 +1974,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - padding
@@ -1708,7 +2001,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -1731,7 +2027,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -1754,7 +2053,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -1777,7 +2079,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -1800,7 +2105,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - padding
@@ -1816,8 +2124,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - installation
   - incompatible
@@ -1832,8 +2143,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1847,8 +2161,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - installation
   - weight
@@ -1864,8 +2181,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - installation
   - incompatible
@@ -1882,8 +2202,11 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - installation
   - incompatible
@@ -1903,8 +2226,11 @@
   - co-1-6-5
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -1925,7 +2251,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - padding
@@ -1941,10 +2270,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - tripod/monopod_attachment_type
   - tripod/monopod_head_type
+  - width
   return_reasons:
   - weight
   - weight_capacity
@@ -1963,9 +2296,12 @@
   - collar/mount_compatible_device
   - collar/mount_design
   - color
+  - height
+  - length
   - mount/stand_features
   - mount_material
   - pattern
+  - width
   return_reasons:
   - weight
   - material
@@ -1983,8 +2319,11 @@
   attributes:
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tripod_handle_type
+  - width
   return_reasons:
   - weight
   - material
@@ -2001,9 +2340,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - spreader_type
+  - width
   return_reasons:
   - weight
   - material
@@ -2029,11 +2371,17 @@
   attributes:
   - color
   - feet_type
+  - folded_length
+  - height_folded
   - leg_lock_type
   - leg_sections
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - height
   - weight
@@ -2050,11 +2398,17 @@
   attributes:
   - color
   - feet_type
+  - folded_length
+  - height_folded
   - leg_lock_type
   - leg_sections
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - height
   - weight_capacity
@@ -2071,11 +2425,17 @@
   attributes:
   - color
   - feet_type
+  - folded_length
+  - height_folded
   - leg_lock_type
   - leg_sections
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - height
   - weight
@@ -2093,11 +2453,17 @@
   attributes:
   - color
   - feet_type
+  - folded_length
+  - height_folded
   - leg_lock_type
   - leg_sections
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - height
   - weight
@@ -2114,11 +2480,17 @@
   attributes:
   - color
   - feet_type
+  - folded_length
+  - height_folded
   - leg_lock_type
   - leg_sections
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - height
   - weight
@@ -2135,11 +2507,17 @@
   attributes:
   - color
   - feet_type
+  - folded_length
+  - height_folded
   - leg_lock_type
   - leg_sections
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - height
   - weight
@@ -2156,11 +2534,17 @@
   attributes:
   - color
   - feet_type
+  - folded_length
+  - height_folded
   - leg_lock_type
   - leg_sections
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - size
   - incompatible
@@ -2176,11 +2560,17 @@
   attributes:
   - color
   - feet_type
+  - folded_length
+  - height_folded
   - leg_lock_type
   - leg_sections
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - height
   - weight
@@ -2197,11 +2587,17 @@
   attributes:
   - color
   - feet_type
+  - folded_length
+  - height_folded
   - leg_lock_type
   - leg_sections
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - height
   - weight
@@ -2218,11 +2614,17 @@
   attributes:
   - color
   - feet_type
+  - folded_length
+  - height_folded
   - leg_lock_type
   - leg_sections
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - height
   - weight
@@ -2267,11 +2669,16 @@
   attributes:
   - borescope_design
   - camera_features
+  - camera_probe_length
   - color
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - probe_diameter
+  - width
   return_reasons:
   - field_of_view
   - resolution
@@ -2306,14 +2713,19 @@
   - flash_modes
   - focus_adjustment
   - focus_type
+  - height
   - image_formats_supported
   - image_sensor_size
+  - internal_storage_capacity
+  - length
   - light_exposure_modes
+  - memory_card_size
   - optical_zoom
   - pattern
   - photo_effects_type
   - scene_modes
   - shooting_modes
+  - width
   return_reasons:
   - battery_life
   - resolution
@@ -2339,14 +2751,19 @@
   - flash_modes
   - focus_adjustment
   - focus_type
+  - height
   - image_formats_supported
   - image_sensor_size
+  - internal_storage_capacity
+  - length
   - light_exposure_modes
+  - memory_card_size
   - optical_zoom
   - pattern
   - photo_effects_type
   - scene_modes
   - shooting_modes
+  - width
   return_reasons:
   - field_of_view
   - battery_life
@@ -2373,14 +2790,19 @@
   - flash_modes
   - focus_adjustment
   - focus_type
+  - height
   - image_formats_supported
   - image_sensor_size
+  - internal_storage_capacity
+  - length
   - light_exposure_modes
+  - memory_card_size
   - optical_zoom
   - pattern
   - photo_effects_type
   - scene_modes
   - shooting_modes
+  - width
   return_reasons:
   - field_of_view
   - battery_life
@@ -2408,14 +2830,19 @@
   - flash_modes
   - focus_adjustment
   - focus_type
+  - height
   - image_formats_supported
   - image_sensor_size
+  - internal_storage_capacity
+  - length
   - light_exposure_modes
+  - memory_card_size
   - optical_zoom
   - pattern
   - photo_effects_type
   - scene_modes
   - shooting_modes
+  - width
   return_reasons:
   - field_of_view
   - battery_life
@@ -2442,14 +2869,19 @@
   - flash_modes
   - focus_adjustment
   - focus_type
+  - height
   - image_formats_supported
   - image_sensor_size
+  - internal_storage_capacity
+  - length
   - light_exposure_modes
+  - memory_card_size
   - optical_zoom
   - pattern
   - photo_effects_type
   - scene_modes
   - shooting_modes
+  - width
   return_reasons:
   - battery_life
   - resolution
@@ -2476,14 +2908,19 @@
   - flash_modes
   - focus_adjustment
   - focus_type
+  - height
   - image_formats_supported
   - image_sensor_size
+  - internal_storage_capacity
+  - length
   - light_exposure_modes
+  - memory_card_size
   - optical_zoom
   - pattern
   - photo_effects_type
   - scene_modes
   - shooting_modes
+  - width
   return_reasons:
   - battery_life
   - weight
@@ -2511,14 +2948,19 @@
   - flash_modes
   - focus_adjustment
   - focus_type
+  - height
   - image_formats_supported
   - image_sensor_size
+  - internal_storage_capacity
+  - length
   - light_exposure_modes
+  - memory_card_size
   - optical_zoom
   - pattern
   - photo_effects_type
   - scene_modes
   - shooting_modes
+  - width
   return_reasons:
   - battery_life
   - resolution
@@ -2546,14 +2988,19 @@
   - flash_modes
   - focus_adjustment
   - focus_type
+  - height
   - image_formats_supported
   - image_sensor_size
+  - internal_storage_capacity
+  - length
   - light_exposure_modes
+  - memory_card_size
   - optical_zoom
   - pattern
   - photo_effects_type
   - scene_modes
   - shooting_modes
+  - width
   return_reasons:
   - field_of_view
   - battery_life
@@ -2580,14 +3027,19 @@
   - flash_modes
   - focus_adjustment
   - focus_type
+  - height
   - image_formats_supported
   - image_sensor_size
+  - internal_storage_capacity
+  - length
   - light_exposure_modes
+  - memory_card_size
   - optical_zoom
   - pattern
   - photo_effects_type
   - scene_modes
   - shooting_modes
+  - width
   return_reasons:
   - battery_life
   - resolution
@@ -2605,8 +3057,11 @@
   - camera_features
   - color
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - field_of_view
   - resolution
@@ -2632,7 +3087,10 @@
   - connectivity_technology
   - exposure_control
   - film_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - battery_life
   - incompatible
@@ -2651,7 +3109,10 @@
   - connectivity_technology
   - exposure_control
   - film_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - battery_life
   - incompatible
@@ -2671,7 +3132,10 @@
   - exposure_control
   - film_format
   - film_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - field_of_view
@@ -2694,7 +3158,10 @@
   - connectivity_technology
   - exposure_control
   - film_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -2713,7 +3180,10 @@
   - connectivity_technology
   - exposure_control
   - film_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - battery_life
   - weight
@@ -2733,7 +3203,10 @@
   - connectivity_technology
   - exposure_control
   - film_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - battery_life
   - incompatible
@@ -2752,7 +3225,10 @@
   - connectivity_technology
   - exposure_control
   - film_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - battery_life
   - weight
@@ -2772,11 +3248,14 @@
   - color
   - connection_method
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
   - power_source
   - surveillance_camera_design
   - surveillance_camera_mounting_type
+  - width
   return_reasons:
   - field_of_view
   - resolution
@@ -2796,11 +3275,15 @@
   - color
   - connection_method
   - connectivity_technology
+  - detection_range
+  - height
+  - length
   - material
   - memory_storage_type
   - pattern
   - power_source
   - trail_camera_design
+  - width
   return_reasons:
   - field_of_view
   - battery_life
@@ -2828,10 +3311,15 @@
   - color
   - compatible_memory_cards
   - connectivity_technology
+  - height
+  - internal_storage_capacity
+  - length
   - material
+  - memory_card_size
   - memory_storage_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - battery_life
   - resolution
@@ -2852,10 +3340,15 @@
   - color
   - compatible_memory_cards
   - connectivity_technology
+  - height
+  - internal_storage_capacity
+  - length
   - material
+  - memory_card_size
   - memory_storage_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - field_of_view
   - battery_life
@@ -2879,10 +3372,15 @@
   - color
   - compatible_memory_cards
   - connectivity_technology
+  - height
+  - internal_storage_capacity
+  - length
   - material
+  - memory_card_size
   - memory_storage_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - field_of_view
   - battery_life
@@ -2906,10 +3404,15 @@
   - color
   - compatible_memory_cards
   - connectivity_technology
+  - height
+  - internal_storage_capacity
+  - length
   - material
+  - memory_card_size
   - memory_storage_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - field_of_view
   - battery_life
@@ -2931,10 +3434,15 @@
   - color
   - compatible_memory_cards
   - connectivity_technology
+  - height
+  - internal_storage_capacity
+  - length
   - material
+  - memory_card_size
   - memory_storage_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - battery_life
   - resolution
@@ -2957,10 +3465,15 @@
   - color
   - compatible_memory_cards
   - connectivity_technology
+  - height
+  - internal_storage_capacity
+  - length
   - material
+  - memory_card_size
   - memory_storage_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - field_of_view
   - resolution
@@ -2983,10 +3496,15 @@
   - color
   - compatible_memory_cards
   - connectivity_technology
+  - height
+  - internal_storage_capacity
+  - length
   - material
+  - memory_card_size
   - memory_storage_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - field_of_view
   - battery_life
@@ -3007,9 +3525,12 @@
   - camera_mounting_type
   - color
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
   - webcam_design
+  - width
   return_reasons:
   - field_of_view
   - resolution
@@ -3032,6 +3553,7 @@
   - lens/slide_material
   - magnification
   - material
+  - objective_diameter
   - pattern
   return_reasons:
   - magnification
@@ -3050,9 +3572,13 @@
   attributes:
   - binocular_design
   - color
+  - height
+  - length
   - magnification
   - material
+  - objective_diameter
   - pattern
+  - width
   return_reasons:
   - magnification
   - field_of_view
@@ -3069,10 +3595,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - magnification
   - material
   - monocular_design
+  - objective_diameter
   - pattern
+  - width
   return_reasons:
   - magnification
   - field_of_view
@@ -3089,9 +3619,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - magnification
   - material
+  - maximum_distance
+  - objective_diameter
   - pattern
+  - width
   return_reasons:
   - range
   - magnification
@@ -3112,6 +3647,7 @@
   - color
   - magnification
   - material
+  - objective_diameter
   - pattern
   - scope_design
   - scope_lens_type
@@ -3131,11 +3667,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - magnification
   - material
+  - objective_diameter
   - pattern
   - scope_design
   - scope_lens_type
+  - width
   return_reasons:
   - magnification
   - field_of_view
@@ -3157,12 +3697,17 @@
   - co-3-4-2-5
   - co-3-4-2-6
   attributes:
+  - aperture
   - color
+  - height
+  - length
   - magnification
   - material
+  - objective_diameter
   - pattern
   - telescope_level
   - telescope_tracking_system
+  - width
   return_reasons:
   - magnification
   - field_of_view
@@ -3178,12 +3723,17 @@
   name: Catadioptric Telescopes
   children: []
   attributes:
+  - aperture
   - color
+  - height
+  - length
   - magnification
   - material
+  - objective_diameter
   - pattern
   - telescope_level
   - telescope_tracking_system
+  - width
   return_reasons:
   - magnification
   - field_of_view
@@ -3199,12 +3749,17 @@
   name: Compound Telescopes
   children: []
   attributes:
+  - aperture
   - color
+  - height
+  - length
   - magnification
   - material
+  - objective_diameter
   - pattern
   - telescope_level
   - telescope_tracking_system
+  - width
   return_reasons:
   - magnification
   - field_of_view
@@ -3220,12 +3775,17 @@
   name: Dobsonian Telescopes
   children: []
   attributes:
+  - aperture
   - color
+  - height
+  - length
   - magnification
   - material
+  - objective_diameter
   - pattern
   - telescope_level
   - telescope_tracking_system
+  - width
   return_reasons:
   - magnification
   - field_of_view
@@ -3241,12 +3801,17 @@
   name: Reflector Telescopes
   children: []
   attributes:
+  - aperture
   - color
+  - height
+  - length
   - magnification
   - material
+  - objective_diameter
   - pattern
   - telescope_level
   - telescope_tracking_system
+  - width
   return_reasons:
   - magnification
   - field_of_view
@@ -3262,12 +3827,17 @@
   name: Refractor Telescopes
   children: []
   attributes:
+  - aperture
   - color
+  - height
+  - length
   - magnification
   - material
+  - objective_diameter
   - pattern
   - telescope_level
   - telescope_tracking_system
+  - width
   return_reasons:
   - magnification
   - field_of_view
@@ -3283,12 +3853,17 @@
   name: Solar Telescopes
   children: []
   attributes:
+  - aperture
   - color
+  - height
+  - length
   - magnification
   - material
+  - objective_diameter
   - pattern
   - telescope_level
   - telescope_tracking_system
+  - width
   return_reasons:
   - magnification
   - field_of_view
@@ -3306,14 +3881,18 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - magnification
   - material
+  - objective_diameter
   - pattern
   - reticle_plane
   - reticle_type
   - scope/sight_design
   - scope/sight_features
   - suitable_for_weapon_type
+  - width
   return_reasons:
   - magnification
   - field_of_view
@@ -3393,8 +3972,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - height
@@ -3411,8 +3993,11 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -3428,9 +4013,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - reel_capacity
+  - width
   return_reasons:
   - size
   - capacity
@@ -3452,8 +4040,11 @@
   - co-4-1-1-4-6
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -3469,7 +4060,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -3486,7 +4080,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -3502,8 +4099,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -3519,8 +4119,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - length
   - grip
@@ -3536,8 +4139,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -3553,8 +4159,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -3570,8 +4179,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - coverage
   - consistency
@@ -3592,8 +4204,11 @@
   - co-4-1-2-5
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -3608,8 +4223,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - adjustability
@@ -3625,11 +4243,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - power_source
   - timer_design
   - timer_features
+  - width
   return_reasons:
   - brightness
   - power_source
@@ -3646,8 +4267,11 @@
   attributes:
   - camera_mounting_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - field_of_view
@@ -3664,8 +4288,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - power_source
@@ -3682,10 +4309,13 @@
   children: []
   attributes:
   - color
+  - height
   - lamp_type
+  - length
   - light_source
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - brightness
@@ -3714,6 +4344,7 @@
   - compatible_film_type
   - pattern
   - photographic_chemical_form
+  - volume
   return_reasons:
   - size
   - format
@@ -3732,6 +4363,7 @@
   - compatible_film_type
   - pattern
   - photographic_chemical_form
+  - volume
   return_reasons:
   - size
   - format
@@ -3750,6 +4382,7 @@
   - compatible_film_type
   - pattern
   - photographic_chemical_form
+  - volume
   return_reasons:
   - size
   - format
@@ -3768,6 +4401,7 @@
   - compatible_film_type
   - pattern
   - photographic_chemical_form
+  - volume
   return_reasons:
   - size
   - format
@@ -3786,6 +4420,7 @@
   - compatible_film_type
   - pattern
   - photographic_chemical_form
+  - volume
   return_reasons:
   - size
   - format
@@ -3804,6 +4439,7 @@
   - compatible_film_type
   - pattern
   - photographic_chemical_form
+  - volume
   return_reasons:
   - size
   - format
@@ -3822,6 +4458,7 @@
   - compatible_film_type
   - pattern
   - photographic_chemical_form
+  - volume
   return_reasons:
   - size
   - format
@@ -3840,6 +4477,7 @@
   - compatible_film_type
   - pattern
   - photographic_chemical_form
+  - volume
   return_reasons:
   - size
   - format
@@ -3858,6 +4496,7 @@
   - compatible_film_type
   - pattern
   - photographic_chemical_form
+  - volume
   return_reasons:
   - size
   - format
@@ -3876,6 +4515,7 @@
   - compatible_film_type
   - pattern
   - photographic_chemical_form
+  - volume
   return_reasons:
   - size
   - format
@@ -3894,6 +4534,7 @@
   - compatible_film_type
   - pattern
   - photographic_chemical_form
+  - volume
   return_reasons:
   - size
   - format
@@ -3909,10 +4550,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - photographic_paper_size
   - photographic_paper_type
+  - width
   return_reasons:
   - size
   - finish
@@ -3931,10 +4575,13 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - light_source
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -3977,8 +4624,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -3994,10 +4644,13 @@
   attributes:
   - color
   - display_mode
+  - height
+  - length
   - material
   - mount/stand_features
   - pattern
   - power_source
+  - width
   return_reasons:
   - range
   - weight
@@ -4015,9 +4668,12 @@
   - accessory_size
   - background_design
   - color
+  - height
+  - length
   - material
   - mount/stand_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4035,8 +4691,11 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4057,10 +4716,13 @@
   - co-4-2-5-4
   attributes:
   - color
+  - height
+  - length
   - material
   - mount/stand_features
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight
@@ -4077,10 +4739,13 @@
   attributes:
   - color
   - diffuser_design
+  - height
+  - length
   - material
   - mount/stand_features
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -4097,11 +4762,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mount/stand_features
   - pattern
   - power_source
   - reflector_design
+  - width
   return_reasons:
   - size
   - color
@@ -4118,12 +4786,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - light_filtering
   - lighting_features
   - material
   - pattern
   - power_source
   - projection_design
+  - width
   return_reasons:
   - size
   - color
@@ -4140,12 +4811,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mount/stand_features
   - pattern
   - power_source
   - softbox_mounting_type
   - softbox_shape
+  - width
   return_reasons:
   - size
   - color
@@ -4164,10 +4838,13 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - lighting_features
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - color
   - weight
@@ -4184,9 +4861,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mount/stand_features
   - pattern
+  - width
   return_reasons:
   - weight
   - length
@@ -4212,9 +4892,15 @@
   - co-4-2-8-10
   attributes:
   - color
+  - folded_length
+  - height_folded
+  - length_folded
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - mount_material
   - pattern
+  - width_folded
   return_reasons:
   - weight
   - weight_capacity
@@ -4231,9 +4917,15 @@
   children: []
   attributes:
   - color
+  - folded_length
+  - height_folded
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - height
   - weight
@@ -4250,9 +4942,15 @@
   children: []
   attributes:
   - color
+  - folded_length
+  - height_folded
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - weight
   - weight_capacity
@@ -4269,9 +4967,15 @@
   children: []
   attributes:
   - color
+  - folded_length
+  - height_folded
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - weight
   - height
@@ -4288,9 +4992,15 @@
   children: []
   attributes:
   - color
+  - folded_length
+  - height_folded
+  - length_folded
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - mount_material
   - pattern
+  - width_folded
   return_reasons:
   - weight_capacity
   - weight
@@ -4306,9 +5016,15 @@
   children: []
   attributes:
   - color
+  - folded_length
+  - height_folded
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - weight_capacity
   - grip
@@ -4325,9 +5041,15 @@
   children: []
   attributes:
   - color
+  - folded_length
+  - height_folded
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - weight_capacity
   - weight
@@ -4344,9 +5066,15 @@
   children: []
   attributes:
   - color
+  - folded_length
+  - height_folded
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - height
   - weight
@@ -4363,9 +5091,15 @@
   children: []
   attributes:
   - color
+  - folded_length
+  - height_folded
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - length
   - weight
@@ -4382,9 +5116,15 @@
   children: []
   attributes:
   - color
+  - folded_length
+  - height_folded
+  - length_folded
   - material
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - pattern
+  - width_folded
   return_reasons:
   - height
   - weight
@@ -4401,9 +5141,15 @@
   children: []
   attributes:
   - color
+  - folded_length
+  - height_folded
+  - length_folded
+  - maximum_length
+  - maximum_load_capacity
   - mount/stand_features
   - mount_material
   - pattern
+  - width_folded
   return_reasons:
   - weight_capacity
   - length
@@ -4420,8 +5166,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4436,9 +5185,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - negative/slide_storage_type
   - pattern
+  - width
   return_reasons:
   - size
   - color

--- a/data/categories/el_electronics.yml
+++ b/data/categories/el_electronics.yml
@@ -75,10 +75,13 @@
   - color
   - display_technology
   - frame_material
+  - height
   - height_adjustment
+  - length
   - pattern
   - payment_mechanism_type
   - power_source
+  - width
   return_reasons:
   - size
   - weight
@@ -108,10 +111,13 @@
   attributes:
   - color
   - compatible_pinball_machine_edition
+  - height
+  - length
   - material
   - pattern
   - power_source
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -129,10 +135,14 @@
   - chemical_product_form
   - color
   - compatible_pinball_machine_edition
+  - height
+  - length
   - material
   - package_type
   - pattern
+  - volume
   - wax_type
+  - width
   return_reasons:
   - finish
   - incompatible
@@ -150,10 +160,13 @@
   - compatible_pinball_machine_edition
   - cover_type
   - durability_features
+  - height
+  - length
   - material
   - pattern
   - protected_component
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -172,8 +185,11 @@
   - color
   - compatible_pinball_machine_edition
   - finish
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -190,9 +206,12 @@
   - compatible_pinball_machine_edition
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -395,12 +414,15 @@
   - cabinet_type
   - color
   - frame_material
+  - height
+  - length
   - pattern
   - payment_mechanism_type
   - pinball_machine_edition
   - pinball_machine_format
   - power_source
   - theme
+  - width
   return_reasons:
   - size
   - weight
@@ -418,10 +440,13 @@
   attributes:
   - color
   - frame_material
+  - height
+  - length
   - pattern
   - payment_mechanism_type
   - power_source
   - scoreboard_features
+  - width
   return_reasons:
   - size
   - weight
@@ -451,10 +476,13 @@
   - color
   - connection_type
   - finish
+  - height
+  - length
   - material
   - pattern
   - power_source
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -480,11 +508,14 @@
   - denomination
   - entry_orientation
   - finish
+  - height
   - interface_type
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -580,10 +611,13 @@
   - color
   - connection_type
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -646,11 +680,14 @@
   - color
   - connection_type
   - finish
+  - height
   - joystick_mounting_style
+  - length
   - material
   - pattern
   - power_source
   - restrictor_gate_shape
+  - width
   return_reasons:
   - size
   - color
@@ -670,6 +707,8 @@
   - color
   - connection_type
   - finish
+  - height
+  - length
   - light_source
   - marquee_substrate
   - material
@@ -677,6 +716,7 @@
   - power_source
   - print_orientation
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -697,14 +737,18 @@
   - color
   - connection_type
   - finish
+  - height
+  - length
   - lighting_options
   - material
   - mounting_style
   - pattern
   - power_source
+  - push_button_size
   - push_button_terminal_type
   - shape
   - switch_mechanism
+  - width
   return_reasons:
   - color
   - incompatible
@@ -967,10 +1011,13 @@
   - control_type
   - display_technology
   - frame_material
+  - height
+  - length
   - pattern
   - payment_mechanism_type
   - power_source
   - theme
+  - width
   return_reasons:
   - size
   - weight
@@ -1145,10 +1192,13 @@
   - color
   - compatible_device
   - connectivity_technology
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1164,10 +1214,13 @@
   - color
   - compatible_device
   - connectivity_technology
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - rack_mounting_style
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1188,12 +1241,15 @@
   - color
   - compatible_device
   - connectivity_technology
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - usb_connector_type
   - usb_standard
+  - width
   return_reasons:
   - sound_quality
   - range
@@ -1288,10 +1344,13 @@
   - durability_features
   - ear_tip_size
   - headphone_jack_type
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - style
@@ -1364,8 +1423,11 @@
   - compatible_device
   - ear_tip_size
   - headphone_cushion_shape
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1384,9 +1446,12 @@
   - compatible_device
   - ear_tip_size
   - headphone_cushion_shape
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1406,9 +1471,12 @@
   - ear_tip_size
   - ear_tip_style
   - headphone_cushion_shape
+  - height
+  - length
   - material
   - pattern
   - size
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1427,10 +1495,13 @@
   - compatible_device
   - connectivity_technology
   - headphone_jack_type
+  - height
+  - length
   - material
   - mount/stand_features
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -1506,9 +1577,12 @@
   - color
   - compatible_device
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - style
   - incompatible
@@ -1528,9 +1602,12 @@
   - color
   - compatible_device
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - style
@@ -1548,11 +1625,14 @@
   - color
   - compatible_device
   - connectivity_technology
+  - height
   - language
+  - length
   - material
   - music_genre
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1618,9 +1698,12 @@
   - color
   - compatible_device
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -1636,12 +1719,16 @@
   - attachment_method
   - color
   - compatible_device
+  - compatible_microphone_size
   - compatible_microphone_thread
   - connectivity_technology
+  - height
+  - length
   - material
   - mount/stand_features
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1658,11 +1745,15 @@
   - attachment_method
   - color
   - compatible_device
+  - compatible_microphone_size
   - connectivity_technology
+  - height
+  - length
   - material
   - mounting_mechanism
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1679,10 +1770,14 @@
   - attachment_method
   - color
   - compatible_device
+  - compatible_microphone_size
   - connectivity_technology
+  - height
+  - length
   - material
   - microphone_windshield_type
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1740,11 +1835,16 @@
   - color
   - compatible_device
   - connectivity_technology
+  - height
   - height_adjustment
+  - length
   - material
+  - maximum_height
   - microphone_thread
+  - minimum_height
   - mount/stand_features
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -1817,9 +1917,12 @@
   - color
   - compatible_device
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - style
@@ -1837,12 +1940,15 @@
   - color
   - compatible_device
   - connectivity_technology
+  - height
+  - length
   - material
   - mobile_phone_accessories_included
   - mobile_phone_connector_type
   - mp3_player_accessories_included
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1866,9 +1972,12 @@
   - compatible_device
   - connectivity_technology
   - cover_features
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -1992,9 +2101,12 @@
   - compatible_device
   - compatible_satellite_radio_service
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2014,6 +2126,8 @@
   - compatible_device
   - compatible_satellite_radio_service
   - connectivity_technology
+  - height
+  - length
   - material
   - mount/stand_features
   - mounting_interface_pattern
@@ -2021,6 +2135,7 @@
   - pattern
   - power_source
   - vehicle_mounting_location
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2154,9 +2269,12 @@
   - color
   - compatible_device
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2178,8 +2296,11 @@
   - color
   - compatible_device
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2201,10 +2322,13 @@
   - color
   - compatible_device
   - connectivity_technology
+  - height
+  - length
   - magnet_type
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2325,8 +2449,11 @@
   - color
   - compatible_device
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2346,13 +2473,17 @@
   - color
   - compatible_device
   - connectivity_technology
+  - height
   - height_adjustment
+  - length
   - lumber/wood_type
   - material
+  - maximum_load_capacity
   - mount/stand_features
   - mount_material
   - mounting_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2370,9 +2501,15 @@
   - color
   - compatible_device
   - connectivity_technology
+  - height
+  - impedance
+  - length
   - material
+  - maximum_frequency
+  - minimum_frequency
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2440,9 +2577,12 @@
   - battery_type
   - color
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2461,8 +2601,11 @@
   - cartridge_type
   - color
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -2483,9 +2626,12 @@
   - brush_material
   - color
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
   - record_cleaning_components_included
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2578,8 +2724,11 @@
   attributes:
   - color
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -2595,9 +2744,12 @@
   attributes:
   - color
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
   - surface_texture
+  - width
   return_reasons:
   - size
   - color
@@ -2865,12 +3017,18 @@
   - display_technology
   - gaming_enhancement_features
   - hdr_format
+  - height
+  - impedance
+  - length
   - material
   - maximum_bit_depth
   - pattern
+  - power_consumption_typical
+  - power_output_typical
   - power_source
   - room_correction_technology
   - video_resolution_supported
+  - width
   - wireless_multi_room_platform
   return_reasons:
   - sound_quality
@@ -2897,11 +3055,18 @@
   - color
   - connectivity_technology
   - device_interface
+  - height
+  - length
   - lumber/wood_type
   - material
   - maximum_bit_depth
   - pattern
+  - peak_power_per_channel
+  - power_consumption_typical
   - power_source
+  - sampling_rate
+  - signal_to_noise_ratio_snr
+  - width
   - wood_finish
   return_reasons:
   - sound_quality
@@ -2925,10 +3090,17 @@
   - connectivity_technology
   - device_interface
   - headphone_jack_type
+  - height
+  - length
   - material
   - maximum_bit_depth
   - pattern
+  - peak_power_per_channel
+  - power_consumption_typical
   - power_source
+  - sampling_rate
+  - signal_to_noise_ratio_snr
+  - width
   return_reasons:
   - sound_quality
   - power_output
@@ -2952,12 +3124,19 @@
   - connectivity_technology
   - cooling_technology
   - device_interface
+  - height
+  - length
   - material
   - maximum_bit_depth
   - mounting_type
   - pattern
+  - peak_power_per_channel
+  - power_consumption_typical
   - power_source
+  - sampling_rate
+  - signal_to_noise_ratio_snr
   - suitable_space
+  - width
   return_reasons:
   - sound_quality
   - power_output
@@ -3005,11 +3184,15 @@
   - device_interface
   - digital_sound_processing
   - fader_type
+  - height
+  - length
   - material
   - maximum_bit_depth
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -3033,11 +3216,14 @@
   - color
   - connectivity_technology
   - device_interface
+  - height
+  - length
   - material
   - maximum_bit_depth
   - pairing_method
   - pattern
   - power_source
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -3062,11 +3248,14 @@
   - connection_type
   - connectivity_technology
   - device_interface
+  - height
+  - length
   - material
   - maximum_bit_depth
   - pairing_method
   - pattern
   - power_source
+  - width
   return_reasons:
   - sound_quality
   - range
@@ -3091,6 +3280,8 @@
   - device_interface
   - fm_transmitter_playback_source
   - frequency/radio_bands_supported
+  - height
+  - length
   - material
   - maximum_bit_depth
   - pairing_method
@@ -3098,6 +3289,7 @@
   - power_source
   - tuner_type
   - usb_connector_type
+  - width
   return_reasons:
   - sound_quality
   - range
@@ -3148,6 +3340,8 @@
   - color
   - connectivity_technology
   - device_interface
+  - height
+  - length
   - material
   - maximum_bit_depth
   - mounting_type
@@ -3156,6 +3350,7 @@
   - rack_format
   - signal_path_technology
   - supported_input_types
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -3175,11 +3370,14 @@
   - connectivity_technology
   - device_interface
   - direct_box_type
+  - height
+  - length
   - material
   - maximum_bit_depth
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -3244,13 +3442,17 @@
   - earphone_features
   - headphone_driver_technology
   - headphone_style
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
+  - maximum_battery_life
   - maximum_bit_depth
   - microphone_type
   - noise_cancellation_technology
   - pattern
   - power_source
+  - width
   return_reasons:
   - style
   - sound_quality
@@ -3275,13 +3477,17 @@
   - device_interface
   - earphone_features
   - headphone_driver_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
+  - maximum_battery_life
   - maximum_bit_depth
   - microphone_type
   - noise_cancellation_technology
   - pattern
   - power_source
+  - width
   return_reasons:
   - sound_quality
   - fit
@@ -3305,13 +3511,17 @@
   - earphone_features
   - headphone_driver_technology
   - headphone_style
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
+  - maximum_battery_life
   - maximum_bit_depth
   - microphone_type
   - noise_cancellation_technology
   - pattern
   - power_source
+  - width
   return_reasons:
   - style
   - sound_quality
@@ -3339,13 +3549,17 @@
   - earphone_features
   - headphone_driver_technology
   - headphone_style
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
+  - maximum_battery_life
   - maximum_bit_depth
   - microphone_type
   - noise_cancellation_technology
   - pattern
   - power_source
+  - width
   return_reasons:
   - sound_quality
   - fit
@@ -3371,13 +3585,17 @@
   - earphone_features
   - headphone_driver_technology
   - headphone_style
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
+  - maximum_battery_life
   - maximum_bit_depth
   - microphone_type
   - noise_cancellation_technology
   - pattern
   - power_source
+  - width
   return_reasons:
   - sound_quality
   - fit
@@ -3403,13 +3621,17 @@
   - earphone_features
   - headphone_driver_technology
   - headphone_style
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
+  - maximum_battery_life
   - maximum_bit_depth
   - microphone_type
   - noise_cancellation_technology
   - pattern
   - power_source
+  - width
   return_reasons:
   - sound_quality
   - fit
@@ -3439,14 +3661,18 @@
   - earphone_features
   - headphone_driver_technology
   - headphone_style
+  - height
   - ingress_protection_ip_rating
+  - length
   - lighting_type
   - material
+  - maximum_battery_life
   - maximum_bit_depth
   - microphone_type
   - noise_cancellation_technology
   - pattern
   - power_source
+  - width
   return_reasons:
   - style
   - sound_quality
@@ -3594,13 +3820,19 @@
   - color
   - connectivity_technology
   - device_interface
+  - height
+  - impedance
+  - length
   - material
   - maximum_bit_depth
+  - maximum_sound_pressure_level_spl
   - microphone_design
   - microphone_thread
   - pattern
   - polar_pattern
   - power_source
+  - signal_to_noise_ratio_snr
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -3629,12 +3861,15 @@
   - connectivity_technology
   - device_interface
   - digital_sound_processing
+  - height
+  - length
   - material
   - maximum_bit_depth
   - mounting_type
   - pattern
   - power_source
   - processor_technology
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -3658,12 +3893,15 @@
   - digital_sound_processing
   - filter_slope
   - filter_topology
+  - height
+  - length
   - material
   - maximum_bit_depth
   - mounting_type
   - pattern
   - power_source
   - processor_technology
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -3733,13 +3971,16 @@
   - device_interface
   - digital_sound_processing
   - effects_processor_form_factor
+  - height
   - input/output_ports
+  - length
   - material
   - maximum_bit_depth
   - mounting_type
   - pattern
   - power_source
   - processor_technology
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -3762,12 +4003,15 @@
   - device_interface
   - digital_sound_processing
   - equalizer_type
+  - height
+  - length
   - material
   - maximum_bit_depth
   - mounting_type
   - pattern
   - power_source
   - processor_technology
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -3788,12 +4032,15 @@
   - control_interface
   - device_interface
   - digital_sound_processing
+  - height
+  - length
   - material
   - maximum_bit_depth
   - mounting_type
   - pattern
   - power_source
   - processor_technology
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -3813,6 +4060,8 @@
   - connectivity_technology
   - device_interface
   - digital_sound_processing
+  - height
+  - length
   - material
   - maximum_bit_depth
   - microphone_preamp_form_factor
@@ -3821,6 +4070,7 @@
   - power_source
   - processor_technology
   - supported_input_types
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -3843,12 +4093,15 @@
   - device_interface
   - digital_sound_processing
   - dynamics_processing_function
+  - height
+  - length
   - material
   - maximum_bit_depth
   - mounting_type
   - pattern
   - power_source
   - processor_technology
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -3869,6 +4122,8 @@
   - connectivity_technology
   - device_interface
   - digital_sound_processing
+  - height
+  - length
   - material
   - maximum_bit_depth
   - mounting_type
@@ -3876,6 +4131,7 @@
   - power_source
   - processor_technology
   - subsonic_filter
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -3905,15 +4161,20 @@
   - compatible_voice_assistant
   - connectivity_technology
   - device_interface
+  - height
+  - impedance
+  - length
   - material
   - maximum_bit_depth
   - mounting_type
   - pattern
   - power_source
+  - rms_rated_power
   - speaker_design
   - speaker_enclosure_type
   - speaker_features
   - speaker_technology
+  - width
   return_reasons:
   - color
   - style
@@ -4157,12 +4418,15 @@
   - color
   - connectivity_technology
   - device_interface
+  - height
+  - length
   - material
   - maximum_bit_depth
   - microphone_type
   - pattern
   - power_source
   - recording_accessories_included
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -4244,12 +4508,16 @@
   - color
   - connectivity_technology
   - frequency/radio_bands_supported
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - media_format
   - pattern
   - power_source
+  - rms_rated_power
   - tuner_type
+  - width
   return_reasons:
   - sound_quality
   - battery_life
@@ -4278,11 +4546,15 @@
   - color
   - compatible_memory_cards
   - connectivity_technology
+  - height
   - ingress_protection_ip_rating
+  - internal_storage_capacity
+  - length
   - material
   - media_format
   - pattern
   - power_source
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -4439,12 +4711,16 @@
   - connectivity_technology
   - device_interface
   - frequency/radio_bands_supported
+  - height
+  - length
   - material
   - media_format
   - pattern
   - power_source
+  - rms_rated_power
   - subwoofer_configuration
   - system_components_included
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -4464,12 +4740,15 @@
   - audio_player/recorder_features
   - color
   - connectivity_technology
+  - height
+  - length
   - material
   - media_format
   - pattern
   - payment_mechanism_type
   - playback_speed_supported
   - power_source
+  - width
   return_reasons:
   - size
   - style
@@ -4491,13 +4770,16 @@
   - battery_type
   - color
   - connectivity_technology
+  - height
   - karaoke_modes
+  - length
   - light_options
   - material
   - media_format
   - microphone_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -4517,7 +4799,9 @@
   - color
   - connectivity_technology
   - frequency/radio_bands_supported
+  - height
   - input/output_ports
+  - length
   - material
   - maximum_bit_depth
   - media_format
@@ -4525,6 +4809,8 @@
   - microphone_type
   - pattern
   - power_source
+  - rms_rated_power
+  - width
   return_reasons:
   - sound_quality
   - battery_life
@@ -4555,7 +4841,9 @@
   - connectivity_technology
   - display_mode
   - frequency/radio_bands_supported
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - media_format
   - pairing_method
@@ -4563,6 +4851,7 @@
   - power_source
   - radio_features
   - tuner_type
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -4588,7 +4877,9 @@
   - connectivity_technology
   - display_mode
   - frequency/radio_bands_supported
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - media_format
   - pairing_method
@@ -4596,6 +4887,7 @@
   - power_source
   - radio_features
   - tuner_type
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -4683,7 +4975,9 @@
   - connectivity_technology
   - display_mode
   - frequency/radio_bands_supported
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - media_format
   - pairing_method
@@ -4691,6 +4985,7 @@
   - power_source
   - radio_features
   - tuner_type
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -4714,8 +5009,10 @@
   - connectivity_technology
   - display_mode
   - frequency/radio_bands_supported
+  - height
   - ingress_protection_ip_rating
   - internet_radio_form_factor
+  - length
   - material
   - media_format
   - pairing_method
@@ -4725,6 +5022,7 @@
   - tuner_type
   - wi_fi_band
   - wi_fi_standard
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -4749,7 +5047,9 @@
   - connectivity_technology
   - display_mode
   - frequency/radio_bands_supported
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - media_format
   - mounting_type
@@ -4759,6 +5059,7 @@
   - radio_features
   - tuner_type
   - vehicle_type
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -4781,7 +5082,9 @@
   - connectivity_technology
   - display_mode
   - frequency/radio_bands_supported
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - media_format
   - modulation_method
@@ -4790,6 +5093,7 @@
   - power_source
   - radio_features
   - tuner_type
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -4817,7 +5121,9 @@
   - connectivity_technology
   - display_mode
   - frequency/radio_bands_supported
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - media_format
   - pairing_method
@@ -4826,6 +5132,7 @@
   - radio_features
   - tuner_type
   - weather_alert_technology
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -4875,16 +5182,21 @@
   - battery_size
   - battery_type
   - color
+  - compatible_tape_size
   - connectivity_technology
   - frequency/radio_bands_supported
+  - height
+  - length
   - material
   - maximum_reel_diameter_supported
   - media_format
   - noise_reduction_system
   - pattern
   - power_source
+  - rms_rated_power
   - tape_speed_supported
   - track_configuration
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -4906,10 +5218,14 @@
   - connectivity_technology
   - device_interface
   - frequency/radio_bands_supported
+  - height
+  - length
   - material
   - media_format
   - pattern
   - power_source
+  - rms_rated_power
+  - width
   - wireless_streaming_protocols_supported
   return_reasons:
   - sound_quality
@@ -4935,6 +5251,8 @@
   - color
   - connectivity_technology
   - frequency/radio_bands_supported
+  - height
+  - length
   - material
   - media_format
   - operating_mode
@@ -4942,8 +5260,10 @@
   - playback_speed_supported
   - player_drive_type
   - power_source
+  - rms_rated_power
   - stylus_type
   - tonearm_type
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -5025,6 +5345,9 @@
   - compatible_memory_cards
   - connectivity_technology
   - frequency/radio_bands_supported
+  - height
+  - internal_storage_capacity
+  - length
   - material
   - media_format
   - microphone_type
@@ -5032,7 +5355,9 @@
   - power_source
   - recording_mode
   - recording_quality
+  - rms_rated_power
   - voice_recorder_form_factor
+  - width
   return_reasons:
   - sound_quality
   - battery_life
@@ -5120,10 +5445,14 @@
   - bullhorn_features
   - color
   - connectivity_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pattern
+  - power_output_typical
   - power_source
+  - width
   return_reasons:
   - sound_quality
   - range
@@ -5153,9 +5482,12 @@
   - device_interface
   - dj_equipment_features
   - dj_software_compatibility
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -5177,11 +5509,14 @@
   - device_interface
   - dj_equipment_features
   - dj_software_compatibility
+  - height
+  - length
   - material
   - pattern
   - power_source
   - sound_effects
   - supported_media_sources
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -5205,11 +5540,14 @@
   - device_interface
   - dj_equipment_features
   - dj_software_compatibility
+  - height
   - input/output_ports
+  - length
   - material
   - mixer_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -5393,12 +5731,18 @@
   - color
   - connectivity_technology
   - device_interface
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
+  - maximum_frequency
+  - minimum_frequency
   - mounting_type
   - pattern
   - power_source
+  - rms_rated_power
   - speaker_technology
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -5503,10 +5847,15 @@
   - connectivity_technology
   - device_interface
   - frequency/radio_bands_supported
+  - height
+  - length
   - material
+  - maximum_frequency
+  - minimum_frequency
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5528,11 +5877,16 @@
   - connection_type
   - connectivity_technology
   - frequency/radio_bands_supported
+  - height
+  - length
   - material
+  - maximum_frequency
+  - minimum_frequency
   - modulation_method
   - mounting_type
   - pattern
   - transmitter_form_factor
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -5772,9 +6126,12 @@
   attributes:
   - color
   - component_mounting_style
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5791,10 +6148,13 @@
   - case_transparency_level
   - color
   - cooling_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - style
@@ -5812,11 +6172,14 @@
   - color
   - component_mounting_style
   - cooling_technology
+  - height
+  - length
   - material
   - pattern
   - processor_socket
   - product_certifications_standards
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5835,8 +6198,11 @@
   - conductor_core_type
   - connector_gender
   - connector_type
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   - wire/rope_material
   return_reasons:
   - color
@@ -5916,9 +6282,12 @@
   - component_output_type
   - component_package_type
   - decoder/encoder_function
+  - height
+  - length
   - logic_family
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - voltage
   - incompatible
@@ -6069,10 +6438,13 @@
   - component_mounting_style
   - component_package_type
   - connectivity_type
+  - height
   - hole_plating_type
+  - length
   - pattern
   - pcb_type
   - product_certifications_standards
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6090,11 +6462,14 @@
   - component_mounting_style
   - component_package_type
   - connectivity_type
+  - height
   - hole_plating_type
+  - length
   - material
   - pattern
   - pcb_type
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - incompatible
@@ -6219,10 +6594,15 @@
   - color
   - component_mounting_style
   - component_package_type
+  - height
+  - length
+  - maximum_cut_off_frequency
+  - minimum_cut_off_frequency
   - passband
   - pattern
   - product_certifications_standards
   - stopband
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6238,10 +6618,15 @@
   - color
   - component_mounting_style
   - component_package_type
+  - height
+  - length
+  - maximum_cut_off_frequency
+  - minimum_cut_off_frequency
   - passband
   - pattern
   - product_certifications_standards
   - stopband
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6257,10 +6642,15 @@
   - color
   - component_mounting_style
   - component_package_type
+  - height
+  - length
+  - maximum_cut_off_frequency
+  - minimum_cut_off_frequency
   - passband
   - pattern
   - product_certifications_standards
   - stopband
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6276,10 +6666,15 @@
   - color
   - component_mounting_style
   - component_package_type
+  - height
+  - length
+  - maximum_cut_off_frequency
+  - minimum_cut_off_frequency
   - passband
   - pattern
   - product_certifications_standards
   - stopband
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6297,10 +6692,15 @@
   - component_package_type
   - connection_type
   - filter_topology
+  - height
+  - length
+  - maximum_cut_off_frequency
+  - minimum_cut_off_frequency
   - passband
   - pattern
   - product_certifications_standards
   - stopband
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6318,10 +6718,15 @@
   - component_package_type
   - connection_type
   - filter_topology
+  - height
+  - length
+  - maximum_cut_off_frequency
+  - minimum_cut_off_frequency
   - passband
   - pattern
   - product_certifications_standards
   - stopband
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6386,8 +6791,11 @@
   - component_mounting_style
   - component_package_type
   - component_tolerance
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6401,6 +6809,7 @@
   children: []
   attributes:
   - capacitance_tolerance
+  - capacitance_value
   - capacitor_application
   - capacitor_polarity
   - color
@@ -6408,8 +6817,12 @@
   - component_package_type
   - component_size_code
   - dielectric_type
+  - height
+  - length
+  - maximum_operating_voltage
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6429,9 +6842,16 @@
   - component_mounting_style
   - component_package_type
   - component_tolerance
+  - height
+  - input_voltage
+  - length
+  - maximum_frequency
+  - maximum_operating_voltage
+  - minimum_frequency
   - output_waveform
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6509,10 +6929,16 @@
   - color
   - component_mounting_style
   - component_package_type
+  - height
   - inductance_tolerance
+  - length
   - material
+  - maximum_inductance
+  - minimum_inductance
   - pattern
   - product_certifications_standards
+  - saturation_current
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6590,9 +7016,13 @@
   - color
   - component_mounting_style
   - component_package_type
+  - height
+  - length
   - pattern
   - product_certifications_standards
   - resistance_tolerance
+  - resistance_value
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6783,11 +7213,16 @@
   - circuit_board_features
   - color
   - component_mounting_style
+  - height
+  - impedance
+  - length
   - material
+  - maximum_operating_temperature
   - pattern
   - pcb_surface_finish
   - pcb_type
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - incompatible
@@ -6805,12 +7240,17 @@
   - color
   - component_mounting_style
   - drone_board_function
+  - height
+  - impedance
   - interface_type
+  - length
   - material
+  - maximum_operating_temperature
   - pattern
   - pcb_surface_finish
   - pcb_type
   - product_certifications_standards
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6831,12 +7271,19 @@
   - color
   - compatible_device
   - component_mounting_style
+  - height
+  - impedance
+  - length
   - material
+  - maximum_current_rating
+  - maximum_operating_temperature
+  - maximum_operating_voltage
   - pattern
   - pcb_surface_finish
   - pcb_type
   - product_certifications_standards
   - usb_connector_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6853,12 +7300,19 @@
   - color
   - compatible_device
   - component_mounting_style
+  - height
+  - impedance
+  - length
   - material
+  - maximum_current_rating
+  - maximum_operating_temperature
+  - maximum_operating_voltage
   - pattern
   - pcb_surface_finish
   - pcb_type
   - product_certifications_standards
   - usb_connector_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6876,13 +7330,20 @@
   - compatible_device
   - component_mounting_style
   - hard_drive_form_factor
+  - height
+  - impedance
+  - length
   - material
+  - maximum_current_rating
+  - maximum_operating_temperature
+  - maximum_operating_voltage
   - pattern
   - pcb_surface_finish
   - pcb_type
   - product_certifications_standards
   - storage_drive_interface_type
   - usb_connector_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6902,7 +7363,14 @@
   - compatible_processor_series
   - component_mounting_style
   - expansion_slots
+  - height
+  - impedance
+  - length
   - material
+  - maximum_current_rating
+  - maximum_operating_temperature
+  - maximum_operating_voltage
+  - memory_capacity
   - memory_technology
   - motherboard_chipset_family
   - motherboard_form_factor
@@ -6919,6 +7387,7 @@
   - usb_connector_type
   - usb_standard
   - wi_fi_standard
+  - width
   return_reasons:
   - size
   - incompatible
@@ -6958,8 +7427,15 @@
   - color
   - component_mounting_style
   - connectivity_technology
+  - height
+  - impedance
+  - length
   - material
+  - maximum_frequency
+  - maximum_operating_temperature
+  - memory_capacity
   - memory_technology
+  - minimum_frequency
   - pattern
   - pcb_surface_finish
   - pcb_type
@@ -6968,6 +7444,7 @@
   - product_certifications_standards
   - usb_connector_type
   - wi_fi_standard
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6985,11 +7462,16 @@
   - compatible_exercise_machine_type
   - component_mounting_style
   - exercise_machine_board_function
+  - height
+  - impedance
+  - length
   - material
+  - maximum_operating_temperature
   - pattern
   - pcb_surface_finish
   - pcb_type
   - product_certifications_standards
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7014,11 +7496,16 @@
   - circuit_board_features
   - color
   - component_mounting_style
+  - height
+  - impedance
+  - length
   - material
+  - maximum_operating_temperature
   - pattern
   - pcb_surface_finish
   - pcb_type
   - product_certifications_standards
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7189,11 +7676,16 @@
   - color
   - compatible_equipment_type
   - component_mounting_style
+  - height
+  - impedance
+  - length
   - material
+  - maximum_operating_temperature
   - pattern
   - pcb_surface_finish
   - pcb_type
   - product_certifications_standards
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7210,13 +7702,18 @@
   - color
   - component_mounting_style
   - drone_board_function
+  - height
+  - impedance
   - item_condition
+  - length
   - material
+  - maximum_operating_temperature
   - pattern
   - pcb_surface_finish
   - pcb_type
   - product_certifications_standards
   - suitable_for_printer_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7232,11 +7729,16 @@
   - circuit_board_features
   - color
   - component_mounting_style
+  - height
+  - impedance
+  - length
   - material
+  - maximum_operating_temperature
   - pattern
   - pcb_surface_finish
   - pcb_type
   - product_certifications_standards
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7257,12 +7759,17 @@
   - circuit_board_features
   - color
   - component_mounting_style
+  - height
+  - impedance
+  - length
   - material
+  - maximum_operating_temperature
   - pattern
   - pcb_surface_finish
   - pcb_type
   - product_certifications_standards
   - television_circuit_board_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7416,10 +7923,17 @@
   - component_mounting_style
   - component_output_type
   - component_package_type
+  - height
+  - length
+  - maximum_current_rating
+  - maximum_operating_temperature
+  - maximum_operating_voltage
   - pattern
   - polarity_configuration
+  - power_dissipation
   - product_certifications_standards
   - semiconductor_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7443,10 +7957,17 @@
   - component_mounting_style
   - component_output_type
   - component_package_type
+  - height
+  - length
+  - maximum_current_rating
+  - maximum_operating_temperature
+  - maximum_operating_voltage
   - pattern
   - polarity_configuration
+  - power_dissipation
   - product_certifications_standards
   - semiconductor_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7608,11 +8129,18 @@
   - component_mounting_style
   - component_output_type
   - component_package_type
+  - height
+  - length
   - logic_family
+  - maximum_current_rating
+  - maximum_operating_temperature
+  - maximum_operating_voltage
   - mounting_technology
   - pattern
+  - power_dissipation
   - product_certifications_standards
   - semiconductor_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7735,11 +8263,18 @@
   - component_mounting_style
   - component_output_type
   - component_package_type
+  - height
   - instruction_set_architecture
+  - length
+  - maximum_current_rating
+  - maximum_operating_temperature
+  - maximum_operating_voltage
   - pattern
+  - power_dissipation
   - processor_cores
   - product_certifications_standards
   - semiconductor_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7761,10 +8296,17 @@
   - component_mounting_style
   - component_output_type
   - component_package_type
+  - height
+  - length
+  - maximum_current_rating
+  - maximum_operating_temperature
+  - maximum_operating_voltage
   - pattern
   - polarity_configuration
+  - power_dissipation
   - product_certifications_standards
   - semiconductor_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8035,11 +8577,15 @@
   name: Answering Machines
   children: []
   attributes:
+  - call_storage_capacity
   - color
   - communication_device_features
   - connectivity_technology
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - storage_capacity
   - incompatible
@@ -8057,8 +8603,11 @@
   - communication_device_features
   - connectivity_technology
   - display_technology
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8076,8 +8625,11 @@
   attributes:
   - color
   - connectivity_technology
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8101,10 +8653,13 @@
   - embellishment/trim_material
   - headphone_style
   - headset_connection_type
+  - height
   - jewelry_material
+  - length
   - microphone_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - fit
   - incompatible
@@ -8125,9 +8680,12 @@
   - carry_options
   - closure_type
   - color
+  - height
   - ingress_protection_ip_rating
+  - length
   - pattern
   - radio_case_design
+  - width
   return_reasons:
   - style
   - incompatible
@@ -8220,11 +8778,16 @@
   - color
   - connectivity_technology
   - frequency/radio_bands_supported
+  - height
   - ingress_protection_ip_rating
+  - length
+  - maximum_frequency
+  - minimum_frequency
   - modulation_method
   - pattern
   - power_source
   - radio_features
+  - width
   return_reasons:
   - battery_life
   - range
@@ -8246,12 +8809,17 @@
   - color
   - connectivity_technology
   - frequency/radio_bands_supported
+  - height
   - ingress_protection_ip_rating
+  - length
+  - maximum_frequency
+  - minimum_frequency
   - modulation_method
   - pattern
   - power_source
   - radio_features
   - radio_form_factor
+  - width
   return_reasons:
   - sound_quality
   - battery_life
@@ -8322,12 +8890,17 @@
   - color
   - connectivity_technology
   - frequency/radio_bands_supported
+  - height
   - ingress_protection_ip_rating
+  - length
+  - maximum_frequency
+  - minimum_frequency
   - modulation_method
   - pattern
   - power_source
   - radio_features
   - radio_form_factor
+  - width
   return_reasons:
   - range
   - incompatible
@@ -8347,12 +8920,17 @@
   - connectivity_technology
   - display_technology
   - frequency/radio_bands_supported
+  - height
   - ingress_protection_ip_rating
+  - length
+  - maximum_frequency
+  - minimum_frequency
   - modulation_method
   - pattern
   - power_source
   - radio_features
   - radio_scanner_form_factor
+  - width
   return_reasons:
   - range
   - incompatible
@@ -8375,12 +8953,17 @@
   - color
   - connectivity_technology
   - frequency/radio_bands_supported
+  - height
   - ingress_protection_ip_rating
+  - length
+  - maximum_frequency
+  - minimum_frequency
   - modulation_method
   - pattern
   - power_source
   - radio_features
   - radio_form_factor
+  - width
   return_reasons:
   - range
   - incompatible
@@ -8472,10 +9055,13 @@
   - connectivity_technology
   - connector_gender
   - durability_features
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8495,14 +9081,19 @@
   - connector_gender
   - device_interface
   - durability_features
+  - height
+  - impedance
   - ingress_protection_ip_rating
   - intercom_wiring_type
+  - length
   - material
+  - maximum_battery_life
   - mounting_type
   - pattern
   - power_source
   - speaker_features
   - speaker_technology
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -8609,11 +9200,14 @@
   - communication_device_features
   - connectivity_technology
   - display_resolution
+  - height
   - ingress_protection_ip_rating
   - intercom_communication_type
+  - length
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -8681,9 +9275,13 @@
   - connectivity_technology
   - display_technology
   - frequency/radio_bands_supported
+  - height
+  - length
+  - maximum_battery_life
   - pager_application
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - range
@@ -8736,7 +9334,9 @@
   - display_resolution
   - display_technology
   - ethernet_lan_interface_type
+  - height
   - ingress_protection_ip_rating
+  - length
   - pattern
   - poe_standard
   - power_source
@@ -8747,6 +9347,7 @@
   - usb_connector_type
   - voip_protocol_support
   - wi_fi_standard
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8772,6 +9373,8 @@
   - handset_type
   - headset_connection_type
   - hearing_aid_compatibility
+  - height
+  - length
   - mounting_type
   - pattern
   - poe_standard
@@ -8779,6 +9382,7 @@
   - telephone_cable_interface
   - telephone_style
   - voip_protocol_support
+  - width
   return_reasons:
   - length
   - incompatible
@@ -8890,13 +9494,18 @@
   - connection_type
   - connectivity_technology
   - cordless_phone_frequency_band
+  - coverage_radius
   - handset_type
+  - height
   - ingress_protection_ip_rating
+  - length
+  - maximum_battery_life
   - mounting_type
   - pattern
   - power_source
   - telephone_style
   - voip_protocol_support
+  - width
   return_reasons:
   - battery_life
   - incompatible
@@ -8999,6 +9608,8 @@
   - connectivity_technology
   - device_interface
   - finish
+  - height
+  - length
   - lens_coating
   - lens_filter_type
   - lens_kit_accessories_included
@@ -9009,6 +9620,7 @@
   - mounting_thread_size
   - pattern
   - theme
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9033,6 +9645,8 @@
   - connectivity_technology
   - control_type
   - finish
+  - height
+  - length
   - light_design
   - light_temperature
   - lighting_features
@@ -9043,6 +9657,7 @@
   - power_source
   - remote_technology
   - theme
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9068,6 +9683,8 @@
   - device_interface
   - durability_features
   - finish
+  - height
+  - length
   - magsafe_compatibility
   - material
   - mounting_thread_size
@@ -9079,6 +9696,7 @@
   - remote_shutter_form_factor
   - remote_technology
   - theme
+  - width
   return_reasons:
   - size
   - range
@@ -9106,12 +9724,19 @@
   - durability_features
   - feet_type
   - finish
+  - folded_length
   - gimbal_stabilization_axes
+  - height_folded
   - leg_lock_type
   - leg_sections
+  - length_folded
   - lighting_features
   - magsafe_compatibility
   - material
+  - maximum_height
+  - maximum_length
+  - maximum_load_capacity
+  - minimum_height
   - mount/stand_features
   - mounting_mechanism
   - mounting_thread_size
@@ -9121,6 +9746,7 @@
   - remote_technology
   - selfie_stick_functionality_type
   - theme
+  - width_folded
   return_reasons:
   - size
   - changed_my_mind
@@ -9319,10 +9945,14 @@
   - connectivity_technology
   - finish
   - hand_side
+  - height
   - ingress_protection_ip_rating
   - integrated_stand_type
+  - length
   - magsafe_compatibility
   - material
+  - maximum_screen_height
+  - maximum_screen_width
   - mobile_phone_case_features
   - pattern
   - personalization_options
@@ -9332,6 +9962,7 @@
   - sustainability
   - theme
   - wallet_features
+  - width
   return_reasons:
   - color
   - too_bulky
@@ -9402,12 +10033,15 @@
   - embellishment/trim_material
   - finish
   - hardware_finish
+  - height
   - jewelry_material
+  - length
   - magsafe_compatibility
   - material
   - pattern
   - phone_strap_accessories_included
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -9495,6 +10129,8 @@
   - currency
   - data_network_generation
   - data_rollover_policy
+  - height
+  - length
   - material
   - pattern
   - plan_service_type
@@ -9503,6 +10139,7 @@
   - supported_countries
   - top_up_method
   - usage_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -9527,6 +10164,8 @@
   - data_rollover_policy
   - denomination
   - finish
+  - height
+  - length
   - material
   - pattern
   - phone_card_delivery_format
@@ -9538,6 +10177,7 @@
   - theme
   - top_up_method
   - usage_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -9560,7 +10200,9 @@
   - data_network_generation
   - data_rollover_policy
   - finish
+  - height
   - identity_verification_requirement
+  - length
   - material
   - pattern
   - plan_service_type
@@ -9571,6 +10213,7 @@
   - theme
   - top_up_method
   - usage_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -9628,14 +10271,17 @@
   - connection_type
   - connectivity_technology
   - finish
+  - height
   - installation_tools_included
   - item_condition
+  - length
   - manufacturer_type
   - material
   - mobile_phone_connector_type
   - pattern
   - power_source
   - recommended_skill_level
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -9928,6 +10574,8 @@
   - connection_type
   - connectivity_technology
   - finish
+  - height
+  - length
   - lumber/wood_type
   - magsafe_compatibility
   - material
@@ -9936,6 +10584,7 @@
   - pattern
   - power_source
   - theme
+  - width
   - wireless_charging_standard
   - wood_finish
   return_reasons:
@@ -9958,10 +10607,13 @@
   - connection_type
   - connectivity_technology
   - finish
+  - height
+  - length
   - material
   - pattern
   - power_source
   - theme
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10224,19 +10876,26 @@
   - connectivity_technology
   - cosmetic_condition
   - data_network
+  - depth
   - display_resolution
   - display_technology
   - headphone_jack_type
   - ingress_protection_ip_rating
+  - internal_storage_capacity
+  - length
+  - maximum_battery_life
   - mobile_phone_form_factor
   - operating_system
   - pattern
   - power_source
+  - ram_memory
   - removable_storage_formats_supported
+  - screen_size
   - sim_card_capability
   - sim_card_type_1
   - sim_card_type_2
   - subscription_type
+  - width
   - wireless_charging_standard
   return_reasons:
   - battery_life
@@ -10313,7 +10972,10 @@
   - connection_type
   - connectivity_technology
   - data_network
+  - height
   - ingress_protection_ip_rating
+  - length
+  - maximum_battery_life
   - operating_system
   - pattern
   - power_source
@@ -10323,6 +10985,7 @@
   - sim_card_capability
   - sim_card_type
   - subscription_type
+  - width
   return_reasons:
   - sound_quality
   - battery_life
@@ -10348,11 +11011,14 @@
   attributes:
   - color
   - connectivity_technology
+  - height
+  - length
   - mounting_type
   - pattern
   - power_source
   - telephone_cable_interface
   - telephone_cord_style
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -10377,6 +11043,8 @@
   - currency
   - data_network
   - denomination
+  - height
+  - length
   - mounting_type
   - pattern
   - phone_card_delivery_format
@@ -10384,6 +11052,7 @@
   - telephone_cable_interface
   - telephone_cord_style
   - theme
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -10895,11 +11564,14 @@
   - communication_device_features
   - connectivity_technology
   - display_resolution
+  - height
+  - length
   - microphone_type
   - mounting_type
   - pattern
   - power_source
   - uc_platform_certification
+  - width
   return_reasons:
   - field_of_view
   - video_quality
@@ -11074,10 +11746,13 @@
   - component_package_type
   - connectivity_technology
   - device_interface
+  - height
   - ingress_protection_ip_rating
+  - length
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -11101,14 +11776,17 @@
   - connectivity_technology
   - conversion_direction
   - device_interface
+  - height
   - ingress_protection_ip_rating
   - input_connection_type
+  - length
   - mounting_type
   - output_connection_type
   - pattern
   - power_source
   - video_resolution_supported
   - video_signal_standard
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -11132,17 +11810,21 @@
   - connectivity_technology
   - conversion_direction
   - device_interface
+  - height
   - ingress_protection_ip_rating
   - input_connection_type
   - input_signal_interface
+  - length
   - maximum_bit_depth
   - mounting_type
   - output_connection_type
   - output_signal_interface
   - pattern
   - power_source
+  - sampling_rate
   - video_resolution_supported
   - video_signal_standard
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -11161,8 +11843,10 @@
   - connectivity_technology
   - conversion_direction
   - device_interface
+  - height
   - ingress_protection_ip_rating
   - input_video_interface
+  - length
   - mounting_type
   - output_video_interface
   - pattern
@@ -11170,6 +11854,7 @@
   - scan_converter_features
   - video_resolution_supported
   - video_signal_standard
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -11241,12 +11926,15 @@
   - connector_mounting_style
   - connector_orientation
   - device_interface
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - termination_method
+  - width
   return_reasons:
   - length
   - incompatible
@@ -11265,13 +11953,18 @@
   - component_package_type
   - connectivity_technology
   - device_interface
+  - height
   - ingress_protection_ip_rating
+  - length
+  - maximum_frequency
+  - minimum_frequency
   - modulation_method
   - mounting_type
   - pattern
   - power_source
   - rf_output_standard
   - video_resolution_supported
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -11293,11 +11986,14 @@
   - connectivity_technology
   - connector_gender
   - device_interface
+  - height
   - ingress_protection_ip_rating
+  - length
   - mounting_type
   - pattern
   - power_source
   - splitter_use
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -11433,13 +12129,19 @@
   - computer_specialized_features
   - energy_efficiency_class
   - graphics_card_type
+  - height
+  - internal_storage_capacity
+  - length
   - memory_technology
   - operating_system
   - pattern
   - power_source
   - processor_cores
   - processor_family
+  - processor_frequency
+  - ram_memory
   - storage_drive_type_installed
+  - width
   return_reasons:
   - speed
   - storage_capacity
@@ -11461,7 +12163,10 @@
   - cooling_technology
   - expansion_slots
   - graphics_card_type
+  - height
   - internal_drive_form_factor_supported
+  - internal_storage_capacity
+  - length
   - memory_form_factor
   - memory_technology
   - motherboard_chipset_family
@@ -11471,12 +12176,15 @@
   - power_source
   - processor_cores
   - processor_family
+  - processor_frequency
   - processor_socket
+  - ram_memory
   - storage_drive_interfaces_supported
   - storage_drive_type_installed
   - storage_types_supported
   - usb_connector_type
   - wi_fi_standard
+  - width
   return_reasons:
   - speed
   - storage_capacity
@@ -11498,7 +12206,10 @@
   - cooling_technology
   - expansion_slots
   - graphics_card_type
+  - height
   - internal_drive_form_factor_supported
+  - internal_storage_capacity
+  - length
   - memory_form_factor
   - memory_technology
   - operating_system
@@ -11506,11 +12217,14 @@
   - power_source
   - processor_cores
   - processor_family
+  - processor_frequency
   - processor_socket
+  - ram_memory
   - storage_drive_interface_type
   - storage_drive_type_installed
   - storage_types_supported
   - supported_raid_levels
+  - width
   return_reasons:
   - speed
   - storage_capacity
@@ -11531,7 +12245,10 @@
   - cooling_technology
   - cosmetic_condition
   - graphics_card_type
+  - height
   - internal_drive_form_factor_supported
+  - internal_storage_capacity
+  - length
   - memory_form_factor
   - memory_technology
   - operating_system
@@ -11541,9 +12258,12 @@
   - power_supply_efficiency_rating
   - processor_cores
   - processor_family
+  - processor_frequency
+  - ram_memory
   - removable_storage_formats_supported
   - storage_drive_type_installed
   - storage_types_supported
+  - width
   return_reasons:
   - speed
   - storage_capacity
@@ -11568,17 +12288,24 @@
   - display_technology
   - energy_efficiency_class
   - graphics_card_type
+  - height
   - ingress_protection_ip_rating
+  - internal_storage_capacity
+  - length
   - memory_technology
   - operating_system
   - pattern
   - power_source
   - processor_cores
   - processor_family
+  - processor_frequency
+  - ram_memory
   - removable_storage_formats_supported
+  - screen_size
   - storage_drive_type_installed
   - touchscreen_technology
   - wi_fi_standard
+  - width
   return_reasons:
   - speed
   - storage_capacity
@@ -11602,19 +12329,26 @@
   - display_technology
   - energy_efficiency_class
   - graphics_card_type
+  - height
   - ingress_protection_ip_rating
+  - internal_storage_capacity
+  - length
   - memory_technology
   - operating_system
   - pattern
   - power_source
   - processor_cores
   - processor_family
+  - processor_frequency
+  - ram_memory
   - removable_storage_formats_supported
   - scanner_sensor_type
+  - screen_size
   - storage_drive_type_installed
   - stylus_support
   - touchscreen_technology
   - wi_fi_standard
+  - width
   return_reasons:
   - storage_capacity
   - incompatible
@@ -11642,16 +12376,23 @@
   - e_reader_display_technology
   - energy_efficiency_class
   - graphics_card_type
+  - height
   - ingress_protection_ip_rating
+  - internal_storage_capacity
+  - length
   - operating_system
   - pattern
   - power_source
   - processor_cores
   - processor_family
+  - processor_frequency
+  - ram_memory
+  - screen_size
   - storage_drive_type_installed
   - stylus_support
   - touchscreen_technology
   - wi_fi_standard
+  - width
   return_reasons:
   - storage_capacity
   - incompatible
@@ -11672,18 +12413,25 @@
   - display_technology
   - energy_efficiency_class
   - graphics_card_type
+  - height
   - ingress_protection_ip_rating
+  - internal_storage_capacity
+  - length
   - memory_technology
   - operating_system
   - pattern
   - power_source
   - processor_cores
   - processor_family
+  - processor_frequency
+  - ram_memory
   - removable_storage_formats_supported
+  - screen_size
   - storage_drive_type_installed
   - stylus_support
   - touchscreen_technology
   - wi_fi_standard
+  - width
   return_reasons:
   - storage_capacity
   - incompatible
@@ -11702,6 +12450,9 @@
   - display_resolution
   - energy_efficiency_class
   - graphics_card_type
+  - height
+  - internal_storage_capacity
+  - length
   - memory_form_factor
   - memory_technology
   - mounting_type
@@ -11711,9 +12462,12 @@
   - power_source
   - processor_cores
   - processor_family
+  - processor_frequency
+  - ram_memory
   - storage_drive_type_installed
   - touch_capabilities
   - touchscreen_technology
+  - width
   return_reasons:
   - size
   - power_source
@@ -11732,11 +12486,14 @@
   - computer_form
   - computer_specialized_features
   - cosmetic_condition
+  - depth
   - display_resolution
   - display_technology
   - graphics_card_type
+  - internal_storage_capacity
   - keyboard_layout
   - keyboard_type
+  - length
   - memory_technology
   - operating_system
   - optical_drive_type
@@ -11744,9 +12501,13 @@
   - power_source
   - processor_cores
   - processor_family
+  - processor_frequency
+  - ram_memory
   - removable_storage_formats_supported
+  - screen_size
   - storage_drive_type_installed
   - storage_types_supported
+  - width
   return_reasons:
   - speed
   - storage_capacity
@@ -11770,7 +12531,10 @@
   - eyewear_frame_material
   - eyewear_lens_material
   - graphics_card_type
+  - height
   - ingress_protection_ip_rating
+  - internal_storage_capacity
+  - length
   - lens_characteristic
   - lens_polarization
   - lens_type
@@ -11780,8 +12544,11 @@
   - power_source
   - processor_cores
   - processor_family
+  - processor_frequency
+  - ram_memory
   - smart_glasses_features
   - storage_drive_type_installed
+  - width
   return_reasons:
   - size
   - color
@@ -11807,16 +12574,23 @@
   - display_technology
   - energy_efficiency_class
   - graphics_card_type
+  - height
+  - internal_storage_capacity
+  - length
   - memory_technology
   - operating_system
   - pattern
   - power_source
   - processor_cores
   - processor_family
+  - processor_frequency
+  - ram_memory
+  - screen_size
   - sim_card_type
   - storage_drive_type_installed
   - stylus_support_type
   - subscription_type
+  - width
   return_reasons:
   - speed
   - storage_capacity
@@ -11841,17 +12615,23 @@
   - energy_efficiency_class
   - ethernet_lan_interface_type
   - graphics_card_type
+  - height
+  - internal_storage_capacity
+  - length
   - memory_technology
   - operating_system
   - pattern
   - power_source
   - processor_cores
   - processor_family
+  - processor_frequency
+  - ram_memory
   - storage_drive_type_installed
   - usb_connector_type
   - vdi_protocol_support
   - video_port_type
   - wi_fi_standard
+  - width
   return_reasons:
   - speed
   - storage_capacity
@@ -11873,17 +12653,23 @@
   - energy_efficiency_class
   - ethernet_lan_interface_type
   - graphics_card_type
+  - height
+  - internal_storage_capacity
+  - length
   - memory_technology
   - operating_system
   - pattern
   - power_source
   - processor_cores
   - processor_family
+  - processor_frequency
+  - ram_memory
   - storage_drive_type_installed
   - usb_connector_type
   - vdi_protocol_support
   - video_port_type
   - wi_fi_standard
+  - width
   return_reasons:
   - speed
   - incompatible
@@ -11905,18 +12691,24 @@
   - energy_efficiency_class
   - ethernet_lan_interface_type
   - graphics_card_type
+  - height
+  - internal_storage_capacity
+  - length
   - memory_technology
   - operating_system
   - pattern
   - power_source
   - processor_cores
   - processor_family
+  - processor_frequency
+  - ram_memory
   - storage_drive_type_installed
   - usb_connector_type
   - usb_standard
   - vdi_protocol_support
   - video_port_type
   - wi_fi_standard
+  - width
   return_reasons:
   - speed
   - incompatible
@@ -11937,15 +12729,22 @@
   - display_technology
   - energy_efficiency_class
   - graphics_card_type
+  - height
+  - internal_storage_capacity
+  - length
   - memory_technology
   - operating_system
   - pattern
   - power_source
   - processor_cores
   - processor_family
+  - processor_frequency
+  - ram_memory
+  - screen_size
   - storage_drive_type_installed
   - touch_capabilities
   - touchscreen_technology
+  - width
   return_reasons:
   - speed
   - storage_capacity
@@ -12127,9 +12926,12 @@
   - color
   - connector_gender
   - connector_orientation
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12149,10 +12951,13 @@
   - connector_gender
   - connector_orientation
   - device_interface
+  - height
+  - length
   - material
   - pattern
   - power_source
   - video_resolution_supported
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12169,12 +12974,15 @@
   - compatible_memory_cards
   - connector_gender
   - connector_orientation
+  - height
   - host_interface
+  - length
   - material
   - memory_form_factor
   - pattern
   - power_source
   - usb_standard
+  - width
   return_reasons:
   - speed
   - incompatible
@@ -12193,10 +13001,14 @@
   - color
   - connector_gender
   - connector_orientation
+  - height
+  - length
   - material
+  - maximum_data_transfer_rate
   - pattern
   - power_source
   - usb_standard
+  - width
   return_reasons:
   - speed
   - incompatible
@@ -12223,10 +13035,13 @@
   - antenna_type
   - color
   - connector_gender
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - length
   - incompatible
@@ -12245,11 +13060,14 @@
   - color
   - connector_gender
   - durability_features
+  - height
+  - length
   - material
   - mount/stand_features
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12266,11 +13084,14 @@
   - antenna_type
   - color
   - connector_gender
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - rotator_control_technology
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12286,7 +13107,9 @@
   - antenna_type
   - color
   - connector_gender
+  - height
   - ingress_protection_ip_rating
+  - length
   - lnb_output
   - lnb_technology
   - material
@@ -12294,6 +13117,7 @@
   - pattern
   - polarization
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12459,12 +13283,17 @@
   - connector_gender
   - device_interface
   - frequency/radio_bands_supported
+  - height
+  - impedance
   - ingress_protection_ip_rating
+  - length
   - material
+  - maximum_gain_level
   - mounting_type
   - pattern
   - polarization
   - power_source
+  - width
   return_reasons:
   - range
   - incompatible
@@ -12642,15 +13471,19 @@
   - el-7-4-10
   attributes:
   - audio_codecs/formats_supported
+  - cable_length
   - color
   - compatible_hdcp
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - power_source
   - splitter/switch_features
   - switching_method
   - video_resolution_supported
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12666,10 +13499,13 @@
   - el-7-4-1-2
   attributes:
   - audio_codecs/formats_supported
+  - cable_length
   - color
   - compatible_hdcp
   - connector_gender
   - dvi_connection_type
+  - height
+  - length
   - material
   - mounting_type
   - pattern
@@ -12679,6 +13515,7 @@
   - supported_dvi_link_type
   - switching_method
   - video_resolution_supported
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12747,11 +13584,14 @@
   attributes:
   - audio_codecs/formats_supported
   - audio_return_channel_support
+  - cable_length
   - color
   - compatible_hdcp
   - connector_gender
   - hdmi_version_supported
   - hdr_format
+  - height
+  - length
   - material
   - pattern
   - power_source
@@ -12759,6 +13599,7 @@
   - splitter_use
   - switching_method
   - video_resolution_supported
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12826,9 +13667,12 @@
   - el-7-4-3-2
   attributes:
   - audio_codecs/formats_supported
+  - cable_length
   - color
   - compatible_hdcp
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - power_source
@@ -12837,6 +13681,7 @@
   - switching_method
   - video_port_type
   - video_resolution_supported
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -13407,12 +14252,16 @@
   - audio_cassette_tape_type
   - color
   - connector_gender
+  - height
+  - internal_storage_capacity
+  - length
   - material
   - media_physical_size
   - optical_disc_recordability
   - pattern
   - power_source
   - read/write_speed
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -13582,11 +14431,14 @@
   attributes:
   - color
   - connector_gender
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pattern
   - power_source
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13603,12 +14455,15 @@
   - adhesive_type
   - color
   - connector_gender
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -13625,12 +14480,15 @@
   attributes:
   - color
   - compatible_cable_tie_material
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - operation_mechanism
   - pattern
   - power_source
   - usage_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -13646,13 +14504,16 @@
   - cable_tray_style
   - color
   - connector_gender
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - product_certifications_standards
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13673,13 +14534,16 @@
   - cable_shielding
   - color
   - connector_gender
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - panel_specification
   - panel_termination
   - pattern
   - power_source
   - usage_type
+  - width
   return_reasons:
   - size
   - capacity
@@ -13796,14 +14660,17 @@
   - color
   - connector_gender
   - durability_features
+  - height
   - ingress_protection_ip_rating
   - legend_type
+  - length
   - marker_format
   - marker_text_color
   - material
   - pattern
   - power_source
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -13874,12 +14741,15 @@
   - color
   - connector_gender
   - flammability_rating_ul_94
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pattern
   - power_source
   - sleeving_style
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -13898,11 +14768,14 @@
   - color
   - connector_gender
   - durability_features
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pattern
   - power_source
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -14052,12 +14925,16 @@
   - el-7-7-7
   attributes:
   - cable_housing_material
+  - cable_length
   - cable_shielding
   - color
   - connector_gender
   - device_interface
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - length
   - incompatible
@@ -14084,15 +14961,19 @@
   - audio/video_cable_connector_type_end_a
   - audio/video_cable_connector_type_end_b
   - cable_housing_material
+  - cable_length
   - cable_shielding
   - color
   - connector_contact_plating
   - connector_gender
   - connector_orientation
   - device_interface
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - length
   - incompatible
@@ -14112,14 +14993,18 @@
   - audio_signal_configuration
   - cable_form_factor
   - cable_housing_material
+  - cable_length
   - cable_shielding
   - color
   - connector_contact_plating
   - connector_gender
   - connector_orientation
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - length
   - sound_quality
@@ -14137,6 +15022,7 @@
   - audio/video_cable_connector_type_end_a
   - audio/video_cable_connector_type_end_b
   - cable_housing_material
+  - cable_length
   - cable_shielding
   - color
   - compatible_resolution
@@ -14144,9 +15030,12 @@
   - connector_gender
   - connector_orientation
   - device_interface
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - length
   - video_quality
@@ -14164,15 +15053,19 @@
   - audio/video_cable_connector_type_end_a
   - audio/video_cable_connector_type_end_b
   - cable_housing_material
+  - cable_length
   - cable_shielding
   - color
   - connector_contact_plating
   - connector_gender
   - connector_orientation
   - device_interface
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - length
   - video_quality
@@ -14190,16 +15083,20 @@
   - audio/video_cable_connector_type_end_a
   - audio/video_cable_connector_type_end_b
   - cable_housing_material
+  - cable_length
   - cable_shielding
   - color
   - connector_contact_plating
   - connector_gender
   - connector_orientation
+  - height
   - input_connection
+  - length
   - material
   - output_connection
   - pattern
   - power_source
+  - width
   - xlr_pin_count
   return_reasons:
   - length
@@ -14368,13 +15265,17 @@
   children: []
   attributes:
   - cable_housing_material
+  - cable_length
   - cable_shielding
   - color
   - connector_gender
   - device_interface
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - length
   - incompatible
@@ -14389,15 +15290,19 @@
   children: []
   attributes:
   - cable_housing_material
+  - cable_length
   - cable_shielding
   - color
   - connector_gender
+  - height
   - keyboard_port_type
+  - length
   - material
   - pattern
   - power_source
   - usb_standard
   - video_port_type
+  - width
   return_reasons:
   - length
   - incompatible
@@ -14416,14 +15321,18 @@
   attributes:
   - cable_housing_material
   - cable_jacket_rating
+  - cable_length
   - cable_shielding
   - color
   - connector_gender
   - ethernet_cable_category
+  - height
+  - length
   - material
   - network_cable_interface
   - pattern
   - power_source
+  - width
   return_reasons:
   - length
   - speed
@@ -14440,6 +15349,7 @@
   attributes:
   - cable_housing_material
   - cable_jacket_rating
+  - cable_length
   - cable_shielding
   - coaxial_cable_series
   - color
@@ -14448,9 +15358,12 @@
   - connector_gender
   - device_interface
   - ethernet_cable_category
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - length
@@ -14468,14 +15381,18 @@
   attributes:
   - cable_housing_material
   - cable_jacket_rating
+  - cable_length
   - cable_shielding
   - color
   - connector_gender
   - ethernet_cable_category
+  - height
+  - length
   - material
   - network_cable_interface
   - pattern
   - power_source
+  - width
   - wire/rope_material
   return_reasons:
   - length
@@ -14522,14 +15439,19 @@
   - el-7-7-5-6
   attributes:
   - cable_housing_material
+  - cable_length
   - cable_shielding
   - color
   - connector_gender
   - device_interface
+  - height
+  - length
   - material
+  - maximum_data_transfer_rate
   - pattern
   - power_source
   - usb_standard
+  - width
   return_reasons:
   - length
   - incompatible
@@ -14544,6 +15466,7 @@
   children: []
   attributes:
   - cable_housing_material
+  - cable_length
   - cable_shielding
   - color
   - connector_1_type
@@ -14551,10 +15474,14 @@
   - connector_gender
   - device_interface
   - firewire_standard
+  - height
+  - length
   - material
+  - maximum_data_transfer_rate
   - pattern
   - power_source
   - usb_standard
+  - width
   return_reasons:
   - length
   - incompatible
@@ -14569,14 +15496,19 @@
   children: []
   attributes:
   - cable_housing_material
+  - cable_length
   - cable_shielding
   - cable_style
   - color
   - connector_gender
+  - height
+  - length
   - material
+  - maximum_data_transfer_rate
   - pattern
   - power_source
   - usb_standard
+  - width
   return_reasons:
   - color
   - length
@@ -14686,14 +15618,18 @@
   - el-7-7-6-2
   attributes:
   - cable_housing_material
+  - cable_length
   - cable_shielding
   - color
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - power_source
   - system/power_cable_connector_type_end_a
   - system/power_cable_connector_type_end_b
+  - width
   return_reasons:
   - length
   - gauge
@@ -14755,15 +15691,19 @@
   children: []
   attributes:
   - cable_housing_material
+  - cable_length
   - cable_shielding
   - color
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - power_source
   - telephone_cable_interface
   - telephone_cable_second_interface
   - telephone_cord_style
+  - width
   return_reasons:
   - length
   - incompatible
@@ -14816,10 +15756,13 @@
   - computer_accessories_included
   - connectivity_technology
   - connector_gender
+  - height
   - keyboard_layout
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -14847,9 +15790,13 @@
   - connector_gender
   - durability_features
   - finish
+  - height
+  - length
   - material
+  - maximum_screen_size
   - pattern
   - power_source
+  - width
   return_reasons:
   - color
   - style
@@ -14996,10 +15943,14 @@
   - compatible_device
   - connector_gender
   - features
+  - height
+  - length
   - material
+  - maximum_height
   - pattern
   - power_source
   - vesa_mounting_pattern
+  - width
   - wireless_charging_standard
   return_reasons:
   - color
@@ -15182,13 +16133,16 @@
   - color
   - connector_gender
   - finish
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pattern
   - power_source
   - tablet_case_functional_features
   - theme
   - usb_connector_type
+  - width
   return_reasons:
   - size
   - color
@@ -15211,14 +16165,18 @@
   - color
   - connector_gender
   - finish
+  - height
   - ingress_protection_ip_rating
   - integrated_stand_type
+  - length
   - material
+  - maximum_screen_size
   - pattern
   - power_source
   - tablet_case_functional_features
   - theme
   - usb_connector_type
+  - width
   return_reasons:
   - size
   - color
@@ -15408,13 +16366,16 @@
   - color
   - connector_gender
   - durability_features
+  - height
   - ingress_protection_ip_rating
   - integrated_stand_type
+  - length
   - material
   - mounting_interface_standard
   - pattern
   - power_source
   - tablet_case_functional_features
+  - width
   return_reasons:
   - size
   - color
@@ -15438,14 +16399,18 @@
   - color
   - connector_gender
   - durability_features
+  - height
   - ingress_protection_ip_rating
   - integrated_stand_type
+  - length
   - material
+  - maximum_screen_size
   - mounting_interface_standard
   - pattern
   - power_source
   - stylus_holder_type
   - tablet_case_functional_features
+  - width
   return_reasons:
   - size
   - color
@@ -15543,12 +16508,15 @@
   - connector_gender
   - filler_material
   - hand_side
+  - height
   - keyboard_format
+  - length
   - material
   - pattern
   - power_source
   - shape
   - theme
+  - width
   - wrist_rest_features
   - wrist_rest_type
   return_reasons:
@@ -15570,11 +16538,14 @@
   - color
   - compatible_device
   - connector_gender
+  - height
   - height_adjustment
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -15594,11 +16565,14 @@
   - compatible_device
   - connector_gender
   - device_interface
+  - height
+  - length
   - material
   - pattern
   - power_source
   - usb_connector_type
   - video_resolution_supported
+  - width
   return_reasons:
   - charging_speed
   - incompatible
@@ -15617,6 +16591,8 @@
   - color
   - compatible_device
   - connector_gender
+  - height
+  - length
   - lighting_type
   - material
   - mouse_pad_features
@@ -15626,6 +16602,7 @@
   - size
   - surface_texture
   - theme
+  - width
   - wrist_rest_type
   return_reasons:
   - size
@@ -15646,11 +16623,14 @@
   - compatible_device
   - connector_gender
   - hardness
+  - height
+  - length
   - material
   - pattern
   - power_source
   - tip_material
   - tip_style
+  - width
   return_reasons:
   - size
   - material
@@ -15673,10 +16653,13 @@
   - compatible_device
   - connectivity_technology
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - power_source
   - tip_material
+  - width
   return_reasons:
   - color
   - style
@@ -15699,7 +16682,9 @@
   - compatible_device
   - connector_gender
   - device_interface
+  - height
   - height_adjustment
+  - length
   - locking_mechanism
   - lumber/wood_type
   - material
@@ -15709,6 +16694,7 @@
   - pattern
   - power_source
   - vesa_mounting_pattern
+  - width
   - wood_finish
   return_reasons:
   - color
@@ -15809,10 +16795,13 @@
   - color
   - connector_gender
   - cooling_technology
+  - height
   - internal_drive_form_factor_supported
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -15900,10 +16889,13 @@
   - compatible_motherboard_form_factor
   - connector_gender
   - finish
+  - height
+  - length
   - lighting_features
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16049,11 +17041,16 @@
   - color
   - connector_gender
   - energy_efficiency_class
+  - height
+  - length
   - material
+  - maximum_operating_temperature
   - pattern
+  - power_output_typical
   - power_source
   - power_supply_form_factor
   - power_supply_modularity
+  - width
   return_reasons:
   - size
   - power_output
@@ -16068,18 +17065,25 @@
   name: Computer Processors
   children: []
   attributes:
+  - cache_size
   - color
   - energy_efficiency_class
   - graphics_card_type
+  - height
   - instruction_set_architecture
+  - length
   - material
   - memory_channels
   - memory_technology
   - pattern
+  - power_consumption_typical
   - power_source
   - processor_cores
   - processor_family
+  - processor_frequency
   - processor_socket
+  - thermal_design_power
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16099,12 +17103,15 @@
   - color
   - connector_gender
   - door_type
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - rack_width_standard
   - ventilation_type
+  - width
   return_reasons:
   - size
   - color
@@ -16218,6 +17225,8 @@
   - components_included
   - computer_accessories_included
   - connector_gender
+  - height
+  - length
   - material
   - motherboard_form_factor
   - pattern
@@ -16225,6 +17234,7 @@
   - processor_cores
   - processor_family
   - storage_types_supported
+  - width
   return_reasons:
   - size
   - incompatible
@@ -16297,9 +17307,12 @@
   - connector_gender
   - connector_type
   - cooling_technology
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -16454,11 +17467,14 @@
   - compatible_power_supply_form_factor
   - connector_gender
   - expansion_slots
+  - height
+  - length
   - lock_type
   - material
   - pattern
   - power_source
   - side_panel_style
+  - width
   return_reasons:
   - size
   - color
@@ -16481,9 +17497,12 @@
   - color
   - connector_gender
   - e_book_reader_part_location
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16499,15 +17518,19 @@
   - authenticity
   - color
   - connector_gender
+  - depth
   - display_resolution
   - e_book_reader_part_location
   - e_reader_display_technology
+  - height
   - material
   - native_aspect_ratio
   - pattern
   - power_source
+  - screen_size
   - screen_surface_finish
   - touchscreen_technology
+  - width
   return_reasons:
   - size
   - incompatible
@@ -16594,10 +17617,13 @@
   - connector_gender
   - cooling_technology
   - device_interface
+  - height
   - host_interface
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -16618,10 +17644,14 @@
   - connector_gender
   - cooling_technology
   - device_interface
+  - height
   - host_interface
+  - length
   - material
   - pattern
   - power_source
+  - sampling_rate
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -16647,10 +17677,13 @@
   - connector_gender
   - cooling_technology
   - device_interface
+  - height
   - host_interface
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -16769,13 +17802,16 @@
   - connector_gender
   - cooling_technology
   - device_interface
+  - height
   - host_interface
+  - length
   - lighting_type
   - material
   - pattern
   - pcie_lane_configuration
   - power_connector_type
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -16877,7 +17913,9 @@
   - connector_gender
   - cooling_technology
   - device_interface
+  - height
   - host_interface
+  - length
   - material
   - operating_system
   - pattern
@@ -16885,6 +17923,7 @@
   - tuner_type
   - tv_broadcast_standards_supported
   - usb_standard
+  - width
   return_reasons:
   - size
   - video_quality
@@ -16908,11 +17947,14 @@
   - cooling_technology
   - device_interface
   - graphics_card_type
+  - height
   - host_interface
+  - length
   - material
   - pattern
   - power_source
   - video_resolution_supported
+  - width
   return_reasons:
   - size
   - video_quality
@@ -17009,12 +18051,15 @@
   - color
   - compatible_device
   - connector_gender
+  - height
   - height_adjustment
+  - length
   - material
   - mount/stand_features
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17036,11 +18081,14 @@
   - color
   - compatible_device
   - connector_gender
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - video_game_platform
+  - width
   return_reasons:
   - size
   - color
@@ -17063,12 +18111,15 @@
   - compatible_device
   - connector_gender
   - durability_features
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - video_game_platform
+  - width
   return_reasons:
   - size
   - color
@@ -17088,11 +18139,14 @@
   - connector_gender
   - cover_features
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - video_game_platform
+  - width
   return_reasons:
   - size
   - color
@@ -17110,6 +18164,8 @@
   - color
   - compatible_device
   - connector_gender
+  - height
+  - length
   - material
   - mounting_type
   - pattern
@@ -17117,6 +18173,7 @@
   - rise_height_class
   - thumb_grip_profile
   - video_game_platform
+  - width
   return_reasons:
   - size
   - color
@@ -17179,14 +18236,17 @@
   attributes:
   - color
   - connector_gender
+  - height
   - keyboard_switch_type
   - keycap_legend_printing_method
   - keycap_profile
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - switch_stem_compatibility
+  - width
   return_reasons:
   - size
   - color
@@ -17315,10 +18375,13 @@
   - compatible_device
   - connector_gender
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -17342,10 +18405,13 @@
   - compatible_device
   - connector_gender
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -17366,11 +18432,14 @@
   - compatible_device
   - connector_gender
   - finish
+  - height
+  - length
   - lighting_features
   - material
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - color
   - stability
@@ -17390,11 +18459,14 @@
   - connector_gender
   - finish
   - glide_style
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - skate_shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17687,12 +18759,15 @@
   - battery_type
   - color
   - connector_gender
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - operating_system
   - pattern
   - power_source
   - scanner_sensor_type
+  - width
   return_reasons:
   - size
   - power_source
@@ -17799,10 +18874,15 @@
   - connectivity_technology
   - connector_gender
   - device_interface
+  - height
+  - internal_storage_capacity
+  - length
   - material
   - operating_system
   - pattern
+  - pen_size
   - power_source
+  - width
   return_reasons:
   - size
   - power_source
@@ -17826,7 +18906,9 @@
   - connectivity_technology
   - connector_gender
   - device_interface
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - mounting_type
   - operating_system
@@ -17834,6 +18916,7 @@
   - power_source
   - security_algorithms
   - usb_connector_type
+  - width
   return_reasons:
   - size
   - power_source
@@ -17855,6 +18938,8 @@
   - connectivity_technology
   - connector_gender
   - fingerprint_capture_method
+  - height
+  - length
   - material
   - operating_system
   - pattern
@@ -17862,6 +18947,7 @@
   - security_algorithms
   - usb_connector_type
   - usb_standard
+  - width
   return_reasons:
   - size
   - power_source
@@ -17892,11 +18978,14 @@
   - color
   - connector_gender
   - haptic_feedback_type
+  - height
+  - length
   - material
   - operating_system
   - pattern
   - power_source
   - systems_supported
+  - width
   return_reasons:
   - size
   - color
@@ -17920,6 +19009,8 @@
   - connector_gender
   - force_feedback_type
   - haptic_feedback_type
+  - height
+  - length
   - material
   - mounting_type
   - operating_system
@@ -17927,6 +19018,7 @@
   - power_source
   - systems_supported
   - wheel_style
+  - width
   return_reasons:
   - size
   - color
@@ -17947,11 +19039,14 @@
   - color
   - connector_gender
   - haptic_feedback_type
+  - height
+  - length
   - material
   - operating_system
   - pattern
   - power_source
   - systems_supported
+  - width
   return_reasons:
   - size
   - color
@@ -17973,13 +19068,16 @@
   - connectivity_technology
   - connector_gender
   - haptic_feedback_type
+  - height
   - joystick_sensor_technology
+  - length
   - lighting_type
   - material
   - operating_system
   - pattern
   - power_source
   - systems_supported
+  - width
   return_reasons:
   - size
   - color
@@ -18002,13 +19100,16 @@
   - connector_gender
   - hand_side
   - haptic_feedback_type
+  - height
   - joystick_sensor_technology
+  - length
   - lighting_features
   - material
   - operating_system
   - pattern
   - power_source
   - systems_supported
+  - width
   return_reasons:
   - size
   - color
@@ -18030,12 +19131,15 @@
   - connectivity_technology
   - connector_gender
   - haptic_feedback_type
+  - height
   - instrument_controller_type
+  - length
   - material
   - operating_system
   - pattern
   - power_source
   - systems_supported
+  - width
   return_reasons:
   - size
   - color
@@ -18209,11 +19313,14 @@
   - color
   - connector_gender
   - hand_side
+  - height
+  - length
   - material
   - operating_system
   - pattern
   - power_source
   - sensor_type
+  - width
   return_reasons:
   - size
   - color
@@ -18312,11 +19419,15 @@
   - display_resolution
   - graphics_tablet_accessories_included
   - graphics_tablet_specialized_features
+  - height
+  - length
   - material
   - operating_system
   - pattern
   - power_source
+  - screen_size
   - stylus_technology
+  - width
   return_reasons:
   - size
   - power_source
@@ -18392,6 +19503,7 @@
   - battery_type
   - color
   - connector_gender
+  - height
   - keyboard_backlight_type
   - keyboard_format
   - keyboard_language
@@ -18401,11 +19513,13 @@
   - keyboard_switch_type
   - keyboard_type
   - keycap_material
+  - length
   - material
   - operating_system
   - pattern
   - pointing_device
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -18494,7 +19608,9 @@
   - connectivity_technology
   - connector_gender
   - device_interface
+  - height
   - keyboard_port_type
+  - length
   - material
   - mounting_type
   - mouse_port_type
@@ -18504,6 +19620,7 @@
   - switching_method
   - usb_standard
   - video_port_type
+  - width
   return_reasons:
   - speed
   - video_quality
@@ -18525,6 +19642,8 @@
   - connectivity_technology
   - connector_gender
   - device_interface
+  - height
+  - length
   - material
   - mounting_type
   - operating_system
@@ -18533,6 +19652,7 @@
   - removable_storage_formats_supported
   - usb_connector_type
   - usb_standard
+  - width
   return_reasons:
   - size
   - speed
@@ -18549,15 +19669,19 @@
   attributes:
   - battery_size
   - battery_type
+  - cable_length
   - color
   - connector_gender
   - hand_side
+  - height
+  - length
   - material
   - mouse/trackball_features
   - mouse_technology
   - operating_system
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -18579,11 +19703,14 @@
   - color
   - connectivity_technology
   - connector_gender
+  - height
   - keypad_style
+  - length
   - material
   - operating_system
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -18604,6 +19731,8 @@
   - color
   - connectivity_technology
   - connector_gender
+  - height
+  - length
   - material
   - operating_system
   - pattern
@@ -18612,6 +19741,7 @@
   - touchpad_form_factor
   - touchscreen_technology
   - usb_connector_type
+  - width
   return_reasons:
   - size
   - color
@@ -18732,10 +19862,13 @@
   - battery_type
   - color
   - connector_gender
+  - height
   - item_condition
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -18752,10 +19885,13 @@
   - color
   - connector_gender
   - hand_side
+  - height
   - item_condition
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18775,12 +19911,15 @@
   - color
   - connector_gender
   - finish
+  - height
   - item_condition
   - keyboard_layout
   - laptop_housing_part_type
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - color
   - incompatible
@@ -18795,14 +19934,18 @@
   children: []
   attributes:
   - authenticity
+  - cable_length
   - cable_shielding
   - color
   - connector_gender
+  - height
   - item_condition
   - laptop_cable_type
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18819,16 +19962,19 @@
   - authenticity
   - color
   - connector_gender
+  - height
   - item_condition
   - keyboard_assembly_type
   - keyboard_language
   - keyboard_layout
   - keyboard_specialized_features
   - keyboard_type
+  - length
   - material
   - pattern
   - pointing_device
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -18846,15 +19992,19 @@
   - connector_gender
   - connector_position
   - connector_type
+  - depth
   - display_resolution
   - display_technology
+  - height
   - item_condition
   - material
   - native_aspect_ratio
   - pattern
   - power_source
+  - screen_size
   - screen_specialized_features
   - screen_surface_finish
+  - width
   return_reasons:
   - size
   - video_quality
@@ -18873,12 +20023,15 @@
   - color
   - condition
   - connector_gender
+  - height
   - item_condition
+  - length
   - material
   - pattern
   - power_source
   - speaker_position_in_laptop
   - speaker_technology
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -18898,14 +20051,18 @@
   - digitizer_surface_finish
   - display_resolution
   - display_technology
+  - height
   - item_condition
+  - length
   - material
   - native_aspect_ratio
   - pattern
   - power_source
+  - screen_size
   - touch_capabilities
   - touchscreen_technology
   - touchscreen_wire_configuration
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -18993,6 +20150,7 @@
   - device_interface
   - lumber/wood_type
   - material
+  - maximum_data_transfer_rate
   - pattern
   - power_source
   - storage_drive_interface_type
@@ -19021,7 +20179,10 @@
   - connector_gender
   - device_interface
   - duplication_operation_mode
+  - height
+  - length
   - material
+  - maximum_data_transfer_rate
   - pattern
   - power_source
   - read/write_speed
@@ -19029,6 +20190,7 @@
   - storage_drive_interface_type
   - storage_drive_interfaces_supported
   - storage_media_type
+  - width
   return_reasons:
   - size
   - speed
@@ -19047,7 +20209,10 @@
   - connector_gender
   - device_interface
   - duplication_operation_mode
+  - height
+  - length
   - material
+  - maximum_data_transfer_rate
   - optical_drive_type
   - pattern
   - power_source
@@ -19056,6 +20221,7 @@
   - storage_drive_interface_type
   - storage_drive_interfaces_supported
   - storage_media_type
+  - width
   return_reasons:
   - size
   - speed
@@ -19074,8 +20240,11 @@
   - connector_gender
   - device_interface
   - duplication_operation_mode
+  - height
   - internal_drive_form_factor_supported
+  - length
   - material
+  - maximum_data_transfer_rate
   - pattern
   - power_source
   - read/write_speed
@@ -19083,6 +20252,7 @@
   - storage_drive_interface_type
   - storage_drive_interfaces_supported
   - storage_media_type
+  - width
   return_reasons:
   - size
   - speed
@@ -19100,7 +20270,10 @@
   - color
   - connector_gender
   - duplication_operation_mode
+  - height
+  - length
   - material
+  - maximum_data_transfer_rate
   - pattern
   - power_source
   - read/write_speed
@@ -19112,6 +20285,7 @@
   - supported_usb_device_types
   - usb_connector_type
   - usb_standard
+  - width
   return_reasons:
   - size
   - speed
@@ -19160,12 +20334,15 @@
   - connector_gender
   - cooling_technology
   - durability_features
+  - height
   - internal_drive_form_factor_supported
+  - length
   - material
   - pattern
   - power_source
   - storage_drive_interface_type
   - storage_media_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -19189,13 +20366,16 @@
   - cover_features
   - durability_features
   - hard_drive_form_factor
+  - height
   - ingress_protection_ip_rating
   - internal_drive_form_factor_supported
+  - length
   - material
   - pattern
   - power_source
   - storage_drive_interface_type
   - storage_media_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -19215,9 +20395,12 @@
   - device_interface
   - durability_features
   - hard_drive_features
+  - height
   - host_interface
   - internal_drive_form_factor_supported
+  - length
   - material
+  - maximum_data_transfer_rate
   - pattern
   - power_source
   - raid_levels_supported
@@ -19225,6 +20408,7 @@
   - storage_drive_interface_type
   - storage_drive_interfaces_supported
   - storage_media_type
+  - width
   return_reasons:
   - size
   - speed
@@ -19249,8 +20433,10 @@
   - cooling_technology
   - durability_features
   - hard_drive_features
+  - height
   - host_interface
   - internal_drive_form_factor_supported
+  - length
   - lock_type
   - m_2_drive_length_supported
   - material
@@ -19259,6 +20445,7 @@
   - storage_drive_interface_type
   - storage_drive_interfaces_supported
   - storage_media_type
+  - width
   return_reasons:
   - size
   - speed
@@ -19385,14 +20572,19 @@
   - el-7-9-14-3-1
   - el-7-9-14-3-2
   attributes:
+  - cache_size
   - chassis_type
   - color
   - connector_gender
   - device_interface
   - hard_drive_features
+  - height
   - host_interface
   - internal_drive_form_factor_supported
+  - internal_storage_capacity
+  - length
   - material
+  - maximum_data_transfer_rate
   - pattern
   - power_source
   - raid_levels_supported
@@ -19400,6 +20592,7 @@
   - storage_drive_interfaces_supported
   - storage_media_type
   - storage_types_supported
+  - width
   return_reasons:
   - size
   - storage_capacity
@@ -19475,20 +20668,27 @@
   attributes:
   - battery_size
   - battery_type
+  - cache_size
   - color
   - connector_gender
   - device_interface
   - hard_drive_features
   - hard_drive_form_factor
   - hard_drive_installation
+  - height
+  - internal_storage_capacity
+  - length
   - material
+  - maximum_data_transfer_rate
   - memory_technology
   - pattern
   - power_source
+  - rotational_speed
   - storage_drive_interface_type
   - storage_drive_type_installed
   - storage_media_type
   - usb_standard
+  - width
   return_reasons:
   - size
   - storage_capacity
@@ -19504,24 +20704,31 @@
   name: Network Storage Systems
   children: []
   attributes:
+  - cache_size
   - chassis_type
   - color
   - connector_gender
   - cooling_technology
   - device_interface
   - ethernet_lan_interface_type
+  - height
+  - internal_storage_capacity
+  - length
   - material
+  - maximum_data_transfer_rate
   - network_protocols_supported
   - operating_system
   - pattern
   - power_source
   - processor_family
+  - processor_frequency
   - raid_levels_supported
   - storage_drive_interface_type
   - storage_drive_interfaces_supported
   - storage_drive_type_installed
   - storage_media_type
   - storage_types_supported
+  - width
   return_reasons:
   - storage_capacity
   - speed
@@ -19541,7 +20748,11 @@
   - color
   - connector_gender
   - device_interface
+  - height
+  - internal_storage_capacity
+  - length
   - material
+  - maximum_data_transfer_rate
   - optical_drive_form_factor
   - optical_drive_loading_mechanism
   - optical_drive_type
@@ -19551,6 +20762,7 @@
   - read/write_speed
   - storage_drive_interface_type
   - storage_media_type
+  - width
   return_reasons:
   - size
   - speed
@@ -19623,7 +20835,11 @@
   - connector_gender
   - device_interface
   - drive_form_factor
+  - height
+  - internal_storage_capacity
+  - length
   - material
+  - maximum_data_transfer_rate
   - mounting_type
   - pattern
   - power_source
@@ -19633,6 +20849,7 @@
   - storage_media_type
   - tape_cartridge_format
   - tape_cartridge_generation
+  - width
   return_reasons:
   - size
   - storage_capacity
@@ -19652,13 +20869,18 @@
   - battery_type
   - color
   - connector_gender
+  - height
+  - internal_storage_capacity
+  - length
   - material
+  - maximum_data_transfer_rate
   - pattern
   - power_source
   - storage_drive_interface_type
   - storage_media_type
   - usb_connector_type
   - usb_standard
+  - width
   return_reasons:
   - size
   - storage_capacity
@@ -19707,9 +20929,12 @@
   - battery_type
   - color
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -19729,10 +20954,13 @@
   - color
   - connector_gender
   - finish
+  - height
   - item_condition
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - color
   - incompatible
@@ -19812,10 +21040,13 @@
   - color
   - connector_gender
   - hand_side
+  - height
+  - length
   - material
   - pattern
   - power_source
   - speaker_technology
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -19836,14 +21067,18 @@
   - battery_type
   - color
   - connector_gender
+  - depth
   - display_interface
   - display_resolution
   - display_technology
+  - height
   - material
   - pattern
   - power_source
+  - screen_size
   - screen_surface_finish
   - touchscreen_technology
+  - width
   return_reasons:
   - video_quality
   - changed_my_mind
@@ -20001,12 +21236,16 @@
   - device_interface
   - downstream_port_types
   - firewire_standard
+  - height
   - host_interface
+  - length
   - material
+  - maximum_data_transfer_rate
   - pattern
   - power_source
   - usb_connector_type
   - usb_standard
+  - width
   return_reasons:
   - size
   - incompatible
@@ -20059,9 +21298,12 @@
   attributes:
   - color
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - scent
   - incompatible
@@ -20086,9 +21328,12 @@
   - color
   - compatible_device
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - signal_types_blocked
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -20106,9 +21351,12 @@
   - compatible_device
   - connector_gender
   - cover_features
+  - height
+  - length
   - material
   - pattern
   - signal_types_blocked
+  - width
   return_reasons:
   - color
   - style
@@ -20129,11 +21377,14 @@
   - compatible_device
   - connector_gender
   - finish
+  - height
+  - length
   - magsafe_compatibility
   - material
   - pattern
   - signal_types_blocked
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -20155,11 +21406,14 @@
   - color
   - compatible_device
   - connector_gender
+  - height
   - keyboard_format
   - keyboard_layout
+  - length
   - material
   - pattern
   - signal_types_blocked
+  - width
   return_reasons:
   - color
   - incompatible
@@ -20183,12 +21437,15 @@
   - connector_gender
   - finish
   - hardness_rating_pencil_scale
+  - height
+  - length
   - material
   - monitor/screen_specialized_features
   - native_aspect_ratio
   - pattern
   - privacy_filtering_direction
   - signal_types_blocked
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -20306,11 +21563,14 @@
   - connector_gender
   - finish
   - hardness_rating_pencil_scale
+  - height
+  - length
   - material
   - pattern
   - screen_protector_coverage_style
   - screen_protector_features
   - signal_types_blocked
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -20443,14 +21703,21 @@
   - el-7-12-4
   - el-7-12-5
   attributes:
+  - cache_size
   - color
   - connector_gender
+  - height
+  - latency
+  - length
   - material
+  - memory_capacity
   - memory_form_factor
   - memory_rank
   - memory_technology
   - pattern
   - power_source
+  - voltage
+  - width
   return_reasons:
   - storage_capacity
   - incompatible
@@ -20465,15 +21732,23 @@
   children: []
   attributes:
   - cache_level
+  - cache_size
   - color
   - component_package_type
   - connector_gender
+  - height
+  - latency
+  - length
   - material
+  - memory_capacity
+  - memory_clock_speed
   - memory_form_factor
   - memory_rank
   - memory_technology
   - pattern
   - power_source
+  - voltage
+  - width
   return_reasons:
   - storage_capacity
   - speed
@@ -20489,13 +21764,18 @@
   children:
   - el-7-12-2-1
   attributes:
+  - cache_size
   - color
   - component_package_type
   - connector_gender
   - device_interface
   - durability_features
   - flash_cell_type
+  - height
+  - latency
+  - length
   - material
+  - memory_capacity
   - memory_form_factor
   - memory_rank
   - memory_storage_type
@@ -20503,6 +21783,8 @@
   - pattern
   - power_source
   - read/write_speed
+  - voltage
+  - width
   return_reasons:
   - storage_capacity
   - speed
@@ -20519,13 +21801,18 @@
   attributes:
   - battery_size
   - battery_type
+  - cache_size
   - color
   - component_package_type
   - connector_gender
   - device_interface
   - durability_features
   - flash_cell_type
+  - height
+  - latency
+  - length
   - material
+  - memory_capacity
   - memory_form_factor
   - memory_rank
   - memory_storage_type
@@ -20533,6 +21820,8 @@
   - pattern
   - power_source
   - read/write_speed
+  - voltage
+  - width
   return_reasons:
   - storage_capacity
   - speed
@@ -20549,16 +21838,24 @@
   attributes:
   - battery_size
   - battery_type
+  - cache_size
   - color
   - connector_gender
   - error_correction_type
+  - height
+  - latency
+  - length
   - material
+  - memory_capacity
+  - memory_clock_speed
   - memory_form_factor
   - memory_rank
   - memory_technology
   - overclock_profile_support
   - pattern
   - power_source
+  - voltage
+  - width
   return_reasons:
   - storage_capacity
   - speed
@@ -20573,15 +21870,22 @@
   name: ROM
   children: []
   attributes:
+  - cache_size
   - color
   - component_package_type
   - connector_gender
+  - height
+  - latency
+  - length
   - material
+  - memory_capacity
   - memory_form_factor
   - memory_rank
   - memory_technology
   - pattern
   - power_source
+  - voltage
+  - width
   return_reasons:
   - storage_capacity
   - incompatible
@@ -20595,14 +21899,22 @@
   name: Video Memory
   children: []
   attributes:
+  - cache_size
   - color
   - connector_gender
+  - height
+  - latency
+  - length
   - material
+  - memory_capacity
+  - memory_clock_speed
   - memory_form_factor
   - memory_rank
   - memory_technology
   - pattern
   - power_source
+  - voltage
+  - width
   return_reasons:
   - storage_capacity
   - incompatible
@@ -20622,11 +21934,14 @@
   - color
   - compatible_memory_cards
   - connector_gender
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pattern
   - power_source
   - removable_storage_formats_supported
+  - width
   return_reasons:
   - color
   - incompatible
@@ -20647,11 +21962,14 @@
   - color
   - compatible_memory_cards
   - connector_gender
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pattern
   - power_source
   - removable_storage_formats_supported
+  - width
   return_reasons:
   - size
   - color
@@ -20741,16 +22059,20 @@
   - compatible_device
   - connector_gender
   - feet_type
+  - height
   - leg_lock_type
   - leg_sections
+  - length
   - magsafe_compatibility
   - material
+  - maximum_height
   - pattern
   - power_source
   - remote_control_functions
   - remote_technology
   - selfie_stick_functionality_type
   - tripod/monopod_head_type
+  - width
   return_reasons:
   - size
   - style
@@ -20820,10 +22142,14 @@
   - compatible_battery_technology
   - connector_gender
   - connector_type
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - product_certifications_standards
+  - voltage
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -20845,10 +22171,14 @@
   - color
   - connector_gender
   - connector_type
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - product_certifications_standards
+  - voltage
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -20869,10 +22199,14 @@
   - color
   - connector_gender
   - connector_type
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - product_certifications_standards
+  - voltage
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -20893,10 +22227,14 @@
   - color
   - connector_gender
   - connector_type
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - product_certifications_standards
+  - voltage
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -20918,10 +22256,14 @@
   - color
   - connector_gender
   - connector_type
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - product_certifications_standards
+  - voltage
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -20942,10 +22284,14 @@
   - color
   - connector_gender
   - connector_type
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - product_certifications_standards
+  - voltage
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -20966,12 +22312,16 @@
   - color
   - connector_gender
   - connector_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - material
   - pattern
   - plug_type
   - product_certifications_standards
+  - voltage
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -20993,10 +22343,14 @@
   - compatible_device
   - connector_gender
   - connector_type
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - product_certifications_standards
+  - voltage
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -21018,11 +22372,15 @@
   - color
   - connector_gender
   - connector_type
+  - height
   - installation_accessories_included
+  - length
   - material
   - pattern
   - plug_type
   - product_certifications_standards
+  - voltage
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -21043,11 +22401,15 @@
   - color
   - connector_gender
   - connector_type
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - plug_type
   - product_certifications_standards
+  - voltage
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -21069,11 +22431,15 @@
   - color
   - connector_gender
   - connector_type
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pattern
   - plug_type
   - product_certifications_standards
+  - voltage
+  - width
   return_reasons:
   - size
   - capacity
@@ -21095,10 +22461,14 @@
   - color
   - connector_gender
   - connector_type
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - product_certifications_standards
+  - voltage
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -21120,10 +22490,14 @@
   - compatible_device
   - connector_gender
   - connector_type
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - product_certifications_standards
+  - voltage
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -21203,10 +22577,13 @@
   - compatible_battery_technology
   - compatible_device
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21228,11 +22605,14 @@
   - compatible_battery_technology
   - compatible_device
   - connector_gender
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pattern
   - plug_type
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21252,11 +22632,14 @@
   - compatible_device
   - connector_gender
   - contact_material
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - plug_type
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -21278,10 +22661,13 @@
   - compatible_battery_technology
   - compatible_device
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - power_source
+  - width
   return_reasons:
   - charging_speed
   - incompatible
@@ -21305,11 +22691,14 @@
   - compatible_battery_technology
   - compatible_device
   - connector_gender
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pattern
   - plug_type
   - power_source
+  - width
   return_reasons:
   - charging_speed
   - incompatible
@@ -21331,12 +22720,15 @@
   - connectivity_technology
   - connector_gender
   - display_mode
+  - height
+  - length
   - material
   - measured_parameters
   - pattern
   - plug_type
   - power_source
   - sensor/measuring_tool_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21425,11 +22817,18 @@
   - color
   - connector_gender
   - fuel_source
+  - height
+  - length
   - material
+  - maximum_operating_temperature
+  - minimum_operating_temperature
   - pattern
   - plug_type
+  - power_output_typical
   - power_source
   - stack_configuration
+  - voltage
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -21452,10 +22851,13 @@
   - color
   - compatible_device
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - power_source
+  - width
   return_reasons:
   - color
   - length
@@ -21473,10 +22875,13 @@
   - color
   - compatible_device
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -21499,11 +22904,14 @@
   - color
   - compatible_device
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - power_source
   - usb_connector_type
+  - width
   return_reasons:
   - color
   - length
@@ -21641,12 +23049,15 @@
   - battery_type
   - color
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - power_conversion_semiconductor_type
   - power_source
   - usb_connector_type
+  - width
   return_reasons:
   - color
   - incompatible
@@ -21666,12 +23077,15 @@
   - color
   - compatible_device
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - power_conversion_semiconductor_type
   - power_source
   - usb_connector_type
+  - width
   return_reasons:
   - size
   - color
@@ -21694,6 +23108,8 @@
   - color
   - compatible_device
   - connector_gender
+  - height
+  - length
   - magsafe_compatibility
   - material
   - mounting_type
@@ -21702,6 +23118,7 @@
   - power_conversion_semiconductor_type
   - power_source
   - usb_connector_type
+  - width
   - wireless_charging_standard
   return_reasons:
   - size
@@ -21808,14 +23225,19 @@
   - battery_type
   - color
   - connector_gender
+  - height
   - ingress_protection_ip_rating
+  - input_voltage
+  - length
   - material
   - mounting_type
   - outlet_type
   - pattern
   - phase_type
   - plug_type
+  - power
   - power_source
+  - width
   return_reasons:
   - power_output
   - incompatible
@@ -21880,14 +23302,21 @@
   - battery_type
   - color
   - connector_gender
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
+  - maximum_operating_temperature
+  - minimum_operating_temperature
   - outlet_type
   - pattern
   - plug_type
   - portability
+  - power_output_typical
   - power_source
   - product_certifications_standards
+  - voltage
+  - width
   return_reasons:
   - power_output
   - capacity
@@ -21904,14 +23333,19 @@
   attributes:
   - battery_size
   - battery_type
+  - cable_length
   - color
   - connector_gender
+  - height
+  - joule_rating
+  - length
   - material
   - mounting_type
   - outlet_type
   - pattern
   - plug_type
   - power_source
+  - width
   return_reasons:
   - length
   - incompatible
@@ -21929,7 +23363,9 @@
   - color
   - compatible_power_supply_form_factor
   - connector_gender
+  - height
   - ingress_protection_ip_rating
+  - length
   - lock_type
   - material
   - mounting_type
@@ -21938,6 +23374,7 @@
   - plug_type
   - power_source
   - ventilation_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -21951,15 +23388,22 @@
   name: Surge Protection Devices
   children: []
   attributes:
+  - cable_length
   - color
   - connector_gender
+  - height
   - ingress_protection_ip_rating
+  - input_voltage
+  - length
   - material
   - mounting_type
   - outlet_type
   - pattern
   - plug_type
   - power_source
+  - response_time
+  - surge_energy_rating
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21976,12 +23420,15 @@
   attributes:
   - color
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - plug_type_input
   - plug_type_output
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22036,6 +23483,7 @@
   name: UPS
   children: []
   attributes:
+  - backup_runtime
   - battery_size
   - battery_technology
   - battery_type
@@ -22043,14 +23491,20 @@
   - color
   - connectivity_technology
   - connector_gender
+  - height
+  - input_voltage
+  - length
   - material
   - outlet_type
   - output_waveform
   - pattern
   - plug_type
+  - power_output_typical
   - power_source
+  - transfer_time
   - ups_topology
   - usb_standard
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -22071,11 +23525,14 @@
   attributes:
   - color
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - phase_type
   - plug_type
   - power_source
+  - width
   return_reasons:
   - length
   - incompatible
@@ -22091,12 +23548,15 @@
   attributes:
   - color
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - phase_type
   - plug_type
   - power_source
   - rack_width_standard
+  - width
   return_reasons:
   - length
   - incompatible
@@ -22236,9 +23696,12 @@
   - compatible_device
   - connectivity_technology
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22398,13 +23861,18 @@
   - antenna_type
   - color
   - connector_gender
+  - coverage_radius
   - data_network
   - frequency/radio_bands_supported
+  - height
+  - length
   - material
   - pattern
   - power_source
   - signal_technology
   - suitable_space
+  - uplink_gain
+  - width
   return_reasons:
   - range
   - incompatible
@@ -22554,10 +24022,15 @@
   - color
   - connector_gender
   - frequency/radio_bands_supported
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - power_output_typical
   - power_source
+  - signal_range
+  - width
   return_reasons:
   - range
   - power_output
@@ -22576,10 +24049,15 @@
   - color
   - connector_gender
   - frequency/radio_bands_supported
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - power_output_typical
   - power_source
+  - signal_range
+  - width
   return_reasons:
   - range
   - power_output
@@ -22602,10 +24080,15 @@
   - cooling_technology
   - data_network
   - frequency/radio_bands_supported
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - power_output_typical
   - power_source
+  - signal_range
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22623,11 +24106,16 @@
   - color
   - connector_gender
   - frequency/radio_bands_supported
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - mounting_type
   - pattern
+  - power_output_typical
   - power_source
+  - signal_range
+  - width
   return_reasons:
   - range
   - power_output
@@ -22769,9 +24257,12 @@
   - el-8-3
   attributes:
   - color
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22792,9 +24283,12 @@
   - closure_type
   - color
   - compatible_device
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -22812,11 +24306,14 @@
   attributes:
   - color
   - gps_compatible_device
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - mount_installation_point
   - mount_interface_system
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -22855,12 +24352,17 @@
   - energy_efficiency_class
   - gps_device_features
   - gps_map_type
+  - height
   - ingress_protection_ip_rating
+  - length
   - map_update_policy
   - mounting_type
   - pattern
+  - power_output_typical
   - power_source
   - satellite_navigation_systems_supported
+  - screen_size
+  - width
   return_reasons:
   - battery_life
   - incompatible
@@ -22925,16 +24427,21 @@
   - color
   - connectivity_technology
   - device_interface
+  - height
   - ingress_protection_ip_rating
+  - length
   - mounting_type
   - pattern
+  - power_output_typical
   - power_source
   - safety_certifications
   - satellite_navigation_systems_supported
+  - screen_size
   - subscription_type
   - tracker_form_factor
   - tracking_purpose
   - update_frequency
+  - width
   return_reasons:
   - battery_life
   - range
@@ -23016,10 +24523,17 @@
   - connectivity_technology
   - device_interface
   - display_resolution
+  - height
   - ingress_protection_ip_rating
+  - length
+  - maximum_frequency
+  - minimum_frequency
   - mounting_type
   - pattern
+  - power_output_typical
   - power_source
+  - screen_size
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23037,15 +24551,23 @@
   - connectivity_technology
   - device_interface
   - display_resolution
+  - height
   - ingress_protection_ip_rating
+  - length
   - marine_navigator_features
+  - maximum_detection_depth
+  - maximum_frequency
+  - minimum_frequency
   - mounting_type
   - pattern
+  - power_output_typical
   - power_source
   - satellite_navigation_systems_supported
+  - screen_size
   - sonar_imaging_modes
   - suitable_for_angling_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - range
   - incompatible
@@ -23068,12 +24590,20 @@
   - device_interface
   - din_size
   - display_resolution
+  - height
   - ingress_protection_ip_rating
+  - length
+  - maximum_frequency
+  - minimum_frequency
   - mounting_type
   - pattern
+  - power_output_typical
   - power_source
+  - rms_rated_power
+  - screen_size
   - supported_audio_sources
   - tuner_type
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -23096,12 +24626,19 @@
   - device_interface
   - display_resolution
   - gps_map_type
+  - height
   - ingress_protection_ip_rating
+  - length
   - marine_navigator_features
+  - maximum_frequency
+  - minimum_frequency
   - mounting_type
   - pattern
+  - power_output_typical
   - power_source
   - satellite_navigation_systems_supported
+  - screen_size
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23149,12 +24686,20 @@
   - connectivity_technology
   - device_interface
   - display_resolution
+  - distance_range
+  - height
   - ingress_protection_ip_rating
+  - length
   - marine_navigator_features
+  - maximum_frequency
+  - minimum_frequency
   - mounting_type
   - pattern
+  - power_output_typical
   - power_source
   - radar_technology
+  - screen_size
+  - width
   return_reasons:
   - range
   - video_quality
@@ -23250,11 +24795,18 @@
   - connectivity_technology
   - device_interface
   - display_resolution
+  - height
   - ingress_protection_ip_rating
+  - length
+  - maximum_frequency
+  - minimum_frequency
   - mounting_type
   - pattern
+  - power_output_typical
   - power_source
   - radio_features
+  - screen_size
+  - width
   return_reasons:
   - battery_life
   - range
@@ -23280,14 +24832,21 @@
   - device_interface
   - display_resolution
   - driver_configuration
+  - height
   - ingress_protection_ip_rating
   - integrated_led_lighting
+  - length
+  - maximum_frequency
+  - minimum_frequency
   - mounting_type
   - pattern
+  - power_output_typical
   - power_source
+  - screen_size
   - speaker_design
   - speaker_features
   - speaker_technology
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -23635,6 +25194,7 @@
   attributes:
   - color
   - pattern
+  - power_consumption_typical
   - power_source
   return_reasons:
   - speed
@@ -23660,15 +25220,21 @@
   - bridge/router_advanced_features
   - color
   - ethernet_lan_interface_type
+  - height
+  - length
+  - maximum_data_transfer_rate
+  - memory_capacity
   - mounting_type
   - network_protocols_supported
   - networking_standards
   - pattern
   - poe_standard
+  - power_consumption_typical
   - power_source
   - security_algorithms
   - wi_fi_band
   - wi_fi_standard
+  - width
   return_reasons:
   - speed
   - incompatible
@@ -23686,17 +25252,24 @@
   - bridge/router_advanced_features
   - color
   - ethernet_lan_interface_type
+  - height
   - ingress_protection_ip_rating
+  - length
   - management_type
+  - maximum_data_transfer_rate
+  - maximum_ethernet_port_speed
+  - memory_capacity
   - mounting_type
   - network_protocols_supported
   - networking_standards
   - pattern
   - poe_standard
+  - power_consumption_typical
   - power_source
   - security_algorithms
   - wi_fi_band
   - wi_fi_standard
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23714,17 +25287,23 @@
   - color
   - data_network
   - ethernet_lan_interface_type
+  - height
+  - length
+  - maximum_data_transfer_rate
+  - memory_capacity
   - mounting_type
   - network_protocols_supported
   - networking_standards
   - pattern
   - poe_standard
+  - power_consumption_typical
   - power_source
   - pstn_connectivity_options
   - security_algorithms
   - voip_protocol_support
   - wi_fi_band
   - wi_fi_standard
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23740,18 +25319,25 @@
   - antenna_type
   - bridge/router_advanced_features
   - color
+  - coverage_radius
   - ethernet_lan_interface_type
+  - height
   - ingress_protection_ip_rating
+  - length
+  - maximum_data_transfer_rate
+  - memory_capacity
   - mesh_networking_technology
   - mounting_type
   - network_protocols_supported
   - networking_standards
   - pattern
   - poe_standard
+  - power_consumption_typical
   - power_source
   - security_algorithms
   - wi_fi_band
   - wi_fi_standard
+  - width
   return_reasons:
   - speed
   - range
@@ -23773,12 +25359,17 @@
   - color
   - data_network
   - ethernet_lan_interface_type
+  - height
+  - length
+  - maximum_data_transfer_rate
+  - memory_capacity
   - mimo_technology
   - mounting_type
   - network_protocols_supported
   - networking_standards
   - pattern
   - poe_standard
+  - power_consumption_typical
   - power_source
   - security_algorithms
   - sim_card_capability
@@ -23786,6 +25377,7 @@
   - wan_interface_type
   - wi_fi_band
   - wi_fi_standard
+  - width
   return_reasons:
   - speed
   - range
@@ -23886,13 +25478,17 @@
   attributes:
   - color
   - ethernet_lan_interface_type
+  - height
+  - length
   - mounting_type
   - multiplexer_technology
   - network_cable_interface
   - network_protocols_supported
   - networking_standards
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - speed
   - incompatible
@@ -23919,12 +25515,16 @@
   attributes:
   - color
   - ethernet_lan_interface_type
+  - height
   - hub/switch_storage_options
+  - length
   - mounting_type
   - network_protocols_supported
   - pattern
   - poe_standard
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - speed
   - incompatible
@@ -23940,13 +25540,17 @@
   attributes:
   - color
   - ethernet_lan_interface_type
+  - height
   - hub/switch_storage_options
+  - length
   - mounting_type
   - network_protocols_supported
   - pattern
   - poe_standard
+  - power_consumption_typical
   - power_source
   - switch_management_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23961,12 +25565,16 @@
   attributes:
   - color
   - ethernet_lan_interface_type
+  - height
   - hub/switch_storage_options
+  - length
   - mounting_type
   - network_protocols_supported
   - pattern
   - poe_standard
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - speed
   - incompatible
@@ -23982,14 +25590,18 @@
   attributes:
   - color
   - ethernet_lan_interface_type
+  - height
   - hub/switch_storage_options
+  - length
   - mounting_type
   - network_protocols_supported
   - pattern
   - poe_standard
+  - power_consumption_typical
   - power_source
   - switch_management_type
   - uplink_port_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24004,13 +25616,17 @@
   attributes:
   - color
   - ethernet_lan_interface_type
+  - height
   - hub/switch_storage_options
+  - length
   - mounting_type
   - network_protocols_supported
   - pattern
   - poe_standard
+  - power_consumption_typical
   - power_source
   - switching_layer
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24029,12 +25645,16 @@
   attributes:
   - color
   - ethernet_lan_interface_type
+  - height
   - hub/switch_storage_options
+  - length
   - mounting_type
   - network_protocols_supported
   - pattern
   - poe_standard
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24130,13 +25750,17 @@
   attributes:
   - color
   - ethernet_lan_interface_type
+  - height
   - hub/switch_storage_options
+  - length
   - mounting_type
   - network_protocols_supported
   - pattern
   - poe_standard
+  - power_consumption_typical
   - power_source
   - switch_management_type
+  - width
   return_reasons:
   - speed
   - incompatible
@@ -24152,13 +25776,17 @@
   attributes:
   - color
   - ethernet_lan_interface_type
+  - height
   - hub/switch_storage_options
+  - length
   - mounting_type
   - network_layer_support
   - network_protocols_supported
   - pattern
   - poe_standard
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24173,13 +25801,17 @@
   attributes:
   - color
   - ethernet_lan_interface_type
+  - height
   - hub/switch_storage_options
+  - length
   - mounting_type
   - network_protocols_supported
   - pattern
   - poe_standard
+  - power_consumption_typical
   - power_source
   - switch_management_type
+  - width
   return_reasons:
   - speed
   - incompatible
@@ -24196,12 +25828,16 @@
   - color
   - cooling_technology
   - ethernet_lan_interface_type
+  - height
   - hub/switch_storage_options
+  - length
   - mounting_type
   - network_protocols_supported
   - pattern
   - poe_standard
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24261,13 +25897,17 @@
   - color
   - connector_type
   - dsl_standard_compatibility
+  - height
+  - length
   - material
   - mounting_type
   - network_cable_interface
   - pattern
+  - power_consumption_typical
   - power_source
   - telephone_cable_interface
   - wi_fi_band
+  - width
   return_reasons:
   - speed
   - incompatible
@@ -24287,12 +25927,17 @@
   - color
   - data_network
   - docsis_standard
+  - height
   - host_interface
+  - length
+  - maximum_data_transfer_rate
   - modem_form_factor
   - modem_technology
   - network_protocols_supported
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - speed
   - incompatible
@@ -24382,13 +26027,17 @@
   - antenna_type
   - card/adapter_installation
   - color
+  - height
   - host_interface
+  - length
   - network_protocols_supported
   - pattern
+  - power_consumption_typical
   - power_source
   - usb_connector_type
   - wi_fi_band
   - wi_fi_standard
+  - width
   return_reasons:
   - speed
   - incompatible
@@ -24503,11 +26152,17 @@
   - chassis_type
   - color
   - ethernet_lan_interface_type
+  - firewall_throughput
+  - height
+  - length
   - network_protocols_supported
   - pattern
   - poe_standard
+  - power_consumption_typical
   - power_source
   - security_algorithms
+  - vpn_throughput
+  - width
   return_reasons:
   - speed
   - incompatible
@@ -24526,10 +26181,14 @@
   - el-12-8-4
   attributes:
   - color
+  - height
+  - length
   - mounting_type
   - pattern
   - poe_standard
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - speed
   - incompatible
@@ -24620,9 +26279,12 @@
   attributes:
   - color
   - ethernet_lan_interface_type
+  - height
+  - length
   - network_protocols_supported
   - networking_standards
   - pattern
+  - power_consumption_typical
   - power_source
   - print_server_form_factor
   - printer_connection_interface
@@ -24630,6 +26292,7 @@
   - usb_standard
   - wi_fi_band
   - wi_fi_standard
+  - width
   return_reasons:
   - speed
   - incompatible
@@ -24647,13 +26310,17 @@
   - el-12-10-3
   attributes:
   - color
+  - height
+  - length
   - network_cable_interface
   - networking_standards
   - pattern
+  - power_consumption_typical
   - power_source
   - transceiver_form_factor
   - wi_fi_band
   - wi_fi_standard
+  - width
   return_reasons:
   - speed
   - coverage
@@ -24770,10 +26437,13 @@
   - el-13-1-11
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - print_technology
   - printer_functions
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24792,10 +26462,13 @@
   - carry_options
   - color
   - durability_features
+  - height
+  - length
   - material
   - pattern
   - print_technology
   - printer_functions
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24813,10 +26486,13 @@
   attributes:
   - 3d_printer_cleaning_kit_components_included
   - color
+  - height
+  - length
   - material
   - pattern
   - print_technology
   - printer_functions
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24889,10 +26565,12 @@
   - application_method
   - color
   - compatible_filament
+  - length
   - material
   - pattern
   - print_technology
   - printer_functions
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24908,11 +26586,16 @@
   attributes:
   - color
   - compatible_filament
+  - compatible_printer_filament_size
+  - extruder_shaft_size
   - gear_ratio
+  - height
+  - length
   - material
   - pattern
   - print_technology
   - printer_functions
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24928,10 +26611,14 @@
   - color
   - filament_type
   - finish
+  - height
+  - length
   - material
   - pattern
   - print_technology
+  - printer_filament_size
   - printer_functions
+  - width
   return_reasons:
   - size
   - color
@@ -24949,12 +26636,16 @@
   attributes:
   - color
   - compatible_filament
+  - height
+  - length
   - material
   - nozzle_coating
+  - nozzle_size
   - nozzle_thread_type
   - pattern
   - print_technology
   - printer_functions
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24970,12 +26661,15 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - pattern
   - print_technology
   - printer_functions
   - shape
   - surface_sides
+  - width
   return_reasons:
   - adhesion
   - incompatible
@@ -25065,14 +26759,19 @@
   - bed_leveling_type
   - color
   - compatible_filament
+  - compatible_printer_filament_size
   - compatible_resin_type
   - enclosure_type
   - energy_efficiency_class
   - file_format_type
+  - height
+  - length
+  - memory_capacity
   - memory_technology
   - pattern
   - print_technology
   - printer_functions
+  - width
   return_reasons:
   - print_quality
   - incompatible
@@ -25151,7 +26850,9 @@
   attributes:
   - cartridge_authenticity
   - color
+  - height
   - ink_type
+  - length
   - manufacturer_type
   - material
   - pattern
@@ -25159,6 +26860,7 @@
   - printer_functions
   - printing_color
   - suitable_for_printer_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -25177,13 +26879,16 @@
   attributes:
   - cartridge_authenticity
   - color
+  - height
   - ink_type
+  - length
   - material
   - pattern
   - print_technology
   - printer_functions
   - printing_color
   - suitable_for_printer_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -25199,7 +26904,9 @@
   - cartridge_authenticity
   - color
   - filter_form_factor
+  - height
   - ink_type
+  - length
   - material
   - pattern
   - print_technology
@@ -25207,6 +26914,7 @@
   - printing_color
   - suitable_for_printer_type
   - vacuum_air_filtering_technology
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -25223,13 +26931,16 @@
   - color
   - filter_material
   - filtration_technology
+  - height
   - ink_type
+  - length
   - material
   - pattern
   - print_technology
   - printer_functions
   - printing_color
   - suitable_for_printer_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -25245,13 +26956,16 @@
   - cartridge_authenticity
   - color
   - filter_material
+  - height
   - ink_type
+  - length
   - material
   - pattern
   - print_technology
   - printer_functions
   - printing_color
   - suitable_for_printer_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -25267,13 +26981,16 @@
   - cartridge_authenticity
   - color
   - filter_material
+  - height
   - ink_type
+  - length
   - material
   - pattern
   - print_technology
   - printer_functions
   - printing_color
   - suitable_for_printer_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -25293,7 +27010,9 @@
   - cartridge_authenticity
   - color
   - compatible_printer
+  - height
   - ink_type
+  - length
   - manufacturer_type
   - material
   - pattern
@@ -25302,6 +27021,7 @@
   - printer_functions
   - printing_color
   - suitable_for_printer_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -25416,13 +27136,16 @@
   attributes:
   - cartridge_authenticity
   - color
+  - height
   - ink_type
+  - length
   - material
   - pattern
   - print_technology
   - printer_functions
   - printing_color
   - suitable_for_printer_type
+  - width
   return_reasons:
   - color
   - incompatible
@@ -25438,7 +27161,9 @@
   attributes:
   - cartridge_authenticity
   - color
+  - height
   - ink_type
+  - length
   - manufacturer_type
   - material
   - pattern
@@ -25446,6 +27171,7 @@
   - printer_functions
   - printing_color
   - suitable_for_printer_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -25460,13 +27186,17 @@
   attributes:
   - cartridge_authenticity
   - color
+  - height
   - ink_type
+  - length
   - material
   - pattern
   - print_technology
   - printer_functions
   - printing_color
   - suitable_for_printer_type
+  - volume
+  - width
   return_reasons:
   - color
   - capacity
@@ -25487,7 +27217,9 @@
   - cartridge_authenticity
   - cartridge_yield_type
   - color
+  - height
   - ink_type
+  - length
   - manufacturer_type
   - material
   - pattern
@@ -25495,6 +27227,8 @@
   - printer_functions
   - printing_color
   - suitable_for_printer_type
+  - volume
+  - width
   return_reasons:
   - color
   - incompatible
@@ -25535,12 +27269,15 @@
   - duplex_component_type
   - duplexer_installation_type
   - duplexing_technology
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - material
   - pattern
   - printer_functions
   - suitable_for_printer_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -25555,12 +27292,16 @@
   attributes:
   - color
   - compatible_printer
+  - height
+  - length
   - material
+  - memory_capacity
   - memory_form_factor
   - memory_technology
   - pattern
   - printer_functions
   - suitable_for_printer_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -25575,14 +27316,18 @@
   attributes:
   - color
   - furniture/fixture_features
+  - height
   - height_adjustment
   - integrated_power/charging_options
+  - length
   - material
+  - maximum_load_capacity
   - mobility_type
   - pattern
   - printer_functions
   - stand/display_type
   - suitable_for_printer_type
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -25603,11 +27348,14 @@
   - color
   - compatible_printer
   - durability_features
+  - height
+  - length
   - material
   - pattern
   - printer_functions
   - spinner_type
   - suitable_for_printer_type
+  - width
   return_reasons:
   - size
   - style
@@ -25629,10 +27377,13 @@
   - cleaning_kit_components_included
   - color
   - dry/wet_cleaning
+  - height
+  - length
   - material
   - pattern
   - printer_functions
   - suitable_for_printer_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -25655,12 +27406,15 @@
   - battery_type
   - color
   - compatible_printer
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - material
   - pattern
   - printer_functions
   - suitable_for_printer_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -25875,6 +27629,9 @@
   - display_technology
   - duplexing_technology
   - energy_efficiency_class
+  - height
+  - length
+  - memory_capacity
   - memory_technology
   - pattern
   - print_technology
@@ -25882,6 +27639,7 @@
   - printer_color_capability
   - printer_form_factor
   - printer_functions
+  - width
   return_reasons:
   - size
   - incompatible
@@ -26030,8 +27788,11 @@
   - el-13-5-5
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -26051,9 +27812,12 @@
   - case_type
   - closure_type
   - color
+  - height
+  - length
   - material
   - pattern
   - scanner_grip_compatibility
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -26068,9 +27832,12 @@
   attributes:
   - color
   - dry/wet_cleaning
+  - height
+  - length
   - material
   - pattern
   - scanner_maintenance_kit_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -26140,7 +27907,10 @@
   - color_depth
   - compatible_paper_size
   - energy_efficiency_class
+  - height
+  - length
   - light_source
+  - memory_capacity
   - memory_technology
   - pattern
   - power_source
@@ -26148,6 +27918,7 @@
   - scanner_features
   - scanner_sensor_type
   - supported_scan_media_type
+  - width
   return_reasons:
   - resolution
   - incompatible
@@ -26165,7 +27936,10 @@
   - color_depth
   - compatible_paper_size
   - energy_efficiency_class
+  - height
+  - length
   - light_source
+  - memory_capacity
   - memory_technology
   - pattern
   - power_source
@@ -26173,6 +27947,7 @@
   - scanner_features
   - scanner_sensor_type
   - supported_scan_media_type
+  - width
   return_reasons:
   - resolution
   - speed
@@ -26192,7 +27967,10 @@
   - compatible_paper_size
   - energy_efficiency_class
   - film_format
+  - height
+  - length
   - light_source
+  - memory_capacity
   - memory_technology
   - pattern
   - power_source
@@ -26200,6 +27978,7 @@
   - scanner_features
   - scanner_sensor_type
   - supported_scan_media_type
+  - width
   return_reasons:
   - resolution
   - incompatible
@@ -26217,7 +27996,10 @@
   - color_depth
   - compatible_paper_size
   - energy_efficiency_class
+  - height
+  - length
   - light_source
+  - memory_capacity
   - memory_technology
   - pattern
   - power_source
@@ -26225,6 +28007,7 @@
   - scanner_features
   - scanner_sensor_type
   - supported_scan_media_type
+  - width
   return_reasons:
   - resolution
   - speed
@@ -26243,7 +28026,10 @@
   - color_depth
   - compatible_paper_size
   - energy_efficiency_class
+  - height
+  - length
   - light_source
+  - memory_capacity
   - memory_technology
   - pattern
   - power_source
@@ -26251,6 +28037,7 @@
   - scanner_features
   - scanner_sensor_type
   - supported_scan_media_type
+  - width
   return_reasons:
   - resolution
   - speed
@@ -26274,7 +28061,10 @@
   - energy_efficiency_class
   - feed_system
   - file_format_type
+  - height
+  - length
   - light_source
+  - memory_capacity
   - memory_technology
   - pattern
   - power_source
@@ -26282,6 +28072,7 @@
   - scanner_features
   - scanner_sensor_type
   - supported_scan_media_type
+  - width
   return_reasons:
   - resolution
   - speed
@@ -26303,7 +28094,10 @@
   - color_depth
   - compatible_paper_size
   - energy_efficiency_class
+  - height
+  - length
   - light_source
+  - memory_capacity
   - memory_technology
   - pattern
   - power_source
@@ -26311,6 +28105,7 @@
   - scanner_features
   - scanner_sensor_type
   - supported_scan_media_type
+  - width
   return_reasons:
   - resolution
   - capacity
@@ -26478,12 +28273,16 @@
   attributes:
   - color
   - connectivity_technology
+  - detection_range
   - display_technology
   - filtering_modes
+  - height
+  - length
   - pattern
   - power_source
   - radar_bands
   - vehicle_mounting_location
+  - width
   return_reasons:
   - range
   - sensitivity
@@ -26500,15 +28299,19 @@
   attributes:
   - color
   - connectivity_technology
+  - detection_range
   - direction_detection_capability
   - display_technology
   - filtering_modes
+  - height
   - ingress_protection_ip_rating
+  - length
   - mounting_type
   - pattern
   - power_source
   - radar_bands
   - radar_technology
+  - width
   return_reasons:
   - range
   - incompatible
@@ -26527,9 +28330,12 @@
   - compatible_vehicle
   - connectivity_technology
   - device_interface
+  - height
+  - length
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -26581,12 +28387,18 @@
   - display_technology
   - energy_efficiency_class_hdr
   - energy_efficiency_class_sdr
+  - height
+  - length
+  - maximum_refresh_rate
   - monitor_shape
   - monitor_specialized_features
   - native_aspect_ratio
   - pattern
+  - power_consumption_typical
   - screen_curvature_rating
+  - screen_size
   - vesa_mounting_pattern
+  - width
   return_reasons:
   - size
   - video_quality
@@ -26640,11 +28452,15 @@
   - display_resolution
   - display_technology
   - energy_efficiency_class
+  - height
   - keystone_correction_type
+  - length
+  - maximum_projection_distance
   - mounting_type
   - native_aspect_ratio
   - pattern
   - projector_light_source
+  - width
   return_reasons:
   - brightness
   - video_quality
@@ -26666,12 +28482,16 @@
   - display_resolution
   - display_technology
   - energy_efficiency_class
+  - height
   - keystone_correction_type
+  - length
+  - maximum_projection_distance
   - mounting_type
   - native_aspect_ratio
   - operating_system
   - pattern
   - projector_light_source
+  - width
   return_reasons:
   - brightness
   - video_quality
@@ -26692,11 +28512,15 @@
   - display_resolution
   - display_technology
   - energy_efficiency_class
+  - height
   - keystone_correction_type
+  - length
+  - maximum_projection_distance
   - mounting_type
   - native_aspect_ratio
   - pattern
   - projector_light_source
+  - width
   return_reasons:
   - brightness
   - incompatible
@@ -26716,12 +28540,16 @@
   - display_technology
   - energy_efficiency_class
   - focus_adjustment
+  - height
   - keystone_correction_type
+  - length
+  - maximum_projection_distance
   - mounting_type
   - native_aspect_ratio
   - pattern
   - power_source
   - projector_light_source
+  - width
   return_reasons:
   - brightness
   - incompatible
@@ -26770,10 +28598,14 @@
   - device_interface
   - display_technology
   - energy_efficiency_class
+  - height
+  - internal_storage_capacity
+  - length
   - pattern
   - power_source
   - recording_functionality
   - video_resolution_supported
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -26794,6 +28626,9 @@
   - device_interface
   - display_technology
   - energy_efficiency_class
+  - height
+  - internal_storage_capacity
+  - length
   - operating_system
   - pattern
   - power_source
@@ -26802,6 +28637,7 @@
   - video_codecs/formats_supported
   - video_resolution_supported
   - wi_fi_standard
+  - width
   return_reasons:
   - video_quality
   - incompatible
@@ -26824,6 +28660,9 @@
   - display_technology
   - energy_efficiency_class
   - hdr_format
+  - height
+  - internal_storage_capacity
+  - length
   - operating_system
   - pattern
   - power_source
@@ -26833,6 +28672,7 @@
   - video_resolution_supported
   - wi_fi_band
   - wi_fi_standard
+  - width
   return_reasons:
   - video_quality
   - incompatible
@@ -26906,19 +28746,27 @@
   - color
   - compatible_voice_assistant
   - contrast_ratio_typical
+  - depth
   - display_resolution
   - display_technology
   - energy_efficiency_class_hdr
   - energy_efficiency_class_sdr
   - hdr_format
+  - height
+  - maximum_refresh_rate
   - native_aspect_ratio
   - pattern
+  - power_consumption_typical
+  - response_time
+  - rms_rated_power
+  - screen_size
   - smart_tv_platform
   - television_shape
   - television_specialized_features
   - tuner_type
   - vesa_mounting_pattern
   - wi_fi_standard
+  - width
   return_reasons:
   - size
   - video_quality
@@ -26973,12 +28821,15 @@
   - embellishment/trim_material
   - eyewear_frame_material
   - eyewear_lens_material
+  - height
   - jewelry_material
+  - length
   - lens_color_combination
   - material
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - style
@@ -27005,9 +28856,12 @@
   - color
   - compatible_device
   - device_interface
+  - height
+  - length
   - material
   - pattern
   - vesa_mounting_pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -27026,11 +28880,14 @@
   - color_accuracy_standards
   - compatible_device
   - device_interface
+  - height
+  - length
   - material
   - operating_system
   - pattern
   - supported_display_technologies
   - usb_connector_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -27166,9 +29023,12 @@
   - device_interface
   - display_resolution
   - display_technology
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -27185,9 +29045,12 @@
   - color
   - durability_features
   - fabric
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -27201,10 +29064,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mount/stand_features
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -27222,9 +29088,11 @@
   - battery_type
   - color
   - compatible_device
+  - depth
   - display_resolution
   - display_technology
   - features
+  - height
   - light_rejection_type
   - material
   - mounting_type
@@ -27232,7 +29100,9 @@
   - pattern
   - screen_material
   - screen_operation_type
+  - screen_size
   - tensioning_system
+  - width
   return_reasons:
   - size
   - incompatible
@@ -27249,11 +29119,14 @@
   - angles_supported
   - color
   - compatible_device
+  - height
   - height_adjustment
+  - length
   - material
   - mount/stand_features
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -27269,11 +29142,14 @@
   attributes:
   - color
   - compatible_device
+  - height
   - lamp_assembly_type
   - lamp_quality_grade
+  - length
   - material
   - pattern
   - projector_light_source
+  - width
   return_reasons:
   - brightness
   - incompatible
@@ -27342,12 +29218,15 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - material
   - media_format
   - mounting_type
   - pattern
   - power_source
   - rewinder_operation_mode
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -27372,10 +29251,13 @@
   - device_interface
   - display_resolution
   - display_technology
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - vesa_mounting_pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -27390,11 +29272,14 @@
   attributes:
   - color
   - compatible_device
+  - height
+  - length
   - material
   - mount/stand_features
   - mounting_type
   - pattern
   - vesa_mounting_pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -27410,12 +29295,15 @@
   attributes:
   - color
   - device_interface
+  - height
+  - length
   - material
   - pattern
   - power_source
   - recording_capability_type
   - video_port_type
   - video_resolution_supported
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -27429,10 +29317,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - light_source
   - material
   - pattern
   - replacement_lamp_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -27446,10 +29337,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - speaker_technology
   - television_speaker_position
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -27584,12 +29478,15 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - mounting_type
   - operating_system
   - pattern
   - power_source
   - video_port_type
   - video_resolution_supported
+  - width
   return_reasons:
   - video_quality
   - incompatible
@@ -27669,9 +29566,12 @@
   attributes:
   - color
   - device_interface
+  - height
+  - length
   - pattern
   - supported_sdi_standards
   - video_signal_standard
+  - width
   return_reasons:
   - video_quality
   - incompatible
@@ -27699,10 +29599,13 @@
   - connectivity_technology
   - device_interface
   - energy_efficiency_class
+  - height
+  - length
   - media_format
   - pattern
   - player/recorder_specialized_features
   - video_codecs/formats_supported
+  - width
   return_reasons:
   - video_quality
   - incompatible
@@ -27723,6 +29626,9 @@
   - connectivity_technology
   - device_interface
   - energy_efficiency_class
+  - height
+  - internal_storage_capacity
+  - length
   - media_format
   - pattern
   - recorder_specialized_features
@@ -27731,6 +29637,7 @@
   - video_codecs/formats_supported
   - video_recorder_type
   - video_resolution_supported
+  - width
   return_reasons:
   - video_quality
   - incompatible
@@ -27753,6 +29660,9 @@
   - color
   - connectivity_technology
   - energy_efficiency_class
+  - height
+  - internal_storage_capacity
+  - length
   - media_format
   - pattern
   - playback_disc_formats
@@ -27761,6 +29671,7 @@
   - video_region_code
   - video_resolution_supported
   - wi_fi_standard
+  - width
   return_reasons:
   - video_quality
   - incompatible
@@ -27807,6 +29718,9 @@
   - color
   - connectivity_technology
   - energy_efficiency_class
+  - height
+  - internal_storage_capacity
+  - length
   - media_format
   - pattern
   - playback_disc_formats
@@ -27816,6 +29730,7 @@
   - video_port_type
   - video_region_code
   - video_resolution_supported
+  - width
   return_reasons:
   - video_quality
   - incompatible
@@ -27837,6 +29752,9 @@
   - connectivity_technology
   - energy_efficiency_class
   - hdr_format
+  - height
+  - internal_storage_capacity
+  - length
   - media_player_form_factor
   - operating_system
   - pattern
@@ -27844,6 +29762,7 @@
   - video_codecs/formats_supported
   - video_resolution_supported
   - wi_fi_standard
+  - width
   return_reasons:
   - video_quality
   - incompatible
@@ -27864,6 +29783,8 @@
   - connectivity_technology
   - device_interface
   - energy_efficiency_class
+  - height
+  - length
   - media_format
   - pattern
   - recorder_specialized_features
@@ -27871,6 +29792,7 @@
   - vcr_configuration
   - video_codecs/formats_supported
   - video_port_type
+  - width
   return_reasons:
   - video_quality
   - incompatible
@@ -27978,12 +29900,16 @@
   - color
   - compression_format
   - ethernet_lan_interface_type
+  - height
+  - internal_storage_capacity
+  - length
   - operating_system
   - pattern
   - raid_levels_supported
   - storage_drive_interfaces_supported
   - storage_drive_type_installed
   - storage_types_supported
+  - width
   return_reasons:
   - storage_capacity
   - video_quality
@@ -28007,13 +29933,18 @@
   - device_interface
   - external_antenna_connector_type
   - frequency/radio_bands_supported
+  - height
+  - length
+  - maximum_transmission_distance
   - mounting_type
   - pattern
   - power_source
   - security_algorithms
+  - transmission_power
   - video_codecs/formats_supported
   - video_resolution_supported
   - wi_fi_standard
+  - width
   return_reasons:
   - range
   - video_quality
@@ -28187,10 +30118,13 @@
   - color
   - connectivity_technology
   - device_interface
+  - height
+  - length
   - material
   - pattern
   - power_source
   - video_game_platform
+  - width
   - wireless_charging_standard
   return_reasons:
   - size
@@ -28215,9 +30149,12 @@
   attributes:
   - color
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
   - video_game_platform
+  - width
   return_reasons:
   - size
   - style
@@ -28235,9 +30172,12 @@
   - color
   - connectivity_technology
   - finish
+  - height
+  - length
   - material
   - pattern
   - video_game_platform
+  - width
   return_reasons:
   - color
   - style
@@ -28376,9 +30316,12 @@
   attributes:
   - color
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
   - video_game_platform
+  - width
   return_reasons:
   - size
   - style
@@ -28401,10 +30344,13 @@
   - connectivity_technology
   - docking_compatibility
   - durability_features
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pattern
   - video_game_platform
+  - width
   return_reasons:
   - size
   - color
@@ -28422,10 +30368,13 @@
   attributes:
   - color
   - connectivity_technology
+  - height
+  - length
   - material
   - pattern
   - screen_protector_finish
   - video_game_platform
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -28443,11 +30392,14 @@
   - connectivity_technology
   - finish
   - game_console_skin_coverage
+  - height
+  - length
   - material
   - pattern
   - texture
   - theme
   - video_game_platform
+  - width
   return_reasons:
   - color
   - style
@@ -28650,10 +30602,14 @@
   - console_system
   - console_type
   - energy_efficiency_class
+  - height
+  - internal_storage_capacity
+  - length
   - pattern
   - power_source
   - region_code
   - usb_connector_type
+  - width
   return_reasons:
   - color
   - storage_capacity

--- a/data/categories/fb_food_beverages_tobacco.yml
+++ b/data/categories/fb_food_beverages_tobacco.yml
@@ -40,9 +40,12 @@
   - allergen_information
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - ingredients
   - organic_certification
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -69,6 +72,9 @@
   - country
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -89,7 +95,10 @@
   - country
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - package_type
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -108,6 +117,9 @@
   - country
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -125,7 +137,10 @@
   - country
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -143,7 +158,10 @@
   - country
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - hard_cider_variety
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -177,6 +195,9 @@
   - dietary_preferences
   - dietary_supplements
   - distillation_method
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -199,6 +220,9 @@
   - dietary_preferences
   - dietary_supplements
   - distillation_method
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -220,6 +244,9 @@
   - dietary_preferences
   - dietary_supplements
   - distillation_method
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -239,7 +266,10 @@
   - dietary_preferences
   - dietary_supplements
   - distillation_method
+  - energy_per_100_ml
+  - energy_per_serving
   - gin_variety
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -258,8 +288,11 @@
   - dietary_preferences
   - dietary_supplements
   - distillation_method
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - liqueur_variety
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -279,7 +312,10 @@
   - dietary_preferences
   - dietary_supplements
   - distillation_method
+  - energy_per_100_ml
+  - energy_per_serving
   - rum_grade
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -302,8 +338,11 @@
   - dietary_preferences
   - dietary_supplements
   - distillation_method
+  - energy_per_100_ml
+  - energy_per_serving
   - shochu_soju_variety
   - spirit_dilution
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -323,11 +362,14 @@
   - dietary_preferences
   - dietary_supplements
   - distillation_method
+  - energy_per_100_ml
+  - energy_per_serving
   - koji_mold_type
   - maturation_vessel_material
   - shochu_base_ingredient
   - shochu_soju_variety
   - spirit_dilution
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -347,8 +389,11 @@
   - dietary_preferences
   - dietary_supplements
   - distillation_method
+  - energy_per_100_ml
+  - energy_per_serving
   - shochu_soju_variety
   - spirit_dilution
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -369,8 +414,11 @@
   - dietary_preferences
   - dietary_supplements
   - distillation_method
+  - energy_per_100_ml
+  - energy_per_serving
   - region
   - tequila_variety
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -390,9 +438,12 @@
   - dietary_preferences
   - dietary_supplements
   - distillation_method
+  - energy_per_100_ml
+  - energy_per_serving
   - filtration_method
   - flavor
   - vodka_base_ingredient
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -406,13 +457,17 @@
   name: Whiskey
   children: []
   attributes:
+  - aging
   - allergen_information
   - country
   - dietary_preferences
   - dietary_supplements
   - distillation_method
+  - energy_per_100_ml
+  - energy_per_serving
   - peat_level
   - region
+  - volume
   - whiskey_style
   - whiskey_variety
   return_reasons:
@@ -525,6 +580,9 @@
   - country
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -544,6 +602,9 @@
   - country
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -563,6 +624,9 @@
   - country
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -582,6 +646,9 @@
   - country
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -602,6 +669,9 @@
   - country
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -621,6 +691,9 @@
   - country
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - texture
@@ -643,6 +716,9 @@
   - country
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -708,8 +784,11 @@
   - country
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - grape_variety
   - region
+  - volume
   - wine_body
   - wine_style
   - wine_sweetness
@@ -763,7 +842,10 @@
   - allergen_information
   - buttermilk_variety
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -832,13 +914,17 @@
   - caffeine_content
   - coffee_bean_species
   - coffee_beverage_variety
+  - coffee_growing_altitude
   - coffee_processing_method
   - coffee_product_form
   - coffee_roast
   - country
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   return_reasons:
   - taste
   - roast_level
@@ -862,9 +948,12 @@
   - decaffeination_method
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - food_product_form
   - grind_size
+  - net_weight
   return_reasons:
   - taste
   - roast_level
@@ -888,7 +977,10 @@
   - country
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   return_reasons:
   - taste
   - roast_level
@@ -910,8 +1002,11 @@
   - country
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - instant_coffee_form
+  - net_weight
   return_reasons:
   - taste
   - roast_level
@@ -977,9 +1072,12 @@
   - allergen_information
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - package_type
   - sugar_content_level
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -1049,9 +1147,12 @@
   - allergen_information
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - package_type
   - texture_inclusions
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -1107,6 +1208,9 @@
   - allergen_information
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   return_reasons:
   - taste
   - dietary_requirements
@@ -1127,6 +1231,9 @@
   - cocoa_product_form
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   return_reasons:
   - taste
   - dietary_requirements
@@ -1143,6 +1250,9 @@
   - allergen_information
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   return_reasons:
   - taste
   - dietary_requirements
@@ -1159,6 +1269,9 @@
   - allergen_information
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   return_reasons:
   - taste
   - consistency
@@ -1210,11 +1323,14 @@
   - allergen_information
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - fruit_source
   - juice_processing_method
   - package_type
   - pulp_content
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -1292,6 +1408,9 @@
   - carbonation
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -1309,6 +1428,9 @@
   - carbonation
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -1326,6 +1448,9 @@
   - carbonation
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -1344,6 +1469,9 @@
   - cocktail_mix_variety
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -1361,6 +1489,9 @@
   - carbonation
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -1385,6 +1516,9 @@
   - carbonation
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -1507,6 +1641,9 @@
   - carbonation
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   - wine_carbonation
   return_reasons:
   - taste
@@ -1553,8 +1690,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - fat_content
   - milk_processing_method
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -1578,6 +1718,9 @@
   - allergen_information
   - barista_suitability
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -1594,6 +1737,9 @@
   - allergen_information
   - barista_suitability
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -1615,6 +1761,9 @@
   - allergen_information
   - barista_suitability
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -1688,9 +1837,12 @@
   - allergen_information
   - barista_suitability
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - formulation_style
   - nutrient_fortification
   - sweetening_type
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -1708,6 +1860,9 @@
   - allergen_information
   - barista_suitability
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -1725,6 +1880,9 @@
   - allergen_information
   - barista_suitability
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -1772,7 +1930,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   - powdered_beverage_variety
   return_reasons:
   - taste
@@ -1835,9 +1996,13 @@
   - allergen_information
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - package_type
   - soda_variety
+  - sugar_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -1857,7 +2022,11 @@
   - beverage_product_form
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - package_type
+  - protein_per_serving
+  - volume
   return_reasons:
   - taste
   - caffeine_level
@@ -1876,8 +2045,12 @@
   - beverage_product_form
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - package_type
+  - protein_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -1895,7 +2068,11 @@
   - beverage_product_form
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - package_type
+  - protein_per_serving
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -1917,7 +2094,10 @@
   - caffeine_content
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
+  - net_weight
   - tea_input_type
   - tea_variety
   return_reasons:
@@ -1938,8 +2118,12 @@
   - caffeine_content
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - herbal_infusion_function
+  - net_weight
+  - steeping_temperature
   - tea_input_type
   - tea_variety
   return_reasons:
@@ -1967,7 +2151,11 @@
   - caffeine_content
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
+  - net_weight
+  - recommended_water_temperature
   - tea_input_type
   - tea_variety
   return_reasons:
@@ -1988,6 +2176,7 @@
   - dietary_preferences
   - dietary_supplements
   - flavor
+  - recommended_water_temperature
   - tea_input_type
   - tea_variety
   return_reasons:
@@ -2006,6 +2195,7 @@
   - dietary_preferences
   - dietary_supplements
   - flavor
+  - recommended_water_temperature
   - tea_input_type
   - tea_variety
   return_reasons:
@@ -2024,6 +2214,7 @@
   - dietary_preferences
   - dietary_supplements
   - flavor
+  - recommended_water_temperature
   - tea_input_type
   - tea_variety
   return_reasons:
@@ -2042,6 +2233,7 @@
   - dietary_preferences
   - dietary_supplements
   - flavor
+  - recommended_water_temperature
   - tea_input_type
   - tea_variety
   return_reasons:
@@ -2060,6 +2252,7 @@
   - dietary_preferences
   - dietary_supplements
   - flavor
+  - recommended_water_temperature
   - tea_input_type
   - tea_variety
   return_reasons:
@@ -2078,6 +2271,7 @@
   - dietary_preferences
   - dietary_supplements
   - flavor
+  - recommended_water_temperature
   - tea_input_type
   - tea_variety
   return_reasons:
@@ -2096,6 +2290,7 @@
   - dietary_preferences
   - dietary_supplements
   - flavor
+  - recommended_water_temperature
   - tea_input_type
   - tea_variety
   return_reasons:
@@ -2114,6 +2309,7 @@
   - dietary_preferences
   - dietary_supplements
   - flavor
+  - recommended_water_temperature
   - tea_input_type
   - tea_variety
   return_reasons:
@@ -2169,9 +2365,12 @@
   - allergen_information
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - sweetener_type
   - vinegar_drink_variety
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -2198,8 +2397,11 @@
   - container_material
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - package_type
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -2218,8 +2420,11 @@
   - container_material
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - package_type
+  - volume
   - water_source
   return_reasons:
   - taste
@@ -2239,8 +2444,11 @@
   - dietary_preferences
   - dietary_supplements
   - distilled_water_intended_use
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - package_type
+  - volume
   - water_purification_method
   return_reasons:
   - taste
@@ -2259,9 +2467,12 @@
   - container_material
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - package_type
   - packaging_material
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -2279,8 +2490,11 @@
   - container_material
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - package_type
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -2400,9 +2614,13 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - food_product_form
   - ingredients
+  - net_volume
+  - net_weight
   - safety_certifications
   - storage_requirements
   return_reasons:
@@ -2439,8 +2657,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - flour/grain_type
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -2459,8 +2680,11 @@
   - allergen_information
   - bagel_size
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - flour/grain_type
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -2479,7 +2703,10 @@
   - allergen_information
   - bakery_items_included
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flour/grain_type
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -2498,8 +2725,11 @@
   - allergen_information
   - bread_variety
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - flour/grain_type
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -2519,9 +2749,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - flour/grain_type
   - frosting_or_icing_type
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -2546,9 +2779,12 @@
   - allergen_information
   - cake_type
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - flour/grain_type
   - frosting_or_icing_type
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -2676,9 +2912,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - flour/grain_type
   - frosting_or_icing_type
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -2732,8 +2971,11 @@
   - cake_shape
   - cake_topping
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - flour/grain_type
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -2757,9 +2999,12 @@
   - allergen_information
   - cookie_variety
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - filling_type
   - flavor
   - flour/grain_type
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -2868,8 +3113,11 @@
   - allergen_information
   - cupcake_size
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - flour/grain_type
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -2887,8 +3135,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - flour/grain_type
+  - net_weight
   - storage_requirements
   - topping_type
   return_reasons:
@@ -2907,8 +3158,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - flour/grain_type
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -2929,9 +3183,13 @@
   - fb-2-1-10-4
   attributes:
   - allergen_information
+  - cone_height
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - flour/grain_type
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -2948,6 +3206,7 @@
   children: []
   attributes:
   - allergen_information
+  - cone_height
   - dietary_preferences
   - flavor
   - flour/grain_type
@@ -2964,6 +3223,7 @@
   children: []
   attributes:
   - allergen_information
+  - cone_height
   - dietary_preferences
   - flavor
   - flour/grain_type
@@ -2980,6 +3240,7 @@
   children: []
   attributes:
   - allergen_information
+  - cone_height
   - dietary_preferences
   - flavor
   - flour/grain_type
@@ -2996,6 +3257,7 @@
   children: []
   attributes:
   - allergen_information
+  - cone_height
   - dietary_preferences
   - flavor
   - flour/grain_type
@@ -3013,9 +3275,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - flour/grain_type
   - muffin_size
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -3042,8 +3307,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - flour/grain_type
+  - net_weight
   - pastry_filling_type
   - storage_requirements
   return_reasons:
@@ -3218,8 +3486,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - flour/grain_type
+  - net_weight
   - pie_crust_type
   - product_format
   - storage_requirements
@@ -3293,7 +3564,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flour/grain_type
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -3313,7 +3587,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flour/grain_type
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -3412,7 +3689,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - fruit_variety
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -3430,7 +3710,10 @@
   - allergen_information
   - candying_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - fruit_variety
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -3448,7 +3731,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - fruit_variety
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -3483,8 +3769,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   - storage_requirements
+  - sugars_per_100_g
   return_reasons:
   - taste
   - texture
@@ -3509,8 +3799,12 @@
   - allergen_information
   - candy_texture
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   - storage_requirements
+  - sugars_per_100_g
   return_reasons:
   - taste
   - texture
@@ -3530,6 +3824,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
+  - sugars_per_100_g
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -3546,6 +3841,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
+  - sugars_per_100_g
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -3562,6 +3858,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
+  - sugars_per_100_g
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -3578,6 +3875,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
+  - sugars_per_100_g
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -3594,6 +3892,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
+  - sugars_per_100_g
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -3610,6 +3909,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
+  - sugars_per_100_g
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -3626,6 +3926,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
+  - sugars_per_100_g
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -3647,8 +3948,12 @@
   - chocolate_type
   - country
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   - storage_requirements
+  - sugars_per_100_g
   return_reasons:
   - taste
   - texture
@@ -3669,6 +3974,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
+  - sugars_per_100_g
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -3686,6 +3992,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
+  - sugars_per_100_g
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -3703,6 +4010,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
+  - sugars_per_100_g
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -3720,6 +4028,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
+  - sugars_per_100_g
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -3737,6 +4046,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
+  - sugars_per_100_g
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -3754,6 +4064,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
+  - sugars_per_100_g
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -3796,8 +4107,13 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
   - heat_level
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -3814,7 +4130,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -3832,8 +4153,13 @@
   - allergen_information
   - curry_variety
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
   - heat_level
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -3854,9 +4180,14 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
+  - net_weight
   - storage_requirements
   - topping_form
+  - volume
   return_reasons:
   - taste
   - texture
@@ -3873,10 +4204,15 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - fruit_topping_format
+  - net_weight
   - storage_requirements
   - topping_form
+  - volume
   return_reasons:
   - taste
   - texture
@@ -3893,9 +4229,14 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
+  - net_weight
   - storage_requirements
   - topping_form
+  - volume
   return_reasons:
   - taste
   - texture
@@ -3944,7 +4285,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -3961,7 +4306,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -3978,12 +4328,17 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
   - honey_form
   - honey_processing_method
   - honey_variety
+  - net_weight
   - package_type
   - storage_requirements
   - usda_honey_grade
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4001,7 +4356,12 @@
   - allergen_information
   - condiment_form
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4018,9 +4378,14 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
   - heat_level
+  - net_weight
   - sauce_product_form
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4037,8 +4402,13 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   - package_type
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4055,9 +4425,14 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
   - heat_level
+  - net_weight
   - recommended_food_pairing
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4074,7 +4449,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4091,7 +4471,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4110,9 +4495,13 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - olive_variety
   - preservation_medium
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4128,10 +4517,15 @@
   children: []
   attributes:
   - allergen_information
+  - caper_size
   - caper_size_grade
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - preservation_medium
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4149,8 +4543,12 @@
   - allergen_information
   - curing_or_preparation_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - preservation_medium
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4167,10 +4565,15 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
   - heat_level
+  - net_weight
   - pasta_sauce_texture
   - pasta_sauce_variety
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4189,8 +4592,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - pickling_method
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4237,9 +4644,14 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
   - heat_level
+  - net_weight
   - sauce_consistency
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4259,8 +4671,13 @@
   - allergen_information
   - condiment_texture
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
   - heat_level
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4309,8 +4726,13 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   - salad_dressing_type
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4327,7 +4749,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4344,9 +4771,13 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - fermentation_method
+  - net_weight
   - soy_sauce_variety
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4363,9 +4794,14 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
   - heat_level
   - intended_culinary_use
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4382,8 +4818,15 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   - syrup_variety
+  - total_sugars_per_100_g
+  - total_sugars_per_serving
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4400,9 +4843,14 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   - sesame_seed_hull_status
   - sesame_seed_roast_level
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4419,7 +4867,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4439,8 +4892,13 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   - sauce_variety
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4502,7 +4960,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4604,8 +5066,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - ingredient_processing_method
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -4623,6 +5089,9 @@
   - allergen_information
   - baking_chip_form
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -4641,6 +5110,9 @@
   - allergen_information
   - chocolate_form
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -4658,10 +5130,15 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - flavor_intensity
   - flavor_solvent_base
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -4678,6 +5155,9 @@
   - allergen_information
   - baking_purpose
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -4695,7 +5175,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - leavening_action_type
+  - net_weight
   - storage_requirements
   return_reasons:
   - dietary_requirements
@@ -4711,6 +5194,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - dietary_requirements
@@ -4726,6 +5212,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -4749,6 +5238,9 @@
   - allergen_information
   - bean_paste_variety
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -4842,6 +5334,9 @@
   - allergen_information
   - bread_crumb_base_ingredient
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -4863,6 +5358,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -4880,6 +5378,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -4897,6 +5398,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -4914,6 +5418,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -4947,6 +5454,9 @@
   - color
   - cookie_decorating_kit_items_included
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - pattern
   - storage_requirements
   return_reasons:
@@ -4977,8 +5487,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - oil_processing_method
+  - smoke_point
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -4995,9 +5509,13 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - oil_processing_method
   - refinement_level
+  - smoke_point
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -5015,8 +5533,12 @@
   - allergen_information
   - coconut_oil_refinement_type
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - oil_processing_method
+  - smoke_point
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -5033,8 +5555,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - oil_processing_method
+  - smoke_point
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -5051,8 +5577,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - oil_processing_method
+  - smoke_point
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -5069,8 +5599,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - oil_processing_method
+  - smoke_point
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -5087,8 +5621,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - oil_processing_method
+  - smoke_point
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -5105,9 +5643,13 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - oil_processing_method
   - sesame_seed_variety
+  - smoke_point
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -5124,8 +5666,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - oil_processing_method
+  - smoke_point
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -5142,9 +5688,13 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - oil_processing_method
+  - smoke_point
   - storage_requirements
   - sunflower_oil_variety
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -5161,8 +5711,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - oil_processing_method
+  - smoke_point
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -5180,6 +5734,7 @@
   - allergen_information
   - dietary_preferences
   - oil_processing_method
+  - smoke_point
   - storage_requirements
   return_reasons:
   - taste
@@ -5197,6 +5752,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - starch_processing_type
   - starch_source
   - storage_requirements
@@ -5215,7 +5773,10 @@
   - allergen_information
   - cooking_wine_variety
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -5232,8 +5793,13 @@
   - allergen_information
   - corn_syrup_variety
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   - primary_sweetener_source
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -5259,8 +5825,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flour/grain_type
   - leavening_agent
+  - net_weight
   - primary_dish_application
   - storage_requirements
   return_reasons:
@@ -5280,8 +5849,11 @@
   - allergen_information
   - dietary_preferences
   - dough_format
+  - energy_per_100_g
+  - energy_per_serving
   - flour/grain_type
   - leavening_agent
+  - net_weight
   - primary_dish_application
   - storage_requirements
   return_reasons:
@@ -5300,9 +5872,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flour/grain_type
   - intended_consumption
   - leavening_agent
+  - net_weight
   - primary_dish_application
   - storage_requirements
   return_reasons:
@@ -5322,8 +5897,11 @@
   - allergen_information
   - crust_taste_profile
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flour/grain_type
   - leavening_agent
+  - net_weight
   - pastry_crust_state
   - pastry_crust_style
   - primary_dish_application
@@ -5451,6 +6029,9 @@
   - allergen_information
   - color
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - pattern
   - storage_requirements
   return_reasons:
@@ -5536,7 +6117,12 @@
   - dietary_preferences
   - egg_component_replaced
   - egg_replacer_main_ingredient
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -5553,8 +6139,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - floss_sugar_granulation_grade
   - floss_sugar_product_form
+  - net_weight
   - storage_requirements
   return_reasons:
   - color
@@ -5573,9 +6162,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flour/grain_type
   - flour_grind_texture
   - flour_processing_method
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -5595,9 +6187,14 @@
   - color
   - coloring_finish
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
   - food_coloring_form
+  - net_weight
   - pattern
   - storage_requirements
+  - volume
   return_reasons:
   - color
   - consistency
@@ -5618,6 +6215,9 @@
   - allergen_information
   - color
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - pattern
   - storage_requirements
   return_reasons:
@@ -5685,8 +6285,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - juice_form
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -5703,9 +6306,12 @@
   - allergen_information
   - color
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - gelatin_or_gelling_agent_source
   - marshmallow_processing_method
   - marshmallow_size
+  - net_weight
   - pattern
   - storage_requirements
   return_reasons:
@@ -5724,7 +6330,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - fat_per_100_g
   - milling_process
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -5742,8 +6352,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - molasses_base_ingredient
   - molasses_grade
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -5765,7 +6378,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - filling_consistency
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -5845,8 +6461,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - fat_rendering_state
   - hydrogenation_level
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -5901,7 +6520,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - fermentation_application
+  - net_weight
   - storage_requirements
   return_reasons:
   - dietary_requirements
@@ -5998,6 +6620,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -6014,6 +6639,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   - sugar_refinement_level
   - sugar_source
@@ -6033,7 +6661,10 @@
   - allergen_information
   - anti_caking_agent
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - icing_sugar_variety
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -6053,6 +6684,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -6114,6 +6748,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   - syrup_base_ingredient
   return_reasons:
@@ -6209,6 +6846,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -6227,6 +6867,9 @@
   - allergen_information
   - concentration_level
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -6244,12 +6887,17 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
   - food_product_form
   - gel_strength
   - gelatin_form
   - gelatin_source
   - leaf_gelatin_grade
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - texture
   - dietary_requirements
@@ -6265,9 +6913,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - filtration_and_mother_status
   - storage_requirements
   - vinegar_variety
+  - volume
   return_reasons:
   - taste
   - dietary_requirements
@@ -6283,6 +6934,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -6303,7 +6957,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - yeast_application
   return_reasons:
@@ -6439,8 +7096,13 @@
   - allergen_information
   - beta_casein_variant
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
   - milk_source_animal
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -6466,7 +7128,10 @@
   - allergen_information
   - beta_casein_variant
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - fat_source
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -6486,7 +7151,10 @@
   - allergen_information
   - beta_casein_variant
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - fat_source
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -6505,8 +7173,11 @@
   - allergen_information
   - beta_casein_variant
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - fat_source
   - food_product_form
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -6527,8 +7198,11 @@
   - beta_casein_variant
   - butter_variety
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - fat_source
   - milk_feeding_method
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -6548,7 +7222,10 @@
   - allergen_information
   - beta_casein_variant
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - fat_source
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -6619,6 +7296,9 @@
   - cheese_texture
   - country
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -6638,8 +7318,12 @@
   - beta_casein_variant
   - coffee_creamer_variety
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - fat_content
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -6658,7 +7342,10 @@
   - beta_casein_variant
   - curd_size
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - fat_content
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -6688,8 +7375,11 @@
   - cream_base_ingredient
   - cream_variety
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - fat_content
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -6710,8 +7400,11 @@
   - cream_base_ingredient
   - cream_variety
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - fat_content
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -6733,8 +7426,11 @@
   - cream_variety
   - dairy_heat_treatment
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - fat_content
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -6879,9 +7575,12 @@
   - allergen_information
   - beta_casein_variant
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - fat_content
   - sour_cream_variety
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -6899,8 +7598,11 @@
   - allergen_information
   - beta_casein_variant
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - fat_content
   - storage_requirements
+  - volume
   - whipped_cream_base
   - whipped_cream_form
   return_reasons:
@@ -6920,8 +7622,11 @@
   - allergen_information
   - beta_casein_variant
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - fat_content
   - flavor
+  - net_weight
   - storage_requirements
   - yogurt_base_ingredient
   return_reasons:
@@ -6985,6 +7690,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - spread_consistency
   - storage_requirements
   return_reasons:
@@ -7004,6 +7712,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - spread_consistency
   - storage_requirements
   return_reasons:
@@ -7022,6 +7733,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - spread_consistency
   - storage_requirements
   return_reasons:
@@ -7042,7 +7756,10 @@
   - cream_cheese_base
   - cream_cheese_form
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   - spread_consistency
   - storage_requirements
   return_reasons:
@@ -7061,6 +7778,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - spread_consistency
   - storage_requirements
   return_reasons:
@@ -7079,7 +7799,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - hummus_base_ingredient
+  - net_weight
   - spread_consistency
   - storage_requirements
   return_reasons:
@@ -7098,8 +7821,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - jam_and_jelly_consistency
+  - net_weight
   - spread_consistency
   - spread_variety
   - storage_requirements
@@ -7119,6 +7845,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - nut_butter_texture
   - nut_butter_variety
   - spread_consistency
@@ -7140,6 +7869,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - spread_consistency
   - storage_requirements
   return_reasons:
@@ -7158,6 +7890,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - spread_consistency
   - storage_requirements
   - tapenade_main_ingredients
@@ -7177,6 +7912,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - spread_consistency
   - storage_requirements
   return_reasons:
@@ -7243,7 +7981,10 @@
   - allergen_information
   - color
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_basket_items_included
+  - net_weight
   - pattern
   - storage_requirements
   return_reasons:
@@ -7302,8 +8043,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -7327,7 +8071,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -7344,7 +8091,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -7361,7 +8111,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -7378,8 +8131,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - ice_cream_format
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -7396,7 +8152,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -7413,7 +8172,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -7464,7 +8226,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -7566,7 +8331,10 @@
   - allergen_information
   - base_type
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -7623,8 +8391,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - drained_weight
+  - energy_per_100_g
+  - energy_per_serving
   - food_packing_medium
   - food_product_form
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -7644,6 +8416,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - packing_medium
   - storage_requirements
   return_reasons:
@@ -7699,6 +8474,9 @@
   - allergen_information
   - cut_or_preparation_style
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -7806,6 +8584,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -7826,7 +8607,10 @@
   - allergen_information
   - dietary_preferences
   - drying_method
+  - energy_per_100_g
+  - energy_per_serving
   - fruit_piece_form
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -7876,6 +8660,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -7894,6 +8681,9 @@
   - allergen_information
   - dietary_preferences
   - dry_bean_variety
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -7957,9 +8747,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cultivar_or_variety
   - fruit_cut_style
+  - net_weight
   - ripeness_stage
   - storage_requirements
   return_reasons:
@@ -7979,8 +8772,11 @@
   - allergen_information
   - apple_variety
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   - taste_profile
   return_reasons:
@@ -8000,8 +8796,11 @@
   - allergen_information
   - atemoya_cultivar
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8020,8 +8819,11 @@
   - allergen_information
   - avocado_variety
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8039,8 +8841,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8059,8 +8864,11 @@
   - allergen_information
   - banana_variety
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8086,8 +8894,11 @@
   - allergen_information
   - berry_species
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8224,8 +9035,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8243,8 +9057,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8263,8 +9080,11 @@
   - allergen_information
   - cherimoya_variety
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8293,8 +9113,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - seed_content
   - storage_requirements
   return_reasons:
@@ -8313,8 +9136,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - seed_content
   - storage_requirements
   return_reasons:
@@ -8333,9 +9159,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
   - kumquat_variety
+  - net_weight
   - seed_content
   - storage_requirements
   return_reasons:
@@ -8354,9 +9183,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
   - lemon_variety
+  - net_weight
   - seed_content
   - storage_requirements
   return_reasons:
@@ -8375,8 +9207,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - seed_content
   - storage_requirements
   return_reasons:
@@ -8395,9 +9230,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
   - lime_variety
+  - net_weight
   - seed_content
   - storage_requirements
   return_reasons:
@@ -8416,8 +9254,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - seed_content
   - storage_requirements
   return_reasons:
@@ -8436,8 +9277,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - seed_content
   - storage_requirements
   return_reasons:
@@ -8527,8 +9371,11 @@
   - coconut_maturity_stage
   - coconut_preparation_form
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8547,8 +9394,11 @@
   - allergen_information
   - date_variety
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8566,9 +9416,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - feijoa_cultivar
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8586,9 +9439,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - fig_variety
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8606,9 +9462,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
   - fruit_mix_variety
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8626,8 +9485,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8645,10 +9507,13 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
   - guava_flesh_color
   - guava_variety
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8666,8 +9531,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8685,9 +9553,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
   - kiwifruit_variety
+  - net_weight
   - produce_grade
   - storage_requirements
   return_reasons:
@@ -8706,9 +9577,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
   - longan_variety
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8726,9 +9600,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
   - loquat_variety
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8746,9 +9623,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
   - lychee_cultivar
+  - net_weight
   - seed_size_classification
   - storage_requirements
   return_reasons:
@@ -8767,8 +9647,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8786,8 +9669,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8805,9 +9691,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
   - mangosteen_variety
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8825,10 +9714,13 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flesh_color
   - food_product_form
   - fruit_cut_style
   - melon_variety
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8846,8 +9738,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - papaya_variety
   - storage_requirements
   return_reasons:
@@ -8866,8 +9761,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - passion_fruit_variety
   - storage_requirements
   return_reasons:
@@ -8886,8 +9784,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - pear_variety
   - storage_requirements
   return_reasons:
@@ -8906,8 +9807,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - persimmon_variety
   - storage_requirements
   return_reasons:
@@ -8926,8 +9830,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - physalis_variety
   - storage_requirements
   return_reasons:
@@ -8946,8 +9853,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -8965,8 +9875,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - pitahaya_flesh_color
   - storage_requirements
   return_reasons:
@@ -8985,8 +9898,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - pomegranate_product_form
   - pomegranate_variety
   - storage_requirements
@@ -9006,8 +9922,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - quince_variety
   - storage_requirements
   return_reasons:
@@ -9026,8 +9945,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -9045,8 +9967,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - sapodillo_variety
   - storage_requirements
   return_reasons:
@@ -9065,8 +9990,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - sapote_variety
   - storage_requirements
   return_reasons:
@@ -9085,8 +10013,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -9104,8 +10035,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - starfruit_variety
   - storage_requirements
   return_reasons:
@@ -9130,8 +10064,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -9149,8 +10086,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -9169,8 +10109,11 @@
   - allergen_information
   - cherry_variety
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -9188,8 +10131,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -9207,8 +10153,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - stone_adhesion
   - stone_fruit_cultivar
   - stone_fruit_variety
@@ -9229,8 +10178,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - plumcot_variety
   - storage_requirements
   return_reasons:
@@ -9249,8 +10201,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - plum_variety
   - storage_requirements
   return_reasons:
@@ -9269,8 +10224,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -9288,8 +10246,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - fruit_cut_style
+  - net_weight
   - storage_requirements
   - tamarind_variety
   return_reasons:
@@ -9422,7 +10383,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9442,8 +10406,11 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - farming_practice
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9465,7 +10432,10 @@
   - artichoke_variety
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9485,7 +10455,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9507,7 +10480,10 @@
   - bean_variety
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9528,7 +10504,10 @@
   - beet_variety
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9549,7 +10528,10 @@
   - cooking_method
   - dietary_preferences
   - edible_plant_part
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9571,7 +10553,10 @@
   - broccoli_variety
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9593,7 +10578,10 @@
   - brussels_sprout_variety
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9614,7 +10602,10 @@
   - cabbage_variety
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9634,7 +10625,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9654,7 +10648,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9676,7 +10673,10 @@
   - carrot_variety
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9697,7 +10697,10 @@
   - cauliflower_variety
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9719,7 +10722,10 @@
   - celery_variety
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9739,7 +10745,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9761,7 +10770,10 @@
   - corn_presentation
   - corn_variety
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9782,7 +10794,10 @@
   - cooking_method
   - cucumber_variety
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9803,7 +10818,10 @@
   - cooking_method
   - dietary_preferences
   - eggplant_variety
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9823,9 +10841,12 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - fennel_trimming
   - fennel_variety
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9845,7 +10866,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9865,7 +10889,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9885,7 +10912,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9905,9 +10935,12 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - garlic_preparation_style
   - garlic_variety
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9927,9 +10960,12 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - ginger_maturity
   - ginger_variety
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9949,8 +10985,11 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - gobo_root_variety
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -9989,8 +11028,11 @@
   - cooking_method
   - cultivation_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - greens_maturity_stage
+  - net_weight
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
@@ -10012,10 +11054,13 @@
   - cooking_method
   - cultivation_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - greens_maturity_stage
   - greens_preparation_state
   - harvest_stage
+  - net_weight
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
@@ -10037,8 +11082,11 @@
   - cooking_method
   - cultivation_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - greens_maturity_stage
+  - net_weight
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
@@ -10061,8 +11109,11 @@
   - cooking_method
   - cultivation_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - greens_maturity_stage
+  - net_weight
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
@@ -10085,8 +11136,11 @@
   - cooking_method
   - cultivation_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - greens_maturity_stage
+  - net_weight
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
@@ -10109,8 +11163,11 @@
   - cooking_method
   - cultivation_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - greens_maturity_stage
+  - net_weight
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
@@ -10133,8 +11190,11 @@
   - cooking_method
   - cultivation_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - greens_maturity_stage
+  - net_weight
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
@@ -10156,9 +11216,12 @@
   - cooking_method
   - cultivation_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - greens_maturity_stage
   - kale_variety
+  - net_weight
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
@@ -10180,9 +11243,12 @@
   - cooking_method
   - cultivation_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - greens_maturity_stage
   - lettuce_variety
+  - net_weight
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
@@ -10204,8 +11270,11 @@
   - cooking_method
   - cultivation_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - greens_maturity_stage
+  - net_weight
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
@@ -10227,9 +11296,12 @@
   - cooking_method
   - cultivation_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - greens_maturity_stage
   - leaf_preparation
+  - net_weight
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
@@ -10252,8 +11324,11 @@
   - cooking_method
   - cultivation_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - greens_maturity_stage
+  - net_weight
   - produce_washing_state
   - spinach_preparation_style
   - spinach_variety
@@ -10277,8 +11352,11 @@
   - cooking_method
   - cultivation_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - greens_maturity_stage
+  - net_weight
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
@@ -10419,7 +11497,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - recommended_storage
   - root_variety
   - storage_requirements
@@ -10441,7 +11522,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -10461,8 +11545,11 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - kohlrabi_variety
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -10482,8 +11569,11 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - leek_variety
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -10503,7 +11593,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -10523,8 +11616,11 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - malanga_variety
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -10544,8 +11640,11 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - mushroom_variety
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -10565,7 +11664,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - okra_variety
   - storage_requirements
   - vegetable_preparation_style
@@ -10586,7 +11688,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - onion_variety
   - storage_requirements
   - vegetable_preparation_style
@@ -10607,7 +11712,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - parsley_root_variety
   - storage_requirements
   - vegetable_preparation_style
@@ -10628,7 +11736,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - parsnip_variety
   - storage_requirements
   - vegetable_preparation_style
@@ -10649,7 +11760,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -10669,7 +11783,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -10689,7 +11806,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - potato_cut_style
   - potato_intended_use
   - potato_variety
@@ -10712,7 +11832,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - radish_variety
   - storage_requirements
   - vegetable_preparation_style
@@ -10733,7 +11856,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - rhubarb_product_cut_type
   - storage_requirements
   - vegetable_preparation_style
@@ -10754,7 +11880,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - shallot_variety
   - storage_requirements
   - vegetable_preparation_style
@@ -10775,7 +11904,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - sprout_presentation
   - storage_requirements
   - vegetable_preparation_style
@@ -10796,7 +11928,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - squash_and_gourd_variety
   - storage_requirements
   - vegetable_preparation_style
@@ -10817,7 +11952,11 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
+  - stalk_length
   - storage_requirements
   - sugar_cane_variety
   - vegetable_preparation_style
@@ -10838,7 +11977,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - sunchoke_variety
   - vegetable_preparation_style
@@ -10859,7 +12001,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - sweet_potato_variety
   - vegetable_preparation_style
@@ -10880,7 +12025,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - tamarillo_variety
   - vegetable_preparation_style
@@ -10901,7 +12049,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - taro_variety
   - vegetable_preparation_style
@@ -10922,7 +12073,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -10944,7 +12098,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - turnip_and_rutabaga_variety
   - vegetable_preparation_style
@@ -11001,7 +12158,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -11021,7 +12181,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - preparation_style
   - storage_requirements
   - vegetable_preparation_style
@@ -11042,7 +12205,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - produce_growth_stage
   - storage_requirements
   - vegetable_preparation_style
@@ -11064,7 +12230,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -11084,7 +12253,10 @@
   - allergen_information
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   - yam_variety
@@ -11106,7 +12278,10 @@
   - cassava_variety
   - cooking_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   - vegetable_preparation_style
   return_reasons:
@@ -11142,7 +12317,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_100_ml
+  - energy_per_serving
+  - net_weight
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - texture
@@ -11193,7 +12373,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - grain_processing_method
+  - net_weight
   - rice_grain_length
   - storage_requirements
   return_reasons:
@@ -11211,7 +12394,11 @@
   children: []
   attributes:
   - allergen_information
+  - carbohydrates_per_100_g
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11229,6 +12416,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11248,6 +12438,9 @@
   - buckwheat_processing_method
   - buckwheat_product_form
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11268,8 +12461,12 @@
   attributes:
   - allergen_information
   - cereal_type
+  - dietary_fiber_per_serving
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11287,6 +12484,7 @@
   attributes:
   - allergen_information
   - cereal_type
+  - dietary_fiber_per_serving
   - dietary_preferences
   - flavor
   - storage_requirements
@@ -11303,6 +12501,7 @@
   attributes:
   - allergen_information
   - cereal_type
+  - dietary_fiber_per_serving
   - dietary_preferences
   - flavor
   - storage_requirements
@@ -11319,6 +12518,7 @@
   attributes:
   - allergen_information
   - cereal_type
+  - dietary_fiber_per_serving
   - dietary_preferences
   - flavor
   - storage_requirements
@@ -11335,6 +12535,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11352,8 +12555,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - millet_processing_method
   - millet_variety
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11378,7 +12584,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11501,6 +12710,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - quinoa_variety
   - storage_requirements
   return_reasons:
@@ -11519,6 +12731,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - rice_processing_method
   - rice_variety
   - storage_requirements
@@ -11538,6 +12753,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11555,7 +12773,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - grind_size
+  - net_weight
   - storage_requirements
   - wheat_product_form
   return_reasons:
@@ -11690,6 +12911,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11716,6 +12940,9 @@
   - egg_production_method
   - egg_size
   - egg_source_animal
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11735,6 +12962,9 @@
   - egg_production_method
   - egg_source_animal
   - egg_white_processing_method
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11755,7 +12985,10 @@
   - egg_farming_method
   - egg_production_method
   - egg_source_animal
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11774,6 +13007,9 @@
   - dietary_preferences
   - egg_production_method
   - egg_source_animal
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11795,6 +13031,9 @@
   - egg_production_method
   - egg_source_animal
   - eggshell_color
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11851,9 +13090,12 @@
   - allergen_information
   - animal_raising_method
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - meat_processing_state
   - meat_quality_grade
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11874,7 +13116,10 @@
   - canned_meat_form
   - canned_meat_variety
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - meat_processing_state
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11904,9 +13149,12 @@
   - cooking_method
   - cuisine
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - meat_processing_state
   - meat_raising_claim
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11929,10 +13177,13 @@
   - cooking_method
   - cuisine
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - meat_cut
   - meat_processing_state
   - meat_raising_claim
+  - net_weight
   - raising_method
   - storage_requirements
   return_reasons:
@@ -11955,10 +13206,13 @@
   - cooking_method
   - cuisine
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - meat_cut
   - meat_processing_state
   - meat_raising_claim
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -11980,10 +13234,13 @@
   - cooking_method
   - cuisine
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - meat_cut
   - meat_processing_state
   - meat_raising_claim
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -12005,11 +13262,14 @@
   - cooking_method
   - cuisine
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - farming_method
   - food_product_form
   - meat_cut
   - meat_processing_state
   - meat_raising_claim
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -12033,10 +13293,13 @@
   - cooking_method
   - cuisine
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - meat_cut
   - meat_processing_state
   - meat_raising_claim
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -12059,10 +13322,13 @@
   - cooking_state
   - cuisine
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - meat_cut
   - meat_processing_state
   - meat_raising_claim
+  - net_weight
   - skin_presence
   - storage_requirements
   return_reasons:
@@ -12085,10 +13351,13 @@
   - cooking_method
   - cuisine
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - meat_cut
   - meat_processing_state
   - meat_raising_claim
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -12177,8 +13446,11 @@
   - animal_raising_method
   - deli_meat_variety
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - meat_processing_state
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -12254,6 +13526,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - seafood_cut
   - seafood_processing_method
   - seafood_source
@@ -12274,7 +13549,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - harvest_method
+  - net_weight
   - seafood_source
   - seafood_type
   - storage_requirements
@@ -12296,7 +13574,10 @@
   - cooking_method
   - cuisine
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - seafood_source
   - seafood_type
   - storage_requirements
@@ -12352,6 +13633,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - nut/seed_type
   - nut_processing_method
   - salt_level
@@ -12372,7 +13656,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - pasta_type
   - storage_requirements
   return_reasons:
@@ -12394,9 +13681,13 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - heating_instructions
   - meal_course
+  - net_weight
+  - preparation_time
   - storage_requirements
   return_reasons:
   - taste
@@ -12418,9 +13709,13 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - heating_instructions
   - meal_course
+  - net_weight
+  - preparation_time
   - serving_temperature
   - storage_requirements
   return_reasons:
@@ -12493,10 +13788,14 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - heating_instructions
   - meal_course
   - meal_preparation_state
+  - net_weight
+  - preparation_time
   - storage_requirements
   return_reasons:
   - taste
@@ -12540,7 +13839,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - seasoning_variety
   - storage_requirements
   return_reasons:
@@ -12558,8 +13860,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
   - material_treatment
+  - net_weight
   - plant_material
   - storage_requirements
   return_reasons:
@@ -12577,6 +13882,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -12593,7 +13901,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - food_product_form
+  - net_weight
   - pepper_variety
   - storage_requirements
   return_reasons:
@@ -12611,7 +13922,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - iodization
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -12732,8 +14046,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - food_product_form
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -12752,6 +14069,9 @@
   - allergen_information
   - breadstick_style
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -12775,6 +14095,9 @@
   - bar_coating
   - bar_texture
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - protein_source
   - storage_requirements
   return_reasons:
@@ -12797,7 +14120,10 @@
   - cereal_bar_texture
   - coating_type
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   - protein_source
   - storage_requirements
   return_reasons:
@@ -12818,6 +14144,9 @@
   - bar_coating
   - bar_texture
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - protein_source
   - storage_requirements
   return_reasons:
@@ -12871,6 +14200,9 @@
   - allergen_information
   - cheese_variety
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -12889,7 +14221,10 @@
   - allergen_information
   - chip_cut_style
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -12907,7 +14242,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -12925,7 +14263,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -12946,7 +14287,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - fruit_snack_form
+  - net_weight
   - snack_processing_method
   - storage_requirements
   return_reasons:
@@ -13015,8 +14359,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - jerky_form
   - meat_type
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -13070,6 +14417,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - popcorn_form
   - popcorn_kernel_variety
   - storage_requirements
@@ -13153,6 +14503,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - pork_rind_form
   - storage_requirements
   return_reasons:
@@ -13171,7 +14524,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   - pretzel_coating
   - pretzel_shape
   - storage_requirements
@@ -13193,8 +14549,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - gelling_agent
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -13244,7 +14603,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -13262,6 +14624,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - salad_topping_base_ingredient
   - storage_requirements
   return_reasons:
@@ -13280,7 +14645,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   - snack_texture
   - storage_requirements
   return_reasons:
@@ -13299,7 +14667,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -13320,7 +14691,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
+  - net_weight
   - storage_requirements
   return_reasons:
   - taste
@@ -13387,6 +14761,9 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - snack_mix_variety
   - storage_requirements
   return_reasons:
@@ -13529,8 +14906,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_ml
+  - energy_per_serving
   - soup_or_broth_variety
   - storage_requirements
+  - volume
   return_reasons:
   - taste
   - consistency
@@ -13557,6 +14937,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
+  - protein_per_100_g
   - storage_requirements
   return_reasons:
   - taste
@@ -13575,7 +14959,11 @@
   - allergen_information
   - cheese_alternative_form
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - primary_plant_base
+  - protein_per_100_g
   - storage_requirements
   return_reasons:
   - taste
@@ -13598,8 +14986,12 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
   - preparation_state
   - primary_plant_protein_source
+  - protein_per_100_g
   - storage_requirements
   return_reasons:
   - taste
@@ -13619,6 +15011,7 @@
   - dietary_preferences
   - preparation_state
   - primary_plant_protein_source
+  - protein_per_100_g
   - storage_requirements
   return_reasons:
   - changed_my_mind
@@ -13635,6 +15028,7 @@
   - dietary_preferences
   - preparation_state
   - primary_plant_protein_source
+  - protein_per_100_g
   - storage_requirements
   return_reasons:
   - changed_my_mind
@@ -13651,6 +15045,7 @@
   - dietary_preferences
   - preparation_state
   - primary_plant_protein_source
+  - protein_per_100_g
   - storage_requirements
   return_reasons:
   - changed_my_mind
@@ -13667,6 +15062,7 @@
   - dietary_preferences
   - preparation_state
   - primary_plant_protein_source
+  - protein_per_100_g
   - storage_requirements
   return_reasons:
   - changed_my_mind
@@ -13683,6 +15079,7 @@
   - dietary_preferences
   - preparation_state
   - primary_plant_protein_source
+  - protein_per_100_g
   - storage_requirements
   return_reasons:
   - changed_my_mind
@@ -13697,6 +15094,11 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - fat_per_serving
+  - net_weight
+  - protein_per_100_g
   - storage_requirements
   return_reasons:
   - taste
@@ -13714,6 +15116,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
+  - protein_per_100_g
   - storage_requirements
   return_reasons:
   - taste
@@ -13735,6 +15141,10 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - energy_per_100_g
+  - energy_per_serving
+  - net_weight
+  - protein_per_100_g
   - storage_requirements
   - tofu_preparation_style
   return_reasons:
@@ -13753,6 +15163,7 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - protein_per_100_g
   - storage_requirements
   - tofu_preparation_style
   return_reasons:
@@ -13768,6 +15179,7 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - protein_per_100_g
   - storage_requirements
   - tofu_preparation_style
   return_reasons:
@@ -13783,6 +15195,7 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - protein_per_100_g
   - storage_requirements
   - tofu_preparation_style
   return_reasons:
@@ -13798,6 +15211,7 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - protein_per_100_g
   - storage_requirements
   - tofu_preparation_style
   return_reasons:
@@ -13813,6 +15227,7 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - protein_per_100_g
   - storage_requirements
   return_reasons:
   - changed_my_mind
@@ -13827,6 +15242,7 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - protein_per_100_g
   - storage_requirements
   return_reasons:
   - changed_my_mind
@@ -13841,6 +15257,7 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - protein_per_100_g
   - storage_requirements
   return_reasons:
   - changed_my_mind
@@ -13855,6 +15272,7 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - protein_per_100_g
   - storage_requirements
   return_reasons:
   - changed_my_mind
@@ -13869,6 +15287,7 @@
   attributes:
   - allergen_information
   - dietary_preferences
+  - protein_per_100_g
   - storage_requirements
   return_reasons:
   - changed_my_mind
@@ -13905,7 +15324,10 @@
   children: []
   attributes:
   - chewing_tobacco_form
+  - net_weight
+  - nicotine_content
   - strength_classification
+  - tar_yield
   - tobacco_type
   return_reasons:
   - flavor
@@ -13923,6 +15345,8 @@
   - cigarette_filter_type
   - cigarette_size
   - cigarette_strength_descriptor
+  - nicotine_content
+  - tar_yield
   - tobacco_type
   return_reasons:
   - flavor
@@ -13939,6 +15363,11 @@
   attributes:
   - cigar_body
   - cigar_wrapper_color
+  - height
+  - length
+  - nicotine_content
+  - tar_yield
+  - width
   return_reasons:
   - flavor
   - nicotine_strength
@@ -13957,6 +15386,9 @@
   - fb-3-5-4
   - fb-3-5-5
   attributes:
+  - net_weight
+  - nicotine_content
+  - tar_yield
   - tobacco_application
   - tobacco_cut_type
   - tobacco_strength
@@ -14055,12 +15487,18 @@
   - fb-3-6-3
   - fb-3-6-4
   attributes:
+  - bowl_depth
+  - bowl_diameter
   - color
   - compatible_pipe_filter_size
+  - height
+  - joint_size
+  - length
   - pattern
   - pipe_shape
   - stem_material
   - tobacco_type
+  - width
   return_reasons:
   - color
   - style
@@ -14076,8 +15514,11 @@
   name: Chillums & One-Hitters
   children: []
   attributes:
+  - bowl_depth
+  - bowl_diameter
   - color
   - compatible_pipe_filter_size
+  - joint_size
   - pattern
   - pipe_shape
   - stem_material
@@ -14093,8 +15534,11 @@
   name: Water Pipes & Bongs
   children: []
   attributes:
+  - bowl_depth
+  - bowl_diameter
   - color
   - compatible_pipe_filter_size
+  - joint_size
   - pattern
   - pipe_shape
   - stem_material
@@ -14110,8 +15554,11 @@
   name: Traditional Smoking Pipes
   children: []
   attributes:
+  - bowl_depth
+  - bowl_diameter
   - color
   - compatible_pipe_filter_size
+  - joint_size
   - pattern
   - pipe_shape
   - stem_material
@@ -14127,8 +15574,11 @@
   name: Hand Pipes
   children: []
   attributes:
+  - bowl_depth
+  - bowl_diameter
   - color
   - compatible_pipe_filter_size
+  - joint_size
   - pattern
   - pipe_shape
   - stem_material
@@ -14157,8 +15607,11 @@
   - color
   - e_cigarette/vaporizer_style
   - e_liquid_flavor
+  - nicotine_content
+  - nicotine_strength
   - pattern
   - vaping_style
+  - volume
   return_reasons:
   - color
   - style
@@ -14176,9 +15629,12 @@
   - color
   - e_liquid_flavor
   - e_liquid_variety
+  - nicotine_content
   - nicotine_source
+  - nicotine_strength
   - pattern
   - vg/pg_ratio
+  - volume
   return_reasons:
   - flavor
   - nicotine_strength
@@ -14195,9 +15651,13 @@
   - coil_connection
   - color
   - e_cigarette/vaporizer_style
+  - e_liquid_capacity
   - e_liquid_flavor
+  - nicotine_content
+  - nicotine_strength
   - pattern
   - vaping_style
+  - volume
   return_reasons:
   - color
   - style
@@ -14223,8 +15683,11 @@
   - e_cigarette/vaporizer_style
   - e_liquid_flavor
   - heating_technology
+  - nicotine_content
+  - nicotine_strength
   - pattern
   - vaping_style
+  - volume
   return_reasons:
   - color
   - style
@@ -14364,10 +15827,13 @@
   attributes:
   - burn_rate
   - color
+  - height
+  - length
   - pattern
   - rolling_paper_format
   - rolling_paper_gum_type
   - rolling_paper_size
+  - width
   return_reasons:
   - size
   - flavor

--- a/data/categories/fr_furniture.yml
+++ b/data/categories/fr_furniture.yml
@@ -83,7 +83,10 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -106,8 +109,11 @@
   attributes:
   - bassinet_cradle_accessory_features
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -228,7 +234,11 @@
   - baby/toddler_furniture_features
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -247,7 +257,11 @@
   - baby/toddler_furniture_features
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -266,7 +280,11 @@
   - baby/toddler_furniture_features
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -285,8 +303,12 @@
   - color
   - crib/toddler_bed_features
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - side_wall_mechanism
+  - width
   return_reasons:
   - size
   - color
@@ -305,7 +327,11 @@
   - baby/toddler_furniture_features
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -325,7 +351,11 @@
   - color
   - cradle_capacity
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -344,7 +374,11 @@
   - baby/toddler_furniture_features
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -363,7 +397,11 @@
   - baby/toddler_furniture_features
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -382,7 +420,11 @@
   - baby/toddler_furniture_features
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -401,8 +443,12 @@
   - baby/toddler_furniture_features
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - travel_bassinet_accessories_included
+  - width
   return_reasons:
   - size
   - color
@@ -438,7 +484,11 @@
   - baby/toddler_furniture_features
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -459,6 +509,7 @@
   attributes:
   - color
   - compatible_crib_format
+  - compatible_mattress_dimensions
   - crib_accessory_features
   - material
   - pattern
@@ -486,7 +537,10 @@
   attributes:
   - color
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -504,8 +558,11 @@
   attributes:
   - color
   - fabric
+  - height
+  - length
   - liner_padding_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -523,8 +580,11 @@
   attributes:
   - color
   - fabric
+  - height
+  - length
   - pattern
   - rail_coverage_configuration
+  - width
   return_reasons:
   - size
   - color
@@ -542,7 +602,10 @@
   attributes:
   - color
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -561,7 +624,10 @@
   - color
   - crib_bumper_features
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -579,7 +645,10 @@
   attributes:
   - color
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -597,7 +666,10 @@
   attributes:
   - color
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -616,8 +688,11 @@
   - color
   - converted_bed_size
   - crib_conversion_kit_components
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -677,7 +752,11 @@
   - convertible_configuration
   - crib/toddler_bed_features
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -695,8 +774,12 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - toddler_bed_features
+  - width
   return_reasons:
   - size
   - color
@@ -714,8 +797,12 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - toddler_bed_features
+  - width
   return_reasons:
   - size
   - color
@@ -732,9 +819,13 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
   - ladder_position
+  - length
+  - maximum_load_capacity
   - pattern
   - toddler_bed_features
+  - width
   return_reasons:
   - size
   - color
@@ -753,7 +844,11 @@
   - color
   - crib_features
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -771,8 +866,12 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - toddler_bed_features
+  - width
   return_reasons:
   - size
   - color
@@ -791,7 +890,11 @@
   - color
   - crib_features
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -809,8 +912,12 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - toddler_bed_features
+  - width
   return_reasons:
   - size
   - color
@@ -828,7 +935,11 @@
   - color
   - crib_features
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -849,8 +960,11 @@
   - fr-1-7-4
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -930,7 +1044,11 @@
   - baby/toddler_seat_features
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -948,8 +1066,12 @@
   attributes:
   - baby/toddler_seat_features
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -968,8 +1090,12 @@
   - baby/toddler_seat_features
   - color
   - convertible_high_chair_modes
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -987,8 +1113,12 @@
   attributes:
   - baby/toddler_seat_features
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -1006,8 +1136,12 @@
   attributes:
   - baby/toddler_seat_features
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -1040,9 +1174,15 @@
   name: Play Sofas
   children: []
   attributes:
+  - armrest_height
   - color
+  - height
+  - length
   - pattern
+  - seat_depth
+  - seat_height
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -1149,7 +1289,10 @@
   - color
   - compatible_bed_frame_style
   - compatible_mattress_size
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1269,7 +1412,11 @@
   - compatible_mattress_size
   - furniture/fixture_material
   - headboard_style
+  - height
+  - length
   - pattern
+  - underbed_clearance_height
+  - width
   return_reasons:
   - size
   - color
@@ -1291,9 +1438,12 @@
   - color
   - compatible_mattress_size
   - headboard_style
+  - height
   - included_pump_type
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - too_firm
@@ -1317,9 +1467,12 @@
   - compatible_mattress_size
   - furniture/fixture_material
   - headboard_style
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - top_bunk_access_method
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -1344,8 +1497,11 @@
   - compatible_mattress_size
   - furniture/fixture_material
   - headboard_style
+  - height
+  - length
   - pattern
   - under_bed_features
+  - width
   return_reasons:
   - size
   - color
@@ -1367,7 +1523,10 @@
   - compatible_mattress_size
   - furniture/fixture_material
   - headboard_style
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1390,7 +1549,10 @@
   - compatible_mattress_size
   - furniture/fixture_material
   - headboard_style
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1413,7 +1575,10 @@
   - compatible_mattress_size
   - furniture/fixture_material
   - headboard_style
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1435,7 +1600,10 @@
   - compatible_mattress_size
   - furniture/fixture_material
   - headboard_style
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1459,9 +1627,12 @@
   - compatible_mattress_size
   - furniture/fixture_material
   - headboard_style
+  - height
+  - length
   - loft_bed_height_classification
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -1486,7 +1657,10 @@
   - compatible_mattress_size
   - furniture/fixture_material
   - headboard_style
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1509,7 +1683,10 @@
   - furniture/fixture_material
   - furniture_finish
   - headboard_style
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1531,8 +1708,12 @@
   - compatible_mattress_size
   - furniture/fixture_material
   - headboard_style
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - underbed_clearance
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -1555,7 +1736,10 @@
   - compatible_mattress_size
   - furniture/fixture_material
   - headboard_style
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1577,7 +1761,10 @@
   - compatible_mattress_size
   - furniture/fixture_material
   - headboard_style
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1599,8 +1786,11 @@
   - compatible_mattress_size
   - furniture/fixture_material
   - headboard_style
+  - height
+  - length
   - pattern
   - trundle_mechanism
+  - width
   return_reasons:
   - size
   - color
@@ -1622,9 +1812,13 @@
   - compatible_mattress_size
   - furniture/fixture_material
   - headboard_style
+  - height
   - integrated_furniture_function
+  - length
   - lift_mechanism_type
+  - maximum_mattress_thickness
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1645,9 +1839,13 @@
   - color
   - compatible_mattress_size
   - headboard_style
+  - height
+  - length
   - material
   - pattern
+  - water_capacity
   - waterbed_stabilization_level
+  - width
   return_reasons:
   - size
   - color
@@ -1667,6 +1865,9 @@
   - footboard_mounting_type
   - footboard_style
   - furniture/fixture_material
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -1684,7 +1885,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1717,9 +1921,12 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - slat_color
   - slat_material
   - slat_pattern
+  - width
   return_reasons:
   - size
   - height
@@ -1745,11 +1952,14 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - lumber/wood_type
   - massage_feature
   - slat_color
   - slat_material
   - slat_pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -1775,9 +1985,12 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - slat_color
   - slat_material
   - slat_pattern
+  - width
   return_reasons:
   - size
   - height
@@ -1800,9 +2013,12 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - slat_color
   - slat_material
   - slat_pattern
+  - width
   return_reasons:
   - size
   - height
@@ -1825,9 +2041,12 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - slat_color
   - slat_material
   - slat_pattern
+  - width
   return_reasons:
   - size
   - height
@@ -1851,9 +2070,12 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - slat_color
   - slat_material
   - slat_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1880,9 +2102,12 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - slat_color
   - slat_material
   - slat_pattern
+  - width
   return_reasons:
   - size
   - height
@@ -1905,9 +2130,12 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - slat_color
   - slat_material
   - slat_pattern
+  - width
   return_reasons:
   - size
   - height
@@ -1957,9 +2185,12 @@
   - coil_system_type
   - color
   - firmness
+  - height
+  - length
   - mattress_features
   - mattress_top_type
   - pattern
+  - width
   return_reasons:
   - size
   - too_firm
@@ -1977,9 +2208,12 @@
   - bedding_size
   - color
   - firmness
+  - height
+  - length
   - mattress_features
   - pattern
   - recommended_sleep_position
+  - width
   return_reasons:
   - size
   - too_firm
@@ -1998,8 +2232,11 @@
   - bedding_size
   - color
   - firmness
+  - height
+  - length
   - mattress_features
   - pattern
+  - width
   return_reasons:
   - size
   - too_firm
@@ -2017,9 +2254,12 @@
   - bedding_size
   - color
   - firmness
+  - height
   - innerspring_coil_type
+  - length
   - mattress_features
   - pattern
+  - width
   return_reasons:
   - size
   - too_firm
@@ -2037,10 +2277,13 @@
   - bedding_size
   - color
   - firmness
+  - height
   - latex_processing_method
   - latex_type
+  - length
   - mattress_features
   - pattern
+  - width
   return_reasons:
   - size
   - too_firm
@@ -2059,10 +2302,13 @@
   - bedding_size
   - color
   - firmness
+  - height
+  - length
   - mattress_features
   - memory_foam_infusion_material
   - pattern
   - sleep_position_suitability
+  - width
   return_reasons:
   - size
   - too_firm
@@ -2081,8 +2327,11 @@
   - bedding_size
   - color
   - firmness
+  - height
+  - length
   - mattress_features
   - pattern
+  - width
   return_reasons:
   - size
   - too_firm
@@ -2100,10 +2349,13 @@
   - bedding_size
   - color
   - firmness
+  - height
+  - length
   - mattress_features
   - pattern
   - water_chamber_configuration
   - water_mattress_construction
+  - width
   return_reasons:
   - size
   - too_firm
@@ -2161,7 +2413,10 @@
   - assembly_required
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2194,10 +2449,13 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - seat_type
   - upholstery_color
   - upholstery_material
   - upholstery_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2216,12 +2474,15 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - seat_color
   - seat_material
   - seat_pattern
   - seat_type
   - upholstery_color
   - upholstery_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2240,10 +2501,13 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - seat_type
   - upholstery_color
   - upholstery_material
   - upholstery_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2263,10 +2527,13 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - seat_type
   - upholstery_color
   - upholstery_material
   - upholstery_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2286,10 +2553,13 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - seat_type
   - upholstery_color
   - upholstery_material
   - upholstery_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2308,10 +2578,13 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - seat_type
   - upholstery_color
   - upholstery_material
   - upholstery_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2330,10 +2603,13 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - seat_type
   - upholstery_color
   - upholstery_material
   - upholstery_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2352,12 +2628,15 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
   - leg_style
+  - length
   - lumber/wood_type
   - seat_type
   - upholstery_color
   - upholstery_material
   - upholstery_pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2377,10 +2656,13 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - seat_type
   - upholstery_color
   - upholstery_material
   - upholstery_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2399,10 +2681,13 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - seat_type
   - upholstery_color
   - upholstery_material
   - upholstery_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2421,10 +2706,13 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - seat_type
   - upholstery_color
   - upholstery_material
   - upholstery_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2443,10 +2731,13 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - seat_type
   - upholstery_color
   - upholstery_material
   - upholstery_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2465,10 +2756,13 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - seat_type
   - upholstery_color
   - upholstery_material
   - upholstery_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2487,11 +2781,14 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - lumber/wood_type
   - seat_type
   - upholstery_color
   - upholstery_material
   - upholstery_pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2511,11 +2808,14 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - lumber/wood_type
   - seat_type
   - upholstery_color
   - upholstery_material
   - upholstery_pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2547,7 +2847,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2566,7 +2869,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2584,7 +2890,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2601,7 +2910,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2619,7 +2931,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2638,8 +2953,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2658,7 +2976,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2676,7 +2997,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2694,7 +3018,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2713,7 +3040,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2732,8 +3062,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - locker_bench_configuration
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2751,9 +3084,12 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - number_of_compartments
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2773,7 +3109,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2792,7 +3131,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2810,7 +3152,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2896,7 +3241,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2914,7 +3262,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2932,7 +3283,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2950,8 +3304,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2970,7 +3327,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2988,7 +3348,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3006,7 +3369,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3024,7 +3390,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3042,7 +3411,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3060,7 +3432,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3078,7 +3453,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3096,7 +3474,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3114,7 +3495,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3132,7 +3516,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3150,7 +3537,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3168,8 +3558,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - mirror_coverage
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3187,7 +3580,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3205,7 +3601,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3244,9 +3643,12 @@
   - frame_material
   - frame_pattern
   - furniture/fixture_features
+  - height
+  - length
   - top_color
   - top_material
   - top_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3278,7 +3680,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3295,7 +3700,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3312,8 +3720,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -3331,7 +3742,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3349,7 +3763,10 @@
   - back_panel_type
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3366,7 +3783,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3383,7 +3803,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3401,7 +3824,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3419,7 +3845,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3436,7 +3865,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3453,7 +3885,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3470,7 +3905,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3487,7 +3925,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3504,7 +3945,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3521,7 +3965,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3542,7 +3989,10 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3561,7 +4011,10 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3580,7 +4033,10 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3600,7 +4056,10 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3619,7 +4078,10 @@
   - color
   - drawer_features
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3637,7 +4099,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3655,8 +4120,13 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - ironing_board_length
+  - ironing_board_width
   - ironing_center_features
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3690,7 +4160,10 @@
   - cabinet_door_style
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3707,7 +4180,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3724,7 +4200,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3743,7 +4222,10 @@
   - color
   - door_closure_mechanism
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3762,7 +4244,10 @@
   - color
   - drawer_slide_type
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3779,7 +4264,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3796,7 +4284,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3813,7 +4304,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3830,7 +4324,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3847,7 +4344,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3864,8 +4364,14 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - oven_housing_configuration
+  - oven_opening_depth
+  - oven_opening_height
+  - oven_opening_width
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3883,7 +4389,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3901,7 +4410,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3919,7 +4431,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3936,7 +4451,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3953,6 +4471,9 @@
   children: []
   attributes:
   - furniture/fixture_material
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -3971,7 +4492,10 @@
   - color
   - door_hinge_position
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3988,7 +4512,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4008,7 +4535,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4060,12 +4590,15 @@
   - frame_material
   - frame_pattern
   - furniture/fixture_features
+  - height
   - leg_color
   - leg_material
   - leg_pattern
+  - length
   - top_color
   - top_material
   - top_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4086,7 +4619,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4164,7 +4700,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4182,9 +4721,12 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
   - interior_lining_material
+  - length
   - lid_hinge_mechanism
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4202,7 +4744,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4279,8 +4824,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - sink_material
+  - width
   return_reasons:
   - size
   - color
@@ -4300,7 +4848,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4347,7 +4898,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4366,7 +4920,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4385,7 +4942,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4404,7 +4964,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4422,7 +4985,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4441,7 +5007,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4459,8 +5028,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -4480,7 +5052,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4500,7 +5075,10 @@
   - color
   - faucet_hole_configuration
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4519,7 +5097,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4545,7 +5126,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4563,8 +5147,11 @@
   - bedroom_vanity_items_included
   - color
   - furniture/fixture_material
+  - height
+  - length
   - mirror_shape
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4581,7 +5168,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4598,8 +5188,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -4617,7 +5210,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4635,8 +5231,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - mirror_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4653,7 +5252,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4670,8 +5272,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - mirror_configuration
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4688,7 +5293,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4707,7 +5315,10 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   - wine_rack_design
   return_reasons:
   - size
@@ -4753,7 +5364,10 @@
   - basket_material
   - color
   - furniture/fixture_features
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4771,9 +5385,12 @@
   attributes:
   - color
   - furniture/fixture_features
+  - height
+  - length
   - material
   - pattern
   - transparency_level
+  - width
   return_reasons:
   - size
   - color
@@ -4792,7 +5409,10 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4811,7 +5431,10 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4831,7 +5454,10 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4851,7 +5477,10 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4888,7 +5517,10 @@
   - assembly_required
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4910,7 +5542,10 @@
   - caster_type
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4972,8 +5607,12 @@
   children: []
   attributes:
   - color
+  - depth
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4996,8 +5635,11 @@
   - fr-6-6
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -5017,8 +5659,11 @@
   - fr-6-1-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -5165,10 +5810,15 @@
   - care_instructions
   - chair_features
   - color
+  - height
+  - length
   - material
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5190,9 +5840,14 @@
   - backrest_type
   - chair_features
   - color
+  - height
+  - length
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5211,10 +5866,15 @@
   - backrest_type
   - chair_features
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -5234,12 +5894,17 @@
   - backrest_type
   - chair_features
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - recliner_control_type
   - recliner_motion_type
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -5259,9 +5924,14 @@
   - backrest_type
   - chair_features
   - color
+  - height
+  - length
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5283,8 +5953,13 @@
   - chair_features
   - color
   - filler_material
+  - height
+  - length
   - pattern
+  - seat_height
+  - seat_width
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5304,6 +5979,7 @@
   - color
   - filler_material
   - pattern
+  - seat_width
   - upholstery_material
   return_reasons:
   - changed_my_mind
@@ -5320,6 +5996,7 @@
   - color
   - filler_material
   - pattern
+  - seat_width
   - upholstery_material
   return_reasons:
   - changed_my_mind
@@ -5336,6 +6013,7 @@
   - color
   - filler_material
   - pattern
+  - seat_width
   - upholstery_material
   return_reasons:
   - changed_my_mind
@@ -5355,9 +6033,14 @@
   - backrest_type
   - chair_features
   - color
+  - height
+  - length
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5376,9 +6059,14 @@
   - backrest_type
   - chair_features
   - color
+  - height
+  - length
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5397,9 +6085,14 @@
   - backrest_type
   - chair_features
   - color
+  - height
+  - length
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5418,9 +6111,14 @@
   - backrest_type
   - chair_features
   - color
+  - height
+  - length
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5439,9 +6137,14 @@
   - backrest_type
   - chair_features
   - color
+  - height
+  - length
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5457,13 +6160,21 @@
   name: Electric Massaging Chairs
   children: []
   attributes:
+  - amperage
   - chair_features
   - color
+  - height
+  - length
   - massage_technique
   - pattern
+  - power_consumption_typical
   - power_source
+  - seat_height
+  - seat_width
   - treatment_area
   - upholstery_material
+  - voltage
+  - width
   return_reasons:
   - size
   - color
@@ -5486,9 +6197,14 @@
   - backrest_type
   - chair_features
   - color
+  - height
+  - length
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5509,6 +6225,7 @@
   - color
   - pattern
   - seat_type
+  - seat_width
   - upholstery_material
   return_reasons:
   - changed_my_mind
@@ -5526,6 +6243,7 @@
   - color
   - pattern
   - seat_type
+  - seat_width
   - upholstery_material
   return_reasons:
   - changed_my_mind
@@ -5543,6 +6261,7 @@
   - color
   - pattern
   - seat_type
+  - seat_width
   - upholstery_material
   return_reasons:
   - changed_my_mind
@@ -5560,6 +6279,7 @@
   - color
   - pattern
   - seat_type
+  - seat_width
   - upholstery_material
   return_reasons:
   - changed_my_mind
@@ -5577,9 +6297,14 @@
   - backrest_type
   - chair_features
   - color
+  - height
+  - length
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5598,10 +6323,15 @@
   - backrest_type
   - chair_features
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -5621,9 +6351,13 @@
   - backrest_type
   - chair_features
   - color
+  - height
+  - length
   - pattern
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5644,10 +6378,15 @@
   - chair_features
   - color
   - gas_lift_class
+  - height
+  - length
   - lumbar_support_type
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5666,9 +6405,14 @@
   - chair_features
   - color
   - hanging_chair_design
+  - height
+  - length
   - pattern
+  - seat_height
+  - seat_width
   - suitable_space
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5688,9 +6432,14 @@
   - backrest_type
   - chair_features
   - color
+  - height
+  - length
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5728,10 +6477,15 @@
   attributes:
   - chair_features
   - color
+  - height
+  - length
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - suitable_space
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5749,10 +6503,15 @@
   attributes:
   - chair_features
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - seat_height
+  - seat_width
   - suitable_space
   - upholstery_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -5772,9 +6531,14 @@
   - backrest_type
   - chair_features
   - color
+  - height
+  - length
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5794,10 +6558,15 @@
   - backrest_type
   - chair_features
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -5817,9 +6586,14 @@
   - backrest_type
   - chair_features
   - color
+  - height
+  - length
   - pattern
+  - seat_height
   - seat_type
+  - seat_width
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -5843,9 +6617,14 @@
   - color
   - footrest_type
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - seat_height
   - seat_height_category
   - seat_type
+  - seat_width
+  - width
   return_reasons:
   - size
   - color
@@ -5866,10 +6645,15 @@
   - color
   - footrest_type
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - seat_height
   - seat_height_category
   - seat_type
+  - seat_width
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -5892,10 +6676,15 @@
   - color
   - footrest_type
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - seat_height
   - seat_height_category
   - seat_type
+  - seat_width
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -5921,6 +6710,7 @@
   - pattern
   - seat_height_category
   - seat_type
+  - seat_width
   - wood_finish
   return_reasons:
   - changed_my_mind
@@ -5939,6 +6729,7 @@
   - color
   - pattern
   - seat_type
+  - seat_width
   - upholstery_material
   return_reasons:
   - changed_my_mind
@@ -5953,7 +6744,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -5974,15 +6768,18 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
   - leg_color
   - leg_material
   - leg_pattern
+  - length
   - material
   - mount/stand_features
   - pattern
   - top_color
   - top_material
   - top_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6005,8 +6802,11 @@
   - assembly_required
   - care_instructions
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6025,8 +6825,11 @@
   - bathroom_furniture_items_included
   - color
   - furniture/fixture_features
+  - height
+  - length
   - pattern
   - tabletop_shape
+  - width
   return_reasons:
   - size
   - color
@@ -6044,8 +6847,11 @@
   - bedroom_furniture_items_included
   - color
   - furniture/fixture_material
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6064,9 +6870,12 @@
   attributes:
   - color
   - furniture/fixture_features
+  - height
   - kitchen/dining_furniture_items_included
+  - length
   - pattern
   - tabletop_shape
+  - width
   return_reasons:
   - size
   - color
@@ -6118,11 +6927,14 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - living_room_furniture_items_included
   - seat_type
   - upholstery_color
   - upholstery_material
   - upholstery_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6143,9 +6955,12 @@
   - assembly_required
   - care_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -6165,8 +6980,11 @@
   - color
   - furniture/fixture_material
   - futon_frame_conversion_mechanism
+  - height
+  - length
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -6184,9 +7002,12 @@
   attributes:
   - color
   - firmness
+  - height
+  - length
   - pattern
   - suitable_space
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -6254,14 +7075,17 @@
   - frame_material
   - frame_pattern
   - furniture/fixture_features
+  - height
   - integrated_power_options
   - leg_color
   - leg_material
   - leg_pattern
+  - length
   - tabletop_color
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
+  - width
   return_reasons:
   - size
   - color
@@ -6464,7 +7288,10 @@
   - chair_features
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6481,8 +7308,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_furniture_items_included
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6503,7 +7333,10 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6521,9 +7354,12 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - tabletop_color
   - tabletop_material
   - tabletop_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6542,7 +7378,10 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6562,8 +7401,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - privacy_or_acoustic_feature
+  - width
   return_reasons:
   - size
   - color
@@ -6628,7 +7470,10 @@
   - fr-13-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6645,7 +7490,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6663,7 +7511,10 @@
   attributes:
   - color
   - furniture/fixture_features
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6685,7 +7536,10 @@
   - fr-13-3-5
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6769,9 +7623,12 @@
   - care_instructions
   - color
   - furniture/fixture_features
+  - height
+  - length
   - material
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -6824,9 +7681,12 @@
   - bedding_size
   - color
   - firmness
+  - height
+  - length
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6845,9 +7705,12 @@
   - bedding_size
   - color
   - firmness
+  - height
+  - length
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6867,9 +7730,12 @@
   - canopy_type
   - color
   - firmness
+  - height
+  - length
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6888,9 +7754,12 @@
   - bedding_size
   - color
   - firmness
+  - height
+  - length
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6909,9 +7778,12 @@
   - bedding_size
   - color
   - firmness
+  - height
+  - length
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6930,9 +7802,12 @@
   - bedding_size
   - color
   - firmness
+  - height
+  - length
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6951,9 +7826,12 @@
   - bedding_size
   - color
   - firmness
+  - height
+  - length
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6972,9 +7850,12 @@
   - bedding_size
   - color
   - firmness
+  - height
+  - length
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6994,11 +7875,14 @@
   - color
   - firmness
   - hanging_suspension_method
+  - height
+  - length
   - lumber/wood_type
   - mounting_type
   - outdoor_equipment_features
   - pattern
   - suspension_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -7018,8 +7902,11 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - outdoor_furniture_items_included
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7052,8 +7939,11 @@
   - fr-15-3-16
   attributes:
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -7069,8 +7959,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -7086,8 +7979,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -7103,9 +7999,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - upholstery_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -7122,8 +8021,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -7139,8 +8041,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -7157,8 +8062,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -7174,8 +8082,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -7191,8 +8102,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -7209,8 +8123,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -7226,8 +8143,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -7243,8 +8163,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -7261,8 +8184,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -7279,8 +8205,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -7296,8 +8225,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -7314,9 +8246,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - upholstery_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -7333,8 +8268,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - upholstery_material
+  - width
   return_reasons:
   - size
   - color
@@ -7379,10 +8317,13 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - outdoor_equipment_features
   - pattern
   - seat_structure
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -7401,9 +8342,12 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - outdoor_equipment_features
   - pattern
   - seat_structure
+  - width
   return_reasons:
   - size
   - color
@@ -7421,9 +8365,12 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - outdoor_equipment_features
   - pattern
   - seat_structure
+  - width
   return_reasons:
   - size
   - color
@@ -7442,11 +8389,14 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - movement_mechanism
   - outdoor_equipment_features
   - pattern
   - seat_structure
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -7493,10 +8443,13 @@
   - chair_features
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - seat_structure
   - seat_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -7517,9 +8470,12 @@
   - chair_features
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - seat_structure
   - seat_type
+  - width
   return_reasons:
   - size
   - color
@@ -7542,11 +8498,14 @@
   - chair_features
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - seat_fabric
   - seat_structure
   - seat_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -7611,9 +8570,12 @@
   - chair_features
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - seat_structure
   - seat_type
+  - width
   return_reasons:
   - size
   - color
@@ -7634,9 +8596,12 @@
   - chair_storage_design
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - seat_structure
   - seat_type
+  - width
   return_reasons:
   - size
   - color
@@ -7656,10 +8621,13 @@
   - chair_features
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - seat_structure
   - seat_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -7737,8 +8705,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sectional_configuration
+  - width
   return_reasons:
   - size
   - color
@@ -7756,8 +8727,13 @@
   - fr-15-4-4-1
   - fr-15-4-4-2
   attributes:
+  - armrest_height
   - color
+  - height
+  - length
   - pattern
+  - seat_depth
+  - width
   return_reasons:
   - size
   - color
@@ -7773,8 +8749,13 @@
   name: Loveseat Sofas
   children: []
   attributes:
+  - armrest_height
   - color
+  - height
+  - length
   - pattern
+  - seat_depth
+  - width
   return_reasons:
   - size
   - color
@@ -7790,8 +8771,14 @@
   name: Sectional Sofas
   children: []
   attributes:
+  - armrest_height
   - color
+  - cushion_thickness
+  - height
+  - length
   - pattern
+  - seat_depth
+  - width
   return_reasons:
   - size
   - color
@@ -7808,9 +8795,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - portability_features
   - seating_surface_material
+  - width
   return_reasons:
   - size
   - color
@@ -7841,9 +8831,12 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - shape
   - suitable_for_storage_type
+  - width
   return_reasons:
   - size
   - color
@@ -7871,8 +8864,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - tabletop_shape
+  - width
   return_reasons:
   - size
   - color
@@ -7889,8 +8885,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - tabletop_shape
+  - width
   return_reasons:
   - size
   - color
@@ -7907,8 +8906,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - tabletop_shape
+  - width
   return_reasons:
   - size
   - color
@@ -7925,9 +8927,12 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - tabletop_shape
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -7945,8 +8950,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - tabletop_shape
+  - width
   return_reasons:
   - size
   - color
@@ -7963,9 +8971,12 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - tabletop_shape
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -7987,8 +8998,12 @@
   - color
   - fire_pit_accessories_included
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_heat_output
   - pattern
   - tabletop_shape
+  - width
   return_reasons:
   - size
   - color
@@ -8006,6 +9021,7 @@
   - color
   - fire_pit_accessories_included
   - furniture/fixture_material
+  - maximum_heat_output
   - pattern
   - tabletop_shape
   return_reasons:
@@ -8022,6 +9038,7 @@
   - color
   - fire_pit_accessories_included
   - furniture/fixture_material
+  - maximum_heat_output
   - pattern
   - tabletop_shape
   return_reasons:
@@ -8038,6 +9055,7 @@
   - color
   - fire_pit_accessories_included
   - furniture/fixture_material
+  - maximum_heat_output
   - pattern
   - tabletop_shape
   return_reasons:
@@ -8057,8 +9075,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - tabletop_shape
+  - width
   return_reasons:
   - size
   - color
@@ -8135,9 +9156,13 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_suitable_water_depth
   - outdoor_table_functionality
   - pattern
   - tabletop_shape
+  - width
   return_reasons:
   - size
   - color
@@ -8187,7 +9212,10 @@
   - fr-16-4
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -8205,7 +9233,10 @@
   attributes:
   - color
   - cover_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -8263,7 +9294,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -8282,8 +9316,11 @@
   - assembly_required
   - color
   - foldability
+  - height
+  - length
   - pattern
   - style
+  - width
   return_reasons:
   - size
   - color
@@ -8305,6 +9342,8 @@
   - assembly_required
   - color
   - furniture/fixture_material
+  - maximum_load_capacity
+  - maximum_load_capacity_per_shelf
   - mounting_type
   - pattern
   - suitable_location
@@ -8332,9 +9371,14 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
+  - maximum_load_capacity_per_shelf
   - mounting_type
   - pattern
   - suitable_location
+  - width
   return_reasons:
   - size
   - color
@@ -8352,9 +9396,14 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
+  - maximum_load_capacity_per_shelf
   - mounting_type
   - pattern
   - suitable_location
+  - width
   return_reasons:
   - size
   - color
@@ -8372,9 +9421,14 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
+  - maximum_load_capacity_per_shelf
   - mounting_type
   - pattern
   - suitable_location
+  - width
   return_reasons:
   - size
   - color
@@ -8392,10 +9446,15 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
+  - maximum_load_capacity
+  - maximum_load_capacity_per_shelf
   - mounting_type
   - pattern
   - suitable_location
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -8413,9 +9472,14 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
+  - maximum_load_capacity_per_shelf
   - mounting_type
   - pattern
   - suitable_location
+  - width
   return_reasons:
   - size
   - color
@@ -8433,10 +9497,15 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
+  - maximum_load_capacity
+  - maximum_load_capacity_per_shelf
   - mounting_type
   - pattern
   - suitable_location
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -8455,6 +9524,7 @@
   attributes:
   - color
   - furniture/fixture_material
+  - maximum_load_capacity_per_shelf
   - mounting_type
   - pattern
   - suitable_location
@@ -8471,6 +9541,7 @@
   attributes:
   - color
   - furniture/fixture_material
+  - maximum_load_capacity_per_shelf
   - mounting_type
   - pattern
   - suitable_location
@@ -8493,9 +9564,14 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
+  - maximum_load_capacity_per_shelf
   - mounting_type
   - pattern
   - suitable_location
+  - width
   return_reasons:
   - size
   - color
@@ -8513,10 +9589,15 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
+  - maximum_load_capacity
+  - maximum_load_capacity_per_shelf
   - mounting_type
   - pattern
   - suitable_location
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -8535,10 +9616,15 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
+  - maximum_load_capacity
+  - maximum_load_capacity_per_shelf
   - mounting_type
   - pattern
   - suitable_location
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -8557,9 +9643,14 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
+  - maximum_load_capacity_per_shelf
   - mounting_type
   - pattern
   - suitable_location
+  - width
   return_reasons:
   - size
   - color
@@ -8577,9 +9668,14 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
+  - maximum_load_capacity_per_shelf
   - mounting_type
   - pattern
   - suitable_location
+  - width
   return_reasons:
   - size
   - color
@@ -8596,10 +9692,15 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
+  - maximum_load_capacity
+  - maximum_load_capacity_per_shelf
   - mounting_type
   - pattern
   - suitable_location
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -8619,6 +9720,7 @@
   attributes:
   - color
   - furniture/fixture_material
+  - maximum_load_capacity_per_shelf
   - mounting_type
   - pattern
   - suitable_location
@@ -8635,6 +9737,7 @@
   attributes:
   - color
   - furniture/fixture_material
+  - maximum_load_capacity_per_shelf
   - mounting_type
   - pattern
   - suitable_location
@@ -8657,7 +9760,10 @@
   - fr-20-7
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -8674,7 +9780,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -8773,9 +9882,12 @@
   attributes:
   - color
   - compatible_seating_capacity
+  - height
+  - length
   - pattern
   - safety_certifications
   - section_orientation_compatibility
+  - width
   return_reasons:
   - size
   - color
@@ -8792,8 +9904,11 @@
   attributes:
   - color
   - compatible_seating_capacity
+  - height
+  - length
   - pattern
   - section_orientation_compatibility
+  - width
   return_reasons:
   - size
   - color
@@ -8811,8 +9926,11 @@
   attributes:
   - color
   - compatible_seating_capacity
+  - height
+  - length
   - pattern
   - section_orientation_compatibility
+  - width
   return_reasons:
   - size
   - color
@@ -8849,6 +9967,7 @@
   - fr-22-7
   - fr-22-8
   attributes:
+  - armrest_height
   - assembly_required
   - backrest_upholstery_color
   - backrest_upholstery_material
@@ -8857,15 +9976,20 @@
   - chaise_or_sectional_orientation
   - color
   - firmness
+  - height
+  - length
   - material
   - pattern
   - reclining_mechanism
   - safety_certifications
+  - seat_depth
+  - seat_height
   - seat_type
   - seat_upholstery_color
   - seat_upholstery_material
   - seat_upholstery_pattern
   - sofa_features
+  - width
   return_reasons:
   - size
   - color
@@ -8881,15 +10005,21 @@
   name: Chaise Longue Sofas
   children: []
   attributes:
+  - armrest_height
   - backrest_upholstery_color
   - backrest_upholstery_material
   - backrest_upholstery_pattern
   - chaise_or_sectional_orientation
   - firmness
+  - height
+  - length
+  - seat_depth
+  - seat_height
   - seat_upholstery_color
   - seat_upholstery_material
   - seat_upholstery_pattern
   - sofa_features
+  - width
   return_reasons:
   - size
   - color
@@ -8905,15 +10035,21 @@
   name: Corner Sofas
   children: []
   attributes:
+  - armrest_height
   - backrest_upholstery_color
   - backrest_upholstery_material
   - backrest_upholstery_pattern
   - chaise_or_sectional_orientation
   - firmness
+  - height
+  - length
+  - seat_depth
+  - seat_height
   - seat_upholstery_color
   - seat_upholstery_material
   - seat_upholstery_pattern
   - sofa_features
+  - width
   return_reasons:
   - size
   - color
@@ -8929,15 +10065,21 @@
   name: Loveseat Sofas
   children: []
   attributes:
+  - armrest_height
   - backrest_upholstery_color
   - backrest_upholstery_material
   - backrest_upholstery_pattern
   - chaise_or_sectional_orientation
   - firmness
+  - height
+  - length
+  - seat_depth
+  - seat_height
   - seat_upholstery_color
   - seat_upholstery_material
   - seat_upholstery_pattern
   - sofa_features
+  - width
   return_reasons:
   - size
   - color
@@ -8953,16 +10095,22 @@
   name: Sectional Sofas
   children: []
   attributes:
+  - armrest_height
   - backrest_upholstery_color
   - backrest_upholstery_material
   - backrest_upholstery_pattern
   - chaise_or_sectional_orientation
   - firmness
+  - height
+  - length
+  - seat_depth
+  - seat_height
   - seat_upholstery_color
   - seat_upholstery_material
   - seat_upholstery_pattern
   - sectional_shape
   - sofa_features
+  - width
   return_reasons:
   - size
   - color
@@ -9033,8 +10181,11 @@
   - fr-23-6
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -9052,8 +10203,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - table_leg_design
+  - width
   return_reasons:
   - size
   - color
@@ -9071,7 +10225,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -9151,14 +10308,17 @@
   - fr-24-7
   attributes:
   - assembly_required
+  - height
   - leg_color
   - leg_material
   - leg_pattern
+  - length
   - material
   - tabletop_color
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
+  - width
   return_reasons:
   - size
   - color
@@ -9178,14 +10338,17 @@
   - fr-24-1-4
   - fr-24-1-5
   attributes:
+  - height
   - leg_color
   - leg_material
   - leg_pattern
+  - length
   - table_base_material
   - tabletop_color
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
+  - width
   return_reasons:
   - size
   - color
@@ -9200,15 +10363,18 @@
   name: Coffee Tables
   children: []
   attributes:
+  - height
   - leg_color
   - leg_material
   - leg_pattern
+  - length
   - lumber/wood_type
   - table_base_material
   - tabletop_color
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -9224,15 +10390,18 @@
   name: End Tables
   children: []
   attributes:
+  - height
   - leg_color
   - leg_material
   - leg_pattern
+  - length
   - lumber/wood_type
   - table_base_material
   - tabletop_color
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -9248,14 +10417,17 @@
   name: Sofa Tables
   children: []
   attributes:
+  - height
   - leg_color
   - leg_material
   - leg_pattern
+  - length
   - table_base_material
   - tabletop_color
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
+  - width
   return_reasons:
   - size
   - color
@@ -9308,14 +10480,17 @@
   name: Activity Tables
   children: []
   attributes:
+  - height
   - leg_color
   - leg_material
   - leg_pattern
+  - length
   - mobility_features
   - tabletop_color
   - tabletop_material
   - tabletop_pattern
   - tabletop_tilt_function
+  - width
   return_reasons:
   - size
   - color
@@ -9334,12 +10509,15 @@
   - frame_material
   - frame_pattern
   - furniture/fixture_features
+  - height
   - leg_color
   - leg_material
   - leg_pattern
+  - length
   - tabletop_color
   - tabletop_material
   - tabletop_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -9357,13 +10535,16 @@
   - fr-24-4-2
   attributes:
   - extension_mechanism
+  - height
   - leg_color
   - leg_material
   - leg_pattern
+  - length
   - table_base_type
   - tabletop_color
   - tabletop_material
   - tabletop_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -9379,14 +10560,17 @@
   children: []
   attributes:
   - extension_mechanism
+  - height
   - leg_color
   - leg_material
   - leg_pattern
+  - length
   - lumber/wood_type
   - table_base_type
   - tabletop_color
   - tabletop_material
   - tabletop_pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -9425,11 +10609,14 @@
   attributes:
   - blanket_color
   - blanket_pattern
+  - height
   - leg_material
+  - length
   - tabletop_color
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
+  - width
   return_reasons:
   - size
   - color
@@ -9449,14 +10636,17 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
   - integrated_charging_options
   - leg_color
   - leg_material
   - leg_pattern
+  - length
   - tabletop_shape
   - top_color
   - top_material
   - top_pattern
+  - width
   return_reasons:
   - size
   - color

--- a/data/categories/ha_hardware.yml
+++ b/data/categories/ha_hardware.yml
@@ -74,6 +74,7 @@
   - color
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - consistency
   - incompatible
@@ -91,6 +92,7 @@
   - color
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - strength
   - incompatible
@@ -108,6 +110,7 @@
   - color
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - strength
   - incompatible
@@ -125,6 +128,7 @@
   - color
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - strength
   - incompatible
@@ -142,6 +146,7 @@
   - color
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - strength
   - incompatible
@@ -160,6 +165,7 @@
   - color
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - strength
   - consistency
@@ -177,6 +183,7 @@
   - color
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - strength
   - incompatible
@@ -196,6 +203,7 @@
   - color
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - strength
   - incompatible
@@ -213,6 +221,7 @@
   - color
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - strength
   - incompatible
@@ -230,6 +239,7 @@
   - color
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - strength
   - incompatible
@@ -248,6 +258,7 @@
   - color
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - strength
   - incompatible
@@ -265,6 +276,7 @@
   - pattern
   - suitable_for_material_type
   - suitable_space
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -281,8 +293,10 @@
   - ha-1-3-3
   attributes:
   - color
+  - length
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - color
   - width
@@ -297,8 +311,10 @@
   children: []
   attributes:
   - color
+  - length
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - color
   - width
@@ -313,8 +329,10 @@
   children: []
   attributes:
   - color
+  - length
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - color
   - width
@@ -329,8 +347,10 @@
   children: []
   attributes:
   - color
+  - length
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - color
   - width
@@ -352,6 +372,7 @@
   - lubricant_dispenser_type
   - pattern
   - suitable_for_material_type
+  - volume
   return_reasons:
   - consistency
   - odor
@@ -372,6 +393,7 @@
   - lubricant_dispenser_type
   - pattern
   - suitable_for_material_type
+  - volume
   return_reasons:
   - consistency
   - incompatible
@@ -391,6 +413,7 @@
   - lubricant_dispenser_type
   - pattern
   - suitable_for_material_type
+  - volume
   return_reasons:
   - consistency
   - incompatible
@@ -410,6 +433,7 @@
   - lubricant_dispenser_type
   - pattern
   - suitable_for_material_type
+  - volume
   return_reasons:
   - consistency
   - incompatible
@@ -429,6 +453,7 @@
   - color
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - size
   - color
@@ -444,9 +469,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - masonry_material
   - pattern
   - suitable_space
+  - weight
+  - width
   return_reasons:
   - size
   - color
@@ -474,6 +503,7 @@
   - pattern
   - suitable_for_material_type
   - suitable_space
+  - weight
   return_reasons:
   - color
   - consistency
@@ -493,6 +523,7 @@
   - pattern
   - suitable_for_material_type
   - suitable_space
+  - weight
   return_reasons:
   - color
   - changed_my_mind
@@ -510,6 +541,7 @@
   - pattern
   - suitable_for_material_type
   - suitable_space
+  - weight
   return_reasons:
   - color
   - changed_my_mind
@@ -527,6 +559,7 @@
   - pattern
   - suitable_for_material_type
   - suitable_space
+  - weight
   return_reasons:
   - color
   - changed_my_mind
@@ -544,6 +577,7 @@
   - pattern
   - suitable_for_material_type
   - suitable_space
+  - weight
   return_reasons:
   - color
   - changed_my_mind
@@ -561,6 +595,7 @@
   - pattern
   - suitable_for_material_type
   - suitable_space
+  - weight
   return_reasons:
   - color
   - changed_my_mind
@@ -578,6 +613,7 @@
   - pattern
   - suitable_for_material_type
   - suitable_space
+  - weight
   return_reasons:
   - color
   - changed_my_mind
@@ -595,6 +631,7 @@
   - pattern
   - suitable_for_material_type
   - suitable_space
+  - weight
   return_reasons:
   - color
   - changed_my_mind
@@ -610,6 +647,7 @@
   - color
   - pattern
   - suitable_space
+  - weight
   return_reasons:
   - color
   - consistency
@@ -634,6 +672,7 @@
   - intended_application
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - color
   - finish
@@ -655,6 +694,7 @@
   - intended_application
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - color
   - finish
@@ -674,6 +714,7 @@
   - intended_application
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - consistency
   - incompatible
@@ -695,6 +736,7 @@
   - primer_use
   - product_formulation
   - suitable_space
+  - volume
   return_reasons:
   - color
   - consistency
@@ -715,6 +757,7 @@
   - intended_application
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - color
   - finish
@@ -737,6 +780,7 @@
   - suitable_for_material_type
   - suitable_space
   - varnish/finish_application
+  - volume
   return_reasons:
   - finish
   - consistency
@@ -754,6 +798,7 @@
   - pattern
   - plumbing_primer_application
   - suitable_space
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -778,6 +823,7 @@
   - pattern
   - suitable_for_material_type
   - suitable_space
+  - volume
   return_reasons:
   - color
   - consistency
@@ -798,6 +844,7 @@
   - pattern
   - suitable_for_material_type
   - suitable_space
+  - volume
   return_reasons:
   - finish
   - incompatible
@@ -818,6 +865,7 @@
   - pattern
   - suitable_for_material_type
   - suitable_space
+  - volume
   return_reasons:
   - finish
   - incompatible
@@ -837,6 +885,7 @@
   - pattern
   - suitable_for_material_type
   - suitable_space
+  - volume
   return_reasons:
   - consistency
   - incompatible
@@ -856,6 +905,7 @@
   - pattern
   - suitable_for_material_type
   - suitable_space
+  - volume
   return_reasons:
   - color
   - incompatible
@@ -875,6 +925,7 @@
   - pattern
   - suitable_for_material_type
   - suitable_space
+  - volume
   return_reasons:
   - finish
   - incompatible
@@ -895,6 +946,7 @@
   - pattern
   - suitable_for_material_type
   - suitable_space
+  - volume
   return_reasons:
   - finish
   - incompatible
@@ -914,6 +966,7 @@
   - color
   - pattern
   - solder/flux_application
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -929,6 +982,7 @@
   - color
   - pattern
   - solder/flux_application
+  - volume
   return_reasons:
   - gauge
   - incompatible
@@ -945,6 +999,7 @@
   - color
   - pattern
   - solder/flux_application
+  - volume
   return_reasons:
   - gauge
   - incompatible
@@ -961,6 +1016,7 @@
   - color
   - pattern
   - solder/flux_application
+  - volume
   return_reasons:
   - consistency
   - residue
@@ -982,6 +1038,7 @@
   - pattern
   - solvent/thinner_application
   - suitable_space
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -998,6 +1055,7 @@
   - pattern
   - solvent_application
   - suitable_space
+  - volume
   return_reasons:
   - consistency
   - incompatible
@@ -1015,6 +1073,7 @@
   - pattern
   - suitable_space
   - thinner_application
+  - volume
   return_reasons:
   - consistency
   - incompatible
@@ -1032,6 +1091,7 @@
   - pattern
   - stripper_application
   - suitable_space
+  - volume
   return_reasons:
   - consistency
   - incompatible
@@ -1058,9 +1118,11 @@
   - color
   - pattern
   - product_formulation
+  - set_time
   - suitable_for_material_type
   - suitable_space
   - wall_patching_application
+  - weight
   return_reasons:
   - color
   - consistency
@@ -1079,9 +1141,11 @@
   - color
   - pattern
   - product_formulation
+  - set_time
   - suitable_for_material_type
   - suitable_space
   - wall_patching_application
+  - weight
   return_reasons:
   - color
   - texture
@@ -1100,9 +1164,11 @@
   - color
   - pattern
   - product_formulation
+  - set_time
   - suitable_for_material_type
   - suitable_space
   - wall_patching_application
+  - weight
   return_reasons:
   - consistency
   - incompatible
@@ -1120,9 +1186,11 @@
   - color
   - pattern
   - product_formulation
+  - set_time
   - suitable_for_material_type
   - suitable_space
   - wall_patching_application
+  - weight
   return_reasons:
   - heat_resistance
   - texture
@@ -1141,9 +1209,11 @@
   - color
   - pattern
   - product_formulation
+  - set_time
   - suitable_for_material_type
   - suitable_space
   - wall_patching_application
+  - weight
   return_reasons:
   - consistency
   - incompatible
@@ -1161,9 +1231,11 @@
   - color
   - pattern
   - product_formulation
+  - set_time
   - suitable_for_material_type
   - suitable_space
   - wall_patching_application
+  - weight
   return_reasons:
   - color
   - texture
@@ -1182,9 +1254,11 @@
   - color
   - pattern
   - product_formulation
+  - set_time
   - suitable_for_material_type
   - suitable_space
   - wall_patching_application
+  - weight
   return_reasons:
   - color
   - texture
@@ -1203,9 +1277,11 @@
   - color
   - pattern
   - product_formulation
+  - set_time
   - suitable_for_material_type
   - suitable_space
   - wall_patching_application
+  - weight
   return_reasons:
   - consistency
   - incompatible
@@ -1223,9 +1299,11 @@
   - color
   - pattern
   - product_formulation
+  - set_time
   - suitable_for_material_type
   - suitable_space
   - wall_patching_application
+  - weight
   return_reasons:
   - consistency
   - incompatible
@@ -1243,9 +1321,11 @@
   - color
   - pattern
   - product_formulation
+  - set_time
   - suitable_for_material_type
   - suitable_space
   - wall_patching_application
+  - weight
   return_reasons:
   - consistency
   - incompatible
@@ -1300,8 +1380,11 @@
   - color
   - edge_style
   - finish
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1349,9 +1432,12 @@
   - color
   - connection_method
   - hardware_material
+  - height
+  - length
   - pattern
   - power_source
   - style
+  - width
   return_reasons:
   - size
   - style
@@ -1374,10 +1460,15 @@
   - hand_side
   - hardware_finish
   - hardware_material
+  - height
+  - length
+  - maximum_door_weight
+  - maximum_door_width
   - pattern
   - power_source
   - recommended_use
   - suitable_for_door_type
+  - width
   return_reasons:
   - size
   - style
@@ -1396,8 +1487,11 @@
   - color
   - door/frame_application
   - door_frame_finish
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -1415,9 +1509,15 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - keyhole_cylinder_size
+  - length
+  - maximum_door_leaf_thickness
+  - minimum_door_leaf_thickness_supported
   - pattern
   - shape
   - style
+  - width
   return_reasons:
   - size
   - style
@@ -1438,8 +1538,11 @@
   - color
   - door_knob_function
   - handle_material
+  - height
+  - length
   - pattern
   - style
+  - width
   return_reasons:
   - size
   - style
@@ -1460,9 +1563,12 @@
   - embellishment/trim_material
   - hardware_finish
   - hardware_material
+  - height
   - jewelry_material
+  - length
   - pattern
   - style
+  - width
   return_reasons:
   - size
   - style
@@ -1480,8 +1586,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
   - style
+  - width
   return_reasons:
   - size
   - style
@@ -1500,8 +1609,11 @@
   - color
   - door_stop_placement
   - hardware_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -1522,7 +1634,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -1540,7 +1655,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -1558,7 +1676,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -1599,8 +1720,11 @@
   - color
   - door_insulation
   - garage_door_material
+  - height
+  - length
   - pattern
   - recommended_use
+  - width
   return_reasons:
   - size
   - color
@@ -1619,8 +1743,11 @@
   - color
   - door_insulation
   - garage_door_material
+  - height
+  - length
   - pattern
   - recommended_use
+  - width
   return_reasons:
   - size
   - color
@@ -1640,8 +1767,11 @@
   - color
   - door_insulation
   - garage_door_material
+  - height
+  - length
   - pattern
   - recommended_use
+  - width
   return_reasons:
   - size
   - color
@@ -1661,8 +1791,11 @@
   - color
   - door_insulation
   - garage_door_material
+  - height
+  - length
   - pattern
   - recommended_use
+  - width
   return_reasons:
   - size
   - color
@@ -1685,8 +1818,12 @@
   - door_material
   - door_suitable_location
   - door_surface_finish
+  - height
+  - length
   - pattern
   - style
+  - thickness
+  - width
   return_reasons:
   - size
   - color
@@ -1704,9 +1841,13 @@
   attributes:
   - building_board_material
   - color
+  - drywall_thickness
   - durability_features
+  - height
+  - length
   - pattern
   - sound_insulation
+  - width
   return_reasons:
   - size
   - thickness
@@ -1721,11 +1862,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - style
   - suitable_location
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -1746,7 +1890,11 @@
   - ha-2-6-4
   attributes:
   - color
+  - glass_thickness
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -1762,7 +1910,11 @@
   children: []
   attributes:
   - color
+  - glass_thickness
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -1778,7 +1930,11 @@
   children: []
   attributes:
   - color
+  - glass_thickness
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -1794,7 +1950,11 @@
   children: []
   attributes:
   - color
+  - glass_thickness
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -1810,7 +1970,11 @@
   children: []
   attributes:
   - color
+  - glass_thickness
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -1828,8 +1992,11 @@
   - ha-2-7-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1846,8 +2013,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1864,8 +2034,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1883,8 +2056,11 @@
   attributes:
   - color
   - hatch_suitable_location
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1907,8 +2083,11 @@
   - ha-2-9-6
   attributes:
   - color
+  - height
   - insulation_material
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -1923,8 +2102,11 @@
   children: []
   attributes:
   - color
+  - height
   - insulation_material
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -1939,8 +2121,11 @@
   children: []
   attributes:
   - color
+  - height
   - insulation_material
+  - length
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -1953,8 +2138,11 @@
   children: []
   attributes:
   - color
+  - height
   - insulation_material
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -1969,8 +2157,11 @@
   children: []
   attributes:
   - color
+  - height
   - insulation_material
+  - length
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -1983,8 +2174,11 @@
   children: []
   attributes:
   - color
+  - height
   - insulation_material
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -1999,8 +2193,11 @@
   children: []
   attributes:
   - color
+  - height
   - insulation_material
+  - length
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -2016,8 +2213,12 @@
   - ha-2-10-3
   attributes:
   - color
+  - height
+  - length
+  - lumber/wood_thickness
   - lumber/wood_type
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -2033,8 +2234,12 @@
   attributes:
   - color
   - hardwood_lumber_grade
+  - height
+  - length
+  - lumber/wood_thickness
   - lumber/wood_type
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -2049,9 +2254,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - lumber/wood_thickness
   - lumber/wood_type
   - pattern
   - plywood_grade
+  - width
   return_reasons:
   - size
   - thickness
@@ -2066,9 +2275,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - lumber/wood_thickness
   - lumber/wood_type
   - pattern
   - softwood_lumber_grade
+  - width
   return_reasons:
   - size
   - thickness
@@ -2083,10 +2296,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - molding_application
   - pattern
   - style
+  - width
   return_reasons:
   - size
   - color
@@ -2106,7 +2322,10 @@
   - ha-2-12-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -2121,7 +2340,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - diameter
   - length
@@ -2137,7 +2359,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - gauge
   - finish
@@ -2152,7 +2377,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - gauge
   - finish
@@ -2189,8 +2417,11 @@
   attributes:
   - color
   - gutter_fitting_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2207,9 +2438,13 @@
   children: []
   attributes:
   - color
+  - depth
   - gutter_style
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2230,7 +2465,10 @@
   attributes:
   - color
   - flashing_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2247,7 +2485,10 @@
   attributes:
   - color
   - flashing_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2264,7 +2505,10 @@
   attributes:
   - color
   - flashing_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2281,7 +2525,10 @@
   attributes:
   - color
   - flashing_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2298,7 +2545,10 @@
   attributes:
   - color
   - flashing_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2317,8 +2567,11 @@
   - ha-2-13-4-3
   attributes:
   - color
+  - height
+  - length
   - pattern
   - shingle/tile_material
+  - width
   return_reasons:
   - size
   - color
@@ -2334,8 +2587,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - shingle/tile_material
+  - width
   return_reasons:
   - size
   - color
@@ -2351,8 +2607,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - shingle/tile_material
+  - width
   return_reasons:
   - size
   - color
@@ -2368,8 +2627,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - shingle/tile_material
+  - width
   return_reasons:
   - size
   - color
@@ -2388,9 +2650,12 @@
   - ha-2-14-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - shutter_finish
+  - width
   return_reasons:
   - size
   - color
@@ -2406,9 +2671,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - shutter_finish
+  - width
   return_reasons:
   - size
   - color
@@ -2424,9 +2692,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - shutter_finish
+  - width
   return_reasons:
   - size
   - color
@@ -2442,9 +2713,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - shutter_finish
+  - width
   return_reasons:
   - size
   - color
@@ -2460,8 +2734,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - siding_material
+  - width
   return_reasons:
   - color
   - style
@@ -2480,8 +2757,12 @@
   - ha-2-16-3
   - ha-2-16-4
   attributes:
+  - acoustic_material_thickness
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -2495,9 +2776,13 @@
   name: Acoustic Panels
   children: []
   attributes:
+  - acoustic_material_thickness
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2513,8 +2798,12 @@
   name: Bass Traps
   children: []
   attributes:
+  - acoustic_material_thickness
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2529,8 +2818,12 @@
   name: Diffusers
   children: []
   attributes:
+  - acoustic_material_thickness
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2546,8 +2839,12 @@
   name: Foam Tiles
   children: []
   attributes:
+  - acoustic_material_thickness
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2568,10 +2865,13 @@
   - ha-2-17-5
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - staircase_features
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -2587,10 +2887,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - staircase_features
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -2606,10 +2909,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - staircase_features
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -2625,10 +2931,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - staircase_features
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -2644,10 +2953,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - staircase_features
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -2663,10 +2975,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - staircase_features
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -2685,12 +3000,15 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - pattern
   - tile_design
   - tile_installation_method
   - tile_look
   - tile_material
   - tile_texture
+  - width
   return_reasons:
   - size
   - color
@@ -2708,11 +3026,14 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - pattern
   - tile_installation_method
   - tile_look
   - tile_material
   - tile_texture
+  - width
   return_reasons:
   - size
   - color
@@ -2730,11 +3051,14 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - pattern
   - tile_design
   - tile_installation_method
   - tile_look
   - tile_material
+  - width
   return_reasons:
   - size
   - color
@@ -2755,10 +3079,14 @@
   - ha-2-19-4
   attributes:
   - building_board_material
+  - building_board_thickness
   - color
   - durability_features
+  - height
+  - length
   - pattern
   - sound_insulation
+  - width
   return_reasons:
   - pattern
   - thickness
@@ -2773,10 +3101,14 @@
   children: []
   attributes:
   - building_board_material
+  - building_board_thickness
   - color
   - durability_features
+  - height
+  - length
   - pattern
   - sound_insulation
+  - width
   return_reasons:
   - pattern
   - thickness
@@ -2791,10 +3123,14 @@
   children: []
   attributes:
   - building_board_material
+  - building_board_thickness
   - color
   - durability_features
+  - height
+  - length
   - pattern
   - sound_insulation
+  - width
   return_reasons:
   - pattern
   - thickness
@@ -2809,10 +3145,14 @@
   children: []
   attributes:
   - building_board_material
+  - building_board_thickness
   - color
   - durability_features
+  - height
+  - length
   - pattern
   - sound_insulation
+  - width
   return_reasons:
   - pattern
   - thickness
@@ -2827,10 +3167,14 @@
   children: []
   attributes:
   - building_board_material
+  - building_board_thickness
   - color
   - durability_features
+  - height
+  - length
   - pattern
   - sound_insulation
+  - width
   return_reasons:
   - pattern
   - thickness
@@ -2849,10 +3193,14 @@
   - ha-2-20-4
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - thickness
   - weather_supply_application_method
   - weatherization_application
+  - width
   return_reasons:
   - size
   - thickness
@@ -2867,10 +3215,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - thickness
   - weather_supply_application_method
   - weatherization_application
+  - width
   return_reasons:
   - size
   - thickness
@@ -2885,9 +3237,13 @@
   children: []
   attributes:
   - color
+  - gap_size
+  - length
   - pattern
+  - roll_size
   - weather_supply_application_method
   - weatherization_application
+  - width
   return_reasons:
   - size
   - thickness
@@ -2902,11 +3258,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - thickness
   - weather_strip_design
   - weather_supply_application_method
   - weatherization_application
+  - width
   return_reasons:
   - size
   - thickness
@@ -2921,10 +3281,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - thickness
   - weather_supply_application_method
   - weatherization_application
+  - width
   return_reasons:
   - size
   - thickness
@@ -2960,7 +3324,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2982,8 +3349,11 @@
   - ha-2-21-2-5
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3000,8 +3370,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3018,8 +3391,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3036,8 +3412,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3054,8 +3433,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3072,8 +3454,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3097,8 +3482,11 @@
   attributes:
   - color
   - glazing_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3115,8 +3503,11 @@
   attributes:
   - color
   - glazing_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3133,8 +3524,11 @@
   attributes:
   - color
   - glazing_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3151,8 +3545,11 @@
   attributes:
   - color
   - glazing_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3169,8 +3566,11 @@
   attributes:
   - color
   - glazing_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3187,8 +3587,11 @@
   attributes:
   - color
   - glazing_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3205,8 +3608,11 @@
   attributes:
   - color
   - glazing_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3245,8 +3651,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -3267,7 +3676,11 @@
   - color
   - fencing_components
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - thickness
+  - width
   return_reasons:
   - color
   - height
@@ -3286,7 +3699,11 @@
   - color
   - fencing_components
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - thickness
+  - width
   return_reasons:
   - color
   - height
@@ -3306,7 +3723,11 @@
   - color
   - fencing_components
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - thickness
+  - width
   return_reasons:
   - color
   - height
@@ -3325,7 +3746,11 @@
   - color
   - fencing_components
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - thickness
+  - width
   return_reasons:
   - color
   - height
@@ -3344,7 +3769,11 @@
   - color
   - fencing_components
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - thickness
+  - width
   return_reasons:
   - color
   - height
@@ -3363,7 +3792,11 @@
   - color
   - fencing_components
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - thickness
+  - width
   return_reasons:
   - height
   - width
@@ -3383,7 +3816,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3400,7 +3836,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3417,7 +3856,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3434,7 +3876,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3452,8 +3897,11 @@
   - ha-3-5-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - height
@@ -3470,7 +3918,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - height
@@ -3486,8 +3937,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - height
@@ -3506,8 +3960,11 @@
   - ha-3-6-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - height
@@ -3524,8 +3981,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - style
@@ -3543,8 +4003,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - style
@@ -3562,8 +4025,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - height
@@ -3580,9 +4046,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - trellis_design
+  - width
   return_reasons:
   - color
   - height
@@ -3603,8 +4072,12 @@
   - ha-3-8-4
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - thickness
+  - width
   return_reasons:
   - color
   - height
@@ -3620,8 +4093,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - thickness
+  - width
   return_reasons:
   - color
   - height
@@ -3638,8 +4115,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - thickness
+  - width
   return_reasons:
   - color
   - length
@@ -3655,8 +4136,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - thickness
+  - width
   return_reasons:
   - color
   - height
@@ -3672,8 +4157,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - thickness
+  - width
   return_reasons:
   - color
   - length
@@ -3693,8 +4182,12 @@
   attributes:
   - color
   - fuel_additives
+  - height
+  - length
   - pattern
   - suitable_space
+  - volume
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -3713,6 +4206,7 @@
   - pattern
   - suitable_space
   - sulfur_content
+  - volume
   return_reasons:
   - burn_rate
   - incompatible
@@ -3734,6 +4228,7 @@
   - kerosene_application
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -3752,6 +4247,7 @@
   - kerosene_application
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -3770,6 +4266,7 @@
   - kerosene_application
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -3788,6 +4285,7 @@
   - pattern
   - propane_application
   - suitable_space
+  - volume
   return_reasons:
   - pressure
   - incompatible
@@ -3806,11 +4304,15 @@
   - ha-5-4
   - ha-5-5
   attributes:
+  - capacity
   - color
   - fuel_container_features
+  - height
+  - length
   - material
   - pattern
   - recommended_use
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -3824,11 +4326,15 @@
   name: Diesel Cans
   children: []
   attributes:
+  - capacity
   - color
   - fuel_container_features
+  - height
+  - length
   - material
   - pattern
   - recommended_use
+  - width
   return_reasons:
   - capacity
   - material
@@ -3844,11 +4350,15 @@
   name: Fuel Transfer Tanks
   children: []
   attributes:
+  - capacity
   - color
   - fuel_container_features
+  - height
+  - length
   - material
   - pattern
   - recommended_use
+  - width
   return_reasons:
   - capacity
   - material
@@ -3864,11 +4374,15 @@
   name: Gas Cans
   children: []
   attributes:
+  - capacity
   - color
   - fuel_container_features
+  - height
+  - length
   - material
   - pattern
   - recommended_use
+  - width
   return_reasons:
   - capacity
   - material
@@ -3884,11 +4398,15 @@
   name: Kerosene Cans
   children: []
   attributes:
+  - capacity
   - color
   - fuel_container_features
+  - height
+  - length
   - material
   - pattern
   - recommended_use
+  - width
   return_reasons:
   - capacity
   - material
@@ -3904,11 +4422,15 @@
   name: Propane Tanks
   children: []
   attributes:
+  - capacity
   - color
   - fuel_container_features
+  - height
+  - length
   - material
   - pattern
   - recommended_use
+  - width
   return_reasons:
   - capacity
   - weight
@@ -3967,8 +4489,12 @@
   attributes:
   - bracket/brace_design
   - color
+  - height
+  - length
   - material
   - pattern
+  - thickness
+  - width
   return_reasons:
   - size
   - finish
@@ -3991,7 +4517,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -4009,8 +4538,14 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - keyhole_cylinder_size
+  - length
+  - maximum_door_leaf_thickness
+  - minimum_door_leaf_thickness_supported
   - pattern
   - style
+  - width
   return_reasons:
   - size
   - style
@@ -4027,9 +4562,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - style
+  - width
   return_reasons:
   - size
   - style
@@ -4046,8 +4584,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -4065,9 +4606,12 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - style
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -4088,10 +4632,13 @@
   - color
   - handle_material
   - hardware_finish
+  - height
   - knob/handle_design
+  - length
   - lumber/wood_type
   - pattern
   - style
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -4109,9 +4656,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - load_capacity
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -4135,7 +4685,11 @@
   - ha-6-4-7
   attributes:
   - color
+  - diameter
+  - height
+  - length
   - pattern
+  - width
   - wire/rope_material
   return_reasons:
   - length
@@ -4152,8 +4706,15 @@
   children: []
   attributes:
   - color
+  - cord_diameter
   - cord_fastening_system
+  - height
+  - length
+  - maximum_cord_length
+  - maximum_load_capacity
   - pattern
+  - weight
+  - width
   - wire/rope_material
   return_reasons:
   - length
@@ -4169,9 +4730,15 @@
   name: Chains
   children: []
   attributes:
+  - chain_diameter
+  - chain_length
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -4186,9 +4753,15 @@
   name: Pull Chains
   children: []
   attributes:
+  - chain_diameter
+  - chain_length
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -4203,9 +4776,15 @@
   name: Ropes & Hardware Cable
   children: []
   attributes:
+  - cable_diameter
+  - cable_length
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - length
   - diameter
@@ -4221,8 +4800,13 @@
   children: []
   attributes:
   - color
+  - diameter
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - length
   - width
@@ -4238,7 +4822,11 @@
   children: []
   attributes:
   - color
+  - diameter
+  - height
+  - length
   - pattern
+  - width
   - wire/rope_material
   return_reasons:
   - length
@@ -4254,8 +4842,13 @@
   children: []
   attributes:
   - color
+  - diameter
+  - height
+  - length
   - pattern
+  - width
   - wire/rope_material
+  - wire_length
   return_reasons:
   - length
   - gauge
@@ -4275,7 +4868,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - inner_diameter
+  - length
+  - outside_diameter
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -4292,7 +4890,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - inner_diameter
+  - length
+  - outside_diameter
   - pattern
+  - width
   return_reasons:
   - size
   - strength
@@ -4309,7 +4912,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - inner_diameter
+  - length
+  - outside_diameter
   - pattern
+  - width
   return_reasons:
   - size
   - strength
@@ -4326,7 +4934,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - inner_diameter
+  - length
+  - outside_diameter
   - pattern
+  - width
   return_reasons:
   - size
   - strength
@@ -4342,9 +4955,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - molding_shape
   - pattern
+  - width
   return_reasons:
   - size
   - shape
@@ -4360,8 +4976,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - pin/rod_diameter
+  - pin/rod_length
+  - width
   return_reasons:
   - diameter
   - length
@@ -4378,8 +4999,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -4396,7 +5021,10 @@
   attributes:
   - color
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -4412,8 +5040,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - thickness
+  - width
   return_reasons:
   - size
   - material
@@ -4433,8 +5065,10 @@
   - ha-6-11-3
   attributes:
   - color
+  - length
   - pattern
   - tape_material
+  - width
   return_reasons:
   - color
   - width
@@ -4449,8 +5083,10 @@
   children: []
   attributes:
   - color
+  - length
   - pattern
   - tape_material
+  - width
   return_reasons:
   - color
   - width
@@ -4465,8 +5101,10 @@
   children: []
   attributes:
   - color
+  - length
   - pattern
   - tape_material
+  - width
   return_reasons:
   - color
   - width
@@ -4481,8 +5119,10 @@
   children: []
   attributes:
   - color
+  - length
   - pattern
   - tape_material
+  - width
   return_reasons:
   - color
   - width
@@ -4497,9 +5137,14 @@
   children: []
   attributes:
   - color
+  - height
+  - hose_diameter
+  - hose_length
   - hose_material
+  - length
   - pattern
   - suitable_for_gas_type
+  - width
   return_reasons:
   - size
   - length
@@ -4517,8 +5162,13 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
   - spike_design
+  - spike_diameter
+  - spike_length
+  - width
   return_reasons:
   - size
   - finish
@@ -4542,9 +5192,14 @@
   - ha-6-14-8
   attributes:
   - color
+  - fastener_diameter
   - fastener_finish
+  - fastener_length
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -4560,10 +5215,15 @@
   children: []
   attributes:
   - color
+  - fastener_diameter
   - fastener_finish
+  - fastener_length
   - hardware_material
+  - height
+  - length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4594,8 +5254,13 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
+  - nail_gauge
+  - nail_length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - finish
@@ -4613,8 +5278,13 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
+  - nail_gauge
+  - nail_length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - finish
@@ -4632,8 +5302,13 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
+  - nail_gauge
+  - nail_length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - finish
@@ -4651,8 +5326,13 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
+  - nail_gauge
+  - nail_length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - finish
@@ -4670,8 +5350,13 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
+  - nail_gauge
+  - nail_length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - color
@@ -4691,8 +5376,13 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
+  - nail_gauge
+  - nail_length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - finish
@@ -4710,8 +5400,13 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
+  - nail_gauge
+  - nail_length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - finish
@@ -4729,8 +5424,13 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
+  - nail_gauge
+  - nail_length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - finish
@@ -4747,8 +5447,13 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
+  - nail_gauge
+  - nail_length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - finish
@@ -4766,8 +5471,13 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
+  - nail_gauge
+  - nail_length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - finish
@@ -4785,8 +5495,13 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
+  - nail_gauge
+  - nail_length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - finish
@@ -4804,8 +5519,13 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
+  - nail_gauge
+  - nail_length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - finish
@@ -4824,8 +5544,13 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
+  - nail_gauge
+  - nail_length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - finish
@@ -4843,8 +5568,13 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
+  - nail_gauge
+  - nail_length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - finish
@@ -4862,8 +5592,13 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
+  - nail_gauge
+  - nail_length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - finish
@@ -4880,10 +5615,16 @@
   attributes:
   - bolt_form
   - color
+  - fastener_diameter
   - fastener_finish
+  - fastener_length
   - hardware_material
+  - height
+  - length
   - nut_form
   - pattern
+  - thread_pitch
+  - width
   return_reasons:
   - size
   - finish
@@ -4899,10 +5640,15 @@
   children: []
   attributes:
   - color
+  - fastener_diameter
   - fastener_finish
+  - fastener_length
   - hardware_material
+  - height
+  - length
   - pattern
   - rivet_form
+  - width
   return_reasons:
   - size
   - finish
@@ -4918,10 +5664,16 @@
   children: []
   attributes:
   - color
+  - fastener_diameter
   - fastener_finish
+  - fastener_length
   - hardware_material
+  - height
+  - length
   - pattern
   - suitable_for_material_type
+  - thread_pitch
+  - width
   return_reasons:
   - size
   - finish
@@ -4952,8 +5704,14 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
   - pattern
+  - screw_diameter
+  - screw_length
   - suitable_for_material_type
+  - thread_pitch
+  - width
   return_reasons:
   - size
   - finish
@@ -4971,8 +5729,14 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
   - pattern
+  - screw_diameter
+  - screw_length
   - suitable_for_material_type
+  - thread_pitch
+  - width
   return_reasons:
   - size
   - length
@@ -4991,8 +5755,14 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
   - pattern
+  - screw_diameter
+  - screw_length
   - suitable_for_material_type
+  - thread_pitch
+  - width
   return_reasons:
   - size
   - finish
@@ -5010,8 +5780,14 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
   - pattern
+  - screw_diameter
+  - screw_length
   - suitable_for_material_type
+  - thread_pitch
+  - width
   return_reasons:
   - size
   - finish
@@ -5029,8 +5805,14 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
   - pattern
+  - screw_diameter
+  - screw_length
   - suitable_for_material_type
+  - thread_pitch
+  - width
   return_reasons:
   - size
   - finish
@@ -5048,8 +5830,14 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
   - pattern
+  - screw_diameter
+  - screw_length
   - suitable_for_material_type
+  - thread_pitch
+  - width
   return_reasons:
   - size
   - finish
@@ -5067,8 +5855,14 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
   - pattern
+  - screw_diameter
+  - screw_length
   - suitable_for_material_type
+  - thread_pitch
+  - width
   return_reasons:
   - size
   - finish
@@ -5086,8 +5880,14 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
   - pattern
+  - screw_diameter
+  - screw_length
   - suitable_for_material_type
+  - thread_pitch
+  - width
   return_reasons:
   - size
   - finish
@@ -5105,8 +5905,14 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
   - pattern
+  - screw_diameter
+  - screw_length
   - suitable_for_material_type
+  - thread_pitch
+  - width
   return_reasons:
   - size
   - finish
@@ -5124,8 +5930,14 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
   - pattern
+  - screw_diameter
+  - screw_length
   - suitable_for_material_type
+  - thread_pitch
+  - width
   return_reasons:
   - size
   - finish
@@ -5143,8 +5955,14 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
   - pattern
+  - screw_diameter
+  - screw_length
   - suitable_for_material_type
+  - thread_pitch
+  - width
   return_reasons:
   - size
   - finish
@@ -5162,8 +5980,14 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
   - pattern
+  - screw_diameter
+  - screw_length
   - suitable_for_material_type
+  - thread_pitch
+  - width
   return_reasons:
   - size
   - finish
@@ -5182,8 +6006,14 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
   - pattern
+  - screw_diameter
+  - screw_length
   - suitable_for_material_type
+  - thread_pitch
+  - width
   return_reasons:
   - size
   - finish
@@ -5201,8 +6031,14 @@
   - color
   - fastener_finish
   - hardware_material
+  - height
+  - length
   - pattern
+  - screw_diameter
+  - screw_length
   - suitable_for_material_type
+  - thread_pitch
+  - width
   return_reasons:
   - size
   - finish
@@ -5218,11 +6054,17 @@
   children: []
   attributes:
   - color
+  - fastener_diameter
   - fastener_finish
+  - fastener_length
   - hardware_material
+  - height
+  - length
   - pattern
   - thread_direction
+  - thread_pitch
   - threaded_rod_size
+  - width
   return_reasons:
   - size
   - finish
@@ -5238,10 +6080,15 @@
   children: []
   attributes:
   - color
+  - fastener_diameter
   - fastener_finish
+  - fastener_length
   - hardware_material
+  - height
+  - length
   - pattern
   - washer_form
+  - width
   return_reasons:
   - size
   - finish
@@ -5260,7 +6107,11 @@
   - door_application
   - hardware_finish
   - hardware_material
+  - height
+  - length
   - pattern
+  - thickness
+  - width
   return_reasons:
   - size
   - finish
@@ -5282,7 +6133,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -5300,8 +6154,11 @@
   - color
   - connector_design
   - hardware_material
+  - height
   - hook_design
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -5318,7 +6175,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -5335,7 +6195,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5352,7 +6216,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5367,8 +6234,13 @@
   children: []
   attributes:
   - color
+  - height
+  - hose_diameter
+  - hose_length
   - hose_material
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -5385,9 +6257,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - metal_molding_application
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -5407,7 +6282,11 @@
   attributes:
   - color
   - cover_material
+  - height
+  - length
   - pattern
+  - thickness
+  - width
   return_reasons:
   - size
   - thickness
@@ -5424,7 +6303,11 @@
   attributes:
   - color
   - cover_material
+  - height
+  - length
   - pattern
+  - thickness
+  - width
   return_reasons:
   - size
   - thickness
@@ -5441,7 +6324,11 @@
   attributes:
   - color
   - cover_material
+  - height
+  - length
   - pattern
+  - thickness
+  - width
   return_reasons:
   - size
   - thickness
@@ -5459,8 +6346,14 @@
   - ha-6-20-2
   attributes:
   - color
+  - height
+  - hose_diameter
+  - hose_length
   - hose_material
+  - length
+  - maximum_operating_pressure
   - pattern
+  - width
   return_reasons:
   - size
   - flexibility
@@ -5477,8 +6370,14 @@
   children: []
   attributes:
   - color
+  - height
+  - hose_diameter
+  - hose_length
   - hose_material
+  - length
+  - maximum_operating_pressure
   - pattern
+  - width
   return_reasons:
   - diameter
   - length
@@ -5495,8 +6394,14 @@
   children: []
   attributes:
   - color
+  - height
+  - hose_diameter
+  - hose_length
   - hose_material
+  - length
+  - maximum_operating_pressure
   - pattern
+  - width
   return_reasons:
   - diameter
   - length
@@ -5513,8 +6418,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -5534,7 +6442,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - inner_diameter
+  - length
+  - outside_diameter
   - pattern
+  - width
   return_reasons:
   - size
   - strength
@@ -5551,7 +6464,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - inner_diameter
+  - length
+  - outside_diameter
   - pattern
+  - width
   return_reasons:
   - size
   - strength
@@ -5568,7 +6486,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - inner_diameter
+  - length
+  - outside_diameter
   - pattern
+  - width
   return_reasons:
   - size
   - strength
@@ -5585,7 +6508,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - inner_diameter
+  - length
+  - outside_diameter
   - pattern
+  - width
   return_reasons:
   - size
   - strength
@@ -5601,8 +6529,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -5626,8 +6557,11 @@
   - ha-6-24-8
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -5646,8 +6580,11 @@
   - ha-6-24-1-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -5663,8 +6600,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -5680,8 +6620,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -5697,8 +6640,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -5720,7 +6666,10 @@
   - battery_type
   - clothing_accessory_material
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -5737,7 +6686,10 @@
   attributes:
   - clothing_accessory_material
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -5755,7 +6707,10 @@
   attributes:
   - clothing_accessory_material
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -5773,7 +6728,10 @@
   attributes:
   - clothing_accessory_material
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -5791,8 +6749,11 @@
   attributes:
   - bag/case_material
   - color
+  - height
+  - length
   - lock_type
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -5810,9 +6771,12 @@
   - ha-6-24-4-3
   attributes:
   - color
+  - height
+  - length
   - lock_type
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -5828,9 +6792,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lock_type
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -5847,9 +6814,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lock_type
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -5865,9 +6835,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lock_type
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -5886,8 +6859,11 @@
   - ha-6-24-5-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -5904,8 +6880,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -5921,8 +6900,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -5941,8 +6923,11 @@
   attributes:
   - color
   - hardware_mounting_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5958,8 +6943,11 @@
   attributes:
   - color
   - hardware_mounting_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5975,8 +6963,11 @@
   attributes:
   - color
   - hardware_mounting_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5991,8 +6982,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - retention
@@ -6011,9 +7005,12 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -6031,8 +7028,11 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - height
@@ -6050,8 +7050,11 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - height
@@ -6068,8 +7071,12 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -6092,7 +7099,13 @@
   - ha-7-6
   attributes:
   - color
+  - flow_rate
+  - height
+  - length
+  - maximum_delivery_height
+  - maximum_operating_pressure
   - pattern
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -6112,9 +7125,15 @@
   - ha-7-1-3
   attributes:
   - color
+  - flow_rate
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
+  - maximum_operating_pressure
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -6131,9 +7150,15 @@
   children: []
   attributes:
   - color
+  - flow_rate
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
+  - maximum_operating_pressure
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -6150,9 +7175,15 @@
   children: []
   attributes:
   - color
+  - flow_rate
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
+  - maximum_operating_pressure
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -6169,9 +7200,15 @@
   children: []
   attributes:
   - color
+  - flow_rate
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
+  - maximum_operating_pressure
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -6191,9 +7228,15 @@
   - ha-7-2-3
   attributes:
   - color
+  - flow_rate
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
   - pattern
+  - power
   - power_source
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -6211,9 +7254,15 @@
   children: []
   attributes:
   - color
+  - flow_rate
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
   - pattern
+  - power
   - power_source
+  - width
   return_reasons:
   - flow_rate
   - operating_noise
@@ -6229,9 +7278,15 @@
   children: []
   attributes:
   - color
+  - flow_rate
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
   - pattern
+  - power
   - power_source
+  - width
   return_reasons:
   - flow_rate
   - pressure
@@ -6248,9 +7303,15 @@
   children: []
   attributes:
   - color
+  - flow_rate
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
   - pattern
+  - power
   - power_source
+  - width
   return_reasons:
   - flow_rate
   - pressure
@@ -6270,10 +7331,17 @@
   - ha-7-3-5
   attributes:
   - color
+  - flow_rate
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
+  - maximum_operating_pressure
   - pattern
+  - power
   - power_source
   - suitable_for_water_feature_type
+  - width
   return_reasons:
   - flow_rate
   - pressure
@@ -6290,10 +7358,17 @@
   children: []
   attributes:
   - color
+  - flow_rate
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
+  - maximum_operating_pressure
   - pattern
+  - power
   - power_source
   - suitable_for_water_feature_type
+  - width
   return_reasons:
   - flow_rate
   - pressure
@@ -6309,10 +7384,17 @@
   children: []
   attributes:
   - color
+  - flow_rate
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
+  - maximum_operating_pressure
   - pattern
+  - power
   - power_source
   - suitable_for_water_feature_type
+  - width
   return_reasons:
   - flow_rate
   - pressure
@@ -6329,10 +7411,17 @@
   children: []
   attributes:
   - color
+  - flow_rate
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
+  - maximum_operating_pressure
   - pattern
+  - power
   - power_source
   - suitable_for_water_feature_type
+  - width
   return_reasons:
   - flow_rate
   - pressure
@@ -6352,8 +7441,13 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
+  - maximum_operating_pressure
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -6371,8 +7465,13 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
+  - maximum_operating_pressure
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -6390,8 +7489,13 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
+  - maximum_operating_pressure
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -6409,8 +7513,13 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
+  - maximum_operating_pressure
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -6431,8 +7540,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -6450,8 +7563,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -6469,8 +7586,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -6488,8 +7609,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -6507,8 +7632,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_delivery_height
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - voltage
@@ -6547,9 +7676,12 @@
   attributes:
   - color
   - dryer_technology
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - voltage
@@ -6568,9 +7700,14 @@
   attributes:
   - color
   - duct_design
+  - duct_diameter
+  - duct_length
   - duct_shape
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -6587,10 +7724,13 @@
   - ha-8-3-2
   - ha-8-3-3
   attributes:
+  - height
   - housing_color
   - housing_pattern
   - hvac_control_type
+  - length
   - power_source
+  - width
   return_reasons:
   - size
   - voltage
@@ -6605,10 +7745,13 @@
   name: Control Panels
   children: []
   attributes:
+  - height
   - housing_color
   - housing_pattern
   - hvac_control_type
+  - length
   - power_source
+  - width
   return_reasons:
   - size
   - voltage
@@ -6623,10 +7766,13 @@
   name: Humidistats
   children: []
   attributes:
+  - height
   - housing_color
   - housing_pattern
   - hvac_control_type
+  - length
   - power_source
+  - width
   return_reasons:
   - size
   - voltage
@@ -6644,11 +7790,14 @@
   - battery_size
   - battery_type
   - display_technology
+  - height
   - housing_color
   - housing_pattern
   - hvac_control_type
+  - length
   - power_source
   - sensor_features
+  - width
   return_reasons:
   - voltage
   - incompatible
@@ -6662,9 +7811,14 @@
   name: Vents & Flues
   children: []
   attributes:
+  - airflow_system_diameter
+  - airflow_system_length
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -6698,9 +7852,12 @@
   children: []
   attributes:
   - color
+  - height
   - key_purpose
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6716,8 +7873,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6736,8 +7896,11 @@
   - ha-9-3-3
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_use
+  - width
   return_reasons:
   - size
   - color
@@ -6753,8 +7916,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_use
+  - width
   return_reasons:
   - color
   - incompatible
@@ -6769,8 +7935,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_use
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6788,9 +7957,12 @@
   - ha-9-4-5
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - security_level
+  - width
   return_reasons:
   - size
   - finish
@@ -6806,9 +7978,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - security_level
+  - width
   return_reasons:
   - length
   - finish
@@ -6824,9 +7999,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - security_level
+  - width
   return_reasons:
   - size
   - finish
@@ -6842,9 +8020,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - security_level
+  - width
   return_reasons:
   - size
   - style
@@ -6861,9 +8042,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - security_level
+  - width
   return_reasons:
   - size
   - style
@@ -6932,8 +8116,12 @@
   children: []
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -6951,8 +8139,11 @@
   - ha-10-1-2-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - finish
   - incompatible
@@ -6967,8 +8158,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -6983,8 +8177,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -6999,8 +8196,12 @@
   children: []
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -7018,8 +8219,13 @@
   - ha-10-1-4-2
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
+  - maximum_operating_pressure
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7035,8 +8241,13 @@
   children: []
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
+  - maximum_operating_pressure
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7051,8 +8262,13 @@
   children: []
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
+  - maximum_operating_pressure
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7069,8 +8285,13 @@
   - ha-10-1-5-2
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
+  - maximum_operating_pressure
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -7086,8 +8307,13 @@
   children: []
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
+  - maximum_operating_pressure
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7102,8 +8328,13 @@
   children: []
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
+  - maximum_operating_pressure
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7120,8 +8351,13 @@
   - ha-10-1-6-2
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
+  - maximum_operating_pressure
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7136,8 +8372,13 @@
   children: []
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
+  - maximum_operating_pressure
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7152,8 +8393,13 @@
   children: []
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
+  - maximum_operating_pressure
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7168,8 +8414,14 @@
   children: []
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
+  - maximum_operating_pressure
   - pattern
+  - thickness
+  - width
   return_reasons:
   - size
   - finish
@@ -7185,9 +8437,13 @@
   children: []
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
   - pattern
   - pipe_clamp_design
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7204,8 +8460,12 @@
   - ha-10-1-9-2
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - pressure
   - flow_rate
@@ -7221,8 +8481,12 @@
   children: []
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - flow_rate
   - incompatible
@@ -7237,8 +8501,12 @@
   children: []
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -7259,8 +8527,12 @@
   - ha-10-1-10-5
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7275,8 +8547,12 @@
   children: []
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7291,8 +8567,12 @@
   children: []
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7309,8 +8589,12 @@
   - battery_size
   - battery_type
   - color
+  - fitting_size
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7325,8 +8609,12 @@
   children: []
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7341,8 +8629,12 @@
   children: []
   attributes:
   - color
+  - fitting_size
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7404,8 +8696,11 @@
   attributes:
   - bathtub_base_design
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -7423,8 +8718,11 @@
   attributes:
   - bathtub_skirt_shape
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -7443,8 +8741,11 @@
   - ha-10-2-1-3-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -7461,8 +8762,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -7479,8 +8783,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -7522,8 +8829,11 @@
   - ha-10-2-2-1-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7539,8 +8849,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7556,8 +8869,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7574,7 +8890,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7590,8 +8909,13 @@
   children: []
   attributes:
   - color
+  - diameter
   - hardware_material
+  - height
+  - length
   - pattern
+  - thickness
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7607,8 +8931,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
   - recommended_use
+  - width
   return_reasons:
   - size
   - finish
@@ -7625,7 +8952,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7640,9 +8970,13 @@
   children: []
   attributes:
   - color
+  - diameter
   - hardware_material
+  - height
+  - length
   - pattern
   - plumbing_trap_design
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7657,8 +8991,12 @@
   children: []
   attributes:
   - color
+  - diameter
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7677,8 +9015,12 @@
   - ha-10-2-3-3
   attributes:
   - color
+  - diameter
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7694,8 +9036,12 @@
   children: []
   attributes:
   - color
+  - diameter
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7711,8 +9057,12 @@
   children: []
   attributes:
   - color
+  - diameter
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7728,8 +9078,12 @@
   children: []
   attributes:
   - color
+  - diameter
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7767,8 +9121,11 @@
   - color
   - connecting_thread
   - faucet_thread
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7789,7 +9146,10 @@
   - color
   - connecting_thread
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7807,7 +9167,10 @@
   - color
   - connecting_thread
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7825,7 +9188,10 @@
   - color
   - connecting_thread
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7843,7 +9209,10 @@
   - color
   - connecting_thread
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7863,7 +9232,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7880,7 +9252,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7897,7 +9272,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7914,7 +9292,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -7958,10 +9339,14 @@
   - ha-10-2-6-1-2
   attributes:
   - color
+  - diameter
   - drain_location
   - hardware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - finish
@@ -7977,10 +9362,14 @@
   children: []
   attributes:
   - color
+  - diameter
   - drain_location
   - hardware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - finish
@@ -7996,10 +9385,14 @@
   children: []
   attributes:
   - color
+  - diameter
   - drain_location
   - hardware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - finish
@@ -8016,10 +9409,16 @@
   - ha-10-2-6-2-1
   - ha-10-2-6-2-2
   attributes:
+  - amperage
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - voltage
+  - width
   return_reasons:
   - size
   - finish
@@ -8037,8 +9436,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - finish
@@ -8055,8 +9457,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - finish
@@ -8077,7 +9482,10 @@
   - color
   - connecting_thread
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -8095,7 +9503,10 @@
   - color
   - connecting_thread
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -8114,7 +9525,10 @@
   - color
   - connecting_thread
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -8131,8 +9545,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
   - shower_base_design
+  - width
   return_reasons:
   - size
   - finish
@@ -8149,7 +9566,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -8169,7 +9589,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -8186,7 +9609,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -8203,7 +9629,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -8220,7 +9649,10 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -8239,8 +9671,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - finish
@@ -8257,8 +9692,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - finish
@@ -8276,8 +9714,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - finish
@@ -8297,7 +9738,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -8314,7 +9758,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -8331,7 +9778,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -8348,7 +9798,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8363,8 +9816,11 @@
   - ha-10-2-7-1
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -8380,8 +9836,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -8427,8 +9886,11 @@
   - ha-10-2-8-1-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -8444,8 +9906,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -8461,8 +9926,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -8481,7 +9949,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -8498,7 +9969,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -8515,7 +9989,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -8533,12 +10010,15 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - lumber/wood_type
   - material
   - material_firmness
   - pattern
   - toilet_cover_design
   - toilet_cover_features
+  - width
   - wood_finish
   return_reasons:
   - finish
@@ -8554,9 +10034,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - toilet_cover_design
+  - width
   return_reasons:
   - finish
   - incompatible
@@ -8571,9 +10054,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - toilet_cover_design
+  - width
   return_reasons:
   - color
   - style
@@ -8588,8 +10074,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - finish
   - incompatible
@@ -8606,8 +10095,11 @@
   - ha-10-2-8-7-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - length
   - finish
@@ -8623,8 +10115,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - length
   - finish
@@ -8640,8 +10135,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - length
   - finish
@@ -8660,9 +10158,12 @@
   attributes:
   - flush_plate_color
   - flush_plate_pattern
+  - height
+  - length
   - material
   - tank_color
   - tank_pattern
+  - width
   return_reasons:
   - finish
   - incompatible
@@ -8678,9 +10179,12 @@
   attributes:
   - flush_plate_color
   - flush_plate_pattern
+  - height
+  - length
   - material
   - tank_color
   - tank_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -8698,9 +10202,12 @@
   attributes:
   - flush_plate_color
   - flush_plate_pattern
+  - height
+  - length
   - material
   - tank_color
   - tank_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -8717,8 +10224,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - finish
   - incompatible
@@ -8755,8 +10265,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -8775,11 +10288,15 @@
   - ha-10-3-2-3
   attributes:
   - bathtub_features
+  - capacity
   - color
   - drain_location
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -8797,11 +10314,15 @@
   children: []
   attributes:
   - bathtub_features
+  - capacity
   - color
   - drain_location
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -8819,11 +10340,15 @@
   children: []
   attributes:
   - bathtub_features
+  - capacity
   - color
   - drain_location
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -8841,11 +10366,15 @@
   children: []
   attributes:
   - bathtub_features
+  - capacity
   - color
   - drain_location
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -8866,8 +10395,11 @@
   - ha-10-3-3-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -8884,8 +10416,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -8902,8 +10437,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -8920,8 +10458,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -8938,11 +10479,17 @@
   children: []
   attributes:
   - color
+  - depth
+  - height
+  - length
   - material
   - pattern
+  - screen_width
   - shower_design
   - shower_features
   - shower_opening_type
+  - thickness
+  - width
   return_reasons:
   - size
   - finish
@@ -8959,6 +10506,7 @@
   - ha-10-3-5-1
   - ha-10-3-5-2
   attributes:
+  - capacity
   - color
   - material
   - pattern
@@ -8979,10 +10527,14 @@
   - ha-10-3-5-1-2
   - ha-10-3-5-1-3
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
   - sink_shape
+  - width
   return_reasons:
   - size
   - finish
@@ -8997,10 +10549,14 @@
   name: Pedestal Sinks
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
   - sink_shape
+  - width
   return_reasons:
   - size
   - finish
@@ -9015,10 +10571,14 @@
   name: Undermount Sinks
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
   - sink_shape
+  - width
   return_reasons:
   - size
   - finish
@@ -9033,11 +10593,15 @@
   name: Vessel Sinks
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
   - sink_mounting_type
   - sink_shape
+  - width
   return_reasons:
   - size
   - finish
@@ -9055,11 +10619,15 @@
   - ha-10-3-5-2-2
   - ha-10-3-5-2-3
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
   - sink_shape
   - sink_type
+  - width
   return_reasons:
   - size
   - finish
@@ -9074,11 +10642,15 @@
   name: Drop-In Sinks
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
   - sink_shape
   - sink_type
+  - width
   return_reasons:
   - size
   - finish
@@ -9093,11 +10665,15 @@
   name: Farmhouse Sinks
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
   - sink_shape
   - sink_type
+  - width
   return_reasons:
   - size
   - finish
@@ -9112,11 +10688,15 @@
   name: Undermount Sinks
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
   - sink_shape
   - sink_type
+  - width
   return_reasons:
   - size
   - finish
@@ -9156,8 +10736,11 @@
   - battery_type
   - bidet_mounting_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -9177,10 +10760,13 @@
   attributes:
   - color
   - flush_system
+  - height
+  - length
   - material
   - pattern
   - toilet_mounting_type
   - toilet_shape
+  - width
   return_reasons:
   - size
   - finish
@@ -9197,9 +10783,12 @@
   attributes:
   - color
   - flush_system
+  - height
+  - length
   - material
   - pattern
   - toilet_shape
+  - width
   return_reasons:
   - finish
   - incompatible
@@ -9215,9 +10804,12 @@
   attributes:
   - color
   - flush_system
+  - height
+  - length
   - material
   - pattern
   - toilet_shape
+  - width
   return_reasons:
   - finish
   - incompatible
@@ -9233,9 +10825,12 @@
   attributes:
   - color
   - flush_system
+  - height
+  - length
   - material
   - pattern
   - toilet_shape
+  - width
   return_reasons:
   - finish
   - incompatible
@@ -9250,9 +10845,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - urinal_mounting_type
+  - width
   return_reasons:
   - size
   - finish
@@ -9271,8 +10869,11 @@
   - ha-10-4-3
   attributes:
   - color
+  - height
   - hose_material
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - incompatible
@@ -9287,8 +10888,11 @@
   children: []
   attributes:
   - color
+  - height
   - hose_material
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - material
@@ -9304,8 +10908,11 @@
   children: []
   attributes:
   - color
+  - height
   - hose_material
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - material
@@ -9321,8 +10928,11 @@
   children: []
   attributes:
   - color
+  - height
   - hose_material
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - material
@@ -9341,8 +10951,13 @@
   - ha-10-5-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - pipe_diameter
+  - pipe_length
+  - width
   return_reasons:
   - diameter
   - length
@@ -9358,8 +10973,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - pipe_diameter
+  - pipe_length
+  - width
   return_reasons:
   - diameter
   - length
@@ -9375,8 +10995,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - pipe_diameter
+  - pipe_length
+  - width
   return_reasons:
   - diameter
   - length
@@ -9392,8 +11017,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - pipe_diameter
+  - pipe_length
+  - width
   return_reasons:
   - diameter
   - length
@@ -9412,8 +11042,11 @@
   - ha-10-6-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -9427,8 +11060,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9443,8 +11079,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - pressure
@@ -9460,8 +11099,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -9498,8 +11140,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - flow_rate
   - taste
@@ -9516,9 +11161,13 @@
   - ha-10-7-2-1
   - ha-10-7-2-2
   attributes:
+  - capacity
   - color
   - hardware_mounting_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - capacity
   - flow_rate
@@ -9533,12 +11182,16 @@
   name: Drinking Fountains
   children: []
   attributes:
+  - capacity
   - color
   - hardware_mounting_type
+  - height
+  - length
   - material
   - pattern
   - placement_supported
   - suitable_space
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9552,9 +11205,13 @@
   name: Water Chillers
   children: []
   attributes:
+  - capacity
   - color
   - hardware_mounting_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - capacity
   - flow_rate
@@ -9570,7 +11227,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - capacity
   - flow_rate
@@ -9591,7 +11251,10 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -9607,8 +11270,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -9622,8 +11288,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - flow_rate
   - incompatible
@@ -9638,7 +11307,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -9654,7 +11326,10 @@
   - ha-10-7-6-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - capacity
   - flow_rate
@@ -9670,7 +11345,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - capacity
   - flow_rate
@@ -9686,7 +11364,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - capacity
   - flow_rate
@@ -9702,7 +11383,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - flow_rate
   - incompatible
@@ -9717,7 +11401,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - flow_rate
   - incompatible
@@ -9732,7 +11419,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -9773,8 +11463,11 @@
   - ha-11-27
   - ha-11-28
   attributes:
+  - amperage
   - color
   - pattern
+  - power_consumption_typical
+  - voltage
   return_reasons:
   - size
   - voltage
@@ -9793,10 +11486,16 @@
   - ha-11-1-2
   - ha-11-1-3
   attributes:
+  - amperage
   - color
+  - diameter
+  - height
+  - length
   - material
   - motor_starting_method
   - pattern
+  - voltage
+  - width
   return_reasons:
   - size
   - voltage
@@ -9812,10 +11511,16 @@
   name: Armatures
   children: []
   attributes:
+  - amperage
   - color
+  - diameter
+  - height
+  - length
   - material
   - motor_starting_method
   - pattern
+  - voltage
+  - width
   return_reasons:
   - size
   - voltage
@@ -9831,10 +11536,16 @@
   name: Rotors
   children: []
   attributes:
+  - amperage
   - color
+  - diameter
+  - height
+  - length
   - material
   - motor_starting_method
   - pattern
+  - voltage
+  - width
   return_reasons:
   - size
   - voltage
@@ -9850,10 +11561,16 @@
   name: Stators
   children: []
   attributes:
+  - amperage
   - color
+  - diameter
+  - height
+  - length
   - material
   - motor_starting_method
   - pattern
+  - voltage
+  - width
   return_reasons:
   - size
   - voltage
@@ -9873,7 +11590,10 @@
   - ha-11-2-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -9890,7 +11610,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -9907,7 +11630,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -9924,7 +11650,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -9942,7 +11671,10 @@
   attributes:
   - brush_material
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -9960,9 +11692,15 @@
   - ha-11-4-1
   - ha-11-4-2
   attributes:
+  - amperage
   - circuit_breaker_panel_form
   - color
+  - height
+  - interrupt_rating
+  - length
   - pattern
+  - voltage
+  - width
   return_reasons:
   - size
   - voltage
@@ -9978,9 +11716,15 @@
   name: Main Breaker Panels
   children: []
   attributes:
+  - amperage
   - circuit_breaker_panel_form
   - color
+  - height
+  - interrupt_rating
+  - length
   - pattern
+  - voltage
+  - width
   return_reasons:
   - size
   - voltage
@@ -9996,9 +11740,15 @@
   name: Sub-Panel Breaker Panels
   children: []
   attributes:
+  - amperage
   - circuit_breaker_panel_form
   - color
+  - height
+  - interrupt_rating
+  - length
   - pattern
+  - voltage
+  - width
   return_reasons:
   - size
   - voltage
@@ -10014,12 +11764,18 @@
   name: Circuit Breakers
   children: []
   attributes:
+  - amperage
   - circuit_breaker_design
   - circuit_breaker_type
   - color
+  - height
+  - interrupt_rating
+  - length
   - pattern
   - recommended_use
   - trip_type
+  - voltage
+  - width
   return_reasons:
   - size
   - voltage
@@ -10057,8 +11813,11 @@
   - ha-11-6-1-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -10074,8 +11833,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10090,8 +11852,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -10107,9 +11872,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - shrink_ratio
+  - tubing_size_before_shrinking
+  - width
   return_reasons:
   - size
   - color
@@ -10128,10 +11897,18 @@
   - ha-11-7-2
   - ha-11-7-3
   attributes:
+  - amperage
   - color
+  - height
+  - length
+  - maximum_rotational_speed
   - motor_starting_method
   - pattern
+  - power
+  - power_consumption_typical
   - power_source
+  - voltage
+  - width
   return_reasons:
   - size
   - voltage
@@ -10148,9 +11925,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_rotational_speed
   - motor_starting_method
   - pattern
+  - power
   - power_source
+  - voltage
+  - width
   return_reasons:
   - size
   - voltage
@@ -10167,9 +11950,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_rotational_speed
   - motor_starting_method
   - pattern
+  - power
   - power_source
+  - voltage
+  - width
   return_reasons:
   - size
   - voltage
@@ -10186,9 +11975,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_rotational_speed
   - motor_starting_method
   - pattern
+  - power
   - power_source
+  - voltage
+  - width
   return_reasons:
   - size
   - voltage
@@ -10207,8 +12002,11 @@
   - ha-11-8-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10223,8 +12021,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - depth
@@ -10241,8 +12042,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - depth
   - configuration
@@ -10259,8 +12063,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -10301,8 +12108,11 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - switch_control_type
+  - width
   return_reasons:
   - color
   - style
@@ -10321,8 +12131,11 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - switch_control_type
+  - width
   return_reasons:
   - color
   - voltage
@@ -10338,8 +12151,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - switch_control_type
+  - width
   return_reasons:
   - color
   - voltage
@@ -10355,8 +12171,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - switch_control_type
+  - width
   return_reasons:
   - color
   - voltage
@@ -10375,7 +12194,10 @@
   - ha-11-10-2-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -10392,7 +12214,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -10409,7 +12234,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -10426,7 +12254,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -10443,7 +12274,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   - wire/rope_material
   return_reasons:
   - length
@@ -10462,7 +12296,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -10479,8 +12316,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - length
   - voltage
@@ -10497,7 +12337,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -10516,11 +12359,19 @@
   - ha-11-15-2
   - ha-11-15-3
   attributes:
+  - amperage
   - color
+  - fuel_efficiency_typical
+  - fuel_tank_capacity
+  - height
   - ignition_system
+  - length
   - pattern
   - phase_type
+  - power
   - power_source
+  - voltage
+  - width
   return_reasons:
   - size
   - voltage
@@ -10536,11 +12387,19 @@
   name: Inverter Generators
   children: []
   attributes:
+  - amperage
   - color
+  - fuel_efficiency_typical
+  - fuel_tank_capacity
+  - height
   - ignition_system
+  - length
   - pattern
   - phase_type
+  - power
   - power_source
+  - voltage
+  - width
   return_reasons:
   - size
   - voltage
@@ -10557,13 +12416,21 @@
   name: Portable Generators
   children: []
   attributes:
+  - amperage
   - battery_size
   - battery_type
   - color
+  - fuel_efficiency_typical
+  - fuel_tank_capacity
+  - height
   - ignition_system
+  - length
   - pattern
   - phase_type
+  - power
   - power_source
+  - voltage
+  - width
   return_reasons:
   - size
   - voltage
@@ -10580,11 +12447,19 @@
   name: Standby Generators
   children: []
   attributes:
+  - amperage
   - color
+  - fuel_efficiency_typical
+  - fuel_tank_capacity
+  - height
   - ignition_system
+  - length
   - pattern
   - phase_type
+  - power
   - power_source
+  - voltage
+  - width
   return_reasons:
   - size
   - voltage
@@ -10604,7 +12479,10 @@
   - ha-11-16-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - voltage
   - range
@@ -10620,7 +12498,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - voltage
   - range
@@ -10638,7 +12519,10 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - voltage
   - range
@@ -10654,7 +12538,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - voltage
   - range
@@ -10672,7 +12559,10 @@
   - ha-11-17-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -10688,7 +12578,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -10704,7 +12597,10 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -10720,7 +12616,10 @@
   - ha-11-18-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -10738,7 +12637,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - voltage
   - amperage
@@ -10755,7 +12657,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - voltage
   - amperage
@@ -10772,8 +12677,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -10790,8 +12698,15 @@
   children: []
   attributes:
   - color
+  - height
+  - input_voltage
+  - length
+  - output_frequency
+  - output_voltage
   - pattern
+  - power_output_typical
   - suitable_space
+  - width
   return_reasons:
   - voltage
   - power_output
@@ -10810,8 +12725,11 @@
   - ha-11-21-3
   attributes:
   - color
+  - height
+  - length
   - pattern
   - socket_type
+  - width
   return_reasons:
   - size
   - voltage
@@ -10828,8 +12746,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - socket_type
+  - width
   return_reasons:
   - size
   - color
@@ -10847,8 +12768,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - socket_type
+  - width
   return_reasons:
   - size
   - color
@@ -10866,8 +12790,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - socket_type
+  - width
   return_reasons:
   - size
   - color
@@ -10888,8 +12815,12 @@
   - ha-11-22-3
   attributes:
   - color
+  - height
+  - length
   - pattern
   - solar_panel_design
+  - voltage
+  - width
   return_reasons:
   - voltage
   - power_output
@@ -10905,8 +12836,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - solar_panel_design
+  - voltage
+  - width
   return_reasons:
   - voltage
   - power_output
@@ -10923,8 +12858,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - solar_panel_design
+  - voltage
+  - width
   return_reasons:
   - voltage
   - power_output
@@ -10940,8 +12879,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - solar_panel_design
+  - voltage
+  - width
   return_reasons:
   - voltage
   - power_output
@@ -10960,10 +12903,16 @@
   - ha-11-23-2
   - ha-11-23-3
   attributes:
+  - amperage
   - color
+  - height
+  - length
   - pattern
+  - power
   - solar_cell_type
   - solar_panel_connections
+  - thickness
+  - width
   return_reasons:
   - size
   - voltage
@@ -10979,9 +12928,15 @@
   name: Monocrystalline Solar Panels
   children: []
   attributes:
+  - amperage
   - color
+  - height
+  - length
   - pattern
+  - power
   - solar_panel_connections
+  - thickness
+  - width
   return_reasons:
   - size
   - voltage
@@ -10997,9 +12952,15 @@
   name: Polycrystalline Solar Panels
   children: []
   attributes:
+  - amperage
   - color
+  - height
+  - length
   - pattern
+  - power
   - solar_panel_connections
+  - thickness
+  - width
   return_reasons:
   - size
   - voltage
@@ -11015,9 +12976,15 @@
   name: Thin-Film Solar Panels
   children: []
   attributes:
+  - amperage
   - color
+  - height
+  - length
   - pattern
+  - power
   - solar_panel_connections
+  - thickness
+  - width
   return_reasons:
   - size
   - voltage
@@ -11036,7 +13003,10 @@
   - ha-11-24-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -11053,7 +13023,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -11070,7 +13043,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -11090,9 +13066,12 @@
   - ha-11-25-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - wall_plate_style
+  - width
   return_reasons:
   - size
   - color
@@ -11109,9 +13088,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - wall_plate_style
+  - width
   return_reasons:
   - size
   - color
@@ -11128,9 +13110,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - wall_plate_style
+  - width
   return_reasons:
   - size
   - color
@@ -11147,10 +13132,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - wall_plate_style
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -11170,7 +13158,10 @@
   - ha-11-26-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -11187,7 +13178,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -11206,7 +13200,10 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - voltage
@@ -11225,8 +13222,11 @@
   - ha-11-27-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - amperage
@@ -11242,8 +13242,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - amperage
@@ -11259,8 +13262,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - amperage
@@ -11279,8 +13285,11 @@
   - ha-11-28-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - amperage
@@ -11297,8 +13306,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - amperage
@@ -11314,8 +13326,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - amperage
@@ -11331,8 +13346,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - amperage
@@ -11348,12 +13366,20 @@
   children: []
   attributes:
   - color
+  - cylinder_bore
+  - dry_weight
   - engine_design
   - engine_purpose
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
+  - length
   - pattern
   - shaft_orientation
   - start_type
+  - stroke
+  - width
   return_reasons:
   - size
   - horsepower
@@ -11368,12 +13394,16 @@
   name: Storage Tanks
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - orientation
   - pattern
   - storage_tank_application
   - suitable_installation
+  - width
   return_reasons:
   - size
   - capacity
@@ -11452,10 +13482,13 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - sandblaster_application
   - sander_type
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11471,10 +13504,13 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - sandblaster_application
   - sander_type
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11490,10 +13526,13 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - sandblaster_application
   - sander_type
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11510,8 +13549,11 @@
   - ha-14-2-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -11527,8 +13569,12 @@
   children: []
   attributes:
   - color
+  - depth
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - incompatible
@@ -11544,7 +13590,11 @@
   attributes:
   - blade_material
   - color
+  - depth
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -11561,7 +13611,10 @@
   - ha-14-3-1
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11577,7 +13630,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11616,10 +13672,14 @@
   - ha-14-4-1-3
   attributes:
   - color
+  - drill_bit_size
   - hardware_material
+  - height
+  - length
   - pattern
   - rotating_direction
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11634,10 +13694,14 @@
   children: []
   attributes:
   - color
+  - drill_bit_size
   - hardware_material
+  - height
+  - length
   - pattern
   - rotating_direction
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11652,10 +13716,14 @@
   children: []
   attributes:
   - color
+  - drill_bit_size
   - hardware_material
+  - height
+  - length
   - pattern
   - rotating_direction
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - length
@@ -11671,10 +13739,14 @@
   children: []
   attributes:
   - color
+  - drill_bit_size
   - hardware_material
+  - height
+  - length
   - pattern
   - rotating_direction
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11689,8 +13761,12 @@
   children: []
   attributes:
   - color
+  - drill_bit_size
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11708,7 +13784,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11724,7 +13803,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11740,7 +13822,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -11757,7 +13842,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_chuck_capacity
+  - minimum_chuck_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -11774,7 +13864,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_chuck_capacity
+  - minimum_chuck_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -11791,7 +13886,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_chuck_capacity
+  - minimum_chuck_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -11809,8 +13909,11 @@
   - ha-14-4-5-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11825,8 +13928,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11841,8 +13947,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11858,8 +13967,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - saw_size
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11874,7 +13987,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11889,7 +14005,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11905,7 +14024,10 @@
   - ha-14-7-1
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - grit
@@ -11921,7 +14043,11 @@
   children: []
   attributes:
   - color
+  - diameter
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - grit
@@ -11940,7 +14066,10 @@
   - ha-14-8-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -11956,7 +14085,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -11972,8 +14104,12 @@
   children: []
   attributes:
   - color
+  - depth
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -11989,8 +14125,12 @@
   children: []
   attributes:
   - color
+  - depth
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -12006,8 +14146,12 @@
   children: []
   attributes:
   - color
+  - depth
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -12026,7 +14170,10 @@
   - ha-14-10-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12041,7 +14188,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12056,7 +14206,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12071,7 +14224,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12086,7 +14242,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - performance
@@ -12103,7 +14262,10 @@
   - ha-14-12-1
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -12119,8 +14281,12 @@
   children: []
   attributes:
   - color
+  - depth
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -12141,7 +14307,10 @@
   - ha-14-13-5
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -12161,8 +14330,11 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - incompatible
@@ -12177,7 +14349,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12192,7 +14367,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12207,7 +14385,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - incompatible
@@ -12237,8 +14418,12 @@
   children: []
   attributes:
   - color
+  - depth
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - mixing_performance
@@ -12272,7 +14457,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12290,6 +14478,7 @@
   attributes:
   - color
   - pattern
+  - volume
   return_reasons:
   - strength
   - incompatible
@@ -12305,6 +14494,7 @@
   attributes:
   - color
   - pattern
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12319,6 +14509,7 @@
   attributes:
   - color
   - pattern
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12332,7 +14523,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12348,7 +14542,12 @@
   attributes:
   - battery_technology
   - color
+  - height
+  - length
+  - maximum_battery_life
   - pattern
+  - voltage
+  - width
   return_reasons:
   - size
   - battery_life
@@ -12365,7 +14564,12 @@
   attributes:
   - battery_technology
   - color
+  - height
+  - length
+  - maximum_battery_life
   - pattern
+  - voltage
+  - width
   return_reasons:
   - size
   - voltage
@@ -12384,7 +14588,10 @@
   - ha-14-18-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12401,9 +14608,16 @@
   - ha-14-18-1-2
   - ha-14-18-1-3
   attributes:
+  - bit_diameter
   - color
+  - cutting_diameter
+  - depth
   - hardware_material
+  - height
+  - length
   - pattern
+  - shank_size
+  - width
   return_reasons:
   - size
   - shape
@@ -12418,9 +14632,16 @@
   name: Edge-Forming Bits
   children: []
   attributes:
+  - bit_diameter
   - color
+  - cutting_diameter
+  - depth
   - hardware_material
+  - height
+  - length
   - pattern
+  - shank_size
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12434,9 +14655,16 @@
   name: Flush-Trim Bits
   children: []
   attributes:
+  - bit_diameter
   - color
+  - cutting_diameter
+  - depth
   - hardware_material
+  - height
+  - length
   - pattern
+  - shank_size
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12450,9 +14678,16 @@
   name: Straight Bits
   children: []
   attributes:
+  - bit_diameter
   - color
+  - cutting_diameter
+  - depth
   - hardware_material
+  - height
+  - length
   - pattern
+  - shank_size
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12468,8 +14703,11 @@
   attributes:
   - color
   - hardware_mounting_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12514,8 +14752,11 @@
   - backing_material
   - backing_pattern
   - grit_type
+  - height
+  - length
   - sanding_application
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - grit
@@ -12535,8 +14776,11 @@
   - backing_material
   - backing_pattern
   - grit_type
+  - height
+  - length
   - sanding_application
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - grit
@@ -12556,8 +14800,11 @@
   - backing_material
   - backing_pattern
   - grit_type
+  - height
+  - length
   - sanding_application
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - grit
@@ -12577,8 +14824,11 @@
   - backing_material
   - backing_pattern
   - grit_type
+  - height
+  - length
   - sanding_application
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - grit
@@ -12598,8 +14848,11 @@
   - backing_material
   - backing_pattern
   - grit_type
+  - height
+  - length
   - sanding_application
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - grit
@@ -12619,8 +14872,11 @@
   - backing_material
   - backing_pattern
   - grit_type
+  - height
+  - length
   - sanding_application
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - grit
@@ -12640,8 +14896,11 @@
   - backing_material
   - backing_pattern
   - grit_type
+  - height
+  - length
   - sanding_application
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - grit
@@ -12661,8 +14920,11 @@
   - backing_material
   - backing_pattern
   - grit_type
+  - height
+  - length
   - sanding_application
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - grit
@@ -12682,8 +14944,11 @@
   - backing_material
   - backing_pattern
   - grit_type
+  - height
+  - length
   - sanding_application
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - grit
@@ -12703,8 +14968,11 @@
   - backing_material
   - backing_pattern
   - grit_type
+  - height
+  - length
   - sanding_application
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - grit
@@ -12725,7 +14993,10 @@
   - ha-14-20-5
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12740,7 +15011,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12755,7 +15029,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12771,7 +15048,10 @@
   attributes:
   - alcohol/solvent_content
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12786,7 +15066,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12801,7 +15084,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12836,7 +15122,10 @@
   attributes:
   - blade_material
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - shape
@@ -12853,7 +15142,10 @@
   attributes:
   - blade_material
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12869,7 +15161,10 @@
   attributes:
   - blade_material
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12885,7 +15180,10 @@
   attributes:
   - blade_material
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12917,8 +15215,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12937,7 +15238,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -12954,7 +15258,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12970,7 +15277,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12986,7 +15296,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -13025,7 +15338,10 @@
   attributes:
   - blade_material
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -13042,7 +15358,10 @@
   attributes:
   - blade_material
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -13059,7 +15378,10 @@
   attributes:
   - blade_material
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - flexibility
@@ -13078,10 +15400,14 @@
   - ha-14-23-2-3
   attributes:
   - blade_material
+  - blade_size
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - tooth_spacing
@@ -13097,10 +15423,14 @@
   children: []
   attributes:
   - blade_material
+  - blade_size
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - tooth_spacing
@@ -13119,7 +15449,10 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - tooth_spacing
@@ -13138,7 +15471,10 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - tooth_spacing
@@ -13156,8 +15492,11 @@
   - ha-14-24-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -13174,7 +15513,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13190,7 +15532,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13205,8 +15550,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - length
   - weight_capacity
@@ -13222,7 +15571,12 @@
   children: []
   attributes:
   - color
+  - drive_diameter
+  - height
+  - length
   - pattern
+  - socket_diameter
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13259,8 +15613,11 @@
   - ha-14-27-1-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - height
@@ -13277,8 +15634,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - height
@@ -13295,8 +15655,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - height
@@ -13313,8 +15676,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -13334,7 +15700,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -13351,7 +15720,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13367,7 +15739,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -13384,7 +15759,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -13400,7 +15778,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -13513,8 +15894,11 @@
   - ha-15-1-3
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - pressure
@@ -13530,8 +15914,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -13548,8 +15935,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - pressure
   - weight
@@ -13565,8 +15955,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - pressure
   - weight
@@ -13583,7 +15976,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -13603,7 +15999,10 @@
   - ha-15-3-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - changed_my_mind
@@ -13617,7 +16016,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - changed_my_mind
@@ -13631,7 +16033,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - changed_my_mind
@@ -13645,7 +16050,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - changed_my_mind
@@ -13661,7 +16069,10 @@
   - ha-15-4-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -13678,7 +16089,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -13695,7 +16109,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -13718,6 +16135,9 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - grip
   - material
@@ -13736,6 +16156,9 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13752,6 +16175,9 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13768,6 +16194,9 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13784,7 +16213,10 @@
   - ha-15-6-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - grip
   - incompatible
@@ -13799,7 +16231,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -13812,7 +16247,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -13825,7 +16263,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -13840,7 +16281,11 @@
   attributes:
   - brush_material
   - color
+  - diameter
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - diameter
   - bristles_too_coarse
@@ -13858,8 +16303,11 @@
   - ha-15-8-2
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - horsepower
   - operating_noise
@@ -13874,8 +16322,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - horsepower
   - operating_noise
@@ -13890,8 +16341,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - horsepower
   - operating_noise
@@ -13906,8 +16360,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - pressure
@@ -13927,6 +16384,9 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - weight
   - bristles_too_coarse
@@ -13970,7 +16430,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -13988,7 +16451,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -14004,7 +16470,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -14025,6 +16494,9 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14041,6 +16513,9 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14057,6 +16532,9 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14073,6 +16551,9 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14087,8 +16568,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14105,7 +16589,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14120,7 +16607,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -14136,7 +16626,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -14151,9 +16644,13 @@
   children: []
   attributes:
   - blade_material
+  - height
   - housing_color
   - housing_material
   - housing_pattern
+  - length
+  - maximum_tube_diameter
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14169,7 +16666,11 @@
   - ha-15-11-6-2
   attributes:
   - color
+  - cutting_depth
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -14184,7 +16685,11 @@
   children: []
   attributes:
   - color
+  - cutting_depth
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14198,7 +16703,11 @@
   children: []
   attributes:
   - color
+  - cutting_depth
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14214,7 +16723,10 @@
   - ha-15-11-7-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14228,7 +16740,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -14243,7 +16758,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14261,7 +16779,10 @@
   - blade_design
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14277,8 +16798,11 @@
   - blade_design
   - color
   - hardware_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -14295,7 +16819,10 @@
   - blade_design
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14311,9 +16838,13 @@
   - ha-15-12-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - pipe_diameter_supported
   - suitable_for_pipe_type
+  - width
   return_reasons:
   - diameter
   - weight
@@ -14329,9 +16860,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - pipe_diameter_supported
   - suitable_for_pipe_type
+  - width
   return_reasons:
   - capacity
   - weight
@@ -14347,9 +16882,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - pipe_diameter_supported
   - suitable_for_pipe_type
+  - width
   return_reasons:
   - capacity
   - weight
@@ -14369,7 +16908,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -14387,7 +16930,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -14404,7 +16951,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -14421,7 +16972,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -14444,6 +16999,9 @@
   - chuck_type
   - color
   - drill_features
+  - maximum_drilling_diameter
+  - maximum_idle_speed
+  - minimum_drilling_diameter
   - pattern
   - power_source
   return_reasons:
@@ -14464,9 +17022,16 @@
   - ha-15-14-1-2
   attributes:
   - color
+  - diameter
   - drill_features
+  - height
+  - length
+  - maximum_drilling_diameter
+  - maximum_idle_speed
+  - minimum_drilling_diameter
   - pattern
   - power_source
+  - width
   return_reasons:
   - diameter
   - weight
@@ -14483,8 +17048,15 @@
   children: []
   attributes:
   - color
+  - diameter
+  - height
+  - length
+  - maximum_drilling_diameter
+  - maximum_idle_speed
+  - minimum_drilling_diameter
   - pattern
   - power_source
+  - width
   return_reasons:
   - diameter
   - length
@@ -14499,9 +17071,16 @@
   children: []
   attributes:
   - color
+  - diameter
   - drill_features
+  - height
+  - length
+  - maximum_drilling_diameter
+  - maximum_idle_speed
+  - minimum_drilling_diameter
   - pattern
   - power_source
+  - width
   return_reasons:
   - diameter
   - power_output
@@ -14520,8 +17099,17 @@
   - color
   - drill_features
   - hardware_mounting_type
+  - height
+  - length
+  - maximum_chuck_capacity
+  - maximum_drilling_diameter
+  - maximum_idle_speed
+  - minimum_chuck_capacity
+  - minimum_drilling_diameter
   - pattern
+  - power
   - power_source
+  - width
   return_reasons:
   - weight
   - power_output
@@ -14544,8 +17132,16 @@
   - chuck_type
   - color
   - drill_features
+  - height
+  - length
+  - maximum_chuck_capacity
+  - maximum_drilling_diameter
+  - maximum_idle_speed
+  - minimum_chuck_capacity
+  - minimum_drilling_diameter
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - power_output
@@ -14565,8 +17161,16 @@
   - chuck_type
   - color
   - drill_features
+  - height
+  - length
+  - maximum_chuck_capacity
+  - maximum_drilling_diameter
+  - maximum_idle_speed
+  - minimum_chuck_capacity
+  - minimum_drilling_diameter
   - pattern
   - power_source
+  - width
   return_reasons:
   - power_output
   - weight
@@ -14584,8 +17188,16 @@
   - chuck_type
   - color
   - drill_features
+  - height
+  - length
+  - maximum_chuck_capacity
+  - maximum_drilling_diameter
+  - maximum_idle_speed
+  - minimum_chuck_capacity
+  - minimum_drilling_diameter
   - pattern
   - power_source
+  - width
   return_reasons:
   - power_output
   - weight
@@ -14605,8 +17217,16 @@
   - chuck_type
   - color
   - drill_features
+  - height
+  - length
+  - maximum_chuck_capacity
+  - maximum_drilling_diameter
+  - maximum_idle_speed
+  - minimum_chuck_capacity
+  - minimum_drilling_diameter
   - pattern
   - power_source
+  - width
   return_reasons:
   - power_output
   - weight
@@ -14624,8 +17244,14 @@
   - color
   - drill_features
   - hardware_mounting_type
+  - height
+  - length
+  - maximum_drilling_diameter
+  - maximum_idle_speed
+  - minimum_drilling_diameter
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -14644,8 +17270,16 @@
   - chuck_type
   - color
   - drill_features
+  - height
+  - length
+  - maximum_chuck_capacity
+  - maximum_drilling_diameter
+  - maximum_idle_speed
+  - minimum_chuck_capacity
+  - minimum_drilling_diameter
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -14662,8 +17296,16 @@
   - chuck_type
   - color
   - drill_features
+  - height
+  - length
+  - maximum_chuck_capacity
+  - maximum_drilling_diameter
+  - maximum_idle_speed
+  - minimum_chuck_capacity
+  - minimum_drilling_diameter
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -14680,8 +17322,16 @@
   - chuck_type
   - color
   - drill_features
+  - height
+  - length
+  - maximum_chuck_capacity
+  - maximum_drilling_diameter
+  - maximum_idle_speed
+  - minimum_chuck_capacity
+  - minimum_drilling_diameter
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -14697,7 +17347,9 @@
   attributes:
   - color
   - hardware_material
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - flexibility
@@ -14741,11 +17393,14 @@
   - battery_size
   - battery_type
   - color
+  - height
   - housing_material
+  - length
   - light_source
   - lighting_features
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - brightness
@@ -14763,10 +17418,13 @@
   - battery_size
   - battery_type
   - color
+  - height
   - housing_material
+  - length
   - light_source
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - brightness
@@ -14784,11 +17442,14 @@
   - battery_size
   - battery_type
   - color
+  - height
   - housing_material
+  - length
   - light_source
   - lumber/wood_type
   - pattern
   - power_source
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -14808,10 +17469,13 @@
   - battery_size
   - battery_type
   - color
+  - height
   - housing_material
+  - length
   - light_source
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - fit
@@ -14828,8 +17492,11 @@
   - ha-15-17-3
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - pressure
   - incompatible
@@ -14844,8 +17511,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - pressure
   - incompatible
@@ -14860,8 +17530,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - pressure
   - incompatible
@@ -14879,8 +17552,11 @@
   - ha-15-18-3
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - power_output
@@ -14897,8 +17573,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight
@@ -14915,8 +17594,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight
@@ -14933,8 +17615,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight
@@ -14955,7 +17640,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -14971,7 +17659,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -14988,7 +17679,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -15005,7 +17699,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -15045,6 +17742,9 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - weight
   - changed_my_mind
@@ -15061,6 +17761,9 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - weight
   - changed_my_mind
@@ -15077,6 +17780,9 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - weight
   - changed_my_mind
@@ -15093,6 +17799,9 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - weight
   - length
@@ -15112,7 +17821,10 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15129,7 +17841,10 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - power_source
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -15149,7 +17864,10 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - power_source
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -15164,8 +17882,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - power_output
@@ -15181,9 +17902,13 @@
   name: Hardware Torches
   children: []
   attributes:
+  - burner_size
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - power_output
@@ -15201,8 +17926,15 @@
   - ha-15-23-2
   attributes:
   - color
+  - height
+  - length
+  - maximum_airflow
+  - maximum_temperature
+  - minimum_temperature
   - pattern
+  - power
   - power_source
+  - width
   return_reasons:
   - weight
   - temperature
@@ -15219,8 +17951,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_airflow
+  - maximum_temperature
+  - minimum_temperature
   - pattern
+  - power
   - power_source
+  - width
   return_reasons:
   - weight
   - temperature
@@ -15237,8 +17976,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_airflow
+  - maximum_temperature
+  - minimum_temperature
   - pattern
+  - power
   - power_source
+  - width
   return_reasons:
   - weight
   - temperature
@@ -15257,10 +18003,16 @@
   - ha-15-24-2
   - ha-15-24-3
   attributes:
+  - chuck_size
   - color
+  - drive_diameter
   - handle_design
+  - height
+  - length
+  - maximum_idle_speed
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - power_output
@@ -15276,10 +18028,16 @@
   name: Impact Drivers
   children: []
   attributes:
+  - chuck_size
   - color
+  - drive_diameter
   - handle_design
+  - height
+  - length
+  - maximum_idle_speed
   - pattern
   - power_source
+  - width
   return_reasons:
   - amperage
   - incompatible
@@ -15293,10 +18051,16 @@
   name: Power Screwdrivers
   children: []
   attributes:
+  - chuck_size
   - color
+  - drive_diameter
   - handle_design
+  - height
+  - length
+  - maximum_idle_speed
   - pattern
   - power_source
+  - width
   return_reasons:
   - amperage
   - incompatible
@@ -15310,10 +18074,16 @@
   name: Screw Guns
   children: []
   attributes:
+  - chuck_size
   - color
+  - drive_diameter
   - handle_design
+  - height
+  - length
+  - maximum_idle_speed
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15327,8 +18097,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - voltage
@@ -15346,6 +18119,10 @@
   attributes:
   - handle_color
   - handle_pattern
+  - height
+  - length
+  - mirror_size
+  - width
   return_reasons:
   - size
   - length
@@ -15386,7 +18163,12 @@
   - color
   - features
   - hardware_material
+  - height
+  - length
+  - maximum_height
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - height
   - weight_capacity
@@ -15406,7 +18188,12 @@
   - color
   - features
   - hardware_material
+  - height
+  - length
+  - maximum_height
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - height
   - weight_capacity
@@ -15423,7 +18210,12 @@
   - color
   - features
   - hardware_material
+  - height
+  - length
+  - maximum_height
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - height
   - weight_capacity
@@ -15441,7 +18233,12 @@
   - color
   - features
   - hardware_material
+  - height
+  - length
+  - maximum_height
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - height
   - weight_capacity
@@ -15458,7 +18255,12 @@
   - color
   - features
   - hardware_material
+  - height
+  - length
+  - maximum_height
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - height
@@ -15479,7 +18281,11 @@
   - color
   - features
   - hardware_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - height
   - weight_capacity
@@ -15496,8 +18302,12 @@
   - color
   - features
   - hardware_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - scaffolding_mounting_type
+  - width
   return_reasons:
   - height
   - weight_capacity
@@ -15514,7 +18324,11 @@
   - color
   - features
   - hardware_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - weight_capacity
   - height
@@ -15531,8 +18345,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - lumber/wood_type
+  - maximum_load_capacity
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - height
@@ -15549,8 +18367,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - height
@@ -15567,9 +18388,12 @@
   attributes:
   - color
   - hardware_material
+  - height
   - lathe_application
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight
@@ -15588,7 +18412,10 @@
   attributes:
   - bulb_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - grip
@@ -15605,7 +18432,10 @@
   attributes:
   - bulb_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - incompatible
@@ -15621,7 +18451,10 @@
   attributes:
   - bulb_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - suction
   - incompatible
@@ -15640,7 +18473,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -15655,7 +18491,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - style
@@ -15671,7 +18510,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -15686,7 +18528,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -15703,7 +18548,12 @@
   - ha-15-31-2
   attributes:
   - color
+  - height
+  - length
+  - maximum_log_diameter
+  - maximum_log_length
   - pattern
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -15718,7 +18568,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_log_diameter
+  - maximum_log_length
   - pattern
+  - width
   return_reasons:
   - weight
   - changed_my_mind
@@ -15732,7 +18587,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_log_diameter
+  - maximum_log_length
   - pattern
+  - width
   return_reasons:
   - operating_noise
   - changed_my_mind
@@ -15748,7 +18608,10 @@
   - ha-15-32-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - weight
@@ -15765,7 +18628,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - strength
@@ -15780,7 +18646,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - strength
@@ -15795,7 +18664,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_operating_distance
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -15837,7 +18710,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -15853,8 +18729,12 @@
   - ha-15-34-2-2
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - volume
+  - width
   return_reasons:
   - size
   - incompatible
@@ -15869,8 +18749,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - volume
+  - width
   return_reasons:
   - size
   - incompatible
@@ -15885,8 +18769,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - volume
+  - width
   return_reasons:
   - size
   - incompatible
@@ -15902,7 +18790,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_operating_distance
   - pattern
+  - width
   return_reasons:
   - length
   - thickness
@@ -15921,7 +18813,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -15936,7 +18831,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -15953,7 +18851,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -15969,7 +18870,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -15984,8 +18888,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
   - sponge_shape
+  - width
   return_reasons:
   - size
   - firmness
@@ -16003,7 +18910,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16018,7 +18928,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16033,7 +18946,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16050,7 +18966,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16065,7 +18984,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16080,7 +19002,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16098,7 +19023,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16113,7 +19041,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16128,7 +19059,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16143,7 +19077,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16156,9 +19093,16 @@
   name: Power Trowels
   children: []
   attributes:
+  - blade_size
   - color
+  - height
+  - length
+  - motor_frequency
   - pattern
+  - power
   - power_source
+  - voltage
+  - width
   return_reasons:
   - horsepower
   - incompatible
@@ -16176,7 +19120,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - changed_my_mind
@@ -16191,7 +19138,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - changed_my_mind
@@ -16206,7 +19156,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - changed_my_mind
@@ -16277,9 +19230,13 @@
   - ha-15-36-1-3
   attributes:
   - display_technology
+  - height
   - housing_color
   - housing_pattern
+  - length
   - measuring_tool_features
+  - transmission_frequency
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16294,9 +19251,13 @@
   children: []
   attributes:
   - display_technology
+  - height
   - housing_color
   - housing_pattern
+  - length
   - measuring_tool_features
+  - transmission_frequency
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16311,9 +19272,13 @@
   children: []
   attributes:
   - display_technology
+  - height
   - housing_color
   - housing_pattern
+  - length
   - measuring_tool_features
+  - transmission_frequency
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16328,9 +19293,13 @@
   children: []
   attributes:
   - display_technology
+  - height
   - housing_color
   - housing_pattern
+  - length
   - measuring_tool_features
+  - transmission_frequency
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16347,7 +19316,10 @@
   - color
   - device_technology
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16367,10 +19339,14 @@
   - anemometer_application
   - color
   - display_technology
+  - height
+  - length
   - measuring_tool_features
   - pattern
   - power_source
   - units_of_measurement
+  - width
+  - wind_speed_accuracy
   return_reasons:
   - range
   - battery_life
@@ -16388,10 +19364,14 @@
   - anemometer_application
   - color
   - display_technology
+  - height
+  - length
   - measuring_tool_features
   - pattern
   - power_source
   - units_of_measurement
+  - width
+  - wind_speed_accuracy
   return_reasons:
   - range
   - battery_life
@@ -16409,10 +19389,14 @@
   - anemometer_application
   - color
   - display_technology
+  - height
+  - length
   - measuring_tool_features
   - pattern
   - power_source
   - units_of_measurement
+  - width
+  - wind_speed_accuracy
   return_reasons:
   - range
   - battery_life
@@ -16430,10 +19414,14 @@
   - anemometer_application
   - color
   - display_technology
+  - height
+  - length
   - measuring_tool_features
   - pattern
   - power_source
   - units_of_measurement
+  - width
+  - wind_speed_accuracy
   return_reasons:
   - range
   - battery_life
@@ -16453,8 +19441,11 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16470,8 +19461,11 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16487,8 +19481,11 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - range
@@ -16505,8 +19502,11 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16528,8 +19528,12 @@
   - color
   - device_technology
   - display_technology
+  - distance_measurement_accuracy
+  - height
+  - length
   - pattern
   - system_of_measurement
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16546,8 +19550,12 @@
   - color
   - device_technology
   - display_technology
+  - distance_measurement_accuracy
+  - height
+  - length
   - pattern
   - system_of_measurement
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16564,8 +19572,12 @@
   - color
   - device_technology
   - display_technology
+  - distance_measurement_accuracy
+  - height
+  - length
   - pattern
   - system_of_measurement
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16582,8 +19594,12 @@
   - color
   - device_technology
   - display_technology
+  - distance_measurement_accuracy
+  - height
+  - length
   - pattern
   - system_of_measurement
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16599,7 +19615,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_operating_distance
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16617,8 +19637,13 @@
   - battery_type
   - color
   - display_technology
+  - distance_measurement_accuracy
+  - distance_range
+  - height
+  - length
   - pattern
   - units_of_measurement
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16636,8 +19661,12 @@
   - battery_type
   - color
   - hardware_material
+  - height
+  - length
   - lumber/wood_type
+  - maximum_operating_distance
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -16658,7 +19687,10 @@
   - battery_type
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16674,7 +19706,10 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - voltage
@@ -16693,7 +19728,10 @@
   - battery_type
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16709,7 +19747,10 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16729,8 +19770,12 @@
   - battery_type
   - color
   - display_technology
+  - flow_rate_accuracy
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16746,8 +19791,12 @@
   attributes:
   - color
   - display_technology
+  - flow_rate_accuracy
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - range
@@ -16766,8 +19815,12 @@
   - battery_type
   - color
   - display_technology
+  - flow_rate_accuracy
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - range
@@ -16789,9 +19842,12 @@
   - color
   - display_technology
   - gases_detected
+  - height
+  - length
   - measuring_tool_features
   - pattern
   - power_source
+  - width
   return_reasons:
   - range
   - battery_life
@@ -16809,9 +19865,12 @@
   - color
   - display_technology
   - gases_detected
+  - height
+  - length
   - measuring_tool_features
   - pattern
   - power_source
+  - width
   return_reasons:
   - range
   - battery_life
@@ -16829,9 +19888,12 @@
   - color
   - display_technology
   - gases_detected
+  - height
+  - length
   - measuring_tool_features
   - pattern
   - power_source
+  - width
   return_reasons:
   - range
   - battery_life
@@ -16853,7 +19915,10 @@
   - battery_type
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - changed_my_mind
@@ -16868,7 +19933,10 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16884,7 +19952,10 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - range
@@ -16901,7 +19972,10 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - range
@@ -16920,7 +19994,10 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16936,7 +20013,10 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - changed_my_mind
@@ -16951,7 +20031,10 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -16968,9 +20051,12 @@
   - color
   - device_technology
   - display_technology
+  - height
+  - length
   - measuring_tool_features
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - range
   - battery_life
@@ -16989,7 +20075,13 @@
   - battery_type
   - color
   - display_technology
+  - height
+  - length
+  - maximum_temperature
+  - minimum_temperature
   - pattern
+  - temperature_accuracy
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17007,7 +20099,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -17022,7 +20117,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -17037,7 +20135,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -17056,8 +20157,11 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - orientation
   - pattern
+  - width
   return_reasons:
   - range
   - changed_my_mind
@@ -17074,8 +20178,11 @@
   - ha-15-36-17-1-3
   attributes:
   - color
+  - height
+  - length
   - orientation
   - pattern
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -17089,8 +20196,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - orientation
   - pattern
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -17104,8 +20214,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - orientation
   - pattern
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -17119,8 +20232,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - orientation
   - pattern
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -17140,8 +20256,12 @@
   - battery_type
   - color
   - display_technology
+  - distance_range
+  - height
+  - length
   - orientation
   - pattern
+  - width
   return_reasons:
   - range
   - brightness
@@ -17158,8 +20278,12 @@
   attributes:
   - color
   - display_technology
+  - distance_range
+  - height
+  - length
   - orientation
   - pattern
+  - width
   return_reasons:
   - range
   - brightness
@@ -17178,8 +20302,12 @@
   - battery_type
   - color
   - display_technology
+  - distance_range
+  - height
+  - length
   - orientation
   - pattern
+  - width
   return_reasons:
   - range
   - brightness
@@ -17196,8 +20324,12 @@
   attributes:
   - color
   - display_technology
+  - distance_range
+  - height
+  - length
   - orientation
   - pattern
+  - width
   return_reasons:
   - range
   - brightness
@@ -17215,8 +20347,11 @@
   - ha-15-36-17-3-2
   attributes:
   - color
+  - height
+  - length
   - orientation
   - pattern
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -17230,8 +20365,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - orientation
   - pattern
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -17245,8 +20383,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - orientation
   - pattern
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -17265,7 +20406,11 @@
   - battery_type
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - weight_measurement_accuracy
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17283,7 +20428,11 @@
   - battery_type
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - weight_measurement_accuracy
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -17300,7 +20449,11 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - weight_measurement_accuracy
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -17316,11 +20469,17 @@
   children: []
   attributes:
   - color
+  - diameter
   - display_technology
+  - distance_measurement_accuracy
+  - distance_range
   - hardware_material
+  - height
+  - length
   - measuring_tool_features
   - pattern
   - units_of_measurement
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -17338,9 +20497,12 @@
   - battery_type
   - color
   - display_technology
+  - height
+  - length
   - measuring_tool_features
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17356,9 +20518,12 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - measuring_tool_features
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17374,9 +20539,12 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - measuring_tool_features
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17394,7 +20562,10 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -17409,7 +20580,10 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -17423,7 +20597,10 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -17441,7 +20618,10 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17456,7 +20636,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - voltage
@@ -17472,7 +20655,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17487,7 +20673,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - voltage
@@ -17505,7 +20694,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_operating_distance
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -17521,7 +20714,11 @@
   - color
   - device_technology
   - display_technology
+  - height
+  - length
+  - maximum_operating_distance
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17537,7 +20734,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_operating_distance
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -17554,7 +20755,10 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17570,7 +20774,10 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17586,7 +20793,10 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17602,7 +20812,10 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17618,12 +20831,19 @@
   attributes:
   - color
   - connection_method
+  - decibel_accuracy
   - device_technology
   - display_technology
   - frequency_weighting
+  - height
+  - length
+  - maximum_sound_detection_level
   - measuring_tool_features
+  - minimum_sound_detection_level
   - pattern
+  - sound_detection_resolution
   - time_weighting
+  - width
   return_reasons:
   - range
   - battery_life
@@ -17643,7 +20863,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -17658,7 +20881,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -17673,7 +20899,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -17688,7 +20917,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -17703,7 +20935,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -17718,7 +20953,11 @@
   - color
   - device_technology
   - display_technology
+  - height
+  - length
+  - maximum_operating_distance
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17734,9 +20973,13 @@
   attributes:
   - color
   - display_technology
+  - distance_measurement_accuracy
+  - height
   - housing_material
+  - length
   - pattern
   - system_of_measurement
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -17752,7 +20995,10 @@
   - color
   - device_technology
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - battery_life
   - incompatible
@@ -17769,10 +21015,16 @@
   - color
   - display_resolution
   - display_technology
+  - height
   - housing_material
+  - length
+  - maximum_battery_life
   - measuring_tool_features
   - pattern
+  - screen_size
+  - thermal_accuracy
   - thermal_detector_type
+  - width
   return_reasons:
   - resolution
   - range
@@ -17791,7 +21043,11 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - temperature_accuracy
+  - width
   return_reasons:
   - length
   - range
@@ -17808,7 +21064,11 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - temperature_accuracy
+  - width
   return_reasons:
   - length
   - range
@@ -17825,8 +21085,12 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - pattern
+  - temperature_accuracy
   - thermocouple_type
+  - width
   return_reasons:
   - length
   - range
@@ -17845,7 +21109,10 @@
   - ha-15-36-35-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17860,7 +21127,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - range
@@ -17876,7 +21146,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17893,7 +21166,10 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17912,7 +21188,10 @@
   - color
   - device_technology
   - display_technology
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17930,9 +21209,12 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - measuring_tool_features
   - pattern
   - power_source
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17948,9 +21230,12 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - measuring_tool_features
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - range
@@ -17967,9 +21252,12 @@
   attributes:
   - color
   - display_technology
+  - height
+  - length
   - measuring_tool_features
   - pattern
   - power_source
+  - width
   return_reasons:
   - range
   - incompatible
@@ -17989,8 +21277,11 @@
   - connection_method
   - device_technology
   - display_technology
+  - height
+  - length
   - measuring_tool_features
   - pattern
+  - width
   return_reasons:
   - range
   - battery_life
@@ -18026,9 +21317,15 @@
   - ha-15-37-1
   - ha-15-37-2
   attributes:
+  - collet_size
   - color
+  - height
+  - length
+  - maximum_idle_speed
   - pattern
+  - power
   - power_source
+  - width
   return_reasons:
   - size
   - weight
@@ -18043,9 +21340,15 @@
   name: Horizontal Milling Machines
   children: []
   attributes:
+  - collet_size
   - color
+  - height
+  - length
+  - maximum_idle_speed
   - pattern
+  - power
   - power_source
+  - width
   return_reasons:
   - size
   - horsepower
@@ -18060,9 +21363,15 @@
   name: Vertical Milling Machines
   children: []
   attributes:
+  - collet_size
   - color
+  - height
+  - length
+  - maximum_idle_speed
   - pattern
+  - power
   - power_source
+  - width
   return_reasons:
   - size
   - horsepower
@@ -18078,8 +21387,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -18097,7 +21409,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - weight
@@ -18115,7 +21430,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -18129,7 +21447,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -18146,8 +21467,11 @@
   - ha-15-40-4
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - power_source
@@ -18164,8 +21488,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - gauge
   - power_output
@@ -18181,8 +21508,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - gauge
   - power_output
@@ -18198,8 +21528,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - gauge
   - power_output
@@ -18215,8 +21548,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - gauge
   - power_output
@@ -18231,9 +21567,13 @@
   name: Oil Filter Drains
   children: []
   attributes:
+  - capacity
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - capacity
   - height
@@ -18280,7 +21620,11 @@
   - battery_type
   - bristle_material
   - color
+  - height
+  - length
+  - nozzle_size
   - pattern
+  - width
   return_reasons:
   - spray_pattern
   - incompatible
@@ -18297,8 +21641,12 @@
   - alcohol/solvent_content
   - bristle_material
   - color
+  - height
+  - length
   - paint_brush_design
+  - paint_brush_size
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -18319,7 +21667,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18335,7 +21686,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18351,7 +21705,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18369,8 +21726,13 @@
   - ha-15-42-4-3
   attributes:
   - color
+  - height
+  - length
   - material
+  - paint_roller_size
   - pattern
+  - pile_depth
+  - width
   return_reasons:
   - size
   - thickness
@@ -18386,8 +21748,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
+  - paint_roller_size
   - pattern
+  - pile_depth
+  - width
   return_reasons:
   - size
   - thickness
@@ -18403,8 +21770,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
+  - paint_roller_size
   - pattern
+  - pile_depth
+  - width
   return_reasons:
   - size
   - thickness
@@ -18420,8 +21792,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
+  - paint_roller_size
   - pattern
+  - pile_depth
+  - width
   return_reasons:
   - size
   - thickness
@@ -18438,8 +21815,12 @@
   - ha-15-42-5-1
   - ha-15-42-5-2
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -18451,8 +21832,12 @@
   name: Power Shakers
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18466,8 +21851,12 @@
   name: Manual Shakers
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -18482,8 +21871,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
   - sponge_shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -18503,8 +21895,11 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - spray_pattern
   - incompatible
@@ -18519,8 +21914,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - spray_pattern
   - weight
@@ -18536,8 +21934,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - spray_pattern
   - incompatible
@@ -18552,8 +21953,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - spray_pattern
   - weight
@@ -18572,7 +21976,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_fine
   - too_coarse
@@ -18588,7 +21995,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - too_fine
@@ -18605,7 +22015,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - too_fine
@@ -18621,9 +22034,14 @@
   children: []
   attributes:
   - alcohol/solvent_content
+  - capacity
   - color
+  - depth
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -18641,7 +22059,10 @@
   - ha-15-43-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - weight
@@ -18657,7 +22078,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - strength
@@ -18672,7 +22096,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - strength
@@ -18690,7 +22117,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - capacity
   - weight
@@ -18707,7 +22137,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - capacity
   - weight
@@ -18724,7 +22157,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - capacity
   - weight
@@ -18742,8 +22178,11 @@
   - ha-15-45-2
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - diameter
   - length
@@ -18759,8 +22198,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - diameter
   - length
@@ -18776,8 +22218,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - diameter
   - length
@@ -18795,7 +22240,11 @@
   attributes:
   - brush_material
   - color
+  - height
+  - length
   - pattern
+  - pipe_brush_size
+  - width
   return_reasons:
   - diameter
   - length
@@ -18814,8 +22263,11 @@
   - ha-15-47-2
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -18830,8 +22282,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - horsepower
   - operating_noise
@@ -18846,8 +22301,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - length
   - width
@@ -18865,9 +22323,13 @@
   - ha-15-48-2
   - ha-15-48-3
   attributes:
+  - blade_size
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - width
@@ -18882,9 +22344,13 @@
   name: Bench Planes
   children: []
   attributes:
+  - blade_size
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - width
@@ -18899,9 +22365,13 @@
   name: Block Planes
   children: []
   attributes:
+  - blade_size
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - width
@@ -18916,9 +22386,13 @@
   name: Router Planes
   children: []
   attributes:
+  - blade_size
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - width
@@ -18938,7 +22412,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - grip
@@ -18954,7 +22431,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -18969,7 +22449,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - tip_size
@@ -18985,7 +22468,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -19000,13 +22486,18 @@
   - ha-15-50-2
   - ha-15-50-3
   attributes:
+  - height
+  - length
   - plunger_shape
   - shaft_color
+  - shaft_length
   - shaft_material
   - shaft_pattern
   - suction_cup_color
   - suction_cup_material
   - suction_cup_pattern
+  - suction_cup_size
+  - width
   return_reasons:
   - length
   - suction
@@ -19021,13 +22512,18 @@
   name: Sink Plungers
   children: []
   attributes:
+  - height
+  - length
   - plunger_shape
   - shaft_color
+  - shaft_length
   - shaft_material
   - shaft_pattern
   - suction_cup_color
   - suction_cup_material
   - suction_cup_pattern
+  - suction_cup_size
+  - width
   return_reasons:
   - diameter
   - length
@@ -19042,13 +22538,18 @@
   name: Toilet Plungers
   children: []
   attributes:
+  - height
+  - length
   - plunger_shape
   - shaft_color
+  - shaft_length
   - shaft_material
   - shaft_pattern
   - suction_cup_color
   - suction_cup_material
   - suction_cup_pattern
+  - suction_cup_size
+  - width
   return_reasons:
   - diameter
   - length
@@ -19066,8 +22567,11 @@
   - ha-15-51-2
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight
@@ -19084,8 +22588,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight
@@ -19102,8 +22609,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight
@@ -19122,8 +22632,11 @@
   - ha-15-52-2
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight
@@ -19139,8 +22652,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - weight
@@ -19155,8 +22671,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - horsepower
@@ -19172,8 +22691,12 @@
   children: []
   attributes:
   - color
+  - depth
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - weight
@@ -19194,7 +22717,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -19210,7 +22736,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -19225,7 +22754,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -19242,7 +22774,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -19260,9 +22795,13 @@
   - ha-15-55-3
   attributes:
   - blade_material
+  - blade_size
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - grip
@@ -19278,9 +22817,13 @@
   children: []
   attributes:
   - blade_material
+  - blade_size
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - grip
@@ -19295,9 +22838,13 @@
   children: []
   attributes:
   - blade_material
+  - blade_size
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - grip
@@ -19313,9 +22860,13 @@
   children: []
   attributes:
   - blade_material
+  - blade_size
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - grip
@@ -19333,7 +22884,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -19349,7 +22903,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -19365,7 +22922,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -19382,7 +22942,10 @@
   - ha-15-57-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -19399,7 +22962,11 @@
   - ha-15-57-1-2
   attributes:
   - color
+  - compatible_rivet_size
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -19414,7 +22981,11 @@
   children: []
   attributes:
   - color
+  - compatible_rivet_size
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -19428,7 +22999,11 @@
   children: []
   attributes:
   - color
+  - compatible_rivet_size
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -19444,7 +23019,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -19458,8 +23036,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - power_output
@@ -19479,8 +23060,11 @@
   - ha-15-59-3
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - power_output
@@ -19496,8 +23080,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - changed_my_mind
@@ -19511,8 +23098,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - changed_my_mind
@@ -19526,8 +23116,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - changed_my_mind
@@ -19543,8 +23136,11 @@
   - color
   - grit_type
   - hardware_material
+  - height
+  - length
   - material_firmness
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -19560,7 +23156,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
+  - maximum_height
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - height
   - weight
@@ -19606,9 +23207,12 @@
   attributes:
   - color
   - hardware_mounting_type
+  - height
+  - length
   - pattern
   - power_source
   - suitable_for_material_type
+  - width
   return_reasons:
   - operating_noise
   - changed_my_mind
@@ -19621,10 +23225,14 @@
   name: Cut-Off Saws
   children: []
   attributes:
+  - blade_size
   - color
+  - height
+  - length
   - pattern
   - power_source
   - suitable_for_material_type
+  - width
   return_reasons:
   - operating_noise
   - changed_my_mind
@@ -19640,9 +23248,13 @@
   - ha-15-62-3-2
   - ha-15-62-3-3
   attributes:
+  - blade_size
   - color
+  - height
+  - length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -19655,9 +23267,13 @@
   name: Back Saws
   children: []
   attributes:
+  - blade_size
   - color
+  - height
+  - length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -19670,9 +23286,13 @@
   name: Coping Saws
   children: []
   attributes:
+  - blade_size
   - color
+  - height
+  - length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -19685,9 +23305,13 @@
   name: Hacksaws
   children: []
   attributes:
+  - blade_size
   - color
+  - height
+  - length
   - pattern
   - suitable_for_material_type
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -19700,12 +23324,20 @@
   name: Handheld Circular Saws
   children: []
   attributes:
+  - amperage
   - battery_size
   - battery_type
+  - blade_size
   - color
+  - cutting_depth
+  - height
+  - length
+  - maximum_idle_speed
   - pattern
+  - power
   - power_source
   - suitable_for_material_type
+  - width
   return_reasons:
   - weight
   - operating_noise
@@ -19720,9 +23352,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - stroke_length
   - suitable_for_material_type
+  - width
   return_reasons:
   - weight
   - operating_noise
@@ -19736,10 +23372,14 @@
   name: Masonry & Tile Saws
   children: []
   attributes:
+  - blade_size
   - color
+  - height
+  - length
   - pattern
   - power_source
   - suitable_for_material_type
+  - width
   return_reasons:
   - operating_noise
   - changed_my_mind
@@ -19753,10 +23393,16 @@
   children: []
   attributes:
   - bevel_type
+  - blade_size
   - color
+  - height
+  - length
+  - maximum_idle_speed
   - pattern
+  - power
   - power_source
   - suitable_for_material_type
+  - width
   return_reasons:
   - operating_noise
   - changed_my_mind
@@ -19769,10 +23415,14 @@
   name: Panel Saws
   children: []
   attributes:
+  - blade_size
   - color
+  - height
+  - length
   - pattern
   - power_source
   - suitable_for_material_type
+  - width
   return_reasons:
   - operating_noise
   - changed_my_mind
@@ -19786,9 +23436,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - stroke_length
   - suitable_for_material_type
+  - width
   return_reasons:
   - weight
   - operating_noise
@@ -19805,9 +23459,12 @@
   - ha-15-62-10-2
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
   - suitable_for_material_type
+  - width
   return_reasons:
   - operating_noise
   - changed_my_mind
@@ -19821,9 +23478,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -19837,9 +23497,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
   - suitable_for_material_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -19852,10 +23515,16 @@
   name: Table Saws
   children: []
   attributes:
+  - blade_size
   - color
+  - height
+  - idle_speed
+  - length
   - pattern
+  - power
   - power_source
   - suitable_for_material_type
+  - width
   return_reasons:
   - operating_noise
   - changed_my_mind
@@ -19873,7 +23542,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - grip
@@ -19889,7 +23561,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - grip
@@ -19905,7 +23580,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - grip
@@ -19921,7 +23599,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - grip
@@ -19936,9 +23617,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
   - suitable_for_material_type
+  - width
   return_reasons:
   - weight
   - power_source
@@ -19954,7 +23638,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - grit
@@ -19972,9 +23659,12 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
   - socket_driver_tip
   - tool_operation
+  - width
   return_reasons:
   - length
   - weight
@@ -19990,8 +23680,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_operating_temperature
   - pattern
+  - power
   - power_source
+  - width
   return_reasons:
   - weight
   - temperature
@@ -20009,7 +23704,10 @@
   - ha-15-68-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -20025,7 +23723,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -20039,7 +23740,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -20059,7 +23763,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -20076,7 +23783,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -20092,7 +23802,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -20108,7 +23821,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -20123,8 +23839,12 @@
   children: []
   attributes:
   - color
+  - compatible_pipe_diameter
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - power_output
@@ -20145,7 +23865,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -20162,7 +23885,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -20178,7 +23904,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -20194,7 +23923,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -20209,7 +23941,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - length
   - grit
@@ -20226,8 +23961,11 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
   - tool_key_tip
+  - width
   return_reasons:
   - size
   - length
@@ -20244,7 +23982,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -20281,7 +24022,10 @@
   - ha-15-75-1-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - changed_my_mind
@@ -20295,7 +24039,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - changed_my_mind
@@ -20309,7 +24056,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -20324,7 +24074,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -20341,8 +24094,11 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -20358,9 +24114,16 @@
   - ha-15-76-1
   - ha-15-76-2
   attributes:
+  - amperage
+  - cable_length
   - color
+  - cutting_depth
+  - height
+  - input_voltage
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - weight
   - power_output
@@ -20375,9 +24138,16 @@
   name: MIG Welders
   children: []
   attributes:
+  - amperage
+  - cable_length
   - color
+  - cutting_depth
+  - height
+  - input_voltage
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - power_output
   - incompatible
@@ -20391,9 +24161,16 @@
   name: TIG Welders
   children: []
   attributes:
+  - amperage
+  - cable_length
   - color
+  - cutting_depth
+  - height
+  - input_voltage
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - power_output
   - incompatible
@@ -20410,9 +24187,16 @@
   - ha-15-77-2
   - ha-15-77-3
   attributes:
+  - amperage
+  - cable_length
   - color
+  - cutting_depth
+  - height
+  - input_voltage
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - length
   - weight
@@ -20428,9 +24212,16 @@
   name: MIG Torches
   children: []
   attributes:
+  - amperage
+  - cable_length
   - color
+  - cutting_depth
+  - height
+  - input_voltage
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - length
   - incompatible
@@ -20444,9 +24235,16 @@
   name: Plasma Cutters
   children: []
   attributes:
+  - amperage
+  - cable_length
   - color
+  - cutting_depth
+  - height
+  - input_voltage
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -20459,9 +24257,16 @@
   name: TIG Torches
   children: []
   attributes:
+  - amperage
+  - cable_length
   - color
+  - cutting_depth
+  - height
+  - input_voltage
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - length
   - incompatible
@@ -20480,7 +24285,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - grip
@@ -20497,7 +24305,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - grip
   - incompatible
@@ -20513,7 +24324,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - grip
   - incompatible
@@ -20529,7 +24343,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - grip
   - incompatible
@@ -20545,8 +24362,13 @@
   attributes:
   - bulb_type
   - color
+  - height
+  - length
+  - luminous_flux
   - pattern
+  - power
   - power_source
+  - width
   return_reasons:
   - weight
   - brightness
@@ -20566,7 +24388,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -20582,7 +24407,10 @@
   attributes:
   - color
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -20599,7 +24427,10 @@
   - color
   - drive_size
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -20616,7 +24447,10 @@
   - color
   - drive_size
   - hardware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - length

--- a/data/categories/hb_health_beauty.yml
+++ b/data/categories/hb_health_beauty.yml
@@ -76,7 +76,10 @@
   - hb-1-1-6
   - hb-1-1-7
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - material
@@ -94,11 +97,14 @@
   - acupuncture_model_type
   - anatomical_detail_displayed
   - body_side
+  - height
   - lamination_type
   - language
+  - length
   - material
   - model_gender_representation
   - mounting_type
+  - width
   return_reasons:
   - size
   - material
@@ -115,11 +121,15 @@
   attributes:
   - handle_material
   - handle_type
+  - height
+  - length
   - material
   - needle_coating_type
+  - needle_diameter
   - needle_gauge
   - needle_material
   - product_sterility
+  - width
   return_reasons:
   - length
   - gauge
@@ -197,8 +207,12 @@
   - bed_pan_features
   - bed_pan_handle_style
   - bed_pan_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - usage_type
+  - width
   return_reasons:
   - size
   - comfort
@@ -258,11 +272,14 @@
   - connectivity_technology
   - control_type
   - durability_features
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - patch_shape
   - pattern
   - usage_type
+  - width
   return_reasons:
   - color
   - incompatible
@@ -377,10 +394,13 @@
   - compatible_device
   - control_type
   - durability_features
+  - height
+  - length
   - material
   - patch_shape
   - pattern
   - usage_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -402,10 +422,13 @@
   - control_solution_level
   - control_type
   - durability_features
+  - height
+  - length
   - material
   - patch_shape
   - pattern
   - usage_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -426,10 +449,13 @@
   - connectivity_technology
   - control_type
   - durability_features
+  - height
+  - length
   - material
   - patch_shape
   - pattern
   - usage_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -449,13 +475,16 @@
   - connectivity_technology
   - control_type
   - durability_features
+  - height
   - lancet_mechanism_type
+  - length
   - material
   - needle_gauge
   - patch_shape
   - pattern
   - product_sterility
   - usage_type
+  - width
   return_reasons:
   - depth
   - grip
@@ -557,9 +586,12 @@
   - compatible_device
   - connectivity_technology
   - durability_features
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -585,9 +617,12 @@
   - cuff_connector_type
   - cuff_size_category
   - durability_features
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -686,10 +721,13 @@
   - connectivity_technology
   - control_type
   - durability_features
+  - height
+  - length
   - material
   - pattern
   - power_source
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -826,12 +864,15 @@
   - compatible_operating_system
   - connectivity_technology
   - display_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - medical_device_certification
   - pattern
   - power_source
   - tracking_metrics
+  - width
   return_reasons:
   - color
   - connectivity
@@ -854,12 +895,16 @@
   - connectivity_technology
   - display_technology
   - glucose_measurement_units
+  - height
   - ingress_protection_ip_rating
+  - length
   - medical_device_certification
   - monitoring_method
   - pattern
   - power_source
+  - test_time
   - tracking_metrics
+  - width
   return_reasons:
   - battery_life
   - speed
@@ -930,11 +975,14 @@
   - color
   - connectivity_technology
   - display_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - medical_device_certification
   - pattern
   - power_source
   - tracking_metrics
+  - width
   return_reasons:
   - cuff_too_big
   - cuff_too_small
@@ -956,13 +1004,16 @@
   - color
   - connectivity_technology
   - display_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - measuring_method
   - medical_device_certification
   - metrics_supported
   - pattern
   - power_source
   - tracking_metrics
+  - width
   return_reasons:
   - connectivity
   - metrics_supported
@@ -1031,8 +1082,11 @@
   - connectivity_technology
   - device_technology
   - display_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
+  - maximum_load_capacity
   - measuring_method
   - medical_device_certification
   - metrics_supported
@@ -1040,6 +1094,7 @@
   - power_source
   - tracking_metrics
   - weight_unit_supported
+  - width
   return_reasons:
   - size
   - color
@@ -1058,11 +1113,14 @@
   - color
   - connectivity_technology
   - display_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - medical_device_certification
   - pattern
   - power_source
   - sensor_type
+  - width
   return_reasons:
   - calibration
   - battery_life
@@ -1081,13 +1139,16 @@
   - color
   - connectivity_technology
   - display_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - medical_device_certification
   - pattern
   - power_source
   - test_format
   - test_sample
   - tracking_metrics
+  - width
   return_reasons:
   - battery_life
   - incompatible
@@ -1106,13 +1167,17 @@
   - color
   - connectivity_technology
   - display_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - medical_device_certification
   - pattern
   - power_source
   - test_format
   - test_sample
+  - test_time
   - usage_type
+  - width
   return_reasons:
   - sensitivity
   - test_format
@@ -1133,14 +1198,18 @@
   - connectivity_technology
   - display_technology
   - fertility_metrics_measured
+  - height
   - ingress_protection_ip_rating
+  - length
   - medical_device_certification
   - pattern
   - power_source
   - result_display
   - test_format
   - test_sample
+  - test_time
   - usage_type
+  - width
   return_reasons:
   - sensitivity
   - test_format
@@ -1211,15 +1280,19 @@
   attributes:
   - color
   - connectivity_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - medical_device_certification
   - pattern
   - power_source
   - result_display
   - test_format
   - test_sample
+  - test_time
   - tracking_metrics
   - usage_type
+  - width
   return_reasons:
   - sensitivity
   - test_format
@@ -1244,12 +1317,15 @@
   - color
   - connectivity_technology
   - display_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - medical_device_certification
   - pattern
   - power_source
   - temperature_measurement
   - test_sample
+  - width
   return_reasons:
   - speed
   - brightness
@@ -1371,13 +1447,16 @@
   - color
   - connectivity_technology
   - display_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - medical_device_certification
   - pattern
   - power_source
   - product_certifications_standards
   - tracking_metrics
   - ultrasound_probe_type
+  - width
   return_reasons:
   - battery_life
   - sound_quality
@@ -1402,12 +1481,15 @@
   - color
   - connectivity_technology
   - display_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - medical_device_certification
   - pattern
   - power_source
   - sensor/measuring_tool_features
   - tracking_metrics
+  - width
   return_reasons:
   - battery_life
   - brightness
@@ -1567,6 +1649,7 @@
   - product_certifications_standards
   - product_sterility
   - treatment_objective
+  - volume
   return_reasons:
   - consistency
   - residue
@@ -1585,7 +1668,10 @@
   attributes:
   - case_transparency_level
   - closure_type
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - color
@@ -2122,11 +2208,13 @@
   - color
   - compression_level
   - durability_features
+  - length
   - medical_tape_material
   - pattern
   - product_certifications_standards
   - product_sterility
   - usage_type
+  - width
   return_reasons:
   - width
   - material
@@ -2405,6 +2493,8 @@
   - dietary_preferences
   - dietary_supplements
   - dietary_use
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - protein_source
   return_reasons:
@@ -2491,6 +2581,8 @@
   - dietary_preferences
   - dietary_supplements
   - dietary_use
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   - package_type
   - product_form
@@ -2636,6 +2728,8 @@
   - dietary_preferences
   - dietary_supplements
   - dietary_use
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   return_reasons:
   - taste
@@ -2695,6 +2789,8 @@
   - dietary_preferences
   - dietary_supplements
   - dietary_use
+  - energy_per_100_g
+  - energy_per_serving
   - flavor
   - package_type
   - texture_level
@@ -2715,6 +2811,8 @@
   - allergen_information
   - dietary_preferences
   - dietary_supplements
+  - energy_per_100_ml
+  - energy_per_serving
   - flavor
   return_reasons:
   - taste
@@ -4308,10 +4406,13 @@
   children: []
   attributes:
   - brightness_levels
+  - height
+  - length
   - light_source
   - light_spectrum
   - light_therapy_device_form_factor
   - power_source
+  - width
   return_reasons:
   - brightness
   - light_spectrum
@@ -4335,11 +4436,14 @@
   - activation_mechanism
   - alert_type
   - connectivity_technology
+  - height
+  - length
   - medical_alarm_features
   - monitoring_service_type
   - mounting_type
   - power_source
   - system_range
+  - width
   return_reasons:
   - range
   - battery_life
@@ -4471,13 +4575,16 @@
   attributes:
   - color
   - engraving
+  - height
   - language
+  - length
   - material
   - medical_identification_type
   - medical_symbol
   - pattern
   - personalization_options
   - product_format
+  - width
   return_reasons:
   - color
   - length
@@ -4870,6 +4977,7 @@
   - color
   - height_adjustment
   - material
+  - maximum_load_capacity
   - mobility/accessibility_equipment_features
   - mounting_type
   - pattern
@@ -4895,14 +5003,18 @@
   - battery_type
   - color
   - folding_mechanism
+  - height
   - height_adjustment
+  - length
   - material
+  - maximum_load_capacity
   - mobility/accessibility_equipment_features
   - mobility_scooter_type
   - mounting_type
   - pattern
   - power_source
   - wheel_type
+  - width
   - width_adjustment
   return_reasons:
   - speed
@@ -4922,8 +5034,11 @@
   attributes:
   - battery_technology
   - color
+  - height
   - height_adjustment
+  - length
   - material
+  - maximum_load_capacity
   - mobility/accessibility_equipment_features
   - mounting_type
   - pattern
@@ -4932,6 +5047,7 @@
   - seat_swivel_mechanism
   - stair_lifts_control_type
   - staircase_type
+  - width
   - width_adjustment
   return_reasons:
   - comfort
@@ -4952,14 +5068,18 @@
   attributes:
   - color
   - handle_type
+  - height
   - height_adjustment
+  - length
   - material
+  - maximum_load_capacity
   - mobility/accessibility_equipment_features
   - mounting_type
   - pattern
   - transfer_aid_type
   - transfer_board_shape
   - transfer_boards_surface_type
+  - width
   - width_adjustment
   return_reasons:
   - weight
@@ -5031,13 +5151,17 @@
   - battery_technology
   - battery_type
   - color
+  - height
   - height_adjustment
+  - length
   - material
+  - maximum_load_capacity
   - mobility/accessibility_equipment_features
   - mounting_type
   - pattern
   - wheel_type
   - wheelchair_type
+  - width
   - width_adjustment
   return_reasons:
   - width
@@ -5085,11 +5209,14 @@
   - color
   - compatible_accessibility_equipment_type
   - hand_side
+  - height
+  - length
   - material
   - mobility/accessibility_equipment_features
   - mobility_scooter_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -5220,12 +5347,15 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
   - height_adjustment
+  - length
   - mobility/accessibility_equipment_features
   - mounting_type
   - pattern
   - portability
   - seat_cushioning
+  - width
   return_reasons:
   - weight_capacity
   - height
@@ -5246,11 +5376,14 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
   - height_adjustment
+  - length
   - mobility/accessibility_equipment_features
   - mounting_type
   - pattern
   - portability
+  - width
   return_reasons:
   - padding
   - height
@@ -5271,12 +5404,15 @@
   - features
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
   - height_adjustment
+  - length
   - mobility/accessibility_equipment_features
   - mounting_type
   - pattern
   - portability
   - shape
+  - width
   return_reasons:
   - height
   - weight_capacity
@@ -5297,7 +5433,9 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
   - height_adjustment
+  - length
   - mobility/accessibility_equipment_features
   - mounting_type
   - pattern
@@ -5305,6 +5443,7 @@
   - seat_cushioning
   - seat_rotation
   - seat_shape
+  - width
   return_reasons:
   - height
   - width
@@ -5325,13 +5464,16 @@
   - furniture/fixture_features
   - furniture/fixture_material
   - hand_side
+  - height
   - height_adjustment
+  - length
   - mobility/accessibility_equipment_features
   - mounting_type
   - pattern
   - portability
   - seat_cushioning
   - seat_rotation
+  - width
   return_reasons:
   - height
   - width
@@ -5351,13 +5493,16 @@
   - finish
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
   - height_adjustment
+  - length
   - mobility/accessibility_equipment_features
   - mounting_type
   - pattern
   - portability
   - seat_cushioning
   - seat_shape
+  - width
   return_reasons:
   - height
   - width
@@ -5521,9 +5666,12 @@
   - age_group
   - color
   - compatible_walking_aid_equipment
+  - height
+  - length
   - material
   - mobility/accessibility_equipment_features
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -5609,6 +5757,7 @@
   - folding_mechanism
   - height_adjustment
   - material
+  - maximum_load_capacity
   - mobility/accessibility_equipment_features
   - pattern
   - power_source
@@ -5638,13 +5787,17 @@
   - color
   - folding_mechanism
   - handle_style
+  - height
   - height_adjustment
+  - length
   - lumber/wood_type
   - material
+  - maximum_load_capacity
   - mobility/accessibility_equipment_features
   - pattern
   - tip_material
   - walking_aid_tip_type
+  - width
   - wood_finish
   return_reasons:
   - style
@@ -5666,12 +5819,16 @@
   - folding_mechanism
   - handle_material
   - handle_style
+  - height
   - height_adjustment
+  - length
   - material
+  - maximum_load_capacity
   - mobility/accessibility_equipment_features
   - pattern
   - tip_material
   - walking_aid_tip_type
+  - width
   return_reasons:
   - height
   - grip
@@ -5690,13 +5847,17 @@
   - folding_mechanism
   - handle_material
   - handle_style
+  - height
   - height_adjustment
+  - length
   - material
+  - maximum_load_capacity
   - mobility/accessibility_equipment_features
   - pattern
   - portability
   - tip_material
   - walking_aid_tip_type
+  - width
   return_reasons:
   - style
   - height
@@ -5715,12 +5876,16 @@
   - color
   - folding_mechanism
   - handle_style
+  - height
   - height_adjustment
+  - length
   - material
+  - maximum_load_capacity
   - mobility/accessibility_equipment_features
   - pattern
   - tip_material
   - walking_aid_tip_type
+  - width
   return_reasons:
   - height
   - grip
@@ -5738,13 +5903,17 @@
   - folding_mechanism
   - handle_material
   - handle_style
+  - height
   - height_adjustment
+  - length
   - lumber/wood_type
   - material
+  - maximum_load_capacity
   - mobility/accessibility_equipment_features
   - pattern
   - tip_material
   - walking_aid_tip_type
+  - width
   - wood_finish
   return_reasons:
   - style
@@ -5843,12 +6012,16 @@
   - cuff_style
   - folding_mechanism
   - handle_material
+  - height
   - height_adjustment
+  - length
   - material
+  - maximum_load_capacity
   - mobility/accessibility_equipment_features
   - pattern
   - power_source
   - tip_material
+  - width
   return_reasons:
   - height
   - weight
@@ -5866,14 +6039,18 @@
   - age_group
   - color
   - folding_mechanism
+  - height
   - height_adjustment
+  - length
   - material
+  - maximum_load_capacity
   - mobility/accessibility_equipment_features
   - pattern
   - power_source
   - walker_brake_type
   - walker_seat_type
   - walker_type
+  - width
   return_reasons:
   - size
   - weight
@@ -5947,9 +6124,12 @@
   attributes:
   - body_area
   - color
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -5962,14 +6142,20 @@
   name: Electrical Muscle Stimulators
   children: []
   attributes:
+  - amperage
   - battery_size
   - battery_type
   - body_area
   - electrode_connector_type
   - electrotherapy_modality
+  - height
+  - length
   - material
   - muscle_stimulator_design
+  - power_consumption_typical
   - power_source
+  - voltage
+  - width
   return_reasons:
   - intensity
   - battery_life
@@ -5988,12 +6174,16 @@
   attributes:
   - age_group
   - body_area
+  - height
   - height_adjustment
+  - length
   - material
+  - maximum_load_capacity
   - mounting_type
   - seat_type
   - suitable_space
   - therapeutic_swing_accessories_included
+  - width
   return_reasons:
   - size
   - support
@@ -6209,9 +6399,12 @@
   attributes:
   - alert_type
   - closure_type
+  - height
+  - length
   - material
   - pillbox_schedule
   - safety_certifications
+  - width
   return_reasons:
   - capacity
   - too_bulky
@@ -6253,9 +6446,12 @@
   attributes:
   - battery_type
   - compatible_patient_profile
+  - height
+  - length
   - material
   - nebulizer_design
   - nebulizer_technology
+  - width
   return_reasons:
   - speed
   - too_bulky
@@ -6271,9 +6467,13 @@
   attributes:
   - compatible_patient_profile
   - cylinder_size_designation
+  - height
+  - length
   - material
+  - oxygen_capacity
   - oxygen_cylinder_outlet_standard
   - oxygen_tank_valve_type
+  - width
   return_reasons:
   - capacity
   - weight
@@ -6293,9 +6493,12 @@
   attributes:
   - compatible_patient_profile
   - connectivity_technology
+  - height
   - humidification_system
+  - length
   - material
   - portability
+  - width
   return_reasons:
   - too_bulky
   - incompatible
@@ -6311,10 +6514,13 @@
   attributes:
   - compatible_patient_profile
   - connectivity_technology
+  - height
   - humidification_system
+  - length
   - material
   - portability
   - therapy_mode_supported
+  - width
   return_reasons:
   - too_bulky
   - incompatible
@@ -6330,10 +6536,13 @@
   attributes:
   - compatible_patient_profile
   - connectivity_technology
+  - height
   - humidification_system
+  - length
   - material
   - portability
   - therapy_mode_supported
+  - width
   return_reasons:
   - too_bulky
   - incompatible
@@ -6349,11 +6558,14 @@
   attributes:
   - compatible_patient_profile
   - connectivity_technology
+  - height
   - humidification_system
   - humidifier_design
+  - length
   - material
   - portability
   - therapy_mode_supported
+  - width
   return_reasons:
   - too_bulky
   - incompatible
@@ -6368,11 +6580,14 @@
   children: []
   attributes:
   - compatible_patient_profile
+  - height
+  - length
   - mask_cushion_material
   - mask_type
   - material
   - size
   - target_gender
+  - width
   return_reasons:
   - fit
   - changed_my_mind
@@ -6387,8 +6602,11 @@
   attributes:
   - compatible_patient_profile
   - heat_settings
+  - height
+  - length
   - material
   - steam_inhaler_design
+  - width
   return_reasons:
   - capacity
   - too_bulky
@@ -6498,10 +6716,13 @@
   children: []
   attributes:
   - closure_type
+  - height
+  - length
   - material
   - product_sterility
   - test_sample
   - usage_type
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -6516,6 +6737,7 @@
   attributes:
   - applicator_type
   - product_form
+  - volume
   return_reasons:
   - consistency
   - scent
@@ -6535,8 +6757,11 @@
   - body_side
   - closure_type
   - compression_level
+  - height
+  - length
   - material
   - size
+  - width
   return_reasons:
   - size
   - compression
@@ -6566,10 +6791,13 @@
   - closure_type
   - color
   - compression_level
+  - height
+  - length
   - material_firmness
   - pattern
   - size
   - support/brace_material
+  - width
   return_reasons:
   - too_tight
   - too_loose
@@ -6592,10 +6820,13 @@
   - color
   - compression_level
   - foot_side
+  - height
+  - length
   - material_firmness
   - pattern
   - size
   - support/brace_material
+  - width
   return_reasons:
   - too_tight
   - too_loose
@@ -6668,10 +6899,13 @@
   - color
   - compression_level
   - features
+  - height
+  - length
   - material_firmness
   - pattern
   - size
   - support/brace_material
+  - width
   return_reasons:
   - size
   - support
@@ -6738,10 +6972,13 @@
   - closure_type
   - color
   - compression_level
+  - height
+  - length
   - material_firmness
   - pattern
   - size
   - support/brace_material
+  - width
   return_reasons:
   - too_tight
   - too_loose
@@ -6761,13 +6998,16 @@
   - closure_type
   - color
   - compression_level
+  - height
   - knee_brace_style
+  - length
   - material_firmness
   - patella_opening_design
   - pattern
   - size
   - support/brace_material
   - support_level
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -6788,12 +7028,15 @@
   - closure_type
   - color
   - compression_level
+  - height
+  - length
   - material_firmness
   - pattern
   - radiology_compatibility
   - size
   - support/brace_material
   - therapeutic_features
+  - width
   return_reasons:
   - too_tight
   - too_loose
@@ -6814,11 +7057,14 @@
   - color
   - compression_level
   - hand_side
+  - height
+  - length
   - material_firmness
   - pattern
   - size
   - splint/stay_configuration
   - support/brace_material
+  - width
   return_reasons:
   - too_tight
   - too_loose
@@ -6939,6 +7185,7 @@
   - lubricant_composition
   - product_form
   - product_sterility
+  - volume
   return_reasons:
   - consistency
   - incompatible
@@ -7214,6 +7461,7 @@
   - jewelry_cleaning_purpose
   - package_type
   - suitable_for_precious_material
+  - volume
   return_reasons:
   - scent
   - incompatible
@@ -7230,10 +7478,13 @@
   - hb-2-2-2
   - hb-2-2-4
   attributes:
+  - height
   - intended_jewelry_type
+  - length
   - material
   - power_source
   - suitable_for_precious_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7249,12 +7500,15 @@
   - bristle_material
   - bristle_shape
   - handle_material
+  - height
   - intended_jewelry_type
+  - length
   - material
   - power_source
   - product_form
   - stiffness
   - suitable_for_precious_material
+  - width
   return_reasons:
   - bristles_too_coarse
   - bristles_too_soft
@@ -7271,12 +7525,15 @@
   - cloth_treatment
   - construction
   - embellishment/trim_material
+  - height
   - intended_jewelry_type
   - jewelry_material
+  - length
   - material
   - product_form
   - suitable_for_precious_material
   - usage_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7289,11 +7546,14 @@
   name: Ultrasonic Jewelry Cleaners
   children: []
   attributes:
+  - height
   - intended_jewelry_type
+  - length
   - material
   - power_source
   - product_form
   - suitable_for_precious_material
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -7315,9 +7575,12 @@
   attributes:
   - closure_type
   - color
+  - height
   - intended_jewelry_type
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7339,8 +7602,10 @@
   attributes:
   - closure_type
   - color
+  - height
   - intended_jewelry_type
   - interior_lining_material
+  - length
   - lock_type
   - lumber/wood_type
   - material
@@ -7349,6 +7614,7 @@
   - power_source
   - product_form
   - shape
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -7470,11 +7736,14 @@
   children: []
   attributes:
   - closure_type
+  - height
   - intended_jewelry_type
+  - length
   - lumber/wood_type
   - material
   - product_form
   - stand/display_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -7497,13 +7766,16 @@
   attributes:
   - closure_type
   - color
+  - height
   - intended_jewelry_type
   - interior_lining_material
+  - length
   - lumber/wood_type
   - material
   - pattern
   - product_form
   - shape
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -7610,12 +7882,15 @@
   - closure_type
   - color
   - finish
+  - height
   - intended_jewelry_type
+  - length
   - lumber/wood_type
   - material
   - pattern
   - product_form
   - shape
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -7633,11 +7908,14 @@
   attributes:
   - closure_type
   - furniture/fixture_features
+  - height
   - intended_jewelry_type
+  - length
   - material
   - mounting_hardware
   - mounting_type
   - product_form
+  - width
   return_reasons:
   - size
   - color
@@ -7688,12 +7966,15 @@
   children: []
   attributes:
   - additional_cleaning_technology
+  - height
   - intended_jewelry_type
   - jewelry_steam_cleaner_features
+  - length
   - material
   - power_source
   - product_form
   - suitable_for_precious_material
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -7707,10 +7988,13 @@
   name: Watch Repair Kits
   children: []
   attributes:
+  - height
   - intended_jewelry_type
   - interior_lining_material
+  - length
   - material
   - product_form
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7799,11 +8083,14 @@
   - hb-3-1-3
   attributes:
   - body_area
+  - height
+  - length
   - material
   - pillow_shape
   - product_form
   - size
   - treatment_objective
+  - width
   return_reasons:
   - size
   - support
@@ -7828,6 +8115,8 @@
   - cover_features
   - filler_material
   - firmness
+  - height
+  - length
   - material
   - pattern
   - pillow_shape
@@ -7835,6 +8124,7 @@
   - size
   - support_cushion_features
   - treatment_objective
+  - width
   return_reasons:
   - size
   - too_firm
@@ -8027,6 +8317,7 @@
   - skin_care_effect
   - soap_making_method
   - suitable_for_skin_type
+  - volume
   return_reasons:
   - scent
   - texture
@@ -8058,6 +8349,7 @@
   - scent
   - skin_care_effect
   - suitable_for_skin_type
+  - volume
   return_reasons:
   - scent
   - texture
@@ -8334,6 +8626,7 @@
   - target_gender
   - texture
   - usage_type
+  - volume
   return_reasons:
   - scent
   - not_suitable_for_skin_type
@@ -8365,6 +8658,7 @@
   - skin_care_effect
   - suitable_for_skin_type
   - usage_type
+  - volume
   - wipe_packaging
   return_reasons:
   - scent
@@ -8487,6 +8781,7 @@
   - skin_care_effect
   - suitable_for_skin_type
   - usage_type
+  - volume
   return_reasons:
   - scent
   - consistency
@@ -8514,6 +8809,7 @@
   - skin_care_effect
   - solubility
   - suitable_for_skin_type
+  - volume
   return_reasons:
   - scent
   - texture
@@ -8652,8 +8948,10 @@
   - cosmetic_set_type
   - embellishment/trim_material
   - fragrance
+  - height
   - ingredients
   - jewelry_material
+  - length
   - material
   - occasion
   - package_type
@@ -8663,6 +8961,7 @@
   - skin_care_effect
   - suitable_for_skin_type
   - target_gender
+  - width
   return_reasons:
   - color
   - not_suitable_for_skin_type
@@ -8684,12 +8983,15 @@
   - battery_type
   - compatible_cosmetic_tools
   - fragrance
+  - height
   - ingredients
+  - length
   - material
   - package_type
   - product_certifications_standards
   - product_form
   - suitable_for_skin_type
+  - width
   return_reasons:
   - scent
   - consistency
@@ -8863,6 +9165,8 @@
   - eyebrow_stencil_shape
   - features
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
@@ -8870,6 +9174,7 @@
   - shape
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - size
   - shape
@@ -8887,6 +9192,8 @@
   - curler_size_compatibility
   - features
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
@@ -8894,6 +9201,7 @@
   - shape
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8913,6 +9221,8 @@
   - fragrance
   - handle_type
   - heat_function
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
@@ -8920,6 +9230,7 @@
   - shape
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - shape
   - changed_my_mind
@@ -8937,8 +9248,11 @@
   - hb-3-2-5-1-6-4
   attributes:
   - color
+  - depth
   - features
   - fragrance
+  - height
+  - length
   - light_source
   - lighting_features
   - magnification
@@ -8951,6 +9265,7 @@
   - shape
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -9089,6 +9404,8 @@
   - constitutive_ingredients
   - features
   - fragrance
+  - height
+  - length
   - material
   - package_type
   - product_certifications_standards
@@ -9096,6 +9413,7 @@
   - shape
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - size
   - absorbency
@@ -9122,6 +9440,8 @@
   - color
   - features
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
@@ -9129,6 +9449,7 @@
   - shape
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - scent
   - changed_my_mind
@@ -9153,6 +9474,8 @@
   - false_eyelash_adhesive_formulation
   - features
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
@@ -9160,6 +9483,7 @@
   - shape
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - drying_speed
   - adhesive_strength
@@ -9270,6 +9594,8 @@
   - eyelash_applicator_design
   - features
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
@@ -9278,6 +9604,7 @@
   - suitable_for_skin_type
   - tip_style
   - usage_type
+  - width
   return_reasons:
   - color
   - grip
@@ -9298,12 +9625,15 @@
   - eyelash_remover_formulation
   - features
   - fragrance
+  - height
+  - length
   - material
   - product_certifications_standards
   - product_form
   - shape
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - scent
   - consistency
@@ -9451,7 +9781,9 @@
   - features
   - fragrance
   - handle_material
+  - height
   - jewelry_material
+  - length
   - lumber/wood_type
   - makeup_brush_application
   - material
@@ -9461,6 +9793,7 @@
   - shape
   - suitable_for_skin_type
   - usage_type
+  - width
   - wood_finish
   return_reasons:
   - bristles_too_soft
@@ -9480,6 +9813,8 @@
   - care_instructions
   - features
   - fragrance
+  - height
+  - length
   - material
   - material_firmness
   - product_certifications_standards
@@ -9489,6 +9824,7 @@
   - suitable_for_skin_type
   - texture
   - usage_type
+  - width
   return_reasons:
   - size
   - shape
@@ -9509,6 +9845,8 @@
   - compatible_makeup
   - features
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
@@ -9516,6 +9854,7 @@
   - shape
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - size
   - capacity
@@ -9537,6 +9876,7 @@
   - durability_features
   - features
   - fragrance
+  - length
   - material
   - product_certifications_standards
   - product_form
@@ -9544,6 +9884,8 @@
   - suitable_for_skin_type
   - tape_material
   - usage_type
+  - volume
+  - width
   return_reasons:
   - adhesive_strength
   - wear
@@ -9724,7 +10066,9 @@
   - construction
   - embellishment/trim_material
   - fragrance
+  - height
   - jewelry_material
+  - length
   - material
   - pattern
   - product_certifications_standards
@@ -9732,6 +10076,7 @@
   - shape
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - size
   - grip
@@ -9750,6 +10095,8 @@
   - fragrance
   - handle_grip_texture
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - material
   - product_certifications_standards
@@ -9759,6 +10106,7 @@
   - tip_material
   - tip_style
   - usage_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -9782,6 +10130,8 @@
   - hand_side
   - handle_design
   - handle_material
+  - height
+  - length
   - material
   - product_certifications_standards
   - product_form
@@ -9790,6 +10140,7 @@
   - suitable_for_skin_type
   - tip_style
   - usage_type
+  - width
   return_reasons:
   - size
   - grip
@@ -9808,6 +10159,8 @@
   - bristle_material
   - color
   - fragrance
+  - height
+  - length
   - material
   - product_certifications_standards
   - product_form
@@ -9815,6 +10168,7 @@
   - suitable_for_skin_type
   - toe_spacer_design
   - usage_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9834,6 +10188,8 @@
   - bristle_material
   - closure_type
   - fragrance
+  - height
+  - length
   - lumber/wood_type
   - material
   - product_certifications_standards
@@ -9842,6 +10198,7 @@
   - suitable_for_skin_type
   - tool/utensil_material
   - usage_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -9861,12 +10218,15 @@
   - bristle_material
   - fragrance
   - grit_type
+  - height
+  - length
   - material
   - product_certifications_standards
   - product_form
   - shape
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - size
   - grit
@@ -9888,6 +10248,8 @@
   - features
   - finish
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
@@ -9895,6 +10257,7 @@
   - shape
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - size
   - sharpness
@@ -9911,12 +10274,15 @@
   attributes:
   - bristle_material
   - fragrance
+  - height
+  - length
   - material
   - product_certifications_standards
   - product_form
   - shape
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - size
   - grit
@@ -9936,6 +10302,8 @@
   - battery_type
   - bristle_material
   - fragrance
+  - height
+  - length
   - material
   - motor_type
   - product_certifications_standards
@@ -9945,6 +10313,7 @@
   - speed_settings
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - grip
   - operating_noise
@@ -9963,6 +10332,8 @@
   - battery_type
   - bristle_material
   - fragrance
+  - height
+  - length
   - light_source
   - material
   - product_certifications_standards
@@ -9970,6 +10341,7 @@
   - shape
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - size
   - speed
@@ -9989,12 +10361,15 @@
   - file_shape
   - fragrance
   - grit_type
+  - height
+  - length
   - material
   - product_certifications_standards
   - product_form
   - shape
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - too_coarse
   - too_fine
@@ -10127,6 +10502,8 @@
   - body_area
   - color
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
@@ -10136,6 +10513,7 @@
   - skin_care_tool_features
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - size
   - grip
@@ -10153,6 +10531,8 @@
   - facial_steamer_features
   - fragrance
   - heat_settings
+  - height
+  - length
   - material
   - product_certifications_standards
   - product_form
@@ -10161,6 +10541,7 @@
   - skin_care_tool_features
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - temperature
   - capacity
@@ -10180,6 +10561,8 @@
   - fragrance
   - grit_type
   - handle_type
+  - height
+  - length
   - material
   - product_certifications_standards
   - product_form
@@ -10189,6 +10572,7 @@
   - speed_settings
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - too_coarse
   - too_fine
@@ -10210,6 +10594,8 @@
   - fragrance
   - handle_material
   - handle_type
+  - height
+  - length
   - material
   - pad_type
   - product_certifications_standards
@@ -10219,6 +10605,7 @@
   - skin_care_tool_features
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - application
   - length
@@ -10237,6 +10624,8 @@
   - fragrance
   - grit_type
   - handle_type
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
@@ -10246,6 +10635,7 @@
   - skin_care_tool_features
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10270,6 +10660,8 @@
   - extractor_items_included
   - extractor_tip_style
   - fragrance
+  - height
+  - length
   - material
   - product_certifications_standards
   - product_form
@@ -10278,6 +10670,7 @@
   - skin_care_tool_features
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - sharpness
   - grip
@@ -10352,6 +10745,8 @@
   - fragrance
   - handle_material
   - heat_function
+  - height
+  - length
   - material
   - needle_material
   - pattern
@@ -10365,6 +10760,7 @@
   - skin_care_tool_features
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - size
   - weight
@@ -10385,6 +10781,8 @@
   - compatible_device
   - fragrance
   - hardness
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
@@ -10394,6 +10792,7 @@
   - skin_care_tool_features
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - too_stiff
   - too_soft
@@ -10415,7 +10814,9 @@
   - bristle_material
   - brush_head_usage
   - fragrance
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - product_certifications_standards
   - product_form
@@ -10425,6 +10826,7 @@
   - speed_settings
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - too_stiff
   - too_soft
@@ -10678,6 +11080,7 @@
   - skin_undertone
   - spf_level
   - suitable_for_skin_type
+  - volume
   return_reasons:
   - shade
   - coverage
@@ -10824,6 +11227,7 @@
   - skin_care_effect
   - spf_level
   - suitable_for_skin_type
+  - volume
   return_reasons:
   - texture
   - consistency
@@ -11060,6 +11464,8 @@
   - eyelash_style
   - eyelash_type
   - fragrance
+  - height
+  - length
   - makeup_features
   - makeup_shade
   - material
@@ -11069,6 +11475,7 @@
   - spf_level
   - suitable_for_skin_type
   - usage_type
+  - width
   return_reasons:
   - style
   - length
@@ -11380,6 +11787,7 @@
   - skin_undertone
   - spf_level
   - suitable_for_skin_type
+  - volume
   return_reasons:
   - finish
   - consistency
@@ -12007,6 +12415,7 @@
   - spf_level
   - spray_purpose
   - suitable_for_skin_type
+  - volume
   return_reasons:
   - finish
   - wear
@@ -12036,6 +12445,7 @@
   - spf_level
   - suitable_for_skin_type
   - theme
+  - volume
   return_reasons:
   - size
   - color
@@ -12125,6 +12535,7 @@
   - product_form
   - skin_care_effect
   - suitable_for_skin_type
+  - volume
   return_reasons:
   - scent
   - consistency
@@ -12151,6 +12562,7 @@
   - product_form
   - skin_care_effect
   - suitable_for_skin_type
+  - volume
   return_reasons:
   - scent
   - texture
@@ -12179,6 +12591,7 @@
   - product_form
   - skin_care_effect
   - suitable_for_skin_type
+  - volume
   return_reasons:
   - scent
   - consistency
@@ -12332,6 +12745,7 @@
   - product_certifications_standards
   - product_form
   - suitable_for_skin_type
+  - volume
   return_reasons:
   - applicator
   - adhesive_strength
@@ -12504,6 +12918,7 @@
   - product_certifications_standards
   - product_form
   - suitable_for_skin_type
+  - volume
   return_reasons:
   - drying_speed
   - finish
@@ -12531,6 +12946,7 @@
   - product_form
   - removal_target
   - suitable_for_skin_type
+  - volume
   return_reasons:
   - scent
   - consistency
@@ -12555,6 +12971,7 @@
   - product_certifications_standards
   - product_form
   - suitable_for_skin_type
+  - volume
   return_reasons:
   - consistency
   - scent
@@ -12668,6 +13085,7 @@
   - season
   - suitable_for_skin_type
   - target_gender
+  - volume
   return_reasons:
   - scent
   - longevity
@@ -12695,6 +13113,7 @@
   - season
   - suitable_for_skin_type
   - target_gender
+  - volume
   return_reasons:
   - scent
   - longevity
@@ -12723,6 +13142,7 @@
   - season
   - suitable_for_skin_type
   - target_gender
+  - volume
   return_reasons:
   - scent
   - longevity
@@ -12751,6 +13171,7 @@
   - season
   - suitable_for_skin_type
   - target_gender
+  - volume
   return_reasons:
   - scent
   - longevity
@@ -12779,6 +13200,7 @@
   - season
   - suitable_for_skin_type
   - target_gender
+  - volume
   return_reasons:
   - scent
   - longevity
@@ -13004,6 +13426,7 @@
   - suitable_for_skin_type
   - target_gender
   - uva_protection_grade
+  - volume
   return_reasons:
   - not_suitable_for_skin_type
   - consistency
@@ -13129,6 +13552,7 @@
   - suitable_for_skin_type
   - target_gender
   - uva_protection_grade
+  - volume
   return_reasons:
   - not_suitable_for_skin_type
   - consistency
@@ -13162,6 +13586,7 @@
   - suitable_for_skin_type
   - texture
   - uva_protection_grade
+  - volume
   return_reasons:
   - scent
   - consistency
@@ -13190,6 +13615,7 @@
   - suitable_for_skin_type
   - talc_content
   - uva_protection_grade
+  - volume
   return_reasons:
   - scent
   - consistency
@@ -13254,6 +13680,7 @@
   - suitable_for_skin_type
   - target_gender
   - uva_protection_grade
+  - volume
   return_reasons:
   - not_suitable_for_skin_type
   - scent
@@ -13280,6 +13707,7 @@
   - suitable_for_skin_type
   - target_gender
   - uva_protection_grade
+  - volume
   return_reasons:
   - not_suitable_for_skin_type
   - scent
@@ -13306,6 +13734,7 @@
   - suitable_for_skin_type
   - target_facial_zone
   - uva_protection_grade
+  - volume
   return_reasons:
   - shape
   - changed_my_mind
@@ -13502,6 +13931,7 @@
   - target_gender
   - texture
   - uva_protection_grade
+  - volume
   return_reasons:
   - scent
   - consistency
@@ -13526,6 +13956,7 @@
   - product_form
   - suitable_for_skin_type
   - uva_protection_grade
+  - volume
   return_reasons:
   - not_suitable_for_skin_type
   - scent
@@ -13552,6 +13983,7 @@
   - product_form
   - suitable_for_skin_type
   - uva_protection_grade
+  - volume
   return_reasons:
   - scent
   - consistency
@@ -13588,6 +14020,7 @@
   - suitable_for_skin_type
   - target_gender
   - uva_protection_grade
+  - volume
   return_reasons:
   - not_suitable_for_skin_type
   - scent
@@ -13607,6 +14040,7 @@
   - alcohol/solvent_content
   - constitutive_ingredients
   - dispenser_type
+  - effect_duration
   - fragrance
   - ingredient_origin
   - material
@@ -13615,6 +14049,7 @@
   - suitable_for_bug_type
   - suitable_for_skin_type
   - uva_protection_grade
+  - volume
   return_reasons:
   - scent
   - wear
@@ -13649,6 +14084,7 @@
   - suitable_for_skin_type
   - sunscreen_filter_type
   - uva_protection_grade
+  - volume
   return_reasons:
   - consistency
   - scent
@@ -13683,6 +14119,7 @@
   - suitable_for_skin_type
   - tan_type
   - uva_protection_grade
+  - volume
   return_reasons:
   - shade
   - wear
@@ -13714,6 +14151,7 @@
   - suitable_for_skin_type
   - tan_type
   - uva_protection_grade
+  - volume
   return_reasons:
   - shade
   - scent
@@ -13745,6 +14183,7 @@
   - tingle_intensity
   - usage_environment
   - uva_protection_grade
+  - volume
   return_reasons:
   - shade
   - consistency
@@ -13887,6 +14326,7 @@
   - skin_care_features
   - suitable_for_skin_type
   - uva_protection_grade
+  - volume
   return_reasons:
   - not_suitable_for_skin_type
   - scent
@@ -13920,6 +14360,7 @@
   - skin_care_features
   - suitable_for_skin_type
   - uva_protection_grade
+  - volume
   return_reasons:
   - too_drying
   - not_suitable_for_skin_type
@@ -13954,6 +14395,7 @@
   - skin_care_features
   - suitable_for_skin_type
   - uva_protection_grade
+  - volume
   return_reasons:
   - scent
   - not_suitable_for_skin_type
@@ -14011,6 +14453,7 @@
   - target_gender
   - texture
   - uva_protection_grade
+  - volume
   return_reasons:
   - consistency
   - scent
@@ -14046,6 +14489,7 @@
   - target_gender
   - texture
   - uva_protection_grade
+  - volume
   return_reasons:
   - consistency
   - scent
@@ -14080,6 +14524,7 @@
   - target_gender
   - texture
   - uva_protection_grade
+  - volume
   return_reasons:
   - consistency
   - scent
@@ -14280,12 +14725,15 @@
   attributes:
   - absorbent_hygiene_product_features
   - cotton_ball_size
+  - height
+  - length
   - material
   - product_certifications_standards
   - product_form
   - product_sterility
   - shape
   - usage_type
+  - width
   return_reasons:
   - size
   - absorbency
@@ -14302,6 +14750,8 @@
   attributes:
   - color
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - product_form
@@ -14311,6 +14761,7 @@
   - tip_material
   - tip_style
   - usage_type
+  - width
   return_reasons:
   - absorbency
   - changed_my_mind
@@ -14331,6 +14782,7 @@
   - product_certifications_standards
   - product_form
   - target_gender
+  - volume
   return_reasons:
   - scent
   - texture
@@ -14356,6 +14808,7 @@
   - scent
   - suitable_for_skin_type
   - target_gender
+  - volume
   return_reasons:
   - scent
   - strength
@@ -14380,6 +14833,7 @@
   - suitable_for_skin_type
   - target_gender
   - usage_type
+  - volume
   return_reasons:
   - scent
   - consistency
@@ -14424,10 +14878,13 @@
   - candle_material
   - candle_shape
   - ear_care_application_method
+  - height
+  - length
   - material
   - product_form
   - scent
   - usage_type
+  - width
   return_reasons:
   - scent
   - burn_time
@@ -14453,6 +14910,7 @@
   - product_form
   - treatment_objective
   - usage_type
+  - volume
   return_reasons:
   - applicator
   - consistency
@@ -14492,11 +14950,14 @@
   - color
   - ear_care_application_method
   - ear_pick_tip_style
+  - height
+  - length
   - lighting_options
   - material
   - pattern
   - product_form
   - usage_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14512,11 +14973,14 @@
   - age_group
   - allergy_friendly_features
   - ear_care_application_method
+  - height
+  - length
   - material
   - product_form
   - product_sterility
   - tip_design
   - usage_type
+  - width
   return_reasons:
   - size
   - flow_rate
@@ -14534,10 +14998,13 @@
   - allergy_friendly_features
   - connectivity_technology
   - ear_care_application_method
+  - height
+  - length
   - material
   - product_form
   - tip_material
   - usage_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14555,10 +15022,13 @@
   - ear_care_application_method
   - earplug_cord_style
   - earplug_type
+  - height
+  - length
   - material
   - mounting_type
   - product_form
   - usage_type
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -14582,9 +15052,13 @@
   - earplug_cord_style
   - earplug_shape
   - earplug_use
+  - height
+  - length
   - material
+  - nrr_rating
   - product_form
   - usage_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14607,9 +15081,13 @@
   - earplug_shape
   - earplug_use
   - hearing_protection_class
+  - height
+  - length
   - material
+  - nrr_rating
   - product_form
   - usage_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14632,9 +15110,13 @@
   - earplug_cord_style
   - earplug_shape
   - earplug_use
+  - height
+  - length
   - material
+  - nrr_rating
   - product_form
   - usage_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14656,9 +15138,13 @@
   - earplug_cord_style
   - earplug_shape
   - earplug_use
+  - height
+  - length
   - material
+  - nrr_rating
   - product_form
   - usage_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14734,12 +15220,16 @@
   - hb-3-7-3
   - hb-3-7-4
   attributes:
+  - capacity
   - enema_device_type
   - enema_nozzle_type
+  - height
+  - length
   - material
   - product_form
   - product_sterility
   - treatment_objective
+  - width
   return_reasons:
   - capacity
   - material
@@ -14855,6 +15345,7 @@
   - product_form
   - scent
   - treatment_objective
+  - volume
   return_reasons:
   - scent
   - wear
@@ -14878,6 +15369,7 @@
   - target_gender
   - treatment_objective
   - usage_type
+  - volume
   return_reasons:
   - scent
   - applicator
@@ -15077,8 +15569,11 @@
   attributes:
   - absorbency_level
   - accessory_size
+  - capacity
   - cervix_height_suitability
   - color
+  - height
+  - length
   - material
   - material_firmness
   - menstrual_cup_shape
@@ -15089,6 +15584,7 @@
   - product_form
   - treatment_objective
   - usage_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15343,6 +15839,7 @@
   - product_form
   - skin_care_effect
   - treatment_objective
+  - volume
   return_reasons:
   - scent
   - texture
@@ -15368,7 +15865,9 @@
   - foot_arch_type
   - footwear_material
   - fragrance
+  - height
   - insole_length_type
+  - length
   - material
   - pattern
   - product_form
@@ -15376,6 +15875,7 @@
   - support_rigidity_level
   - target_gender
   - treatment_objective
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15399,7 +15899,9 @@
   - foot_arch_type
   - footwear_material
   - fragrance
+  - height
   - insole_length_type
+  - length
   - material
   - material_firmness
   - orthotic_coverage_length
@@ -15408,6 +15910,7 @@
   - support_rigidity_level
   - target_gender
   - treatment_objective
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15433,7 +15936,9 @@
   - foot_arch_type
   - footwear_material
   - fragrance
+  - height
   - insole_length_type
+  - length
   - material
   - product_form
   - size
@@ -15442,6 +15947,7 @@
   - target_gender
   - treatment_objective
   - usage_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15469,7 +15975,9 @@
   - foot_arch_type
   - footwear_material
   - fragrance
+  - height
   - insole_length_type
+  - length
   - material
   - product_form
   - skin_care_effect
@@ -15477,6 +15985,7 @@
   - target_gender
   - treatment_objective
   - usage_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15497,12 +16006,15 @@
   - body_area
   - fragrance
   - hardness
+  - height
+  - length
   - material
   - product_form
   - skin_care_effect
   - toe_spacer_design
   - treatment_objective
   - usage_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15692,12 +16204,15 @@
   - fragrance
   - grooming_kit_format
   - hair_care_items_included
+  - height
+  - length
   - material
   - pattern
   - product_form
   - scalp_concern
   - suitable_for_hair_type
   - target_gender
+  - width
   return_reasons:
   - scent
   - consistency
@@ -15726,6 +16241,7 @@
   - pattern
   - product_form
   - target_gender
+  - volume
   return_reasons:
   - shade
   - coverage
@@ -15752,6 +16268,7 @@
   - product_form
   - suitable_for_hair_type
   - target_gender
+  - volume
   return_reasons:
   - scent
   - not_suitable_for_hair_type
@@ -15770,10 +16287,13 @@
   - color
   - conditioner_effect
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - product_form
   - target_gender
+  - width
   return_reasons:
   - size
   - incompatible
@@ -15799,6 +16319,7 @@
   - product_form
   - suitable_for_hair_type
   - target_gender
+  - volume
   return_reasons:
   - color
   - coverage
@@ -15903,6 +16424,7 @@
   - suitable_for_hair_type
   - target_gender
   - treatment_type
+  - volume
   return_reasons:
   - scent
   - consistency
@@ -15926,10 +16448,13 @@
   - compatible_chemical_treatment_strength_level
   - conditioner_effect
   - fragrance
+  - height
+  - length
   - material
   - product_form
   - suitable_for_hair_type
   - target_gender
+  - width
   return_reasons:
   - not_suitable_for_hair_type
   - scent
@@ -16049,9 +16574,12 @@
   - hair_shear_type
   - hand_side
   - handle_design
+  - height
+  - length
   - material
   - product_form
   - target_gender
+  - width
   return_reasons:
   - length
   - grip
@@ -16073,11 +16601,14 @@
   - conditioner_effect
   - fragrance
   - heat_settings
+  - height
+  - length
   - material
   - pattern
   - plug_type
   - product_form
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -16161,6 +16692,7 @@
   - product_form
   - suitable_for_hair_type
   - target_gender
+  - volume
   return_reasons:
   - scent
   - texture
@@ -16394,9 +16926,12 @@
   - conditioner_effect
   - durability_features
   - fragrance
+  - height
+  - length
   - material
   - product_form
   - suitable_for_hair_type
+  - width
   return_reasons:
   - size
   - color
@@ -16418,11 +16953,14 @@
   - durability_features
   - embellishment/trim_material
   - fragrance
+  - height
   - jewelry_material
+  - length
   - lumber/wood_type
   - material
   - product_form
   - suitable_for_hair_type
+  - width
   - wood_finish
   return_reasons:
   - too_big
@@ -16450,12 +16988,15 @@
   - embellishment/trim_material
   - finish
   - fragrance
+  - height
   - jewelry_material
+  - length
   - lumber/wood_type
   - material
   - pin_tip_type
   - product_form
   - suitable_for_hair_type
+  - width
   - wood_finish
   return_reasons:
   - too_big
@@ -16551,9 +17092,12 @@
   - conditioner_effect
   - durability_features
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - product_form
+  - width
   return_reasons:
   - size
   - incompatible
@@ -16571,8 +17115,11 @@
   - conditioner_effect
   - durability_features
   - fragrance
+  - height
+  - length
   - material
   - product_form
+  - width
   return_reasons:
   - heat_resistance
   - incompatible
@@ -16728,11 +17275,14 @@
   - fragrance
   - hair_styling_items_included
   - heat_settings
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - product_form
   - suitable_for_hair_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -16760,11 +17310,14 @@
   - fragrance
   - hair_styling_items_included
   - heat_settings
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - product_form
   - suitable_for_hair_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -16795,12 +17348,15 @@
   - hair_styling_tool_features
   - handle_material
   - heat_settings
+  - height
   - jewelry_material
+  - length
   - lumber/wood_type
   - material
   - pattern
   - product_form
   - suitable_for_hair_type
+  - width
   - wood_finish
   return_reasons:
   - not_suitable_for_hair_type
@@ -16823,10 +17379,13 @@
   - fragrance
   - hair_styling_items_included
   - heat_settings
+  - height
+  - length
   - material
   - pattern
   - product_form
   - suitable_for_hair_type
+  - width
   return_reasons:
   - size
   - temperature
@@ -16853,11 +17412,14 @@
   - hair_styling_items_included
   - handle_material
   - heat_settings
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - product_form
   - suitable_for_hair_type
+  - width
   - wood_finish
   return_reasons:
   - too_stiff
@@ -16885,10 +17447,13 @@
   - hair_styling_items_included
   - handle_material
   - heat_settings
+  - height
+  - length
   - material
   - pattern
   - product_form
   - suitable_for_hair_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -16915,10 +17480,13 @@
   - fragrance
   - hair_styling_items_included
   - heat_settings
+  - height
+  - length
   - material
   - pattern
   - product_form
   - suitable_for_hair_type
+  - width
   return_reasons:
   - not_suitable_for_hair_type
   - weight
@@ -16945,10 +17513,14 @@
   - hair_styling_items_included
   - hair_styling_tool_features
   - heat_settings
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - product_form
   - suitable_for_hair_type
+  - width
   return_reasons:
   - barrel_size
   - temperature
@@ -16975,10 +17547,13 @@
   - hair_styling_items_included
   - heat_function
   - heat_settings
+  - height
+  - length
   - material
   - pattern
   - product_form
   - suitable_for_hair_type
+  - width
   return_reasons:
   - barrel_size
   - not_suitable_for_hair_type
@@ -17004,10 +17579,14 @@
   - hair_styling_items_included
   - hair_styling_tool_features
   - heat_settings
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - speed_settings
   - suitable_for_hair_type
+  - width
   return_reasons:
   - weight
   - temperature
@@ -17031,11 +17610,14 @@
   - hair_styling_items_included
   - hair_styling_tool_features
   - heat_settings
+  - height
+  - length
   - material
   - pattern
   - plate_type
   - product_form
   - suitable_for_hair_type
+  - width
   return_reasons:
   - color
   - temperature
@@ -17061,10 +17643,14 @@
   - hair_styling_tool_features
   - hair_type
   - heat_settings
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - product_form
   - suitable_for_hair_type
+  - width
   return_reasons:
   - temperature
   - weight
@@ -17150,6 +17736,7 @@
   - product_form
   - suitable_for_hair_type
   - target_gender
+  - volume
   return_reasons:
   - scent
   - not_suitable_for_hair_type
@@ -17180,6 +17767,7 @@
   - product_form
   - suitable_for_hair_type
   - target_gender
+  - volume
   return_reasons:
   - scent
   - not_suitable_for_hair_type
@@ -17210,6 +17798,7 @@
   - shampoo_type
   - suitable_for_hair_type
   - target_gender
+  - volume
   return_reasons:
   - scent
   - not_suitable_for_hair_type
@@ -17241,6 +17830,7 @@
   - shampoo_type
   - suitable_for_hair_type
   - target_gender
+  - volume
   return_reasons:
   - scent
   - not_suitable_for_hair_type
@@ -17395,9 +17985,12 @@
   - handle_grip_texture
   - handle_material
   - handle_type
+  - height
+  - length
   - material
   - product_form
   - treatment_objective
+  - width
   return_reasons:
   - length
   - too_coarse
@@ -17422,10 +18015,13 @@
   - fragrance
   - heat_function
   - heat_source
+  - height
+  - length
   - material
   - product_form
   - scent
   - treatment_objective
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -17446,6 +18042,8 @@
   - detailed_ingredients
   - fragrance
   - heat_function
+  - height
+  - length
   - massage_area
   - massage_mechanism_dimensionality
   - massage_technique
@@ -17454,6 +18052,7 @@
   - reclining_function
   - treatment_objective
   - upholstery_material
+  - width
   return_reasons:
   - too_bulky
   - too_firm
@@ -17483,6 +18082,7 @@
   - suitable_for_skin_type
   - texture
   - treatment_objective
+  - volume
   return_reasons:
   - scent
   - consistency
@@ -17500,10 +18100,13 @@
   - battery_type
   - detailed_ingredients
   - fragrance
+  - height
+  - length
   - material
   - product_form
   - stone_name
   - treatment_objective
+  - width
   return_reasons:
   - capacity
   - temperature
@@ -17522,6 +18125,8 @@
   - detailed_ingredients
   - fragrance
   - heating_method
+  - height
+  - length
   - massage_stone_texture
   - material
   - product_form
@@ -17530,6 +18135,7 @@
   - stone_name
   - stone_type
   - treatment_objective
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -17547,12 +18153,15 @@
   attributes:
   - detailed_ingredients
   - fragrance
+  - height
   - height_adjustment
+  - length
   - lumber/wood_type
   - material
   - product_form
   - treatment_objective
   - upholstery_material
+  - width
   - wood_finish
   return_reasons:
   - width
@@ -17578,10 +18187,13 @@
   - body_area
   - detailed_ingredients
   - fragrance
+  - height
+  - length
   - massage_technique
   - material
   - product_form
   - treatment_objective
+  - width
   return_reasons:
   - intensity
   - changed_my_mind
@@ -17596,6 +18208,7 @@
   - hb-3-11-8-1-1
   - hb-3-11-8-1-2
   attributes:
+  - amperage
   - application_area
   - battery_size
   - battery_type
@@ -17605,12 +18218,17 @@
   - detailed_ingredients
   - fragrance
   - heat_function
+  - height
+  - length
   - massage_technique
   - material
   - pattern
+  - power_consumption_typical
   - product_form
   - speed_settings
   - treatment_objective
+  - voltage
+  - width
   return_reasons:
   - intensity
   - changed_my_mind
@@ -17689,11 +18307,14 @@
   - color
   - detailed_ingredients
   - fragrance
+  - height
+  - length
   - massage_technique
   - material
   - pattern
   - product_form
   - treatment_objective
+  - width
   return_reasons:
   - too_firm
   - too_soft
@@ -17881,11 +18502,14 @@
   - firmness
   - fragrance
   - heat_function
+  - height
+  - length
   - massage_technique
   - material
   - product_form
   - speed_settings
   - treatment_objective
+  - width
   return_reasons:
   - intensity
   - too_firm
@@ -18076,6 +18700,7 @@
   - oral_care_function
   - package_type
   - product_form
+  - volume
   return_reasons:
   - flavor
   - strength
@@ -18171,9 +18796,12 @@
   - fit_type
   - flavor
   - hardness
+  - height
+  - length
   - material
   - oral_care_function
   - product_form
+  - width
   return_reasons:
   - fit
   - too_bulky
@@ -18188,11 +18816,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - nozzle_type
   - oral_care_function
   - pattern
   - product_form
+  - width
   return_reasons:
   - flow_rate
   - incompatible
@@ -18209,12 +18840,16 @@
   - battery_size
   - battery_type
   - dental_water_jet_operation
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - nozzle_type
   - oral_care_function
   - product_form
   - water_flosser_modes
+  - water_tank_capacity
+  - width
   return_reasons:
   - pressure
   - capacity
@@ -18234,6 +18869,7 @@
   - material
   - oral_care_function
   - product_form
+  - volume
   return_reasons:
   - flavor
   - consistency
@@ -18250,9 +18886,12 @@
   - hb-3-12-7-2
   attributes:
   - flavor
+  - height
+  - length
   - material
   - oral_care_function
   - product_form
+  - width
   return_reasons:
   - scent
   - flavor
@@ -18304,9 +18943,12 @@
   attributes:
   - chemical_product_form
   - dental_repair_kit_certifications
+  - height
+  - length
   - material
   - oral_care_function
   - product_form
+  - width
   return_reasons:
   - shade
   - changed_my_mind
@@ -18329,11 +18971,14 @@
   - denture_retention_mechanism
   - denture_teeth_color
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - material
   - oral_care_function
   - product_form
   - target_gender
+  - width
   return_reasons:
   - shade
   - fit
@@ -18398,12 +19043,15 @@
   attributes:
   - accessory_size
   - handle_grip_texture
+  - height
+  - length
   - material
   - material_firmness
   - oral_care_function
   - product_form
   - stimulator_tip_shape
   - tip_material
+  - width
   return_reasons:
   - grip
   - too_firm
@@ -18420,16 +19068,22 @@
   children: []
   attributes:
   - accessory_size
+  - amperage
   - battery_type
   - handle_grip_texture
+  - height
+  - length
   - material
   - material_firmness
   - oral_care_function
+  - power_consumption_typical
   - product_form
   - speed_settings
   - stimulator_tip_shape
   - tip_material
   - tool_mobility
+  - voltage
+  - width
   return_reasons:
   - battery_life
   - grip
@@ -18446,6 +19100,8 @@
   - accessory_size
   - handle_grip_texture
   - handle_material
+  - height
+  - length
   - material
   - material_firmness
   - oral_care_function
@@ -18453,6 +19109,7 @@
   - stimulator_tip_shape
   - tip_material
   - usage_type
+  - width
   return_reasons:
   - grip
   - too_firm
@@ -18475,6 +19132,7 @@
   - material
   - oral_care_function
   - product_form
+  - volume
   return_reasons:
   - flavor
   - strength
@@ -18497,11 +19155,14 @@
   - closure_type
   - color
   - drainage_feature
+  - height
+  - length
   - material
   - oral_care_function
   - pattern
   - product_form
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -18522,11 +19183,14 @@
   - closure_type
   - color
   - drainage_feature
+  - height
+  - length
   - material
   - oral_care_function
   - pattern
   - product_form
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -18548,12 +19212,15 @@
   - closure_type
   - color
   - drainage_feature
+  - height
+  - length
   - material
   - oral_care_function
   - pattern
   - product_certifications_standards
   - product_form
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -18572,12 +19239,15 @@
   - charging_interface_type
   - cleaning_mode
   - color
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - nozzle_type
   - oral_care_function
   - pattern
   - product_form
+  - width
   return_reasons:
   - pressure
   - capacity
@@ -18628,6 +19298,8 @@
   - charcoal_source_material
   - chemical_grade
   - flavor
+  - height
+  - length
   - material
   - oral_care_function
   - package_type
@@ -18635,6 +19307,7 @@
   - product_certifications_standards
   - product_form
   - usage_frequency
+  - width
   return_reasons:
   - flavor
   - texture
@@ -18654,14 +19327,17 @@
   - battery_size
   - battery_type
   - flavor
+  - height
   - ingress_protection_ip_rating
   - led_light_mode
+  - length
   - light_spectrum
   - material
   - oral_care_function
   - peroxide_content
   - product_form
   - usage_frequency
+  - width
   return_reasons:
   - fit
   - changed_my_mind
@@ -18725,12 +19401,15 @@
   - cleaning_instructions
   - closure_type
   - flavor
+  - height
+  - length
   - material
   - oral_care_function
   - peroxide_content
   - product_form
   - tray_compatibility
   - usage_frequency
+  - width
   return_reasons:
   - size
   - color
@@ -18753,6 +19432,7 @@
   - peroxide_content
   - product_form
   - usage_frequency
+  - volume
   return_reasons:
   - flavor
   - strength
@@ -18774,6 +19454,7 @@
   - peroxide_content
   - product_form
   - usage_frequency
+  - volume
   return_reasons:
   - flavor
   - strength
@@ -18795,6 +19476,7 @@
   - peroxide_content
   - product_form
   - usage_frequency
+  - volume
   return_reasons:
   - flavor
   - strength
@@ -18809,12 +19491,15 @@
   children: []
   attributes:
   - flavor
+  - height
+  - length
   - material
   - oral_care_function
   - peroxide_content
   - product_form
   - suitable_for_user_sensitivity_level
   - usage_frequency
+  - width
   return_reasons:
   - flavor
   - strength
@@ -18956,11 +19641,14 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - material
   - oral_care_function
   - pattern
   - product_form
   - usage_type
+  - width
   return_reasons:
   - length
   - width
@@ -18983,10 +19671,13 @@
   - hb-3-12-16-7
   attributes:
   - cleaning_instructions
+  - height
+  - length
   - material
   - oral_care_function
   - product_form
   - suitable_for_toothbrush
+  - width
   return_reasons:
   - size
   - color
@@ -19004,12 +19695,15 @@
   - cleaning_instructions
   - closure_type
   - color
+  - height
+  - length
   - material
   - mounting_type
   - oral_care_function
   - pattern
   - product_form
   - suitable_for_toothbrush
+  - width
   return_reasons:
   - color
   - incompatible
@@ -19029,12 +19723,15 @@
   - cleaning_instructions
   - color
   - firmness
+  - height
+  - length
   - material
   - oral_care_function
   - pattern
   - product_form
   - suitable_for_toothbrush
   - toothbrush_head_type
+  - width
   return_reasons:
   - size
   - too_stiff
@@ -19056,6 +19753,8 @@
   - cleaning_instructions
   - color
   - drying_method
+  - height
+  - length
   - material
   - mounting_type
   - oral_care_function
@@ -19063,6 +19762,7 @@
   - product_form
   - sterilization_method
   - suitable_for_toothbrush
+  - width
   return_reasons:
   - size
   - capacity
@@ -19166,6 +19866,8 @@
   - color
   - firmness
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - material
   - oral_care_function
@@ -19173,6 +19875,7 @@
   - product_form
   - toothbrush_head_size
   - usage_type
+  - width
   - wood_finish
   return_reasons:
   - too_soft
@@ -19190,6 +19893,7 @@
   children: []
   attributes:
   - age_group
+  - amperage
   - battery_size
   - battery_type
   - bristle_hardness
@@ -19202,13 +19906,18 @@
   - connectivity_technology
   - firmness
   - handle_material
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - oral_care_function
   - pattern
+  - power_consumption_typical
   - product_form
   - toothbrush_head_size
   - usage_type
+  - voltage
+  - width
   return_reasons:
   - battery_life
   - too_soft
@@ -19231,6 +19940,8 @@
   - color
   - firmness
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - material
   - oral_care_function
@@ -19239,6 +19950,7 @@
   - product_form
   - toothbrush_head_size
   - usage_type
+  - width
   - wood_finish
   return_reasons:
   - too_soft
@@ -19263,6 +19975,8 @@
   - handle_grip_texture
   - handle_material
   - hardness
+  - height
+  - length
   - material
   - oral_care_function
   - oral_care_items_included
@@ -19270,6 +19984,7 @@
   - product_form
   - toothbrush_head_size
   - usage_type
+  - width
   return_reasons:
   - too_soft
   - too_stiff
@@ -19289,12 +20004,15 @@
   attributes:
   - color
   - dispensing_operation_type
+  - height
+  - length
   - material
   - mounting_type
   - oral_care_function
   - pattern
   - product_form
   - usage_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -19355,11 +20073,15 @@
   - detailed_ingredients
   - flavor
   - fluoride_content
+  - height
+  - length
   - material
   - oral_care_function
   - product_certifications_standards
   - product_form
   - toothpaste_type
+  - volume
+  - width
   return_reasons:
   - flavor
   - texture
@@ -19374,12 +20096,15 @@
   name: Toothpicks
   children: []
   attributes:
+  - height
+  - length
   - lumber/wood_type
   - material
   - oral_care_function
   - product_form
   - toothpick_design
   - usage_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -19503,6 +20228,7 @@
   - ph_level
   - product_form
   - sensation_effect
+  - volume
   return_reasons:
   - consistency
   - scent
@@ -19564,6 +20290,7 @@
   - skin_care_effect
   - suitable_for_skin_type
   - target_gender
+  - volume
   return_reasons:
   - scent
   - not_suitable_for_skin_type
@@ -19589,6 +20316,7 @@
   - suitable_for_body/facial_hair
   - suitable_for_skin_type
   - target_gender
+  - volume
   return_reasons:
   - scent
   - consistency
@@ -19607,13 +20335,18 @@
   - hb-3-14-3-4
   - hb-3-14-3-5
   attributes:
+  - amperage
   - beard_care_benefits
   - blade_material
   - color
+  - height
+  - length
   - material
   - pattern
   - product_form
   - target_gender
+  - voltage
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -19730,17 +20463,23 @@
   - hb-3-14-4-2
   - hb-3-14-4-3
   attributes:
+  - amperage
   - battery_size
   - battery_type
   - beard_care_benefits
   - color
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - product_form
   - razor_flexibility
   - razor_head_design
   - target_gender
   - usage_conditions
+  - voltage
+  - width
   return_reasons:
   - closeness
   - grip
@@ -19755,15 +20494,21 @@
   name: Foil Electric Razors
   children: []
   attributes:
+  - amperage
   - battery_size
   - battery_type
   - beard_care_benefits
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
+  - power_consumption_typical
   - product_form
   - razor_flexibility
   - razor_head_design
   - target_gender
+  - voltage
+  - width
   return_reasons:
   - closeness
   - battery_life
@@ -19777,17 +20522,23 @@
   name: Rotary Electric Razors
   children: []
   attributes:
+  - amperage
   - battery_size
   - battery_type
   - beard_care_benefits
   - charging_interface_type
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
+  - power_consumption_typical
   - product_form
   - razor_flexibility
   - razor_head_design
   - target_gender
   - usage_conditions
+  - voltage
+  - width
   return_reasons:
   - battery_life
   - closeness
@@ -19811,13 +20562,16 @@
   - blade_material
   - body_area
   - clipper/trimmer_type
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - product_form
   - razor_flexibility
   - razor_head_design
   - target_gender
   - usage_conditions
+  - width
   return_reasons:
   - battery_life
   - grip
@@ -19916,10 +20670,13 @@
   - battery_type
   - beard_care_benefits
   - color
+  - height
+  - length
   - material
   - pattern
   - product_form
   - target_gender
+  - width
   return_reasons:
   - size
   - incompatible
@@ -20017,12 +20774,15 @@
   - blade_material
   - clipper_motor_type
   - color
+  - height
+  - length
   - material
   - pattern
   - product_form
   - target_gender
   - tool_mobility
   - usage_conditions
+  - width
   return_reasons:
   - grip
   - weight
@@ -20065,11 +20825,14 @@
   - allergy_friendly_features
   - body_area
   - fragrance
+  - height
+  - length
   - material
   - product_certifications_standards
   - product_form
   - suitable_for_skin_type
   - target_gender
+  - width
   return_reasons:
   - scent
   - not_suitable_for_skin_type
@@ -20086,10 +20849,13 @@
   attributes:
   - body_area
   - hair_care_technology
+  - height
+  - length
   - material
   - needle_material
   - product_form
   - target_gender
+  - width
   return_reasons:
   - power_output
   - changed_my_mind
@@ -20106,7 +20872,9 @@
   - battery_type
   - body_area
   - color
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - pain_reduction_technology
   - pattern
@@ -20115,6 +20883,7 @@
   - suitable_for_skin_type
   - target_gender
   - usage_conditions
+  - width
   return_reasons:
   - not_suitable_for_skin_type
   - speed
@@ -20133,11 +20902,14 @@
   - color
   - compatible_wax_container_size
   - compatible_wax_form
+  - height
+  - length
   - material
   - pattern
   - product_form
   - target_gender
   - temperature_control
+  - width
   return_reasons:
   - capacity
   - speed
@@ -20158,10 +20930,13 @@
   attributes:
   - battery_technology
   - body_area
+  - height
+  - length
   - material
   - product_form
   - suitable_for_skin_tone
   - target_gender
+  - width
   return_reasons:
   - size
   - not_suitable_for_skin_type
@@ -20179,11 +20954,14 @@
   - battery_technology
   - battery_type
   - body_area
+  - height
+  - length
   - material
   - product_form
   - suitable_for_skin_tone
   - target_gender
   - treatment_modes
+  - width
   return_reasons:
   - not_suitable_for_skin_type
   - power_output
@@ -20199,11 +20977,14 @@
   attributes:
   - battery_technology
   - body_area
+  - height
+  - length
   - material
   - product_form
   - suitable_for_skin_tone
   - target_gender
   - tool_mobility
+  - width
   return_reasons:
   - size
   - not_suitable_for_skin_type
@@ -20244,12 +21025,15 @@
   - hb-3-14-7-6-5
   attributes:
   - fragrance
+  - height
+  - length
   - lumber/wood_type
   - material
   - product_certifications_standards
   - product_form
   - suitable_for_skin_type
   - target_gender
+  - width
   - wood_finish
   return_reasons:
   - not_suitable_for_skin_type
@@ -20403,11 +21187,14 @@
   - blade_coating
   - blade_edge_configuration
   - blade_material
+  - height
+  - length
   - material
   - product_form
   - razor_head_design
   - target_gender
   - usage_type
+  - width
   return_reasons:
   - sharpness
   - closeness
@@ -20543,12 +21330,15 @@
   - cleaning_instructions
   - color
   - handle_type
+  - height
   - interior_texture
+  - length
   - lumber/wood_type
   - material
   - pattern
   - product_form
   - target_gender
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -20639,11 +21429,14 @@
   - bristle_material
   - color
   - handle_material
+  - height
   - knot_shape
+  - length
   - material
   - pattern
   - product_form
   - target_gender
+  - width
   return_reasons:
   - size
   - too_stiff
@@ -20666,6 +21459,7 @@
   - shaving_cream_formulation
   - suitable_for_skin_type
   - target_gender
+  - volume
   return_reasons:
   - scent
   - consistency
@@ -20685,12 +21479,15 @@
   - brush_type
   - fragrance
   - handle_material
+  - height
+  - length
   - material
   - product_form
   - razor_type
   - shaving_kit_components
   - suitable_for_skin_type
   - target_gender
+  - width
   return_reasons:
   - razor_type
   - grip
@@ -20709,11 +21506,14 @@
   - beard_care_benefits
   - constitutive_ingredients
   - fragrance
+  - height
+  - length
   - material
   - product_form
   - suitable_for_skin_type
   - target_gender
   - usage_type
+  - width
   return_reasons:
   - scent
   - not_suitable_for_skin_type
@@ -20878,9 +21678,12 @@
   - features
   - filler_material
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - product_form
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -20909,10 +21712,13 @@
   - allergy_friendly_features
   - body_area
   - features
+  - height
+  - length
   - material
   - product_form
   - size
   - treatment_objective
+  - width
   return_reasons:
   - material
   - fit
@@ -20932,10 +21738,13 @@
   - body_area
   - features
   - fragrance
+  - height
+  - length
   - material
   - product_form
   - size
   - treatment_objective
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -20955,10 +21764,13 @@
   - chin_strap_style
   - closure_type
   - features
+  - height
+  - length
   - material
   - product_form
   - size
   - treatment_objective
+  - width
   return_reasons:
   - too_tight
   - too_loose
@@ -20978,13 +21790,16 @@
   - allergy_friendly_features
   - body_area
   - features
+  - height
   - jaw_advancement_adjustability
+  - length
   - mandibular_device_fitting_method
   - material
   - product_certifications_standards
   - product_form
   - size
   - treatment_objective
+  - width
   return_reasons:
   - too_bulky
   - fit
@@ -21003,11 +21818,14 @@
   - body_area
   - fastener_type
   - features
+  - height
+  - length
   - material
   - product_form
   - size
   - treatment_objective
   - usage_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -21025,11 +21843,14 @@
   - allergy_friendly_features
   - body_area
   - features
+  - height
+  - length
   - material
   - product_form
   - size
   - treatment_objective
   - usage_type
+  - width
   return_reasons:
   - size
   - fit
@@ -21049,12 +21870,15 @@
   - cleaning_instructions
   - color
   - features
+  - height
+  - length
   - material
   - product_certifications_standards
   - product_form
   - size
   - treatment_objective
   - usage_type
+  - width
   return_reasons:
   - too_bulky
   - fit
@@ -21142,12 +21966,15 @@
   - features
   - filler_material
   - filler_support
+  - height
   - inflation_method
+  - length
   - material
   - pattern
   - product_form
   - travel_pillow_features
   - travel_pillow_shape
+  - width
   return_reasons:
   - too_firm
   - too_bulky
@@ -21168,11 +21995,15 @@
   - color
   - connectivity_technology
   - features
+  - height
+  - length
   - light_options
   - material
   - pattern
+  - power_consumption_typical
   - product_form
   - soothing_sounds
+  - width
   return_reasons:
   - sound_quality
   - too_loud
@@ -21225,11 +22056,14 @@
   - accessory_size
   - color
   - floor_configuration
+  - height
+  - length
   - material
   - panel_transparency
   - pattern
   - product_form
   - tent_setup_style
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -21247,10 +22081,13 @@
   - hb-3-17-1
   - hb-3-17-2
   attributes:
+  - height
+  - length
   - light_source
   - material
   - orientation
   - product_form
+  - width
   return_reasons:
   - size
   - power_output
@@ -21299,10 +22136,13 @@
   - features
   - finish
   - grip_texture
+  - height
+  - length
   - material
   - pattern
   - product_form
   - tip_style
+  - width
   return_reasons:
   - color
   - grip
@@ -21487,6 +22327,7 @@
   - product_sterility
   - solution_type
   - usage_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21506,9 +22347,11 @@
   - hb-3-19-1-4-6
   attributes:
   - age_group
+  - base_curve_bc
   - color
   - compatible_contact_lenses
   - contact_lens_material
+  - lens_diameter
   - material
   - product_form
   - product_sterility
@@ -21529,9 +22372,11 @@
   children: []
   attributes:
   - age_group
+  - base_curve_bc
   - color
   - compatible_contact_lenses
   - contact_lens_material
+  - lens_diameter
   - material
   - product_form
   - product_sterility
@@ -21553,9 +22398,11 @@
   children: []
   attributes:
   - age_group
+  - base_curve_bc
   - color
   - compatible_contact_lenses
   - contact_lens_material
+  - lens_diameter
   - material
   - product_form
   - product_sterility
@@ -21576,9 +22423,11 @@
   children: []
   attributes:
   - age_group
+  - base_curve_bc
   - color
   - compatible_contact_lenses
   - contact_lens_material
+  - lens_diameter
   - lens_tint_type
   - material
   - product_form
@@ -21602,9 +22451,11 @@
   children: []
   attributes:
   - age_group
+  - base_curve_bc
   - color
   - compatible_contact_lenses
   - contact_lens_material
+  - lens_diameter
   - material
   - product_form
   - product_sterility
@@ -21626,9 +22477,11 @@
   children: []
   attributes:
   - age_group
+  - base_curve_bc
   - color
   - compatible_contact_lenses
   - contact_lens_material
+  - lens_diameter
   - material
   - product_form
   - product_sterility
@@ -21697,6 +22550,7 @@
   - package_type
   - product_form
   - product_sterility
+  - volume
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -21711,6 +22565,8 @@
   - age_group
   - color
   - eyewear_lens_material
+  - height
+  - length
   - lens_coating
   - lens_polarization
   - lens_refractive_index
@@ -21718,6 +22574,7 @@
   - material
   - pattern
   - product_sterility
+  - width
   return_reasons:
   - prescription
   - clarity
@@ -21743,7 +22600,9 @@
   - eyewear_frame_shape
   - eyewear_hinge_type
   - eyewear_lens_material
+  - height
   - jewelry_material
+  - length
   - lens_coating
   - lens_color
   - lens_pattern
@@ -21755,6 +22614,7 @@
   - target_gender
   - temple_color
   - temple_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -21812,11 +22672,14 @@
   - closure_type
   - color
   - compatible_eyewear_type
+  - height
   - interior_lining_material
+  - length
   - material
   - pattern
   - product_form
   - product_sterility
+  - width
   return_reasons:
   - color
   - too_bulky
@@ -21893,11 +22756,14 @@
   - bottle_type
   - color
   - compatible_eyewear_type
+  - height
+  - length
   - material
   - pattern
   - product_form
   - product_sterility
   - solution_type
+  - width
   return_reasons:
   - scent
   - incompatible
@@ -21919,11 +22785,14 @@
   - color
   - compatible_eyewear_type
   - eyewear_lens_material
+  - height
+  - length
   - lens_type
   - material
   - pattern
   - product_form
   - product_sterility
+  - width
   return_reasons:
   - color
   - incompatible
@@ -22021,12 +22890,15 @@
   - embellishment/trim_material
   - eyewear_strap_features
   - eyewear_strap_or_chain_style
+  - height
   - jewelry_material
+  - length
   - length_adjustability
   - material
   - pattern
   - product_form
   - product_sterility
+  - width
   return_reasons:
   - color
   - style
@@ -22051,12 +22923,15 @@
   - embellishment/trim_material
   - eyewear_strap_features
   - eyewear_strap_or_chain_style
+  - height
   - jewelry_material
+  - length
   - length_adjustability
   - material
   - pattern
   - product_form
   - product_sterility
+  - width
   return_reasons:
   - color
   - style
@@ -22080,11 +22955,14 @@
   - eyewear_compatibility
   - eyewear_strap_features
   - eyewear_strap_or_chain_style
+  - height
+  - length
   - length_adjustability
   - material
   - pattern
   - product_form
   - product_sterility
+  - width
   return_reasons:
   - color
   - style
@@ -22169,6 +23047,8 @@
   - age_group
   - color
   - eyewear_lens_material
+  - height
+  - length
   - lens_coating
   - lens_filter_category
   - lens_type
@@ -22176,6 +23056,7 @@
   - pattern
   - product_sterility
   - uv_protection
+  - width
   return_reasons:
   - lens_color
   - clarity

--- a/data/categories/hg_home_garden.yml
+++ b/data/categories/hg_home_garden.yml
@@ -86,8 +86,11 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -104,8 +107,11 @@
   - finish
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -125,7 +131,10 @@
   - furniture/fixture_features
   - furniture/fixture_material
   - hardware_finish
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -144,8 +153,11 @@
   - furniture/fixture_features
   - furniture/fixture_material
   - hardware_finish
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -164,9 +176,12 @@
   - durability_features
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - mounting_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -187,10 +202,13 @@
   - finish
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - lumber/wood_type
   - mounting_hardware
   - mounting_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -209,12 +227,16 @@
   - allergy_friendly_features
   - care_instructions
   - color
+  - depth
+  - diameter
+  - length
   - pattern
   - pile_type
   - rug/mat_features
   - rug/mat_material
   - rug/mat_shape
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -233,10 +255,13 @@
   - color
   - filler_material
   - firmness
+  - height
+  - length
   - material
   - mounting_hardware
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -254,9 +279,12 @@
   - bathroom_accessory_compatibility
   - color
   - hardware_finish
+  - height
+  - length
   - mount_material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -274,9 +302,12 @@
   - bathroom_accessories_included
   - color
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -294,9 +325,12 @@
   - color
   - compatible_tissue_box_type
   - finish
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -314,9 +348,12 @@
   - color
   - finish
   - hand_dryer_accessory_type
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -332,10 +369,14 @@
   attributes:
   - color
   - control_type
+  - height
   - housing_material
   - ingress_protection_ip_rating
+  - length
   - mounting_type
   - pattern
+  - power_consumption_typical
+  - width
   return_reasons:
   - size
   - color
@@ -354,8 +395,11 @@
   - door_type
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -372,9 +416,12 @@
   attributes:
   - color
   - hardware_finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -395,8 +442,11 @@
   - grab_bar_shape
   - handle_grip_texture
   - hardware_material
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -415,9 +465,12 @@
   - color
   - hardware_finish
   - hardware_material
+  - height
+  - length
   - pattern
   - shape
   - shower_curtain_ring_type
+  - width
   return_reasons:
   - color
   - style
@@ -435,9 +488,12 @@
   - care_instructions
   - color
   - durability_features
+  - height
+  - length
   - material
   - pattern
   - shower_curtain_mounting_type
+  - width
   return_reasons:
   - size
   - color
@@ -455,9 +511,12 @@
   - color
   - finish
   - hardware_material
+  - height
+  - length
   - mounting_type
   - pattern
   - rod_shape
+  - width
   return_reasons:
   - color
   - style
@@ -472,12 +531,16 @@
   name: Soap & Lotion Dispensers
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - soap_dispenser_operation_type
+  - width
   return_reasons:
   - size
   - color
@@ -495,10 +558,13 @@
   - color
   - drainage_design
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -518,8 +584,11 @@
   - bristle_shape
   - bristle_stiffness
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -540,9 +609,12 @@
   - color
   - features
   - handle_material
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -560,8 +632,11 @@
   - color
   - features
   - finish
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - style
@@ -581,8 +656,11 @@
   - color
   - features
   - handle_material
+  - height
+  - length
   - pattern
   - replaceable_brush_head
+  - width
   return_reasons:
   - color
   - style
@@ -614,9 +692,12 @@
   attributes:
   - color
   - hardware_finish
+  - height
+  - length
   - material
   - orientation
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -633,10 +714,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_toothbrush
   - toothbrush_holder_features
+  - width
   return_reasons:
   - size
   - color
@@ -658,9 +742,12 @@
   attributes:
   - color
   - hardware_finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -678,11 +765,14 @@
   attributes:
   - color
   - hardware_finish
+  - height
+  - length
   - lumber/wood_type
   - material
   - mounting_type
   - pattern
   - towel_holder_design
+  - width
   return_reasons:
   - size
   - color
@@ -700,9 +790,12 @@
   - color
   - hardware_finish
   - heat_function
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -794,13 +887,16 @@
   attributes:
   - camera_shape
   - color
+  - height
   - ingress_protection_ip_rating
+  - length
   - lighting_options
   - material
   - pattern
   - power_source
   - suitable_space
   - surveillance_camera_mounting_type
+  - width
   return_reasons:
   - size
   - style
@@ -818,11 +914,14 @@
   - color
   - connectivity_technology
   - control_type
+  - height
   - home_alarm_features
+  - length
   - mounting_type
   - pattern
   - power_source
   - sensor_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -839,12 +938,15 @@
   - battery_size
   - color
   - connectivity_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - motion_sensor_type
   - mounting_type
   - pattern
   - power_source
   - suitable_space
+  - width
   return_reasons:
   - size
   - range
@@ -860,6 +962,8 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mirror_curvature
   - mounting_type
@@ -867,6 +971,7 @@
   - safety_mirror_features
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - incompatible
@@ -881,13 +986,16 @@
   children: []
   attributes:
   - color
+  - height
   - ingress_protection_ip_rating
+  - length
   - light_source
   - material
   - motion_sensor_type
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - brightness
@@ -908,6 +1016,8 @@
   - color
   - display_resolution
   - display_technology
+  - height
+  - length
   - monitor_mounting_type
   - native_aspect_ratio
   - pattern
@@ -915,6 +1025,7 @@
   - power_source
   - recorder_type
   - video_port_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -932,6 +1043,8 @@
   - contrast_ratio_typical
   - display_resolution
   - display_technology
+  - height
+  - length
   - monitor/screen_specialized_features
   - monitor_mounting_type
   - native_aspect_ratio
@@ -939,6 +1052,7 @@
   - poe_standard
   - power_source
   - video_port_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -956,12 +1070,15 @@
   - connectivity_technology
   - display_resolution
   - display_technology
+  - height
+  - length
   - monitor/screen_specialized_features
   - monitor_mounting_type
   - native_aspect_ratio
   - pattern
   - poe_standard
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -998,9 +1115,12 @@
   - hg-2-7-7
   attributes:
   - color
+  - height
+  - length
   - lock_type
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1016,11 +1136,14 @@
   attributes:
   - color
   - hardware_finish
+  - height
+  - length
   - lock_keying_option
   - lock_type
   - material
   - pattern
   - security_level
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1036,14 +1159,17 @@
   attributes:
   - color
   - connectivity_technology
+  - height
   - ingress_protection_ip_rating
   - keypad_style
+  - length
   - lighting_options
   - lock_type
   - material
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1059,9 +1185,12 @@
   attributes:
   - color
   - compatible_lock_type
+  - height
   - key_blade_type
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1077,10 +1206,13 @@
   attributes:
   - closure_type
   - color
+  - height
+  - length
   - material
   - pattern
   - protected_item_type
   - rfid_frequency
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1136,10 +1268,13 @@
   - hg-2-8-7
   attributes:
   - color
+  - height
+  - length
   - lock_type
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - lock_type
@@ -1156,10 +1291,13 @@
   attributes:
   - color
   - fire_protection_class
+  - height
+  - length
   - lock_type
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - lock_type
@@ -1175,10 +1313,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lock_type
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - lock_type
@@ -1194,10 +1335,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lock_type
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - lock_type
@@ -1214,11 +1358,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lock_type
   - material
   - mounting_type
   - pattern
   - security_level
+  - width
   return_reasons:
   - size
   - lock_type
@@ -1289,13 +1436,16 @@
   - battery_size
   - color
   - connectivity_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - motion_sensor_type
   - mounting_type
   - pattern
   - power_source
   - security_sensor_subtype
   - suitable_space
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1485,6 +1635,8 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - lighting_options
   - material
   - mounting_type
@@ -1492,6 +1644,7 @@
   - pattern
   - shape
   - surface_reflectivity
+  - width
   return_reasons:
   - size
   - color
@@ -1512,12 +1665,15 @@
   attributes:
   - arrangement
   - color
+  - height
+  - length
   - material
   - pattern
   - plant_class
   - plant_name
   - stem_length
   - suitable_location
+  - width
   return_reasons:
   - size
   - color
@@ -1535,6 +1691,8 @@
   - arrangement
   - color
   - decoration_material
+  - height
+  - length
   - material_treatment
   - pattern
   - plant_class
@@ -1544,6 +1702,7 @@
   - planter_material
   - stem_length
   - suitable_location
+  - width
   return_reasons:
   - size
   - color
@@ -1561,6 +1720,8 @@
   - arrangement
   - color
   - decoration_material
+  - height
+  - length
   - material_treatment
   - mounting_type
   - pattern
@@ -1571,6 +1732,7 @@
   - stem_length
   - suitable_location
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -1589,6 +1751,8 @@
   - color
   - decoration_material
   - durability_features
+  - height
+  - length
   - material_treatment
   - pattern
   - plant_class
@@ -1598,6 +1762,7 @@
   - shrub_shape
   - stem_length
   - suitable_location
+  - width
   return_reasons:
   - size
   - color
@@ -1615,6 +1780,8 @@
   - arrangement
   - color
   - decoration_material
+  - height
+  - length
   - light_source
   - lumber/wood_type
   - material_treatment
@@ -1627,6 +1794,7 @@
   - suitable_space
   - tree_shape
   - tree_stand_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -1670,9 +1838,12 @@
   - condition
   - decoration_material
   - frame_style
+  - height
+  - length
   - orientation
   - pattern
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -1693,11 +1864,13 @@
   - color
   - decoration_material
   - frame_style
+  - length
   - mounting_type
   - orientation
   - pattern
   - shape
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -1724,12 +1897,15 @@
   - artwork_frame_material
   - color
   - frame_style
+  - height
+  - length
   - material
   - orientation
   - pattern
   - printing_method
   - rarity
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -1751,12 +1927,15 @@
   - color
   - finish
   - frame_style
+  - height
+  - length
   - material
   - orientation
   - pattern
   - printing_method
   - rarity
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -1777,6 +1956,8 @@
   - artwork_frame_material
   - color
   - frame_style
+  - height
+  - length
   - material
   - orientation
   - pattern
@@ -1784,6 +1965,7 @@
   - printing_method
   - rarity
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -1805,6 +1987,8 @@
   - color
   - frame_style
   - glazing_material
+  - height
+  - length
   - material
   - orientation
   - painting_medium
@@ -1814,6 +1998,7 @@
   - rarity
   - signature_placement
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -1887,13 +2072,16 @@
   - embellishment/trim_material
   - finish
   - frame_style
+  - height
   - jewelry_material
+  - length
   - lumber/wood_type
   - material
   - mounting_type
   - orientation
   - pattern
   - theme
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -1918,7 +2106,10 @@
   - cover_pattern
   - filler_material
   - filler_support
+  - height
+  - length
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -1938,8 +2129,11 @@
   - color
   - features
   - handle_type
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -1965,10 +2159,13 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - suitable_for_bird_type
+  - width
   return_reasons:
   - size
   - color
@@ -1987,10 +2184,13 @@
   - attachment_type
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - suitable_for_bird_type
+  - width
   return_reasons:
   - size
   - color
@@ -2008,10 +2208,13 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - suitable_for_bird_type
+  - width
   return_reasons:
   - size
   - color
@@ -2030,10 +2233,13 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - suitable_for_bird_type
+  - width
   return_reasons:
   - size
   - color
@@ -2052,10 +2258,13 @@
   - cleaning_instructions
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - suitable_for_bird_type
+  - width
   return_reasons:
   - size
   - color
@@ -2074,11 +2283,14 @@
   - color
   - compatible_feeder_type
   - durability_features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - shape
   - suitable_for_bird_type
+  - width
   return_reasons:
   - size
   - color
@@ -2096,10 +2308,13 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - suitable_for_bird_type
+  - width
   return_reasons:
   - size
   - color
@@ -2117,11 +2332,14 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - squirrel_resistance
   - suitable_for_bird_type
+  - width
   return_reasons:
   - size
   - color
@@ -2138,12 +2356,15 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - shape
   - suitable_for_bird_type
   - weather_guard_mounting_method
+  - width
   return_reasons:
   - size
   - color
@@ -2186,9 +2407,12 @@
   - decoration_material
   - durability_features
   - feeder_design
+  - height
+  - length
   - mounting_hardware
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2210,11 +2434,14 @@
   - decoration_material
   - durability_features
   - feeder_design
+  - height
+  - length
   - lumber/wood_type
   - mounting_hardware
   - mounting_type
   - pattern
   - suitable_for_bird_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2236,9 +2463,12 @@
   - color
   - decoration_material
   - durability_features
+  - height
+  - length
   - mounting_hardware
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2259,10 +2489,13 @@
   - decoration_material
   - durability_features
   - feeder_design
+  - height
+  - length
   - mounting_hardware
   - mounting_type
   - pattern
   - squirrel_feed_type
+  - width
   return_reasons:
   - size
   - color
@@ -2284,10 +2517,13 @@
   - hg-3-9-10
   attributes:
   - color
+  - height
+  - length
   - material
   - outdoor_equipment_features
   - pattern
   - suitable_for_bird_type
+  - width
   return_reasons:
   - size
   - color
@@ -2304,6 +2540,8 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
@@ -2311,6 +2549,7 @@
   - perch_design
   - perch_surface_texture
   - suitable_for_bird_type
+  - width
   return_reasons:
   - size
   - color
@@ -2328,12 +2567,15 @@
   attributes:
   - animal_type
   - color
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
   - predator_guard_style
   - suitable_for_bird_type
+  - width
   return_reasons:
   - size
   - color
@@ -2351,11 +2593,14 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
   - suitable_for_bird_type
+  - width
   return_reasons:
   - size
   - color
@@ -2416,10 +2661,13 @@
   - animal_type
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_hardware
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2437,11 +2685,14 @@
   - animal_type
   - color
   - durability_features
+  - height
+  - length
   - lumber/wood_type
   - material
   - mounting_hardware
   - mounting_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2460,12 +2711,15 @@
   - animal_type
   - color
   - durability_features
+  - height
+  - length
   - lumber/wood_type
   - material
   - mounting_hardware
   - mounting_type
   - pattern
   - suitable_for_bird_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2485,10 +2739,13 @@
   - color
   - durability_features
   - entrance_slot_design
+  - height
+  - length
   - material
   - mounting_hardware
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2539,11 +2796,14 @@
   attributes:
   - color
   - decoration_material
+  - height
+  - length
   - mounting_hardware
   - mounting_type
   - pattern
   - power_source
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -2560,10 +2820,13 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - pattern
   - shape
   - theme
+  - width
   return_reasons:
   - color
   - style
@@ -2581,11 +2844,14 @@
   - blade_sidedness
   - celebration_type
   - color
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - printed_sides
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -2605,10 +2871,13 @@
   - color
   - cover_features
   - fabric
+  - height
+  - length
   - pattern
   - shape
   - suitable_for_chair_type
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -2632,9 +2901,12 @@
   - cover_pattern
   - filler_material
   - firmness
+  - height
+  - length
   - shape
   - suitable_for_chair_type
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -2659,9 +2931,12 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2676,10 +2951,13 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -2697,10 +2975,13 @@
   attributes:
   - color
   - dial_finish
+  - height
+  - length
   - material
   - numeral_style
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -2721,9 +3002,12 @@
   - construction
   - embellishment/trim_material
   - finish
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -2743,10 +3027,13 @@
   - color
   - display_mode
   - finish
+  - height
+  - length
   - material
   - numeral_style
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -2768,10 +3055,13 @@
   - clock_movement_type
   - color
   - finish
+  - height
+  - length
   - material
   - pattern
   - pendulum_compatibility
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2852,6 +3142,8 @@
   - connectivity_technology
   - display_mode
   - display_technology
+  - height
+  - length
   - material
   - numeral_style
   - pattern
@@ -2859,6 +3151,7 @@
   - shape
   - stand/display_type
   - time_format
+  - width
   return_reasons:
   - size
   - color
@@ -2881,6 +3174,8 @@
   - clock_movement_type
   - color
   - display_mode
+  - height
+  - length
   - material
   - numeral_style
   - pattern
@@ -2888,6 +3183,7 @@
   - shape
   - stand/display_type
   - timepiece_features
+  - width
   return_reasons:
   - size
   - color
@@ -2908,6 +3204,8 @@
   - clock_movement_type
   - color
   - display_mode
+  - height
+  - length
   - material
   - numeral_style
   - pattern
@@ -2915,6 +3213,7 @@
   - shape
   - stand/display_type
   - timepiece_features
+  - width
   return_reasons:
   - size
   - color
@@ -2935,12 +3234,15 @@
   - clock_movement_type
   - color
   - display_mode
+  - height
+  - length
   - material
   - numeral_style
   - pattern
   - power_source
   - shape
   - timepiece_features
+  - width
   return_reasons:
   - size
   - color
@@ -2962,12 +3264,15 @@
   - clock_movement_type
   - color
   - display_mode
+  - height
+  - length
   - material
   - numeral_style
   - pattern
   - power_source
   - shape
   - stand/display_type
+  - width
   return_reasons:
   - size
   - color
@@ -2989,12 +3294,15 @@
   - clock_movement_type
   - color
   - display_mode
+  - height
+  - length
   - material
   - numeral_style
   - pattern
   - power_source
   - shape
   - stand/display_type
+  - width
   return_reasons:
   - size
   - color
@@ -3015,6 +3323,8 @@
   - clock_movement_type
   - color
   - display_mode
+  - height
+  - length
   - lumber/wood_type
   - material
   - numeral_style
@@ -3023,6 +3333,7 @@
   - shape
   - stand/display_type
   - style
+  - width
   return_reasons:
   - size
   - color
@@ -3063,12 +3374,15 @@
   - clock_movement_type
   - color
   - display_mode
+  - height
+  - length
   - material
   - numeral_style
   - pattern
   - power_source
   - shape
   - stand/display_type
+  - width
   return_reasons:
   - size
   - color
@@ -3086,8 +3400,11 @@
   - color
   - finish
   - frame_material
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3106,10 +3423,13 @@
   - celebration_type
   - color
   - decoration_material
+  - height
+  - length
   - mounting_type
   - pattern
   - suitable_space
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -3128,9 +3448,12 @@
   - color
   - decoration_material
   - finish
+  - height
+  - length
   - pattern
   - shape
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -3148,9 +3471,12 @@
   - color
   - decoration_material
   - finish
+  - height
+  - length
   - pattern
   - shape
   - style
+  - width
   return_reasons:
   - size
   - color
@@ -3167,10 +3493,13 @@
   attributes:
   - color
   - decoration_material
+  - height
   - jar_shape
+  - length
   - lid_type
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3188,6 +3517,8 @@
   - color
   - decoration_material
   - finish
+  - height
+  - length
   - material
   - mounting_hardware
   - mounting_type
@@ -3196,6 +3527,7 @@
   - personalization_options
   - shape
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -3213,9 +3545,12 @@
   - color
   - decoration_material
   - finish
+  - height
+  - length
   - mounting_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -3234,9 +3569,12 @@
   - decoration_material
   - features
   - finish
+  - height
   - item_style
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -3257,11 +3595,14 @@
   - door_mat_base_material
   - door_mat_base_pattern
   - door_mat_surface_material
+  - height
+  - length
   - mat_features
   - pile_type
   - shape
   - suitable_space
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -3278,9 +3619,12 @@
   attributes:
   - color
   - embellishments
+  - height
+  - length
   - material
   - pattern
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -3297,9 +3641,12 @@
   attributes:
   - arrangement
   - color
+  - height
+  - length
   - pattern
   - plant_name
   - preservation_method
+  - width
   return_reasons:
   - color
   - style
@@ -3314,10 +3661,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - light_exposure_requirement
   - pattern
   - shape
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - color
@@ -3335,9 +3685,12 @@
   - color
   - decoration_material
   - finish
+  - height
+  - length
   - material
   - pattern
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -3356,7 +3709,10 @@
   - decoration_material
   - finial_shape
   - hardware_finish
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3378,8 +3734,11 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3396,11 +3755,14 @@
   attributes:
   - color
   - durability_features
+  - height
   - ingress_protection_ip_rating
+  - length
   - light_source
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -3418,9 +3780,12 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3438,10 +3803,13 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - pole_construction_type
+  - width
   return_reasons:
   - size
   - color
@@ -3493,12 +3861,15 @@
   - color
   - flag_attachment_style
   - flag_shape
+  - height
+  - length
   - material
   - orientation
   - pattern
   - printed_sides
   - suitable_space
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -3555,11 +3926,14 @@
   - candle_shape
   - candle_type
   - color
+  - height
+  - length
   - light_options
   - light_temperature
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -3598,12 +3972,15 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - suitable_for_water_feature_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - color
@@ -3622,12 +3999,18 @@
   - hg-3-35-2-3
   attributes:
   - color
+  - flow_rate
+  - height
+  - length
   - light_options
   - material
+  - maximum_operating_pressure
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
   - suitable_location
+  - width
   return_reasons:
   - color
   - style
@@ -3644,15 +4027,20 @@
   - battery_size
   - battery_type
   - color
+  - flow_rate
   - fountain_design
+  - height
+  - length
   - light_options
   - lighting_features
   - material
+  - maximum_operating_pressure
   - mounting_type
   - pattern
   - power_source
   - suitable_location
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -3668,13 +4056,18 @@
   children: []
   attributes:
   - color
+  - flow_rate
+  - height
+  - length
   - light_options
   - material
+  - maximum_operating_pressure
   - mounting_type
   - pattern
   - power_source
   - suitable_location
   - suitable_space
+  - width
   return_reasons:
   - color
   - style
@@ -3689,11 +4082,16 @@
   children: []
   attributes:
   - color
+  - flow_rate
+  - height
+  - length
   - material
+  - maximum_operating_pressure
   - mounting_type
   - pattern
   - power_source
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -3713,9 +4111,12 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -3732,9 +4133,12 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - pattern
   - personalization_options
+  - width
   return_reasons:
   - size
   - color
@@ -3751,10 +4155,13 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - pattern
   - shape
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -3787,12 +4194,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - personalization_options
   - theme
   - units_of_measurement
+  - width
   return_reasons:
   - size
   - color
@@ -3812,11 +4222,14 @@
   - decoration_material
   - finish
   - floor_protection_transparency_level
+  - height
+  - length
   - pattern
   - placement_supported
   - shape
   - theme
   - wallpaper_application_method
+  - width
   return_reasons:
   - size
   - color
@@ -3840,10 +4253,13 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - pattern
   - suitable_space
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -3862,6 +4278,8 @@
   - candle_type
   - color
   - finish
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
@@ -3869,6 +4287,7 @@
   - suitable_space
   - theme
   - warmer_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -3889,12 +4308,15 @@
   - color
   - decoration_material
   - finish
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - shape
   - suitable_space
   - theme
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -3913,10 +4335,13 @@
   - alcohol/solvent_content
   - color
   - finish
+  - height
+  - length
   - material
   - pattern
   - suitable_space
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -3936,13 +4361,16 @@
   - battery_type
   - color
   - finish
+  - height
   - incense_holder_style
   - incense_type
+  - length
   - lumber/wood_type
   - material
   - pattern
   - suitable_space
   - theme
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -4160,9 +4588,12 @@
   attributes:
   - color
   - fragrance_level
+  - height
+  - length
   - pattern
   - scent
   - usage_type
+  - width
   return_reasons:
   - scent
   - too_strong
@@ -4181,10 +4612,13 @@
   - alcohol/solvent_content
   - color
   - fragrance_level
+  - height
+  - length
   - pattern
   - product_form
   - scent
   - usage_type
+  - width
   return_reasons:
   - scent
   - longevity
@@ -4206,10 +4640,14 @@
   - candle_type
   - color
   - decoration_material
+  - diameter
   - fragrance_level
+  - height
+  - length
   - pattern
   - scent
   - usage_type
+  - width
   return_reasons:
   - color
   - scent
@@ -4235,6 +4673,7 @@
   - pattern
   - scent
   - usage_type
+  - volume
   return_reasons:
   - scent
   - too_strong
@@ -4252,11 +4691,14 @@
   - alcohol/solvent_content
   - color
   - fragrance_level
+  - height
   - incense_type
+  - length
   - material
   - pattern
   - scent
   - usage_type
+  - width
   return_reasons:
   - scent
   - too_strong
@@ -4275,12 +4717,15 @@
   - alcohol/solvent_content
   - color
   - fragrance_level
+  - height
+  - length
   - material_treatment
   - package_type
   - pattern
   - plant_material
   - scent
   - usage_type
+  - width
   return_reasons:
   - scent
   - too_strong
@@ -4299,11 +4744,14 @@
   - alcohol/solvent_content
   - color
   - fragrance_level
+  - height
+  - length
   - pattern
   - scent
   - shape
   - usage_type
   - wax_type
+  - width
   return_reasons:
   - scent
   - too_strong
@@ -4359,10 +4807,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - sand_color
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -4383,10 +4834,13 @@
   - displayed_character
   - durability_features
   - finish
+  - height
+  - length
   - lighting_options
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4405,12 +4859,15 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - light_options
   - material
   - mounting_type
   - pattern
   - power_source
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -4430,6 +4887,8 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - light_options
   - lighting_options
   - material
@@ -4437,6 +4896,7 @@
   - pattern
   - power_source
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -4457,6 +4917,8 @@
   - battery_type
   - color
   - durability_features
+  - height
+  - length
   - light_options
   - light_source
   - material
@@ -4464,6 +4926,7 @@
   - pattern
   - power_source
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -4522,9 +4985,12 @@
   - decoration_material
   - durability_features
   - finish
+  - height
+  - length
   - material
   - orientation
   - pattern
+  - width
   return_reasons:
   - size
   - finish
@@ -4549,9 +5015,12 @@
   - compatible_mailbox_size
   - durability_features
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4572,10 +5041,13 @@
   - compatible_mailbox_size
   - durability_features
   - finish
+  - height
+  - length
   - material
   - pattern
   - season
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -4595,9 +5067,12 @@
   - compatible_mailbox_type
   - durability_features
   - finish
+  - height
+  - length
   - lock_type
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4617,8 +5092,11 @@
   - durability_features
   - finish
   - flag_shape
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4636,11 +5114,14 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - mounting_type
   - pattern
   - post_installation_method
   - post_material
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -4661,9 +5142,12 @@
   - durability_features
   - finish
   - furniture/fixture_material
+  - height
+  - length
   - lock_type
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4697,9 +5181,12 @@
   - color
   - decoration_material
   - durability_features
+  - height
+  - length
   - lock_type
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4719,6 +5206,8 @@
   - color
   - edge_style
   - frame_design
+  - height
+  - length
   - lighting_options
   - material
   - mirror_type
@@ -4726,6 +5215,7 @@
   - orientation
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -4779,10 +5269,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - power_source
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -4800,8 +5293,11 @@
   attributes:
   - color
   - decoration_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -4819,12 +5315,15 @@
   - color
   - decoration_material
   - durability_features
+  - height
+  - length
   - lighting_options
   - mounting_type
   - orientation
   - pattern
   - power_source
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -4846,8 +5345,11 @@
   - cover_pattern
   - filler_material
   - firmness
+  - height
+  - length
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -4869,10 +5371,13 @@
   - decoration_material
   - format_supported
   - frame_style
+  - height
+  - length
   - mounting_type
   - orientation
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -4912,9 +5417,12 @@
   - closure_type
   - color
   - decoration_material
+  - height
+  - length
   - material
   - pattern
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -4932,12 +5440,15 @@
   - closure_type
   - color
   - decoration_material
+  - height
+  - length
   - lid_type
   - lock_type
   - material
   - pattern
   - personalization_options
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -4958,11 +5469,14 @@
   - construction
   - decoration_material
   - embellishment/trim_material
+  - height
+  - length
   - material
   - money_retrieval_method
   - pattern
   - shape
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -4980,9 +5494,12 @@
   - color
   - decoration_material
   - finish
+  - height
+  - length
   - mounting_hardware
   - pattern
   - rain_chain_style
+  - width
   return_reasons:
   - size
   - color
@@ -4999,11 +5516,14 @@
   attributes:
   - color
   - display_mode
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - units_of_measurement
+  - width
   return_reasons:
   - size
   - style
@@ -5018,11 +5538,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - magnet_type
   - material
   - pattern
   - shape
   - theme
+  - width
   return_reasons:
   - color
   - style
@@ -5040,6 +5563,9 @@
   - backing_material
   - care_instructions
   - color
+  - depth
+  - diameter
+  - length
   - pattern
   - pile_type
   - rug_features
@@ -5047,6 +5573,7 @@
   - rug_shape
   - style
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -5078,12 +5605,15 @@
   - celebration_type
   - color
   - decoration_material
+  - height
+  - length
   - lighting_features
   - material
   - pattern
   - power_source
   - suitable_space
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -5100,6 +5630,8 @@
   attributes:
   - celebration_type
   - color
+  - height
+  - length
   - lighting_features
   - material
   - pattern
@@ -5107,6 +5639,7 @@
   - suitable_space
   - theme
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -5125,6 +5658,8 @@
   - closure_type
   - color
   - decoration_material
+  - height
+  - length
   - lighting_features
   - material
   - pattern
@@ -5132,6 +5667,7 @@
   - shape
   - suitable_space
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -5149,11 +5685,14 @@
   - celebration_type
   - color
   - fixation_type
+  - height
+  - length
   - lighting_features
   - pattern
   - power_source
   - suitable_space
   - tree_stand_material
+  - width
   return_reasons:
   - size
   - color
@@ -5172,6 +5711,8 @@
   - chemical_safety_features
   - color
   - egg_decorating_items_included
+  - height
+  - length
   - lighting_features
   - paint/dye_form
   - pattern
@@ -5179,6 +5720,7 @@
   - recommended_age_group
   - suitable_space
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -5197,12 +5739,15 @@
   - battery_type
   - celebration_type
   - color
+  - height
+  - length
   - lighting_features
   - material
   - pattern
   - power_source
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -5220,11 +5765,14 @@
   - celebration_type
   - color
   - finish
+  - height
+  - length
   - lighting_features
   - material
   - ornament_hook_style
   - pattern
   - suitable_space
+  - width
   - wire_thickness
   return_reasons:
   - size
@@ -5248,6 +5796,8 @@
   - decoration_material
   - embellishment/trim_material
   - finish
+  - height
+  - length
   - lighting_features
   - lighting_options
   - material
@@ -5259,6 +5809,7 @@
   - shape
   - suitable_space
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -5276,10 +5827,13 @@
   - celebration_type
   - color
   - decoration_material
+  - height
+  - length
   - lighting_features
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -5297,6 +5851,8 @@
   - celebration_type
   - color
   - decoration_material
+  - height
+  - length
   - lighting_features
   - material
   - pattern
@@ -5305,6 +5861,7 @@
   - stocking_toe_orientation
   - suitable_space
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -5326,11 +5883,14 @@
   - celebration_type
   - color
   - doll_type
+  - height
+  - length
   - lighting_features
   - material
   - pattern
   - power_source
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -5425,6 +5985,8 @@
   - battery_type
   - celebration_type
   - color
+  - height
+  - length
   - lighting_features
   - lighting_options
   - lumber/wood_type
@@ -5432,6 +5994,7 @@
   - pattern
   - power_source
   - suitable_space
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -5456,11 +6019,14 @@
   - celebration_type
   - color
   - decoration_material
+  - height
+  - length
   - lighting_features
   - lighting_options
   - pattern
   - power_source
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -5571,11 +6137,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mounting_type
   - orientation
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -5594,10 +6163,13 @@
   - closure_type
   - color
   - cover_features
+  - height
+  - length
   - material
   - pattern
   - slipcover_stretch_type
   - suitable_for_furniture_type
+  - width
   return_reasons:
   - color
   - fit
@@ -5612,11 +6184,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - light_options
   - material
   - pattern
   - power_source
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -5633,11 +6208,14 @@
   attributes:
   - color
   - hanging_attachment_type
+  - height
+  - length
   - material
   - pattern
   - shape
   - suitable_space
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -5654,11 +6232,14 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - shape
   - sundial_type
+  - width
   return_reasons:
   - size
   - color
@@ -5680,7 +6261,10 @@
   - cover_pattern
   - filler_material
   - filler_support
+  - height
+  - length
   - throw_pillow_shape
+  - width
   return_reasons:
   - size
   - color
@@ -5698,10 +6282,13 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - lock_type
   - material
   - pattern
   - style
+  - width
   return_reasons:
   - size
   - color
@@ -5719,11 +6306,14 @@
   - hg-3-66-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - shape
   - theme
   - vase_filler_type
+  - width
   return_reasons:
   - size
   - color
@@ -5741,10 +6331,13 @@
   - celebration_type
   - color
   - finish
+  - height
+  - length
   - material
   - pattern
   - shape
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -5760,11 +6353,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - shape
   - theme
   - vase_filler_type
+  - width
   return_reasons:
   - size
   - color
@@ -5784,10 +6380,13 @@
   attributes:
   - color
   - decoration_material
+  - height
   - item_style
+  - length
   - material
   - pattern
   - vase_shape
+  - width
   return_reasons:
   - size
   - color
@@ -5854,6 +6453,8 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - pattern
   - pattern_match_type
@@ -5862,6 +6463,7 @@
   - wallpaper_application_method
   - wallpaper_removal_type
   - wallpaper_washability_rating
+  - width
   return_reasons:
   - size
   - color
@@ -5919,10 +6521,13 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - roof_decor_shape
+  - width
   return_reasons:
   - size
   - color
@@ -5943,10 +6548,13 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - roof_decor_shape
+  - width
   return_reasons:
   - size
   - color
@@ -6023,10 +6631,13 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - roof_decor_shape
+  - width
   return_reasons:
   - size
   - color
@@ -6043,11 +6654,14 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_type
   - musical_key
   - pattern
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -6067,10 +6681,13 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -6087,6 +6704,8 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - lighting_features
   - material
   - mounting_type
@@ -6094,6 +6713,7 @@
   - pattern
   - power_source
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -6111,11 +6731,14 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -6131,12 +6754,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - magnet_type
   - material
   - pattern
   - shape
   - suitable_space
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -6178,8 +6804,11 @@
   - color
   - hardware_finish
   - hardware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -6200,8 +6829,11 @@
   - finial_shape
   - hardware_finish
   - hardware_material
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6223,9 +6855,12 @@
   - fabric
   - hardware_finish
   - hardware_material
+  - height
   - item_style
+  - length
   - mounting_hardware
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6244,9 +6879,12 @@
   - fabric
   - hardware_finish
   - hardware_material
+  - height
   - item_style
+  - length
   - mounting_hardware
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6266,10 +6904,13 @@
   - fabric
   - hardware_finish
   - hardware_material
+  - height
   - item_style
+  - length
   - material
   - mounting_hardware
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6312,9 +6953,12 @@
   - finish
   - hardware_finish
   - hardware_material
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - color
   - style
@@ -6334,9 +6978,12 @@
   - finish
   - hardware_finish
   - hardware_material
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - color
   - style
@@ -6357,10 +7004,13 @@
   - finish
   - hardware_finish
   - hardware_material
+  - height
+  - length
   - lumber/wood_type
   - material
   - mounting_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -6380,9 +7030,12 @@
   - finish
   - hardware_finish
   - hardware_material
+  - height
   - hook_style
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - color
   - style
@@ -6402,8 +7055,11 @@
   - finish
   - hardware_finish
   - hardware_material
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6422,9 +7078,12 @@
   - finish
   - hardware_finish
   - hardware_material
+  - height
+  - length
   - mounting_type
   - pattern
   - rod_shape
+  - width
   - window_rod_type
   return_reasons:
   - size
@@ -6487,13 +7146,18 @@
   attributes:
   - care_instructions
   - color
+  - curtain_drop
   - curtain_heading_style
   - curtain_lining_type
+  - curtain_width
   - fabric
+  - height
+  - length
   - light_control
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6511,13 +7175,18 @@
   attributes:
   - care_instructions
   - color
+  - curtain_drop
   - curtain_heading_style
   - curtain_lining_type
+  - curtain_width
   - fabric
+  - height
+  - length
   - light_control
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6535,13 +7204,18 @@
   attributes:
   - care_instructions
   - color
+  - curtain_drop
   - curtain_heading_style
   - curtain_lining_type
+  - curtain_width
   - fabric
+  - height
+  - length
   - light_control
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -6559,12 +7233,15 @@
   attributes:
   - artwork_frame_material
   - color
+  - height
+  - length
   - light_control
   - mounting_type
   - orientation
   - pattern
   - shape
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -6585,10 +7262,13 @@
   - blind/shade_style
   - color
   - control_technology
+  - height
+  - length
   - lift_mechanism
   - light_control
   - mounting_type
   - pattern
+  - width
   - window_treatment_material
   return_reasons:
   - size
@@ -6608,10 +7288,13 @@
   - blind/shade_style
   - color
   - control_technology
+  - height
+  - length
   - lift_mechanism
   - light_control
   - mounting_type
   - pattern
+  - width
   - window_treatment_material
   return_reasons:
   - size
@@ -6631,10 +7314,13 @@
   - blind/shade_style
   - color
   - control_technology
+  - height
+  - length
   - lift_mechanism
   - light_control
   - mounting_type
   - pattern
+  - width
   - window_treatment_material
   return_reasons:
   - size
@@ -6653,8 +7339,11 @@
   attributes:
   - color
   - film_application_method
+  - height
+  - length
   - light_control
   - pattern
+  - width
   - window_film_installation_surface
   - window_film_type
   - window_treatment_material
@@ -6674,12 +7363,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - light_control
   - material
   - mounting_type
   - pattern
   - rib_material
   - screen_material
+  - width
   - window_screen_type
   return_reasons:
   - size
@@ -6700,11 +7392,14 @@
   attributes:
   - color
   - curtain_heading_style
+  - height
+  - length
   - light_control
   - material
   - mounting_type
   - pattern
   - style
+  - width
   - window_treatment_lining_type
   return_reasons:
   - size
@@ -6723,11 +7418,14 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - light_control
   - material
   - mounting_hardware
   - pattern
   - style
+  - width
   - window_treatment_lining_type
   return_reasons:
   - size
@@ -6745,12 +7443,15 @@
   attributes:
   - color
   - curtain_lining_type
+  - height
+  - length
   - light_control
   - material
   - mounting_type
   - pattern
   - style
   - valance_style
+  - width
   - window_treatment_lining_type
   return_reasons:
   - size
@@ -6771,13 +7472,17 @@
   - hg-3-75-5
   attributes:
   - color
+  - diameter
+  - height
   - language
+  - length
   - lighting_options
   - map_style
   - material
   - pattern
   - power_source
   - relief_style
+  - width
   return_reasons:
   - size
   - color
@@ -6793,7 +7498,10 @@
   children: []
   attributes:
   - color
+  - diameter
+  - height
   - language_version
+  - length
   - lighting_options
   - map_style
   - material
@@ -6801,6 +7509,7 @@
   - power_source
   - relief_style
   - stand/display_type
+  - width
   return_reasons:
   - size
   - color
@@ -6816,13 +7525,17 @@
   children: []
   attributes:
   - color
+  - diameter
+  - height
   - language
+  - length
   - lighting_options
   - map_style
   - material
   - pattern
   - power_source
   - relief_style
+  - width
   return_reasons:
   - size
   - color
@@ -6838,13 +7551,17 @@
   children: []
   attributes:
   - color
+  - diameter
+  - height
   - language
+  - length
   - lighting_options
   - map_style
   - material
   - pattern
   - power_source
   - relief_style
+  - width
   return_reasons:
   - size
   - color
@@ -6861,14 +7578,18 @@
   attributes:
   - age_group
   - color
+  - diameter
   - globe_map_content
+  - height
   - language
+  - length
   - lighting_options
   - map_style
   - material
   - pattern
   - power_source
   - relief_style
+  - width
   return_reasons:
   - size
   - color
@@ -6888,12 +7609,15 @@
   attributes:
   - celebration_type
   - color
+  - height
+  - length
   - lighting_options
   - material
   - pattern
   - plant_name
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -6911,6 +7635,8 @@
   - celebration_type
   - color
   - garland_style
+  - height
+  - length
   - light_source
   - lighting_options
   - material
@@ -6921,6 +7647,7 @@
   - shape
   - suitable_space
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -6937,6 +7664,8 @@
   attributes:
   - celebration_type
   - color
+  - height
+  - length
   - lighting_options
   - material
   - material_treatment
@@ -6946,6 +7675,7 @@
   - season
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -7037,7 +7767,10 @@
   - hg-4-8
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7054,9 +7787,12 @@
   - alert_type
   - color
   - connectivity_technology
+  - height
+  - length
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7071,8 +7807,11 @@
   attributes:
   - color
   - emergency_blanket_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7088,9 +7827,13 @@
   - color
   - dietary_preferences
   - food_product_form
+  - height
+  - length
   - package_type
   - pattern
   - preparation_type
+  - shelf_life
+  - width
   return_reasons:
   - size
   - shelf_life
@@ -7106,9 +7849,12 @@
   attributes:
   - color
   - emergency_items_included
+  - height
   - ingress_protection_ip_rating
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7125,8 +7871,11 @@
   - color
   - furniture_anchor_type
   - hardware_material
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7203,9 +7952,12 @@
   - color
   - handle_material
   - handle_type
+  - height
+  - length
   - material
   - pattern
   - tip_material
+  - width
   return_reasons:
   - size
   - style
@@ -7222,9 +7974,12 @@
   - color
   - finish
   - grate_design
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7240,9 +7995,12 @@
   attributes:
   - color
   - hardware_finish
+  - height
   - item_style
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7259,10 +8017,13 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7278,10 +8039,13 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -7301,8 +8065,11 @@
   - finish
   - fireplace_tool_items_included
   - handle_material
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7323,8 +8090,11 @@
   attributes:
   - color
   - fireplace_fuel_form
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_seasoning_method
   return_reasons:
   - size
@@ -7341,8 +8111,11 @@
   - color
   - fireplace_fuel_form
   - firewood_seasoning
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7398,10 +8171,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -7426,7 +8202,10 @@
   - durability_features
   - finish
   - furniture/fixture_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7444,8 +8223,11 @@
   - durability_features
   - finish
   - furniture/fixture_material
+  - height
+  - length
   - mounting_hardware
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -7462,8 +8244,11 @@
   - durability_features
   - finish
   - furniture/fixture_material
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7483,8 +8268,11 @@
   - cover_material
   - durability_features
   - finish
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7551,8 +8339,11 @@
   - durability_features
   - finish
   - furniture/fixture_material
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -7572,9 +8363,12 @@
   - finish
   - furniture/fixture_material
   - handle_type
+  - height
+  - length
   - mounting_type
   - pattern
   - wheel_type
+  - width
   return_reasons:
   - size
   - color
@@ -7594,11 +8388,14 @@
   - durability_features
   - finish
   - furniture/fixture_material
+  - height
+  - length
   - mounting_type
   - pattern
   - placement_supported
   - style
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -7631,11 +8428,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mounting_type
+  - noise_level
   - pattern
   - power_source
   - speed_settings
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7672,9 +8473,12 @@
   - assembly_required
   - color
   - flue_type
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -7693,9 +8497,12 @@
   - color
   - control_type
   - flue_type
+  - height
+  - length
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - style
@@ -7712,11 +8519,14 @@
   attributes:
   - color
   - flue_type
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -7757,10 +8567,13 @@
   - color
   - connectivity_technology
   - fire_alarm_panel_type
+  - height
   - ingress_protection_ip_rating
+  - length
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7780,10 +8593,13 @@
   - color
   - connectivity_technology
   - detector_operation_mode
+  - height
   - ingress_protection_ip_rating
+  - length
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7853,11 +8669,14 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - lock_type
   - material
   - mounting_type
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -7947,11 +8766,15 @@
   - color
   - extinguisher_rating
   - extinguishing_agent_type
+  - extinguishing_agent_volume
   - fire_extinguisher_items_included
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - suitable_for_fire_class
+  - width
   return_reasons:
   - size
   - weight
@@ -7967,10 +8790,13 @@
   attributes:
   - color
   - hardware_finish
+  - height
+  - length
   - material
   - pattern
   - sprinkler_orientation
   - sprinkler_response_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7989,9 +8815,12 @@
   - connectivity_technology
   - detector_operation_mode
   - detector_type
+  - height
+  - length
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8014,9 +8843,12 @@
   - detector_operation_mode
   - detector_type
   - hazards_detected
+  - height
+  - length
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8038,11 +8870,14 @@
   - detector_type
   - display_mode
   - gases_detected
+  - height
+  - length
   - mounting_type
   - pattern
   - power_source
   - product_certifications_standards
   - sensor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8063,9 +8898,12 @@
   - detector_operation_mode
   - detector_type
   - hazards_detected
+  - height
+  - length
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8099,12 +8937,15 @@
   - alert_type
   - color
   - connectivity_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - mounting_type
   - pattern
   - power_source
   - sensor_type
   - water_sensor_design
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8120,11 +8961,14 @@
   - alert_type
   - color
   - connectivity_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - mounting_type
   - pattern
   - power_source
   - sensor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8142,12 +8986,15 @@
   - color
   - connectivity_technology
   - display_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - mounting_type
   - pattern
   - power_source
   - sensor_type
   - thermal_detector_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8214,8 +9061,11 @@
   attributes:
   - color
   - compatible_air_conditioner_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8233,8 +9083,11 @@
   - color
   - compatible_air_conditioner_type
   - durability_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -8250,9 +9103,12 @@
   attributes:
   - color
   - compatible_air_conditioner_type
+  - height
+  - length
   - material
   - merv_rating
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8325,8 +9181,11 @@
   - hg-8-2-4
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8343,8 +9202,11 @@
   - air_purifier_filter_technology
   - air_purifier_filtration_rating
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8403,8 +9265,11 @@
   - hg-8-3-4
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8421,8 +9286,11 @@
   - color
   - compatible_dehumidifier_technology
   - filter_material
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8440,8 +9308,11 @@
   - dehumidifier_refill_form
   - desiccant_material
   - fragrance
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -8478,8 +9349,11 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8498,11 +9372,14 @@
   - bulb_size
   - color
   - finish
+  - height
+  - length
   - light_source
   - lighting_features
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -8603,9 +9480,12 @@
   - cleaning_surfaces
   - color
   - compatible_vacuum_type
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8624,10 +9504,13 @@
   - cleaning_surfaces
   - color
   - compatible_vacuum_type
+  - height
+  - length
   - material
   - pattern
   - shape
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8645,9 +9528,12 @@
   - cleaning_surfaces
   - color
   - compatible_vacuum_type
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8666,11 +9552,14 @@
   - cleaning_surfaces
   - color
   - compatible_vacuum_type
+  - height
+  - length
   - material
   - pad_cleaning_action
   - pad_type
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - material
@@ -8692,9 +9581,12 @@
   - color
   - compatible_vacuum_type
   - handle_material
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8713,9 +9605,12 @@
   - cleaning_surfaces
   - color
   - compatible_vacuum_type
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8733,10 +9628,13 @@
   - cleaning_surfaces
   - color
   - compatible_vacuum_type
+  - height
+  - length
   - material
   - pattern
   - steam_nozzle_type
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8799,8 +9697,11 @@
   - hg-8-6-10
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8816,9 +9717,12 @@
   attributes:
   - color
   - filter_material
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8833,9 +9737,12 @@
   attributes:
   - boiler_system
   - color
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8849,9 +9756,12 @@
   children: []
   attributes:
   - color
+  - height
   - hose_material
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8865,9 +9775,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - pipe_connection_method
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8884,8 +9797,11 @@
   - color
   - flue_pipe_connection_type
   - flue_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8900,9 +9816,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - orientation
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8917,11 +9836,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - sheath_material
   - thermocouple_junction_type
   - thermocouple_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8984,8 +9906,11 @@
   - color
   - compatible_radiator_style
   - finish
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -9009,8 +9934,11 @@
   - color
   - compatible_radiator_style
   - finish
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9029,8 +9957,11 @@
   - color
   - compatible_radiator_style
   - finish
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9048,8 +9979,11 @@
   - color
   - compatible_radiator_style
   - finish
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9067,8 +10001,11 @@
   - color
   - compatible_radiator_style
   - finish
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9177,9 +10114,12 @@
   - hg-8-8-4
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9195,10 +10135,13 @@
   attributes:
   - color
   - filter_material
+  - height
   - humidifier_filter_type
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9284,9 +10227,12 @@
   - hg-8-9-1-8
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_fabric_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9302,10 +10248,13 @@
   attributes:
   - color
   - compatible_garment_steamer_design
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - suitable_for_fabric_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9319,10 +10268,13 @@
   children: []
   attributes:
   - color
+  - height
   - height_adjustment
+  - length
   - material
   - pattern
   - suitable_for_fabric_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9340,9 +10292,12 @@
   - bag/case_material
   - bag_closure
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_fabric_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9424,8 +10379,11 @@
   - hg-8-9-2-5
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9442,9 +10400,12 @@
   - chemical_product_form
   - color
   - fragrance
+  - height
   - iron_cleaner_purpose
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -9457,8 +10418,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9472,9 +10436,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - spray_pattern
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -9514,8 +10481,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9535,8 +10505,11 @@
   - hg-8-9-4-5
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -9623,9 +10596,12 @@
   attributes:
   - color
   - compatible_fuel_type
+  - height
+  - length
   - material
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9641,11 +10617,14 @@
   attributes:
   - closure_type
   - color
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9750,10 +10729,13 @@
   attributes:
   - color
   - compatible_vacuum_type
+  - height
+  - length
   - material
   - pattern
   - usage_type
   - vacuum_air_filtering_technology
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9769,10 +10751,13 @@
   attributes:
   - color
   - compatible_vacuum_type
+  - height
+  - length
   - material
   - pattern
   - usage_type
   - vacuum_air_filtering_technology
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9791,10 +10776,13 @@
   - color
   - compatible_vacuum_type
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - suitable_for_breed_size
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9813,7 +10801,10 @@
   - color
   - compatible_vacuum_type
   - fragrance
+  - height
+  - length
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9830,9 +10821,12 @@
   - color
   - compatible_vacuum_type
   - dust_container_type
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9851,9 +10845,12 @@
   - color
   - compatible_vacuum_type
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9869,10 +10866,13 @@
   attributes:
   - color
   - compatible_vacuum_type
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9891,10 +10891,13 @@
   - cleaning_surfaces
   - color
   - compatible_vacuum_type
+  - height
+  - length
   - lighting_features
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9910,9 +10913,12 @@
   attributes:
   - color
   - compatible_vacuum_type
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9930,9 +10936,12 @@
   - color
   - compatible_vacuum_type
   - fragrance
+  - height
+  - length
   - pattern
   - usage_type
   - vacuum_air_filtering_technology
+  - width
   return_reasons:
   - size
   - capacity
@@ -9950,9 +10959,12 @@
   - color
   - compatible_vacuum_type
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9971,11 +10983,14 @@
   - compatible_vacuum_type
   - dry/wet_cleaning
   - fragrance
+  - height
+  - length
   - material
   - pad_type
   - pattern
   - shape
   - usage_type
+  - width
   return_reasons:
   - size
   - material
@@ -9993,12 +11008,15 @@
   - color
   - compatible_vacuum_type
   - fragrance
+  - height
   - hose_material
+  - length
   - material
   - pattern
   - usage_type
   - vacuum_air_filtering_technology
   - vacuum_hose_connection_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10014,11 +11032,14 @@
   attributes:
   - color
   - compatible_vacuum_type
+  - height
+  - length
   - material
   - pattern
   - shape
   - usage_type
   - vacuum_air_filtering_technology
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10035,11 +11056,14 @@
   - color
   - compatible_vacuum_type
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - shape
   - usage_type
   - vacuum_air_filtering_technology
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10056,9 +11080,12 @@
   - color
   - compatible_vacuum_type
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - scent
@@ -10076,10 +11103,13 @@
   - color
   - compatible_vacuum_type
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - usage_type
   - vacuum_air_filtering_technology
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10097,9 +11127,12 @@
   - cleaning_surfaces
   - color
   - compatible_vacuum_type
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - material
@@ -10117,9 +11150,12 @@
   - attachment_type
   - color
   - compatible_vacuum_type
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10135,9 +11171,12 @@
   attributes:
   - color
   - compatible_vacuum_type
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10154,9 +11193,12 @@
   - attachment_type
   - color
   - compatible_vacuum_type
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10172,8 +11214,11 @@
   attributes:
   - color
   - compatible_vacuum_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10260,8 +11305,11 @@
   attributes:
   - color
   - compatible_water_heater_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10277,8 +11325,11 @@
   attributes:
   - color
   - connecting_thread
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10292,12 +11343,18 @@
   name: Hot Water Tanks
   children: []
   attributes:
+  - amperage
+  - capacity
   - color
   - energy_efficiency_class
+  - height
   - insulation_material
+  - length
   - material
   - orientation
   - pattern
+  - power_consumption_typical
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -10313,9 +11370,12 @@
   attributes:
   - color
   - connecting_thread
+  - height
+  - length
   - material
   - pattern
   - water_heater_element_connection_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -10328,12 +11388,16 @@
   name: Water Heater Expansion Tanks
   children: []
   attributes:
+  - capacity
   - color
   - connecting_thread
+  - height
   - internal_membrane_type
+  - length
   - material
   - orientation
   - pattern
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -10348,9 +11412,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -10364,9 +11431,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - vent_pipe_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -10385,10 +11455,13 @@
   attributes:
   - color
   - compatible_water_heater_type
+  - height
   - ice_bucket_insulation
+  - length
   - material
   - orientation
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -10584,6 +11657,7 @@
   - color
   - energy_efficiency_class
   - pattern
+  - power_consumption_typical
   - safety_certifications
   return_reasons:
   - size
@@ -10615,6 +11689,7 @@
   - energy_efficiency_class
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
   return_reasons:
   - size
@@ -10637,9 +11712,15 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
+  - maximum_room_area
   - mounting_type
+  - noise_level
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - operating_noise
   - energy_efficiency
@@ -10719,16 +11800,23 @@
   name: Air Purifiers
   children: []
   attributes:
+  - air_purification_rate_cadr
   - air_purifier_filter_technology
   - battery_size
   - battery_type
   - color
   - connectivity_technology
   - energy_efficiency_class
+  - height
+  - length
+  - maximum_room_area
   - mounting_type
+  - noise_level
   - pattern
+  - power_consumption_typical
   - power_source
   - speed_settings
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -10747,11 +11835,18 @@
   - drainage_method
   - dryer_technology
   - energy_efficiency_class
+  - height
   - humidity_control_method
   - hvac_control_type
+  - length
+  - maximum_room_area
   - mounting_type
+  - noise_level
   - pattern
+  - power_consumption_typical
   - power_source
+  - water_tank_capacity
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -10769,10 +11864,16 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
+  - maximum_room_area
   - mounting_type
+  - noise_level
   - pattern
   - phase_type
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - energy_efficiency
@@ -10795,10 +11896,16 @@
   - color
   - energy_efficiency_class
   - evaporation_technology
+  - height
+  - length
+  - maximum_room_area
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
   - speed_settings
+  - water_tank_capacity
+  - width
   return_reasons:
   - size
   - color
@@ -10818,9 +11925,15 @@
   - color
   - energy_efficiency_class
   - evaporation_technology
+  - height
+  - length
+  - maximum_room_area
   - pattern
+  - power_consumption_typical
   - power_source
   - speed_settings
+  - water_tank_capacity
+  - width
   return_reasons:
   - size
   - color
@@ -10839,9 +11952,15 @@
   - color
   - energy_efficiency_class
   - evaporation_technology
+  - height
+  - length
+  - maximum_room_area
   - pattern
+  - power_consumption_typical
   - power_source
   - speed_settings
+  - water_tank_capacity
+  - width
   return_reasons:
   - size
   - color
@@ -10887,10 +12006,17 @@
   - battery_type
   - color
   - energy_efficiency_class
+  - fan_diameter
+  - height
+  - length
+  - maximum_room_area
   - mounting_type
+  - noise_level
   - oscillation_mode
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -10911,8 +12037,15 @@
   - blade_material
   - color
   - energy_efficiency_class
+  - fan_diameter
+  - height
+  - length
+  - maximum_room_area
+  - noise_level
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -10931,11 +12064,18 @@
   - battery_type
   - color
   - energy_efficiency_class
+  - fan_diameter
+  - height
+  - length
+  - maximum_room_area
   - mounting_type
+  - noise_level
   - oscillation_type
   - pattern
+  - power_consumption_typical
   - power_source
   - speed_settings
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -10953,9 +12093,16 @@
   - battery_type
   - color
   - energy_efficiency_class
+  - fan_diameter
+  - height
+  - length
+  - maximum_room_area
+  - noise_level
   - pattern
+  - power_consumption_typical
   - power_source
   - speed_settings
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -10972,11 +12119,18 @@
   - color
   - control_type
   - energy_efficiency_class
+  - fan_diameter
+  - height
   - ingress_protection_ip_rating
+  - length
+  - maximum_room_area
   - mounting_type
+  - noise_level
   - pattern
+  - power_consumption_typical
   - power_source
   - speed_settings
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -10992,9 +12146,16 @@
   attributes:
   - color
   - energy_efficiency_class
+  - fan_diameter
+  - height
+  - length
+  - maximum_room_area
+  - noise_level
   - pattern
+  - power_consumption_typical
   - power_source
   - speed_settings
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -11059,9 +12220,13 @@
   - energy_efficiency_class
   - flue_type
   - heating_stages
+  - height
+  - length
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - energy_efficiency
   - operating_noise
@@ -11081,10 +12246,14 @@
   - energy_efficiency_class
   - flue_type
   - heating_stages
+  - height
+  - length
   - mounting_type
   - orientation
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - operating_noise
   - changed_my_mind
@@ -11102,9 +12271,13 @@
   - flue_type
   - furnace_configuration
   - heating_stages
+  - height
+  - length
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - operating_noise
   - changed_my_mind
@@ -11119,13 +12292,17 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - mounting_type
   - orientation
   - pattern
+  - power_consumption_typical
   - power_source
   - radiator_design_type
   - suitable_space
+  - width
   return_reasons:
   - size
   - energy_efficiency
@@ -11140,17 +12317,24 @@
   name: Humidifiers
   children: []
   attributes:
+  - air_purification_rate_cadr
   - battery_size
   - battery_type
   - color
   - energy_efficiency_class
   - evaporation_technology
+  - height
   - humidifier_design
   - humidifier_features
   - humidity_control_method
+  - length
+  - maximum_room_area
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
+  - water_tank_capacity
+  - width
   return_reasons:
   - size
   - capacity
@@ -11170,11 +12354,17 @@
   - battery_type
   - color
   - energy_efficiency_class
+  - height
   - hose_material
+  - length
+  - maximum_room_area
   - mounting_type
+  - noise_level
   - nozzle_material
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -11194,12 +12384,16 @@
   - color
   - energy_efficiency_class
   - heat_settings
+  - height
   - ignition_system
+  - length
   - material
   - mounting_type
   - patio_heater_safety_features
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - energy_efficiency
@@ -11218,11 +12412,15 @@
   - color
   - energy_efficiency_class
   - heat_settings
+  - height
   - hvac_control_type
+  - length
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
   - space_heater_safety_features
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -11256,8 +12454,12 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - speed_settings
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -11276,10 +12478,12 @@
   - hg-9-3-5
   - hg-9-3-6
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
   - pattern
+  - power_consumption_typical
   - power_source
   return_reasons:
   - size
@@ -11301,11 +12505,16 @@
   - hg-9-3-1-6
   - hg-9-3-1-7
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -11318,11 +12527,16 @@
   name: Canister Carpet Shampooers
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -11335,11 +12549,16 @@
   name: Carpet Extractors
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -11353,13 +12572,18 @@
   name: Dry Carpet Shampooers
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - dust_container_type
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - tool_mobility
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -11372,11 +12596,16 @@
   name: Dual Tank Carpet Shampooers
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -11389,11 +12618,16 @@
   name: Portable Carpet Shampooers
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -11406,11 +12640,16 @@
   name: Steam Carpet Shampooers
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -11423,11 +12662,16 @@
   name: Upright Carpet Shampooers
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -11445,11 +12689,17 @@
   - hg-9-3-2-4
   - hg-9-3-2-5
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - steam_pressure
+  - width
   return_reasons:
   - size
   - capacity
@@ -11463,11 +12713,17 @@
   name: Canister Carpet Steamers
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - steam_pressure
+  - width
   return_reasons:
   - size
   - capacity
@@ -11481,11 +12737,17 @@
   name: Handheld Carpet Steamers
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - steam_pressure
+  - width
   return_reasons:
   - size
   - capacity
@@ -11499,11 +12761,17 @@
   name: Multi-Purpose Steam Cleaners
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - steam_pressure
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -11516,11 +12784,17 @@
   name: Professional Carpet Steamers
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - steam_pressure
+  - width
   return_reasons:
   - size
   - capacity
@@ -11534,11 +12808,17 @@
   name: Upright Carpet Steamers
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - steam_pressure
+  - width
   return_reasons:
   - size
   - capacity
@@ -11554,12 +12834,17 @@
   attributes:
   - battery_size
   - battery_type
+  - capacity
   - cleaning_surfaces
   - color
   - dust_container_type
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -11580,12 +12865,17 @@
   - hg-9-3-4-8
   attributes:
   - battery_type
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
   - floor_scrubber_brush_type
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -11599,12 +12889,17 @@
   name: Compact Floor Scrubbers
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
   - floor_scrubber_brush_type
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -11620,12 +12915,17 @@
   attributes:
   - battery_technology
   - battery_type
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
   - floor_scrubber_brush_type
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -11641,12 +12941,17 @@
   attributes:
   - bristle_stiffness
   - brush_material
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
   - floor_scrubber_brush_type
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -11661,12 +12966,17 @@
   children: []
   attributes:
   - battery_type
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
   - floor_scrubber_brush_type
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -11681,13 +12991,18 @@
   children: []
   attributes:
   - battery_type
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
   - floor_scrubber_brush_type
   - handle_material
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -11702,12 +13017,17 @@
   children: []
   attributes:
   - battery_type
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
   - floor_scrubber_brush_type
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -11737,11 +13057,16 @@
   name: Handheld Steam Cleaners
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - weight
   - capacity
@@ -11762,11 +13087,16 @@
   - hg-9-3-6-5
   - hg-9-3-6-6
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -11780,11 +13110,16 @@
   name: 2-in-1 Steam Mops
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -11798,11 +13133,16 @@
   name: Cylinder Steam Mops
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -11816,11 +13156,16 @@
   name: Handheld Steam Mops
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -11834,11 +13179,16 @@
   name: Multi-Surface Steam Mops
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -11852,11 +13202,16 @@
   name: Upright Steam Mops
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -11870,15 +13225,20 @@
   name: Vacuum Steam Mops
   children: []
   attributes:
+  - capacity
   - cleaning_surfaces
   - color
   - dirt_separating_method
   - dry/wet_cleaning
   - dust_container_type
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - vacuum_air_filtering_technology
+  - width
   return_reasons:
   - size
   - capacity
@@ -11898,9 +13258,13 @@
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - tool_mobility
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -11916,10 +13280,14 @@
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - speed_settings
   - tool_mobility
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -11935,10 +13303,14 @@
   - cleaning_surfaces
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - speed_settings
   - tool_mobility
+  - width
   return_reasons:
   - operating_noise
   - weight
@@ -11970,8 +13342,12 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -11990,9 +13366,13 @@
   - battery_type
   - color
   - energy_efficiency_class
+  - height
   - ingress_protection_ip_rating
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12010,10 +13390,14 @@
   - color
   - connection_method
   - energy_efficiency_class
+  - height
   - ingress_protection_ip_rating
+  - length
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12030,9 +13414,13 @@
   - battery_type
   - code_technology
   - color
+  - height
   - ingress_protection_ip_rating
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12049,9 +13437,14 @@
   - color
   - connection_type
   - energy_efficiency_class
+  - height
+  - length
+  - maximum_load_capacity
   - operation_method
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12075,6 +13468,7 @@
   - color
   - energy_efficiency_class
   - pattern
+  - power_consumption_typical
   - power_source
   return_reasons:
   - size
@@ -12091,16 +13485,24 @@
   name: Dryers
   children: []
   attributes:
+  - amperage
   - color
+  - depth
   - door_hinge_position
   - dryer_drum_material
   - dryer_features
   - dryer_venting_type
   - energy_efficiency_class
+  - height
+  - length
   - loading_type
+  - maximum_spin_speed
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
+  - rated_capacity_weight
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -12118,9 +13520,15 @@
   - color
   - energy_efficiency_class
   - garment_steamer_design
+  - heating_time
+  - height
   - ironing_features
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - water_tank_capacity
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -12138,11 +13546,17 @@
   - hg-9-8-3-2
   attributes:
   - color
+  - cord_length
   - energy_efficiency_class
+  - height
   - ironing_features
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - soleplate_type
+  - water_tank_capacity
+  - width
   return_reasons:
   - size
   - energy_efficiency
@@ -12159,11 +13573,17 @@
   children: []
   attributes:
   - color
+  - cord_length
   - energy_efficiency_class
+  - height
   - ironing_features
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - soleplate_type
+  - water_tank_capacity
+  - width
   return_reasons:
   - size
   - capacity
@@ -12179,11 +13599,17 @@
   children: []
   attributes:
   - color
+  - cord_length
   - energy_efficiency_class
+  - height
   - ironing_features
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - soleplate_type
+  - water_tank_capacity
+  - width
   return_reasons:
   - size
   - capacity
@@ -12205,11 +13631,15 @@
   - color
   - dryer_venting_type
   - energy_efficiency_class
+  - height
+  - length
   - loading_type
   - pattern
+  - power_consumption_typical
   - power_source
   - washer/dryer_features
   - washing_programs
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -12228,11 +13658,15 @@
   - color
   - dryer_venting_type
   - energy_efficiency_class
+  - height
+  - length
   - loading_type
   - pattern
+  - power_consumption_typical
   - power_source
   - washer/dryer_features
   - washing_programs
+  - width
   return_reasons:
   - operating_noise
   - changed_my_mind
@@ -12248,11 +13682,15 @@
   - color
   - dryer_venting_type
   - energy_efficiency_class
+  - height
+  - length
   - loading_type
   - pattern
+  - power_consumption_typical
   - power_source
   - washer/dryer_features
   - washing_programs
+  - width
   return_reasons:
   - operating_noise
   - changed_my_mind
@@ -12268,11 +13706,15 @@
   - color
   - dryer_venting_type
   - energy_efficiency_class
+  - height
+  - length
   - loading_type
   - pattern
+  - power_consumption_typical
   - power_source
   - washer/dryer_features
   - washing_programs
+  - width
   return_reasons:
   - operating_noise
   - changed_my_mind
@@ -12288,11 +13730,15 @@
   - color
   - dryer_venting_type
   - energy_efficiency_class
+  - height
+  - length
   - loading_type
   - pattern
+  - power_consumption_typical
   - power_source
   - washer/dryer_features
   - washing_programs
+  - width
   return_reasons:
   - operating_noise
   - changed_my_mind
@@ -12307,10 +13753,14 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
   - ironing_features
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - soleplate_type
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -12326,15 +13776,23 @@
   name: Washing Machines
   children: []
   attributes:
+  - amperage
   - color
   - control_type
+  - depth
   - energy_efficiency_class
+  - height
+  - length
   - loading_type
+  - maximum_spin_speed
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
+  - rated_capacity_weight
   - washing_machine_features
   - washing_programs
+  - width
   return_reasons:
   - capacity
   - operating_noise
@@ -12368,9 +13826,13 @@
   - color
   - energy_efficiency_class
   - heat_function
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - ultrasonic_cleaner_accessories_included
+  - width
   return_reasons:
   - size
   - capacity
@@ -12396,9 +13858,14 @@
   - dry/wet_cleaning
   - dust_container_type
   - energy_efficiency_class
+  - height
+  - length
+  - noise_level
   - pattern
+  - power_consumption_typical
   - power_source
   - vacuum_air_filtering_technology
+  - width
   return_reasons:
   - size
   - suction
@@ -12419,9 +13886,14 @@
   - dry/wet_cleaning
   - dust_container_type
   - energy_efficiency_class
+  - height
+  - length
+  - noise_level
   - pattern
+  - power_consumption_typical
   - power_source
   - vacuum_air_filtering_technology
+  - width
   return_reasons:
   - size
   - suction
@@ -12445,9 +13917,14 @@
   - dry/wet_cleaning
   - dust_container_type
   - energy_efficiency_class
+  - height
+  - length
+  - noise_level
   - pattern
+  - power_consumption_typical
   - power_source
   - vacuum_air_filtering_technology
+  - width
   return_reasons:
   - size
   - suction
@@ -12523,8 +14000,12 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -12541,11 +14022,16 @@
   attributes:
   - boiler_system
   - color
+  - domestic_hot_water_flow
   - energy_efficiency_class
+  - height
+  - length
   - orientation
   - pattern
+  - power_consumption_typical
   - power_source
   - suitable_space
+  - width
   return_reasons:
   - size
   - energy_efficiency
@@ -12626,9 +14112,12 @@
   attributes:
   - color
   - fragrance
+  - height
+  - length
   - liner_installation_method
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -12649,9 +14138,12 @@
   - color
   - film_application_method
   - floor_protection_transparency_level
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - thickness
@@ -12671,9 +14163,12 @@
   - film_reusability
   - floor_protection_transparency_level
   - floor_surface_compatibility
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - thickness
@@ -12691,10 +14186,13 @@
   - color
   - film_application_method
   - floor_protection_transparency_level
+  - height
+  - length
   - material
   - pattern
   - rug/mat_features
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -12715,9 +14213,12 @@
   - color
   - fabric
   - floor_surface_compatibility
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -12734,10 +14235,13 @@
   - care_instructions
   - color
   - garage_floor_mat_style
+  - height
+  - length
   - mat_features
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -12753,11 +14257,15 @@
   children: []
   attributes:
   - bag_closure
+  - capacity
   - color
   - fragrance
+  - height
+  - length
   - load_capacity
   - material
   - pattern
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -12809,9 +14317,12 @@
   - handle_connection_type
   - handle_length_adjustability
   - handle_material
+  - height
+  - length
   - pattern
   - suitable_space
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12830,10 +14341,13 @@
   - bristle_stiffness
   - bristle_tip_type
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_space
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12851,10 +14365,13 @@
   - bristle_stiffness
   - color
   - handle_material
+  - height
+  - length
   - material
   - pattern
   - suitable_space
   - usage_type
+  - width
   return_reasons:
   - size
   - material
@@ -12869,14 +14386,18 @@
   children: []
   attributes:
   - bucket_features
+  - capacity
   - color
   - handle_material
   - handle_type
+  - height
+  - length
   - material
   - pattern
   - shape
   - suitable_space
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -12895,11 +14416,14 @@
   - cleaning_surfaces
   - color
   - dust_container_type
+  - height
+  - length
   - material
   - pattern
   - power_source
   - suitable_space
   - usage_type
+  - width
   return_reasons:
   - size
   - capacity
@@ -12938,10 +14462,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_space
   - usage_type
+  - width
   return_reasons:
   - scent
   - material
@@ -12963,10 +14490,13 @@
   - duster_head_material
   - handle_material
   - handle_type
+  - height
+  - length
   - material
   - pattern
   - suitable_space
   - usage_type
+  - width
   return_reasons:
   - size
   - material
@@ -12985,10 +14515,13 @@
   - features
   - handle_material
   - handle_type
+  - height
+  - length
   - material
   - pattern
   - suitable_space
   - usage_type
+  - width
   return_reasons:
   - size
   - style
@@ -13056,6 +14589,7 @@
   - ph_level
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - incompatible
@@ -13086,6 +14620,7 @@
   - scent
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13114,6 +14649,7 @@
   - suitable_space
   - targeted_stains
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13139,6 +14675,7 @@
   - ph_level
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13167,6 +14704,7 @@
   - scent
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13195,6 +14733,7 @@
   - ph_level
   - product_certifications_standards
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13220,6 +14759,7 @@
   - ph_level
   - product_certifications_standards
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13245,6 +14785,7 @@
   - ph_level
   - product_certifications_standards
   - usage_type
+  - volume
   return_reasons:
   - scent
   - incompatible
@@ -13271,6 +14812,7 @@
   - ph_level
   - product_certifications_standards
   - usage_type
+  - volume
   return_reasons:
   - scent
   - incompatible
@@ -13299,6 +14841,7 @@
   - suitable_for_fabric_type
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13328,6 +14871,7 @@
   - product_certifications_standards
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13354,6 +14898,7 @@
   - sheen/gloss_level
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13382,6 +14927,7 @@
   - ph_level
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13410,6 +14956,7 @@
   - product_form
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13439,6 +14986,7 @@
   - product_certifications_standards
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13469,6 +15017,7 @@
   - suitable_for_pest_type
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13495,6 +15044,7 @@
   - product_certifications_standards
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13524,6 +15074,7 @@
   - suitable_space
   - targeted_stains
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13551,6 +15102,7 @@
   - product_certifications_standards
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13580,6 +15132,7 @@
   - stainless_steel_cleaner_features
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13606,6 +15159,7 @@
   - stainless_steel_cleaner_features
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -13632,6 +15186,7 @@
   - stainless_steel_cleaner_features
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -13658,6 +15213,7 @@
   - product_certifications_standards
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13688,6 +15244,7 @@
   - product_certifications_standards
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13716,6 +15273,7 @@
   - product_certifications_standards
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - incompatible
@@ -13744,6 +15302,7 @@
   - product_certifications_standards
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - incompatible
@@ -13794,6 +15353,7 @@
   - ph_level
   - suitable_space
   - usage_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -13810,12 +15370,15 @@
   - cleaning_surfaces
   - color
   - dry/wet_cleaning
+  - height
+  - length
   - material
   - mop_head_type
   - pattern
   - suitable_space
   - usage_type
   - washing_method
+  - width
   return_reasons:
   - size
   - material
@@ -13835,12 +15398,15 @@
   - dry/wet_cleaning
   - duster_head_material
   - handle_material
+  - height
+  - length
   - material
   - mop_wringing_mechanism
   - pad_type
   - pattern
   - suitable_space
   - usage_type
+  - width
   return_reasons:
   - size
   - material
@@ -13862,11 +15428,14 @@
   - cleaning_surfaces
   - color
   - dry/wet_cleaning
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - suitable_space
   - usage_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -13888,12 +15457,15 @@
   - dry/wet_cleaning
   - handle_material
   - handle_type
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - power_source
   - suitable_space
   - usage_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -13913,10 +15485,13 @@
   - cleaning_surfaces
   - color
   - fabric
+  - height
+  - length
   - material
   - pattern
   - suitable_space
   - usage_type
+  - width
   return_reasons:
   - size
   - material
@@ -13936,12 +15511,15 @@
   - abrasive_material
   - cleaning_surfaces
   - color
+  - height
+  - length
   - material
   - pattern
   - scrubbing_strength
   - shape
   - suitable_space
   - usage_type
+  - width
   return_reasons:
   - size
   - material
@@ -14020,11 +15598,14 @@
   - cleaning_surfaces
   - color
   - handle_material
+  - height
+  - length
   - material
   - pattern
   - squeegee_blade_design
   - suitable_space
   - usage_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14043,8 +15624,11 @@
   attributes:
   - color
   - fragrance
+  - height
+  - length
   - package_type
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14060,9 +15644,12 @@
   - allergy_friendly_features
   - color
   - fragrance
+  - height
+  - length
   - package_type
   - pattern
   - tissue_lotion_content
+  - width
   return_reasons:
   - size
   - scent
@@ -14079,10 +15666,13 @@
   - color
   - fold_type
   - fragrance
+  - height
+  - length
   - material
   - package_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -14100,9 +15690,12 @@
   - color
   - fold_type
   - fragrance
+  - height
+  - length
   - material
   - package_type
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -14119,10 +15712,13 @@
   - absorbent_hygiene_product_features
   - color
   - fragrance
+  - height
+  - length
   - material
   - package_type
   - pattern
   - scent
+  - width
   return_reasons:
   - scent
   - material
@@ -14137,12 +15733,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - suitable_space
   - thermometer_design
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -14201,6 +15800,7 @@
   - material
   - pattern
   - targeted_stains
+  - volume
   return_reasons:
   - scent
   - capacity
@@ -14256,10 +15856,13 @@
   - chemical_product_form
   - color
   - features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - capacity
@@ -14276,10 +15879,13 @@
   - chemical_product_form
   - color
   - features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - capacity
@@ -14296,10 +15902,13 @@
   - chemical_product_form
   - color
   - features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - capacity
@@ -14320,6 +15929,7 @@
   - package_type
   - pattern
   - scent
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -14363,6 +15973,7 @@
   - package_type
   - pattern
   - scent
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -14386,6 +15997,7 @@
   - package_type
   - pattern
   - scent
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -14410,6 +16022,7 @@
   - pattern
   - scent
   - suitable_for_fabric_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -14432,6 +16045,7 @@
   - pattern
   - sustainability
   - targeted_stains
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -14452,6 +16066,7 @@
   - package_type
   - pattern
   - suitable_for_fabric_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -14468,9 +16083,12 @@
   - attachment_method
   - chemical_product_form
   - color
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - material
@@ -14486,10 +16104,13 @@
   attributes:
   - chemical_product_form
   - color
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14509,8 +16130,11 @@
   - color
   - cover_features
   - fabric
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -14532,8 +16156,11 @@
   - color
   - cover_features
   - fabric
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - pattern
@@ -14552,9 +16179,12 @@
   - care_instructions
   - color
   - cover_features
+  - height
   - ironing_board_pad_shape
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - thickness
   - fit
@@ -14572,9 +16202,12 @@
   attributes:
   - color
   - compatible_ironing_board_type
+  - height
+  - length
   - material
   - mounting_hardware
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -14590,11 +16223,14 @@
   attributes:
   - color
   - compatible_ironing_board_type
+  - height
   - height_adjustment
+  - length
   - material
   - mounting_hardware
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -14627,11 +16263,14 @@
   - color
   - cover_material
   - features
+  - height
   - height_adjustment
   - ironing_board_form_factor
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -14699,9 +16338,12 @@
   - color
   - features
   - handle_type
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -14743,11 +16385,14 @@
   - bag_closure
   - care_instructions
   - color
+  - height
   - laundry_wash_accessory_type
+  - length
   - material
   - mesh_type
   - pattern
   - shape
+  - width
   return_reasons:
   - material
   - capacity
@@ -14803,10 +16448,13 @@
   attributes:
   - color
   - handle_material
+  - height
+  - length
   - lint_roller_type
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14828,6 +16476,7 @@
   - material
   - pattern
   - suitable_for_fabric_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -14849,6 +16498,7 @@
   - package_type
   - pattern
   - suitable_for_fabric_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -14871,6 +16521,7 @@
   - pattern
   - product_form
   - suitable_for_fabric_type
+  - volume
   return_reasons:
   - scent
   - changed_my_mind
@@ -14916,9 +16567,12 @@
   - color
   - desiccant_material
   - fragrance
+  - height
+  - length
   - moisture_absorber_form
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -14960,12 +16614,15 @@
   - color
   - fly_swatter_type
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - power_source
   - suitable_for_pest_type
   - suitable_space
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -15005,17 +16662,23 @@
   name: Electric Traps
   children: []
   attributes:
+  - amperage
   - battery_size
   - battery_type
   - color
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
   - suitable_for_pest_type
   - suitable_space
   - usage_type
+  - voltage
+  - width
   return_reasons:
   - size
   - capacity
@@ -15034,12 +16697,15 @@
   - bug_type
   - color
   - glue_trap_design
+  - height
+  - length
   - material
   - pattern
   - power_source
   - suitable_for_pest_type
   - suitable_space
   - usage_type
+  - width
   return_reasons:
   - size
   - capacity
@@ -15076,12 +16742,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - power_source
   - suitable_for_pest_type
   - suitable_space
   - usage_type
+  - width
   return_reasons:
   - size
   - capacity
@@ -15096,12 +16765,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - power_source
   - suitable_for_pest_type
   - suitable_space
   - usage_type
+  - width
   return_reasons:
   - size
   - capacity
@@ -15116,12 +16788,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - power_source
   - suitable_for_pest_type
   - suitable_space
   - usage_type
+  - width
   return_reasons:
   - size
   - capacity
@@ -15304,6 +16979,7 @@
   - color
   - ingredients
   - pest_control_method
+  - protection_time
   - suitable_for_pest_type
   - suitable_space
   return_reasons:
@@ -15328,6 +17004,7 @@
   - pattern
   - pest_control_method
   - power_source
+  - protection_time
   - repellent_mechanism
   - suitable_for_pest_type
   - suitable_space
@@ -15352,6 +17029,7 @@
   - ingredients
   - pattern
   - pest_control_method
+  - protection_time
   - suitable_for_pest_type
   - suitable_space
   return_reasons:
@@ -15369,9 +17047,13 @@
   - care_instructions
   - color
   - cover_material
+  - diameter
+  - height
+  - length
   - pattern
   - rug/mat_features
   - shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -15385,11 +17067,15 @@
   children: []
   attributes:
   - color
+  - diameter
   - features
   - floor_surface_compatibility
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - thickness
@@ -15431,10 +17117,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - product_form
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -15451,7 +17140,10 @@
   - closure_type
   - color
   - durability_features
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -15468,9 +17160,12 @@
   - bristle_material
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - shoe_brush_type
   - stiffness
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -15484,9 +17179,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - product_form
+  - width
   return_reasons:
   - size
   - color
@@ -15503,10 +17201,13 @@
   attributes:
   - color
   - heat_settings
+  - height
+  - length
   - material
   - pattern
   - power_source
   - shoe_dryer_technology
+  - width
   return_reasons:
   - size
   - capacity
@@ -15525,8 +17226,11 @@
   - color
   - features
   - handle_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -15547,9 +17251,12 @@
   - features
   - handle_material
   - handle_type
+  - height
+  - length
   - material
   - mobility/accessibility_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -15636,9 +17343,12 @@
   - features
   - handle_material
   - handle_type
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -15734,10 +17444,13 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -15819,9 +17532,12 @@
   - hg-10-14-11-4
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - size_adjustability
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -15836,9 +17552,12 @@
   attributes:
   - color
   - footwear_type_compatibility
+  - height
+  - length
   - material
   - pattern
   - size_adjustability
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -15852,12 +17571,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - shoe_fit
   - shoe_size
   - shoe_tree_design
   - size_adjustability
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -15900,10 +17622,13 @@
   attributes:
   - backing_material
   - color
+  - height
+  - length
   - material
   - pattern
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -15972,11 +17697,14 @@
   attributes:
   - charging_interface_type
   - color
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - valet_organizer_features
+  - width
   - wireless_charging_standard
   return_reasons:
   - size
@@ -15995,10 +17723,13 @@
   - hg-10-16-1-2-2
   attributes:
   - color
+  - height
   - height_adjustment
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -16016,10 +17747,13 @@
   attributes:
   - color
   - furniture/fixture_features
+  - height
   - height_adjustment
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -16037,10 +17771,13 @@
   attributes:
   - color
   - furniture/fixture_features
+  - height
   - height_adjustment
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -16059,9 +17796,12 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -16078,10 +17818,13 @@
   attributes:
   - color
   - features
+  - height
   - hook_design
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -16099,10 +17842,13 @@
   - closure_type
   - color
   - handle_type
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -16123,9 +17869,12 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -16144,10 +17893,13 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - shoe_organizer_design
+  - width
   return_reasons:
   - size
   - color
@@ -16166,9 +17918,12 @@
   - color
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -16237,9 +17992,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lock_type
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -16256,10 +18014,13 @@
   attributes:
   - color
   - drawer_organizer_features
+  - height
+  - length
   - material
   - organizer_application
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -16279,8 +18040,11 @@
   - bag_closure
   - color
   - compression_method
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -16298,10 +18062,13 @@
   - closure_type
   - color
   - handle_type
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -16319,11 +18086,14 @@
   - closure_type
   - color
   - handle_type
+  - height
+  - length
   - lid_type
   - material
   - pattern
   - shape
   - stacking_capability
+  - width
   return_reasons:
   - size
   - color
@@ -16340,8 +18110,11 @@
   attributes:
   - color
   - furniture/fixture_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -16365,9 +18138,12 @@
   - closure_type
   - color
   - format_supported
+  - height
+  - length
   - material
   - orientation
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -16389,10 +18165,13 @@
   - color
   - cover_material
   - format_supported
+  - height
+  - length
   - material
   - orientation
   - pattern
   - stationery_binding_type
+  - width
   return_reasons:
   - size
   - color
@@ -16412,9 +18191,12 @@
   - closure_type
   - color
   - format_supported
+  - height
+  - length
   - material
   - orientation
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -16499,10 +18281,13 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - mounting_hardware
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -16519,10 +18304,13 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - mounting_hardware
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -16539,10 +18327,13 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - mounting_hardware
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -16561,11 +18352,14 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - mounting_hardware
   - mounting_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -16582,11 +18376,14 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - mounting_hardware
   - mounting_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -16603,11 +18400,14 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - mounting_hardware
   - mounting_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -16624,11 +18424,14 @@
   attributes:
   - color
   - finish
+  - height
   - hook_design
+  - length
   - material
   - mounting_hardware
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -16700,9 +18503,12 @@
   attributes:
   - color
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - incompatible
@@ -16721,8 +18527,11 @@
   - disposable/reusable_bag_features
   - disposable_bag_material
   - fragrance
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - incompatible
@@ -16740,9 +18549,12 @@
   - filter_material
   - filter_technology
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - incompatible
@@ -16776,6 +18588,7 @@
   - hg-10-18-3
   - hg-10-18-4
   attributes:
+  - capacity
   - color
   - lid_type
   - material
@@ -16799,7 +18612,10 @@
   name: Dumpsters
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - lid_type
   - lock_type
   - material
@@ -16809,6 +18625,7 @@
   - pattern
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - capacity
@@ -16827,9 +18644,12 @@
   - hg-10-18-2-4
   - hg-10-18-2-5
   attributes:
+  - capacity
   - color
   - compatible_hazardous_waste_type
   - durability_features
+  - height
+  - length
   - lid_type
   - material
   - mounting_type
@@ -16838,6 +18658,7 @@
   - pattern
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -16957,7 +18778,10 @@
   name: Recycling Containers
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - lid_type
   - material
   - mounting_type
@@ -16968,6 +18792,7 @@
   - shape
   - suitable_space
   - trash_can_features
+  - width
   return_reasons:
   - size
   - color
@@ -16984,7 +18809,10 @@
   - hg-10-18-4-1
   - hg-10-18-4-2
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - lid_type
   - material
   - mounting_type
@@ -16994,6 +18822,7 @@
   - shape
   - suitable_location
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -17008,7 +18837,10 @@
   name: Trash Cans
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - lid_type
   - material
   - mounting_type
@@ -17019,6 +18851,7 @@
   - suitable_location
   - suitable_space
   - trash_can_features
+  - width
   return_reasons:
   - size
   - color
@@ -17033,7 +18866,10 @@
   name: Wastebaskets
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - lid_type
   - material
   - mounting_type
@@ -17044,6 +18880,7 @@
   - suitable_location
   - suitable_space
   - trash_can_features
+  - width
   return_reasons:
   - size
   - color
@@ -17067,10 +18904,13 @@
   - color
   - compatible_waste_container_type
   - durability_features
+  - height
+  - length
   - material
   - pattern
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17088,10 +18928,13 @@
   - compatible_waste_container_type
   - durability_features
   - handle_type
+  - height
+  - length
   - material
   - pattern
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - capacity
@@ -17109,12 +18952,15 @@
   - color
   - compatible_waste_container_type
   - durability_features
+  - height
+  - length
   - locking_mechanism
   - material
   - mounting_type
   - pattern
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -17133,12 +18979,15 @@
   - color
   - compatible_waste_container_type
   - durability_features
+  - height
   - language
+  - length
   - material
   - pattern
   - shape
   - suitable_space
   - waste_container_sign_message
+  - width
   return_reasons:
   - size
   - color
@@ -17155,12 +19004,15 @@
   - color
   - compatible_waste_container_type
   - durability_features
+  - height
+  - length
   - lid_type
   - material
   - pattern
   - shape
   - suitable_space
   - waste_container_lid_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17177,6 +19029,8 @@
   - color
   - compatible_waste_container_type
   - durability_features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
@@ -17184,6 +19038,7 @@
   - suitable_space
   - wheel_bearing_type
   - wheel_tread_style
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17282,9 +19137,13 @@
   attributes:
   - barware_items_included
   - barware_material
+  - capacity
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -17306,14 +19165,18 @@
   attributes:
   - barware_items_included
   - barware_material
+  - capacity
   - cleaning_instructions
   - color
   - draft_gas_type
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - temperature_control
+  - width
   return_reasons:
   - size
   - color
@@ -17414,8 +19277,11 @@
   - barware_material
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - color
   - style
@@ -17433,8 +19299,11 @@
   - barware_material
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - color
   - style
@@ -17452,8 +19321,11 @@
   - barware_material
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - color
   - style
@@ -17471,12 +19343,16 @@
   attributes:
   - barware_items_included
   - barware_material
+  - capacity
   - cleaning_instructions
   - color
   - handle_style
+  - height
   - insulation_type
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - color
   - style
@@ -17493,13 +19369,17 @@
   attributes:
   - barware_items_included
   - barware_material
+  - capacity
   - cleaning_instructions
   - color
   - handle_style
+  - height
   - insulation_type
+  - length
   - pattern
   - power_source
   - shape
+  - width
   return_reasons:
   - color
   - style
@@ -17517,13 +19397,17 @@
   - barware_items_included
   - barware_material
   - beverage_tub_features
+  - capacity
   - cleaning_instructions
   - color
   - handle_style
   - handle_type
+  - height
   - insulation_type
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - color
   - style
@@ -17547,8 +19431,11 @@
   - barware_material
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -17568,8 +19455,11 @@
   - bottle_cap_liner_type
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -17587,8 +19477,11 @@
   - barware_material
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -17607,8 +19500,11 @@
   - bottle_cap_liner_type
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -17627,9 +19523,12 @@
   - bottle_cap_liner_type
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - tamper_evident_feature
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -17648,8 +19547,11 @@
   - bottle_cap_gasket_material
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -17668,7 +19570,10 @@
   - cleaning_instructions
   - color
   - compatible_beverage_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -17689,9 +19594,12 @@
   - cleaning_instructions
   - color
   - finish
+  - height
+  - length
   - mounting_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -17712,11 +19620,15 @@
   - coaster_features
   - color
   - construction
+  - diameter
   - durability_features
   - embellishment/trim_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - shape
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -17737,7 +19649,10 @@
   - cleaning_instructions
   - color
   - finish
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -17764,7 +19679,10 @@
   - cleaning_instructions
   - color
   - finish
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -17785,7 +19703,10 @@
   - color
   - finish
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -17805,9 +19726,12 @@
   - cleaning_instructions
   - color
   - finish
+  - height
+  - length
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -17824,12 +19748,16 @@
   attributes:
   - barware_items_included
   - barware_material
+  - capacity
   - cleaning_instructions
   - color
   - construction
   - embellishment/trim_material
   - finish
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -17850,7 +19778,10 @@
   - cocktail_strainer_type
   - color
   - finish
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -17870,7 +19801,10 @@
   - cleaning_instructions
   - color
   - finish
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -17934,8 +19868,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - style
@@ -17949,6 +19886,7 @@
   name: Electric Corkscrews
   children: []
   attributes:
+  - amperage
   - barware_items_included
   - barware_material
   - battery_size
@@ -17956,8 +19894,13 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - voltage
+  - width
   return_reasons:
   - size
   - color
@@ -17978,7 +19921,10 @@
   - color
   - corkscrew_accessories_included
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -17997,7 +19943,10 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -18019,7 +19968,10 @@
   - corkscrew_hinge_type
   - corkscrew_tools_included
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -18039,7 +19991,10 @@
   - color
   - handle_material
   - hardware_finish
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -18110,12 +20065,16 @@
   attributes:
   - barware_items_included
   - barware_material
+  - capacity
   - cleaning_instructions
   - color
   - drinkware_shape
+  - height
   - intended_beverage_type
+  - length
   - pattern
   - stopper_type
+  - width
   return_reasons:
   - size
   - color
@@ -18136,8 +20095,11 @@
   - barware_material
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - theme
+  - width
   return_reasons:
   - color
   - style
@@ -18155,8 +20117,11 @@
   - blade_material
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -18169,15 +20134,20 @@
   children: []
   attributes:
   - barware_material
+  - capacity
   - cleaning_instructions
   - color
+  - diameter
   - finish
   - handle_type
+  - height
   - ice_bucket_accessories_included
   - ice_bucket_insulation
+  - length
   - lid_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -18196,8 +20166,11 @@
   - barware_material
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   - wine_aerator_type
   return_reasons:
   - size
@@ -18217,9 +20190,12 @@
   - barware_material
   - cleaning_instructions
   - color
+  - height
+  - length
   - mounting_type
   - orientation
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -18314,8 +20290,11 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - color
@@ -18337,7 +20316,10 @@
   - cleaning_instructions
   - color
   - cookware/bakeware_features
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -18353,12 +20335,17 @@
   children: []
   attributes:
   - bakeware_shape
+  - bakeware_size
   - cleaning_instructions
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - depth
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - color
@@ -18375,12 +20362,17 @@
   children: []
   attributes:
   - bakeware_shape
+  - bakeware_size
   - cleaning_instructions
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - depth
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -18394,12 +20386,17 @@
   children: []
   attributes:
   - bakeware_shape
+  - bakeware_size
   - cleaning_instructions
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - depth
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - color
@@ -18420,8 +20417,11 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - color
@@ -18438,14 +20438,19 @@
   children: []
   attributes:
   - bakeware_shape
+  - bakeware_size
   - cleaning_instructions
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - depth
+  - height
+  - length
   - pan_bottom_type
   - pattern
   - pie_pan_edge_style
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - color
@@ -18462,13 +20467,17 @@
   children: []
   attributes:
   - bakeware_shape
+  - bakeware_size
   - cleaning_instructions
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - pizza_pan_style
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - color
@@ -18484,12 +20493,16 @@
   children: []
   attributes:
   - bakeware_shape
+  - bakeware_size
   - cleaning_instructions
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
   - glaze_finish
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -18509,8 +20522,11 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - color
@@ -18527,13 +20543,18 @@
   children: []
   attributes:
   - bakeware_shape
+  - bakeware_size
   - cleaning_instructions
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - depth
   - handle_material
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - color
@@ -18577,8 +20598,11 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -18597,8 +20621,11 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -18617,8 +20644,11 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -18637,8 +20667,11 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -18655,8 +20688,11 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -18672,8 +20708,11 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -18690,8 +20729,11 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - features
+  - height
+  - length
   - pattern
   - roasting_rack_shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -18752,8 +20794,11 @@
   - cookware/bakeware_material
   - cookware_coating_type
   - handle_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -18776,8 +20821,11 @@
   - cookware_coating_type
   - cookware_items_included
   - handle_material
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - color
@@ -18800,9 +20848,13 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - cookware_coating_type
+  - cookware_size
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -18823,9 +20875,13 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - cookware_coating_type
+  - cookware_size
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -18846,9 +20902,13 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - cookware_coating_type
+  - cookware_size
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -18863,6 +20923,7 @@
   name: Double Boilers
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - compatible_stove_top_type
@@ -18871,7 +20932,10 @@
   - cookware_coating_type
   - cookware_items_included
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -18884,6 +20948,7 @@
   name: Dutch Ovens
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - compatible_stove_top_type
@@ -18891,9 +20956,12 @@
   - cookware/bakeware_material
   - cookware_coating_type
   - handle_material
+  - height
   - inner_pot_coating
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -18909,6 +20977,7 @@
   name: Fermentation & Pickling Crocks
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - compatible_stove_top_type
@@ -18917,9 +20986,12 @@
   - cookware_coating_type
   - fermentation_crock_type
   - handle_material
+  - height
+  - length
   - lid_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -18942,10 +21014,15 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - cookware_coating_type
+  - cookware_size
+  - depth
   - handle_material
+  - height
+  - length
   - pattern
   - product_certifications_standards
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -18966,7 +21043,10 @@
   - cookware/bakeware_material
   - cookware_coating_type
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -18987,10 +21067,14 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - cookware_coating_type
+  - cookware_size
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - color
@@ -19007,6 +21091,7 @@
   - hg-11-2-3-10-1
   - hg-11-2-3-10-2
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - compatible_stove_top_type
@@ -19014,7 +21099,10 @@
   - cookware/bakeware_material
   - cookware_coating_type
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -19030,6 +21118,7 @@
   children: []
   attributes:
   - canner_type
+  - capacity
   - cleaning_instructions
   - color
   - compatible_stove_top_type
@@ -19037,8 +21126,11 @@
   - cookware/bakeware_material
   - cookware_coating_type
   - handle_material
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -19053,6 +21145,7 @@
   name: Pressure Cookers
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - compatible_stove_top_type
@@ -19060,9 +21153,12 @@
   - cookware/bakeware_material
   - cookware_coating_type
   - handle_material
+  - height
+  - length
   - pattern
   - pressure_cooker_safety_features
   - pressure_settings
+  - width
   return_reasons:
   - size
   - color
@@ -19083,10 +21179,15 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - cookware_coating_type
+  - depth
+  - diameter
   - handle_material
+  - height
+  - length
   - pattern
   - product_certifications_standards
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -19107,9 +21208,14 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - cookware_coating_type
+  - cookware_size
+  - depth
   - handle_material
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - color
@@ -19132,10 +21238,15 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - cookware_coating_type
+  - cookware_size
+  - depth
   - handle_material
+  - height
+  - length
   - pattern
   - product_certifications_standards
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -19156,10 +21267,15 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - cookware_coating_type
+  - cookware_size
+  - depth
   - handle_material
+  - height
+  - length
   - pattern
   - product_certifications_standards
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -19180,10 +21296,15 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - cookware_coating_type
+  - cookware_size
+  - depth
   - handle_material
+  - height
+  - length
   - pattern
   - product_certifications_standards
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -19198,14 +21319,19 @@
   name: Stock Pots
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - compatible_stove_top_type
   - cookware/bakeware_features
   - cookware/bakeware_material
   - cookware_coating_type
+  - cookware_size
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -19220,6 +21346,7 @@
   name: Stovetop Kettles
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - compatible_stove_top_type
@@ -19228,9 +21355,12 @@
   - cookware_coating_type
   - finish
   - handle_material
+  - height
+  - length
   - lid_type
   - pattern
   - whistling
+  - width
   return_reasons:
   - size
   - color
@@ -19247,16 +21377,21 @@
   - hg-11-2-3-16-1
   - hg-11-2-3-16-2
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - compatible_stove_top_type
   - cookware/bakeware_features
   - cookware/bakeware_material
   - cookware_coating_type
+  - cookware_size
   - glaze_finish
   - handle_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -19271,6 +21406,7 @@
   name: Clay Cooking Pots
   children: []
   attributes:
+  - capacity
   - clay_pot_material
   - cleaning_instructions
   - color
@@ -19278,10 +21414,14 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - cookware_coating_type
+  - cookware_size
   - glaze_finish
   - handle_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -19296,16 +21436,21 @@
   name: Tagines
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - compatible_stove_top_type
   - cookware/bakeware_features
   - cookware/bakeware_material
   - cookware_coating_type
+  - cookware_size
   - glaze_finish
   - handle_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -19326,10 +21471,14 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - cookware_coating_type
+  - cookware_size
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   - wok_bottom_type
   return_reasons:
   - size
@@ -19391,7 +21540,10 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - cookware_items_included
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -19439,8 +21591,11 @@
   - fastener_type
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -19459,11 +21614,15 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - cookware_lid_style
+  - cookware_size
   - handle_material
+  - height
+  - length
   - lid_vent_type
   - pattern
   - product_certifications_standards
   - shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -19487,8 +21646,11 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -19505,8 +21667,11 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -19524,8 +21689,11 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -19544,10 +21712,13 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - handle_material
+  - height
+  - length
   - mounting_hardware
   - pattern
   - pressure_cooker_handle_type
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -19567,11 +21738,14 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - display_mode
+  - height
+  - length
   - mounting_type
   - pattern
   - power_source
   - shape
   - timer_design
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -19588,8 +21762,11 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -19641,8 +21818,11 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -19663,8 +21843,11 @@
   - compatible_stove_top_type
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -19686,8 +21869,11 @@
   - cookware/bakeware_features
   - cookware/bakeware_material
   - handle_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -19704,8 +21890,12 @@
   - compatible_stove_top_type
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - diameter
+  - height
+  - length
   - pattern
   - shape
+  - width
   - wok_bottom_type
   return_reasons:
   - incompatible
@@ -19784,6 +21974,7 @@
   - hg-11-3-13
   - hg-11-3-14
   attributes:
+  - capacity
   - cleaning_instructions
   - closure_type
   - color
@@ -19805,18 +21996,22 @@
   name: Airpots
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - closure_type
   - color
   - dispensing_mechanism
   - handle_type
+  - height
   - insulation_material
   - insulation_type
+  - length
   - lid_type
   - material
   - pattern
   - product_certifications_standards
   - safety_certifications
+  - width
   return_reasons:
   - color
   - capacity
@@ -19831,15 +22026,19 @@
   children: []
   attributes:
   - bottle/container_closure
+  - capacity
   - carry_options
   - cleaning_instructions
   - color
   - handle_type
+  - height
   - insulation_material
+  - length
   - lid_type
   - material
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - color
   - capacity
@@ -19853,15 +22052,19 @@
   name: Coolers
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - closure_type
   - color
   - cooler_style
   - handle_type
+  - height
   - insulation_material
+  - length
   - material
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - size
   - capacity
@@ -19877,15 +22080,19 @@
   - hg-11-3-4-1
   - hg-11-3-4-2
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - handle_type
+  - height
   - insulation_capability
   - insulation_material
+  - length
   - material
   - pattern
   - safety_certifications
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -19899,17 +22106,21 @@
   name: Can & Bottle Sleeves
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - closure_type
   - color
+  - height
   - insulation_capability
   - insulation_material
+  - length
   - material
   - pattern
   - personalization_options
   - safety_certifications
   - suitable_for_container_type
   - usage_type
+  - width
   return_reasons:
   - color
   - capacity
@@ -19923,14 +22134,18 @@
   name: Cup Sleeves
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
+  - height
   - insulation_capability
   - insulation_material
+  - length
   - material
   - pattern
   - safety_certifications
   - usage_type
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -19943,18 +22158,22 @@
   name: Flasks
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - closure_type
   - color
   - finish
   - flask_insulation_type
   - handle_type
+  - height
   - insulation_material
+  - length
   - lid_type
   - material
   - pattern
   - personalization_options
   - safety_certifications
+  - width
   return_reasons:
   - color
   - capacity
@@ -19970,14 +22189,18 @@
   attributes:
   - bag_closure
   - bag_style
+  - capacity
   - cleaning_instructions
   - closure_type
   - color
   - food_bag_material
   - handle_type
+  - height
   - insulation_material
+  - length
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - color
   - capacity
@@ -19997,17 +22220,21 @@
   - hg-11-3-7-5
   attributes:
   - age_group
+  - capacity
   - carry_options
   - cleaning_instructions
   - closure_type
   - color
   - food_carrier_insulation_type
   - handle_type
+  - height
   - insulation_material
+  - length
   - material
   - pattern
   - safety_certifications
   - sterilization_instructions
+  - width
   return_reasons:
   - color
   - capacity
@@ -20024,15 +22251,19 @@
   - age_group
   - bag_closure
   - bag_strap_type
+  - capacity
   - carry_options
   - cleaning_instructions
   - color
   - food_bag_material
   - food_carrier_insulation_type
   - handle_type
+  - height
   - insulation_material
+  - length
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - size
   - color
@@ -20048,19 +22279,23 @@
   children: []
   attributes:
   - age_group
+  - capacity
   - carry_options
   - cleaning_instructions
   - closure_type
   - color
   - food_carrier_insulation_type
   - handle_type
+  - height
   - insulation_material
+  - length
   - lunch_set_items_included
   - material
   - pattern
   - safety_certifications
   - shape
   - sterilization_instructions
+  - width
   return_reasons:
   - color
   - capacity
@@ -20075,19 +22310,23 @@
   children: []
   attributes:
   - age_group
+  - capacity
   - carry_options
   - cleaning_instructions
   - closure_type
   - color
   - food_carrier_insulation_type
   - handle_type
+  - height
   - insulation_material
+  - length
   - lid_type
   - material
   - pattern
   - safety_certifications
   - shape
   - sterilization_instructions
+  - width
   return_reasons:
   - size
   - color
@@ -20105,15 +22344,19 @@
   attributes:
   - age_group
   - bag_closure
+  - capacity
   - carry_options
   - cleaning_instructions
   - color
   - food_carrier_insulation_type
   - handle_type
+  - height
   - insulation_material
+  - length
   - material
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - color
   - capacity
@@ -20151,15 +22394,19 @@
   children: []
   attributes:
   - basket_material
+  - capacity
   - cleaning_instructions
   - closure_type
   - color
   - handle_type
+  - height
   - insulation_material
   - insulation_type
+  - length
   - lumber/wood_type
   - pattern
   - safety_certifications
+  - width
   - wood_finish
   return_reasons:
   - color
@@ -20174,14 +22421,18 @@
   name: Replacement Drink Lids
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - handle_type
+  - height
+  - length
   - lid_type
   - material
   - pattern
   - safety_certifications
   - suitable_for_container_type
+  - width
   return_reasons:
   - color
   - incompatible
@@ -20195,16 +22446,20 @@
   name: Thermoses
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - closure_type
   - color
+  - height
   - insulation_material
   - insulation_technology
+  - length
   - lid_type
   - material
   - pattern
   - safety_certifications
   - thermos_handle_type
+  - width
   return_reasons:
   - size
   - color
@@ -20220,17 +22475,21 @@
   children: []
   attributes:
   - age_group
+  - capacity
   - cleaning_instructions
   - closure_type
   - color
   - handle_type
+  - height
   - insulation_material
   - insulation_type
+  - length
   - lid_type
   - material
   - pattern
   - safety_certifications
   - spout_type
+  - width
   return_reasons:
   - size
   - color
@@ -20248,12 +22507,16 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_closure
+  - capacity
   - cleaning_instructions
   - color
   - handle_type
+  - height
   - insulation_material
+  - length
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - color
   - capacity
@@ -20335,16 +22598,20 @@
   - hg-11-4-1-2
   attributes:
   - bread_storage_ventilation
+  - capacity
   - cleaning_instructions
   - closure_type
   - color
   - food_storage_features
   - food_storage_material
+  - height
+  - length
   - lid_type
   - lumber/wood_type
   - pattern
   - product_certifications_standards
   - shape
+  - width
   - wood_finish
   return_reasons:
   - color
@@ -20400,6 +22667,7 @@
   name: Candy Buckets
   children: []
   attributes:
+  - capacity
   - celebration_type
   - closure_type
   - color
@@ -20407,8 +22675,11 @@
   - food_storage_material
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - color
   - capacity
@@ -20422,14 +22693,18 @@
   name: Cookie Jars
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - closure_type
   - color
   - food_storage_features
   - food_storage_material
+  - height
+  - length
   - lid_type
   - pattern
   - shape
+  - width
   return_reasons:
   - color
   - capacity
@@ -20443,16 +22718,20 @@
   name: Food Container Covers
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - closure_type
   - color
   - cover_features
   - food_storage_features
   - food_storage_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - shape
   - usage_type
+  - width
   - wood_finish
   return_reasons:
   - capacity
@@ -20467,15 +22746,19 @@
   name: Food Storage Bags
   children: []
   attributes:
+  - capacity
   - closure_type
   - color
   - food_bag_material
   - food_storage_bag_features
   - food_storage_bag_type
   - food_storage_features
+  - height
+  - length
   - pattern
   - shape
   - usage_type
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -20488,15 +22771,19 @@
   name: Food Storage Containers
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - closure_type
   - color
   - food_storage_features
   - food_storage_material
+  - height
+  - length
   - lid_type
   - lumber/wood_type
   - pattern
   - shape
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -20522,9 +22809,12 @@
   - food_storage_features
   - food_storage_material
   - food_wrap_features
+  - height
+  - length
   - pattern
   - shape
   - usage_type
+  - width
   - wrap_format
   return_reasons:
   - changed_my_mind
@@ -20543,9 +22833,12 @@
   - food_storage_features
   - food_storage_material
   - food_wrap_features
+  - height
+  - length
   - pattern
   - shape
   - usage_type
+  - width
   - wrap_format
   return_reasons:
   - changed_my_mind
@@ -20563,10 +22856,13 @@
   - food_storage_features
   - food_storage_material
   - food_wrap_features
+  - height
+  - length
   - parchment_paper_coating
   - pattern
   - shape
   - usage_type
+  - width
   - wrap_format
   return_reasons:
   - changed_my_mind
@@ -20584,10 +22880,13 @@
   - food_storage_features
   - food_storage_material
   - food_wrap_features
+  - height
+  - length
   - pattern
   - safety_certifications
   - shape
   - usage_type
+  - width
   - wrap_format
   return_reasons:
   - changed_my_mind
@@ -20605,10 +22904,13 @@
   - food_storage_features
   - food_storage_material
   - food_wrap_features
+  - height
+  - length
   - pattern
   - shape
   - usage_type
   - wax_type
+  - width
   - wrap_format
   return_reasons:
   - changed_my_mind
@@ -20660,15 +22962,19 @@
   name: Honey Jars
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - closure_type
   - color
   - food_storage_features
   - food_storage_material
+  - height
+  - length
   - lid_type
   - pattern
   - planter_material
   - shape
+  - width
   return_reasons:
   - color
   - capacity
@@ -20709,11 +23015,14 @@
   - closure_type
   - color
   - food_storage_material
+  - height
   - label_content_type
+  - length
   - material
   - pattern
   - shape
   - usage_type
+  - width
   return_reasons:
   - color
   - incompatible
@@ -20733,10 +23042,13 @@
   - compatible_wrap_material
   - cutting_mechanism_type
   - food_storage_material
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - usage_type
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -20751,10 +23063,13 @@
   - closure_type
   - color
   - food_storage_material
+  - height
+  - length
   - material
   - oxygen_indicator_type
   - pattern
   - usage_type
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -20774,9 +23089,12 @@
   - closure_type
   - color
   - food_storage_material
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -20794,9 +23112,12 @@
   - closure_type
   - color
   - food_storage_material
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -20814,9 +23135,12 @@
   - closure_type
   - color
   - food_storage_material
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -20833,9 +23157,12 @@
   - closure_type
   - color
   - food_storage_material
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -20909,8 +23236,11 @@
   - cleaning_instructions
   - color
   - cookware/bakeware_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -20929,7 +23259,10 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -20946,8 +23279,11 @@
   - cleaning_instructions
   - color
   - cookware/bakeware_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -20963,8 +23299,11 @@
   - cleaning_instructions
   - color
   - cookware/bakeware_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21043,10 +23382,13 @@
   - cleaning_instructions
   - coffee_decanter_warmer_features
   - color
+  - height
+  - length
   - material
   - pattern
   - power_source
   - temperature_control
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21061,10 +23403,13 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
   - insulation_type
+  - length
   - lid_type
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21082,8 +23427,11 @@
   - color
   - filter_bleaching_method
   - filter_material
+  - height
+  - length
   - pattern
   - usage_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21099,8 +23447,11 @@
   - cleaning_instructions
   - coffee_grinder_accessory_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21115,12 +23466,16 @@
   attributes:
   - burr_shape
   - cleaning_instructions
+  - coffee_beans_capacity
   - color
   - grind_size
   - grinding_mechanism_material
   - grinding_mechanism_type
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -21161,8 +23516,11 @@
   - cleaning_instructions
   - color
   - compatible_coffee_maker_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21178,8 +23536,11 @@
   - cleaning_instructions
   - color
   - compatible_coffee_maker_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21196,9 +23557,12 @@
   - color
   - compatible_coffee_capsule_system
   - compatible_coffee_maker_type
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21214,10 +23578,13 @@
   - cleaning_instructions
   - color
   - compatible_coffee_maker_type
+  - height
+  - length
   - lid_type
   - material
   - pattern
   - sprinkle_opening_style
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21233,8 +23600,11 @@
   - cleaning_instructions
   - color
   - compatible_coffee_maker_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21250,8 +23620,11 @@
   - cleaning_instructions
   - color
   - compatible_coffee_maker_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21267,8 +23640,11 @@
   - cleaning_instructions
   - color
   - compatible_coffee_maker_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -21286,9 +23662,12 @@
   - compatible_coffee_maker_type
   - cup_warmer_features
   - heat_settings
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21305,8 +23684,11 @@
   - color
   - compatible_coffee_maker_type
   - finish
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21322,9 +23704,12 @@
   - cleaning_instructions
   - color
   - compatible_coffee_maker_type
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21341,8 +23726,11 @@
   - color
   - compatible_coffee_maker_type
   - dripper_design
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21358,8 +23746,11 @@
   - cleaning_instructions
   - color
   - compatible_coffee_maker_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -21378,8 +23769,11 @@
   - compatible_coffee_maker_type
   - finish
   - handle_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -21397,8 +23791,11 @@
   - color
   - compatible_coffee_maker_type
   - finish
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -21415,9 +23812,12 @@
   - cleaning_instructions
   - color
   - compatible_coffee_maker_type
+  - height
+  - length
   - lid_type
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -21434,9 +23834,12 @@
   - cleaning_instructions
   - color
   - compatible_coffee_maker_type
+  - height
+  - length
   - material
   - milk_frothing_method
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21452,8 +23855,11 @@
   - cleaning_instructions
   - color
   - compatible_coffee_maker_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21470,9 +23876,12 @@
   - cleaning_instructions
   - color
   - compatible_coffee_maker_type
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21488,8 +23897,11 @@
   - cleaning_instructions
   - color
   - compatible_coffee_maker_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21505,8 +23917,11 @@
   - cleaning_instructions
   - color
   - compatible_coffee_maker_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21522,8 +23937,11 @@
   - cleaning_instructions
   - color
   - compatible_coffee_maker_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21539,8 +23957,11 @@
   - cleaning_instructions
   - color
   - compatible_coffee_maker_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21557,8 +23978,11 @@
   - color
   - compatible_coffee_maker_type
   - connecting_thread
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21604,9 +24028,12 @@
   - cleaning_instructions
   - color
   - filter_material
+  - height
+  - length
   - material
   - pattern
   - water_filter_application
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21619,13 +24046,17 @@
   name: Frothing Pitchers
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - handle_type
+  - height
+  - length
   - pattern
   - pitcher_spout_style
   - power_source
   - tool/utensil_material
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -21640,10 +24071,13 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - number_of_compartments
   - pattern
   - portafilter_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21759,9 +24193,12 @@
   - cleaning_instructions
   - color
   - compatible_stove_top_type
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -21781,9 +24218,12 @@
   - color
   - compatible_stove_top_type
   - fragrance
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - scent
   - changed_my_mind
@@ -21799,10 +24239,13 @@
   - cleaning_instructions
   - color
   - compatible_stove_top_type
+  - height
+  - length
   - material
   - pattern
   - shape
   - usage_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21841,10 +24284,13 @@
   - cleaning_instructions
   - color
   - compatible_stove_top_type
+  - height
+  - length
   - material
   - pattern
   - shape
   - usage_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -21861,9 +24307,12 @@
   - color
   - compatible_stove_top_type
   - finish
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -21881,9 +24330,12 @@
   - color
   - compatible_stove_top_type
   - grease_filter_material
+  - height
+  - length
   - pattern
   - range_hood_filter_type
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22007,7 +24459,10 @@
   - color
   - disposable/reusable_bag_features
   - food_bag_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -22085,9 +24540,12 @@
   - cleaning_instructions
   - color
   - cookware/bakeware_features
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -22105,9 +24563,12 @@
   - color
   - cookware/bakeware_features
   - handle_type
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22123,10 +24584,13 @@
   - cleaning_instructions
   - color
   - cookware/bakeware_features
+  - height
+  - length
   - lid_type
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22160,8 +24624,11 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22180,8 +24647,11 @@
   - color
   - dishwasher_accessory_type
   - finish
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22228,9 +24698,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22250,8 +24723,11 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -22267,9 +24743,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - plug_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22284,9 +24763,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - lid_type
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22301,9 +24783,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22352,8 +24837,11 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -22371,9 +24859,13 @@
   - color
   - cookware/bakeware_features
   - cookware_lid_style
+  - diameter
+  - height
+  - length
   - lid_features
   - material
   - shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -22388,11 +24880,14 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - spray_pattern
   - sprayer_operation_mechanism
   - usage_type
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -22408,9 +24903,12 @@
   - cleaning_instructions
   - color
   - features
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -22496,8 +24994,12 @@
   - cleaning_instructions
   - color
   - cooking_gel_fuel_base
+  - height
+  - length
   - material
   - pattern
+  - volume
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22513,9 +25015,13 @@
   - color
   - cooking_gel_fuel_base
   - fuel_source
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - volume
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22532,8 +25038,12 @@
   - cooking_gel_fuel_base
   - fuel_container_features
   - fuel_source
+  - height
+  - length
   - material
   - pattern
+  - volume
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22550,8 +25060,12 @@
   - cooking_gel_fuel_base
   - fuel_container_features
   - fuel_source
+  - height
+  - length
   - material
   - pattern
+  - volume
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22567,8 +25081,12 @@
   - color
   - cooking_gel_fuel_base
   - fuel_source
+  - height
+  - length
   - material
   - pattern
+  - volume
+  - width
   return_reasons:
   - burn_time
   - incompatible
@@ -22585,8 +25103,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -22601,9 +25122,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
   - height_adjustment
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -22637,9 +25161,12 @@
   - cleaning_instructions
   - color
   - food_dehydrator_surface_type
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22656,10 +25183,13 @@
   - color
   - cookware/bakeware_features
   - food_dehydrator_surface_type
+  - height
+  - length
   - material
   - pattern
   - shape
   - usage_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22676,9 +25206,12 @@
   - color
   - food_dehydrator_surface_type
   - food_dehydrator_tray_type
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22714,9 +25247,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22732,9 +25268,12 @@
   - cleaning_instructions
   - color
   - food_processor_attachments_included
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22749,12 +25288,15 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
   - stackability
   - stackable_design
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22772,9 +25314,12 @@
   - cleaning_instructions
   - color
   - cutting_disc_function
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22822,9 +25367,12 @@
   - attachment_type
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22840,9 +25388,12 @@
   - cleaning_instructions
   - color
   - cookware_coating_type
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22857,9 +25408,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22875,9 +25429,12 @@
   - cleaning_instructions
   - color
   - drum_grating_styles_included
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22892,9 +25449,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22909,9 +25469,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22927,9 +25490,12 @@
   - cleaning_instructions
   - color
   - grating_surface_coarseness
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22945,9 +25511,12 @@
   - cleaning_instructions
   - color
   - grind_size
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22962,9 +25531,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22979,9 +25551,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -22998,9 +25573,12 @@
   - cleaning_instructions
   - color
   - grind_size
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23015,10 +25593,13 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pasta_shape_type
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23034,9 +25615,12 @@
   - blade_material
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23051,10 +25635,13 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - safety_certifications
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23069,9 +25656,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23086,9 +25676,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23104,9 +25697,12 @@
   - blade_material
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_for_food_processor_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23142,8 +25738,11 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -23160,10 +25759,13 @@
   - cleaning_instructions
   - color
   - gasket_profile_type
+  - height
+  - length
   - magnet_type
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23179,9 +25781,12 @@
   - cleaning_instructions
   - color
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23196,8 +25801,11 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - shelf_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23213,11 +25821,14 @@
   - cleaning_instructions
   - color
   - display_mode
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - temperature_measurement
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23267,8 +25878,11 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -23286,8 +25900,11 @@
   - color
   - garbage_disposal_stopper_style
   - hardware_finish
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -23363,9 +25980,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
   - ice_cream_maker_accessories_included
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23380,9 +26000,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
   - ice_cream_maker_accessories_included
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23430,8 +26053,11 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -23447,8 +26073,11 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23463,10 +26092,13 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - lid_type
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -23501,8 +26133,11 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -23519,9 +26154,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -23598,9 +26236,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23615,9 +26256,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -23633,9 +26277,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23650,9 +26297,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -23720,8 +26370,11 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -23739,8 +26392,11 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -23755,10 +26411,13 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - shape
   - ventilation_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -23774,9 +26433,12 @@
   - cleaning_instructions
   - color
   - features
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -23791,10 +26453,13 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - plate_coupling_pattern
   - shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -23893,10 +26558,14 @@
   - color
   - features
   - flavor
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - shape
+  - weight
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23914,11 +26583,15 @@
   - country
   - features
   - flavor
+  - height
+  - length
   - lumber/wood_type
   - material
   - package_type
   - pattern
   - shape
+  - weight
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23936,10 +26609,14 @@
   - color
   - features
   - flavor
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - shape
+  - weight
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23956,11 +26633,15 @@
   - color
   - features
   - flavor
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - product_certifications_standards
   - shape
+  - weight
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23977,11 +26658,15 @@
   - color
   - features
   - flavor
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - shape
   - sustainability
+  - weight
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24015,8 +26700,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -24032,9 +26720,12 @@
   - cleaning_instructions
   - color
   - furniture/fixture_features
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -24053,9 +26744,12 @@
   - color
   - compatible_outdoor_grill_style
   - cover_features
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -24074,9 +26768,12 @@
   - color
   - compatible_grill_type
   - cookware/bakeware_features
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24095,10 +26792,13 @@
   - compatible_grill_type
   - cookware/bakeware_features
   - features
+  - height
+  - length
   - material
   - outdoor_grill_rack_type
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24118,9 +26818,12 @@
   - cookware/bakeware_material
   - features
   - food_dehydrator_surface_type
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24146,9 +26849,12 @@
   - compatible_fuel_type
   - features
   - finish
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24168,9 +26874,12 @@
   - features
   - finish
   - fuel_source
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24188,9 +26897,12 @@
   - compatible_fuel_type
   - features
   - finish
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24209,11 +26921,14 @@
   - compatible_fuel_type
   - features
   - finish
+  - height
   - ignition_system
+  - length
   - material
   - pattern
   - power_source
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24235,11 +26950,14 @@
   - features
   - finish
   - grill_thermometer_type
+  - height
+  - length
   - material
   - pattern
   - power_source
   - shape
   - temperature_measurement
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24330,8 +27048,11 @@
   - cleaning_instructions
   - color
   - cookware/bakeware_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24349,9 +27070,12 @@
   - color
   - cookware/bakeware_features
   - handle_type
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24369,9 +27093,12 @@
   - color
   - compatible_grill_type
   - cookware/bakeware_features
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24388,10 +27115,13 @@
   - cleaning_instructions
   - color
   - features
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -24411,10 +27141,13 @@
   - color
   - features
   - flavor
+  - height
+  - length
   - lumber/wood_type
   - material
   - package_type
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24430,11 +27163,14 @@
   - color
   - features
   - flavor
+  - height
+  - length
   - lumber/wood_type
   - material
   - package_type
   - pattern
   - smoking_chip_size
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24450,10 +27186,13 @@
   - color
   - features
   - flavor
+  - height
+  - length
   - lumber/wood_type
   - material
   - package_type
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24520,9 +27259,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pasta_shape_type
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24538,9 +27280,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pasta_shape_type
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24556,10 +27301,13 @@
   - cleaning_instructions
   - color
   - features
+  - height
+  - length
   - material
   - mounting_type
   - pasta_shape_type
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -24575,10 +27323,13 @@
   - attachment_type
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pasta_shape_type
   - pasta_type
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24593,10 +27344,13 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pasta_shape_type
   - pasta_type
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24631,8 +27385,11 @@
   - color
   - dietary_preferences
   - flavor
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24651,8 +27408,11 @@
   - dietary_preferences
   - disposable/reusable_bag_features
   - food_bag_material
+  - height
+  - length
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -24674,8 +27434,11 @@
   - cleaning_instructions
   - color
   - compatible_stove_fuel_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24692,11 +27455,14 @@
   - cleaning_instructions
   - color
   - compatible_stove_fuel_type
+  - height
+  - length
   - mat/rug_shape
   - pattern
   - product_certifications_standards
   - rug/mat_features
   - rug/mat_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -24714,8 +27480,11 @@
   - compatible_stove_fuel_type
   - durability_features
   - fire_starter_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24732,8 +27501,11 @@
   - compatible_stove_fuel_type
   - compatible_stove_type
   - features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24750,8 +27522,11 @@
   - cleaning_instructions
   - color
   - compatible_stove_fuel_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24808,9 +27583,12 @@
   - duct_shape
   - extraction_type
   - finish
+  - height
+  - length
   - material
   - pattern
   - range_hood_filter_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24830,10 +27608,13 @@
   - duct_shape
   - extraction_type
   - finish
+  - height
+  - length
   - material
   - pattern
   - range_hood_filter_type
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24853,8 +27634,11 @@
   - duct_shape
   - extraction_type
   - finish
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24874,9 +27658,12 @@
   - duct_shape
   - extraction_type
   - finish
+  - height
+  - length
   - material
   - pattern
   - vent_style
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24937,8 +27724,11 @@
   - cleaning_instructions
   - color
   - compatible_refrigerator_compartment
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -24956,10 +27746,13 @@
   - color
   - compatible_refrigerator_compartment
   - display_mode
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - temperature_measurement
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -24975,9 +27768,12 @@
   - cleaning_instructions
   - color
   - compatible_refrigerator_compartment
+  - height
+  - length
   - pattern
   - shelf_location_in_appliance
   - shelf_material
+  - width
   return_reasons:
   - size
   - incompatible
@@ -25057,8 +27853,11 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -25075,9 +27874,12 @@
   - bottle_closure_type
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - safety_certifications
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -25094,9 +27896,12 @@
   - color
   - cylinder_connector_type
   - gas_type
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -25115,9 +27920,12 @@
   - color
   - dietary_preferences
   - flavor
+  - height
+  - length
   - material
   - pattern
   - sweetener_type
+  - width
   return_reasons:
   - taste
   - dietary_requirements
@@ -25136,11 +27944,14 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - lid_type
   - material
   - pattern
   - steam_table_pan_size
   - steam_table_pan_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -25156,11 +27967,14 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - lid_type
   - material
   - pattern
   - steam_table_pan_cover_features
   - steam_table_pan_size
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -25175,12 +27989,15 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - lid_type
   - material
   - pan_perforation_type
   - pattern
   - shape
   - steam_table_pan_size
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -25216,8 +28033,11 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -25235,8 +28055,11 @@
   - cleaning_instructions
   - closure_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -25251,8 +28074,11 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -25267,8 +28093,11 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -25284,8 +28113,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -25318,10 +28150,13 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -25339,9 +28174,12 @@
   - cleaning_instructions
   - color
   - food_bag_material
+  - height
+  - length
   - pattern
   - product_certifications_standards
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -25397,7 +28235,10 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -25415,7 +28256,10 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -25432,8 +28276,11 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -25450,9 +28297,12 @@
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - height
+  - length
   - pattern
   - shape
   - waffle_style
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -25490,8 +28340,11 @@
   - cleaning_instructions
   - color
   - compatible_water_cooler_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -25506,12 +28359,16 @@
   attributes:
   - bottle/container_closure
   - bottle_fill_state
+  - capacity
   - cleaning_instructions
   - color
   - compatible_water_cooler_type
+  - height
+  - length
   - material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -25609,8 +28466,11 @@
   - cleaning_instructions
   - color
   - finish
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -25675,9 +28535,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - incompatible
@@ -25695,9 +28558,12 @@
   - color
   - flavor
   - food_product_form
+  - height
+  - length
   - material
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - taste
   - dietary_requirements
@@ -25711,12 +28577,16 @@
   name: Pots
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
+  - height
+  - length
   - lid_type
   - material
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -25974,9 +28844,12 @@
   - color
   - energy_efficiency_class
   - heat_settings
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -25990,12 +28863,18 @@
   name: Breadmakers
   children: []
   attributes:
+  - amperage
   - color
   - crust_browning_level
   - energy_efficiency_class
+  - height
+  - length
   - material
+  - maximum_bread_weight
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -26013,9 +28892,12 @@
   - color
   - control_type
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -26041,9 +28923,12 @@
   - coffee_input_type
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -26064,8 +28949,11 @@
   - color
   - drinkware_material
   - energy_efficiency_class
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -26080,14 +28968,20 @@
   name: Electric & Stovetop Espresso Pots
   children: []
   attributes:
+  - amperage
   - cleaning_instructions
   - coffee_input_type
   - color
   - compatible_stove_top_type
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
+  - voltage
+  - width
   return_reasons:
   - size
   - color
@@ -26107,11 +29001,16 @@
   - color
   - energy_efficiency_class
   - espresso_boiler_type
+  - height
+  - length
   - material
   - milk_frothing_system
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
+  - water_tank_capacity
+  - width
   return_reasons:
   - size
   - color
@@ -26132,9 +29031,12 @@
   - drinkware_insulation
   - energy_efficiency_class
   - filter_material
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -26153,9 +29055,12 @@
   - color
   - compatible_stove_top_type
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -26175,9 +29080,12 @@
   - compatible_stove_top_type
   - energy_efficiency_class
   - filter_material
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -26250,12 +29158,15 @@
   - color
   - control_type
   - energy_efficiency_class
+  - height
   - ignition_system
+  - length
   - mounting_type
   - pattern
   - power_source
   - stove_top_type
   - top_surface_material
+  - width
   return_reasons:
   - size
   - capacity
@@ -26272,10 +29183,13 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -26293,10 +29207,13 @@
   - color
   - cooking_compartments
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
   - power_source
   - temperature_control
+  - width
   return_reasons:
   - size
   - capacity
@@ -26313,10 +29230,13 @@
   - blade_material
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
   - power_source
   - tool_operation
+  - width
   return_reasons:
   - size
   - capacity
@@ -26330,15 +29250,22 @@
   name: Dishwashers
   children: []
   attributes:
+  - amperage
   - color
   - control_type
   - dishwasher_wash_programs
   - drying_system
   - energy_efficiency_class
+  - height
+  - length
   - material
   - mounting_type
+  - noise_level
   - pattern
+  - power_consumption_typical
   - power_source
+  - water_consumption_per_cycle
+  - width
   return_reasons:
   - color
   - capacity
@@ -26352,12 +29279,18 @@
   name: Electric Griddles & Grills
   children: []
   attributes:
+  - amperage
   - color
   - cookware/bakeware_features
   - cookware/bakeware_material
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - voltage
+  - width
   return_reasons:
   - size
   - capacity
@@ -26371,13 +29304,20 @@
   name: Electric Kettles
   children: []
   attributes:
+  - amperage
   - color
   - electric_kettle_features
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
   - temperature_control
+  - voltage
+  - water_tank_capacity
+  - width
   return_reasons:
   - size
   - color
@@ -26394,15 +29334,22 @@
   - hg-11-7-12-1
   - hg-11-7-12-2
   attributes:
+  - amperage
   - cleaning_instructions
   - color
   - control_type
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - cookware_size
   - energy_efficiency_class
   - heat_settings
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - voltage
+  - width
   return_reasons:
   - size
   - capacity
@@ -26417,18 +29364,25 @@
   name: Electric Skillets
   children: []
   attributes:
+  - amperage
   - cleaning_instructions
   - color
   - control_type
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - cookware_size
   - energy_efficiency_class
   - heat_settings
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
   - shape
   - temperature_control
+  - voltage
+  - width
   return_reasons:
   - size
   - capacity
@@ -26442,16 +29396,23 @@
   name: Electric Woks
   children: []
   attributes:
+  - amperage
   - cleaning_instructions
   - color
   - control_type
   - cookware/bakeware_features
   - cookware/bakeware_material
+  - cookware_size
   - energy_efficiency_class
   - heat_settings
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
+  - voltage
+  - width
   return_reasons:
   - size
   - capacity
@@ -26472,9 +29433,12 @@
   - energy_efficiency_class
   - fondue_pot_type
   - fondue_set_pieces_included
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -26498,9 +29462,13 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - color
   - capacity
@@ -26518,9 +29486,13 @@
   - color
   - egg_cooker_functions
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - color
   - capacity
@@ -26536,9 +29508,13 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - color
   - capacity
@@ -26552,12 +29528,17 @@
   name: Rice Cookers
   children: []
   attributes:
+  - capacity
   - color
   - cookware/bakeware_material
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - rice_cooker_functions
+  - width
   return_reasons:
   - color
   - capacity
@@ -26571,14 +29552,19 @@
   name: Slow Cookers
   children: []
   attributes:
+  - capacity
   - color
   - control_type
   - cookware/bakeware_material
   - energy_efficiency_class
   - heat_settings
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - shape
+  - width
   return_reasons:
   - color
   - capacity
@@ -26592,14 +29578,19 @@
   name: Thermal Cookers
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - compatible_stove_top_type
   - cookware/bakeware_material
   - energy_efficiency_class
+  - height
   - insulation_material
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - color
   - capacity
@@ -26616,9 +29607,13 @@
   - color
   - control_type
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - color
   - capacity
@@ -26666,11 +29661,15 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - orientation
   - pattern
+  - power_consumption_typical
   - power_source
   - temperature_control
+  - width
   return_reasons:
   - color
   - capacity
@@ -26692,9 +29691,12 @@
   - control_type
   - energy_efficiency_class
   - grinding_mechanism_type
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -26714,10 +29716,13 @@
   - energy_efficiency_class
   - grind_size
   - grinding_mechanism_type
+  - height
+  - length
   - material
   - pattern
   - power_source
   - speed_settings
+  - width
   return_reasons:
   - color
   - capacity
@@ -26738,9 +29743,12 @@
   - grating_surface_coarseness
   - grinding_mechanism_type
   - handle_material
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -26776,10 +29784,13 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
   - power_source
   - speed_settings
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -26800,10 +29811,13 @@
   - cleaning_instructions
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
   - power_source
   - speed_settings
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -26877,10 +29891,13 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
   - power_source
   - speed_settings
+  - width
   return_reasons:
   - color
   - capacity
@@ -26931,10 +29948,13 @@
   - color
   - control_type
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
   - power_source
   - smoker_type
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -26955,9 +29975,13 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - color
   - capacity
@@ -26974,11 +29998,15 @@
   - color
   - cooking_compartments
   - energy_efficiency_class
+  - height
+  - length
   - lid_type
   - material
   - pattern
+  - power_consumption_typical
   - power_source
   - shape
+  - width
   return_reasons:
   - color
   - capacity
@@ -26994,11 +30022,15 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - light_source
   - material
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - color
   - capacity
@@ -27014,10 +30046,14 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
   - inner_pot_coating
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - color
   - style
@@ -27034,13 +30070,17 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
   - product_certifications_standards
   - steam_table_pan_size_compatibility
   - temperature_control
+  - width
   return_reasons:
   - size
   - capacity
@@ -27089,15 +30129,22 @@
   - hg-11-7-20-2
   - hg-11-7-20-3
   attributes:
+  - amperage
   - color
   - door_hinge_orientation
   - energy_efficiency_class
   - freezer_configuration
+  - freezing_capacity
+  - height
+  - length
   - material
   - mounting_type
+  - noise_level
   - pattern
+  - power_consumption_typical
   - power_source
   - star_rating
+  - width
   return_reasons:
   - size
   - color
@@ -27172,9 +30219,12 @@
   - blade_material
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -27190,9 +30240,12 @@
   - color
   - energy_efficiency_class
   - garbage_disposal_feed_type
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -27209,12 +30262,15 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
   - ignition_system
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - top_surface_material
+  - width
   return_reasons:
   - size
   - capacity
@@ -27234,9 +30290,12 @@
   - color
   - energy_efficiency_class
   - heat_settings
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - color
   - capacity
@@ -27284,14 +30343,20 @@
   name: Ice Cream Makers
   children: []
   attributes:
+  - bowl_capacity
   - cleaning_instructions
   - color
   - compatible_recipes
   - energy_efficiency_class
   - freezing_method
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
+  - preparation_time
+  - width
   return_reasons:
   - color
   - capacity
@@ -27310,10 +30375,13 @@
   - blade_material
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
   - power_source
   - speed_settings
+  - width
   return_reasons:
   - size
   - capacity
@@ -27331,10 +30399,13 @@
   - color
   - energy_efficiency_class
   - grating_surface_coarseness
+  - height
+  - length
   - material
   - pattern
   - power_source
   - speed_settings
+  - width
   return_reasons:
   - size
   - capacity
@@ -27352,10 +30423,13 @@
   - cleaning_instructions
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
   - power_source
   - speed_settings
+  - width
   return_reasons:
   - size
   - capacity
@@ -27371,12 +30445,15 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
   - ice_shape
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - water_supply_type
+  - width
   return_reasons:
   - size
   - color
@@ -27393,12 +30470,15 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
   - juicer_type
+  - length
   - material
   - pattern
   - power_source
   - pulp_ejection_type
   - safety_certifications
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -27422,8 +30502,11 @@
   - energy_efficiency_class
   - grit_type
   - handle_material
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -27438,14 +30521,20 @@
   children: []
   attributes:
   - abrasive_material
+  - amperage
   - angles_supported
   - color
   - energy_efficiency_class
   - grit_type
   - handle_material
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
+  - voltage
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -27464,9 +30553,12 @@
   - energy_efficiency_class
   - grit_type
   - handle_material
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -27485,9 +30577,12 @@
   - energy_efficiency_class
   - grit_type
   - handle_material
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -27506,9 +30601,12 @@
   - energy_efficiency_class
   - grit_type
   - handle_material
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -27526,10 +30624,13 @@
   - color
   - energy_efficiency_class
   - grit_type
+  - height
+  - length
   - lubricant_requirement
   - pattern
   - power_source
   - stone_shape
+  - width
   return_reasons:
   - size
   - grit
@@ -27546,12 +30647,16 @@
   - color
   - control_type
   - energy_efficiency_class
+  - height
+  - length
   - material
   - microwave_oven_functions
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
   - turntable_type
+  - width
   return_reasons:
   - size
   - color
@@ -27571,10 +30676,13 @@
   - cleaning_instructions
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - milk_frother_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -27590,10 +30698,13 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - mochi_maker_functions
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -27610,10 +30721,14 @@
   - color
   - energy_efficiency_class
   - grill_grate_material
+  - height
   - ignition_system
+  - length
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -27631,13 +30746,18 @@
   - control_type
   - cooking_compartments
   - energy_efficiency_class
+  - height
+  - length
   - material
+  - maximum_temperature
   - mounting_type
   - oven_accessories_included
   - pattern
+  - power_consumption_typical
   - power_source
   - roaster_oven_functions
   - self_cleaning_method
+  - width
   return_reasons:
   - size
   - capacity
@@ -27654,9 +30774,12 @@
   - cleaning_instructions
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -27670,12 +30793,18 @@
   name: Popcorn Makers
   children: []
   attributes:
+  - amperage
+  - capacity
   - cleaning_instructions
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -27694,12 +30823,17 @@
   - hg-11-7-38-3
   - hg-11-7-38-4
   attributes:
+  - amperage
   - color
   - energy_efficiency_class
+  - height
   - ignition_system
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -27790,6 +30924,7 @@
   name: Range Hoods
   children: []
   attributes:
+  - amperage
   - color
   - control_type
   - cover_features
@@ -27797,12 +30932,17 @@
   - extraction_type
   - finish
   - grease_filter_material
+  - height
+  - length
   - light_source
   - light_temperature
   - material
   - mounting_type
+  - noise_level
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -27819,12 +30959,15 @@
   - color
   - cooking_compartments
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
   - power_source
   - range_installation_type
   - self_cleaning_method
   - stove_top_type
+  - width
   return_reasons:
   - size
   - capacity
@@ -27840,16 +30983,23 @@
   - hg-11-7-41-1
   - hg-11-7-41-2
   attributes:
+  - amperage
+  - capacity
   - color
   - energy_efficiency_class
   - finish
+  - height
+  - length
   - material
   - mounting_type
+  - noise_level
   - pattern
+  - power_consumption_typical
   - power_source
   - refrigerator_configuration
   - star_rating
   - umbrella_opening_mechanism
+  - width
   return_reasons:
   - size
   - color
@@ -27906,12 +31056,17 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
+  - maximum_temperature
   - mounting_type
   - oven_accessories_included
   - pattern
+  - power_consumption_typical
   - power_source
   - roaster_oven_functions
+  - width
   return_reasons:
   - size
   - capacity
@@ -27929,10 +31084,13 @@
   - co2_cylinder_compatibility
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
   - power_source
   - soda_maker_accessories_included
+  - width
   return_reasons:
   - size
   - color
@@ -27948,11 +31106,16 @@
   children: []
   attributes:
   - blade_material
+  - capacity
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -27966,13 +31129,18 @@
   name: Tea Makers
   children: []
   attributes:
+  - capacity
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
   - tea_input_type
   - temperature_control
+  - width
   return_reasons:
   - size
   - capacity
@@ -27999,10 +31167,14 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
   - temperature_control
+  - width
   return_reasons:
   - size
   - color
@@ -28021,11 +31193,15 @@
   - control_type
   - cooking_compartments
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
   - roaster_oven_functions
   - temperature_control
+  - width
   return_reasons:
   - size
   - color
@@ -28042,10 +31218,14 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
   - temperature_control
+  - width
   return_reasons:
   - size
   - color
@@ -28063,10 +31243,14 @@
   - color
   - energy_efficiency_class
   - heat_settings
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
   - temperature_control
+  - width
   return_reasons:
   - size
   - color
@@ -28083,10 +31267,14 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
   - temperature_control
+  - width
   return_reasons:
   - size
   - color
@@ -28104,9 +31292,13 @@
   - color
   - cookware/bakeware_material
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - temperature_control
+  - width
   return_reasons:
   - size
   - color
@@ -28125,10 +31317,14 @@
   - color
   - energy_efficiency_class
   - heat_settings
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
   - temperature_control
+  - width
   return_reasons:
   - size
   - color
@@ -28145,10 +31341,14 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
   - temperature_control
+  - width
   return_reasons:
   - size
   - color
@@ -28165,11 +31365,15 @@
   attributes:
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
   - temperature_control
   - toaster_features
+  - width
   return_reasons:
   - size
   - color
@@ -28187,9 +31391,13 @@
   - color
   - cookware/bakeware_material
   - energy_efficiency_class
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - temperature_control
+  - width
   return_reasons:
   - size
   - color
@@ -28207,10 +31415,14 @@
   - color
   - cookware/bakeware_features
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
   - temperature_control
+  - width
   return_reasons:
   - size
   - color
@@ -28242,12 +31454,18 @@
   name: Trash Compactors
   children: []
   attributes:
+  - amperage
   - body_material
+  - capacity
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -28265,13 +31483,18 @@
   - hg-11-7-48-2
   - hg-11-7-48-3
   attributes:
+  - amperage
   - color
   - cutter_options
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
   - sealing_modes
+  - width
   return_reasons:
   - size
   - capacity
@@ -28345,10 +31568,13 @@
   - color
   - dispensing_temperature_options
   - energy_efficiency_class
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -28367,11 +31593,14 @@
   attributes:
   - color
   - filter_material
+  - height
+  - length
   - mounting_type
   - pattern
   - power_source
   - water_filter_application
   - water_filtration_technology
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -28451,17 +31680,22 @@
   name: Wine Fridges
   children: []
   attributes:
+  - amperage
   - color
   - door_material
   - door_type
   - energy_efficiency_class
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - power_consumption_typical
   - power_source
   - shelf_material
   - star_rating
   - temperature_zones
+  - width
   return_reasons:
   - size
   - color
@@ -28477,11 +31711,16 @@
   name: Yogurt Makers
   children: []
   attributes:
+  - capacity
   - color
   - energy_efficiency_class
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -28644,10 +31883,13 @@
   - color
   - fabric
   - handle_material
+  - height
+  - length
   - pattern
   - size
   - target_gender
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -28667,10 +31909,13 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - lumber/wood_type
   - shape
   - steam_table_pan_type
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -28689,8 +31934,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -28712,8 +31960,11 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - lumber/wood_type
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -28728,12 +31979,16 @@
   name: Beverage Dispensers
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - dispensing_mechanism
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - color
   - capacity
@@ -28755,10 +32010,13 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - material
   - pattern
   - tool/utensil_material
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -28776,10 +32034,13 @@
   - color
   - compatible_coupler_size
   - decorating_bag_features
+  - height
+  - length
   - material
   - pattern
   - tool/utensil_material
   - usage_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -28796,10 +32057,13 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - power_source
   - tool/utensil_material
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -28874,8 +32138,11 @@
   - edge_type
   - embellishment/trim_material
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -28894,11 +32161,14 @@
   - compatible_can_size
   - crushing_method
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - power_source
   - suitable_for_container_type
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -28917,10 +32187,13 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - power_source
   - tool/utensil_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -28935,8 +32208,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -28954,8 +32230,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -28974,10 +32253,13 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - shape
   - strainer_style
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -28995,9 +32277,12 @@
   - colander_style
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -29015,10 +32300,13 @@
   - color
   - grating_surface_coarseness
   - handle_material
+  - height
+  - length
   - pattern
   - shape
   - strainer_type
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -29036,8 +32324,11 @@
   - color
   - dispenser_type
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -29055,10 +32346,13 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - shape
   - theme
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -29076,10 +32370,13 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - power_source
   - theme
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -29102,8 +32399,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - incompatible
@@ -29121,8 +32421,11 @@
   - color
   - compatible_cooking_thermometer_type
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -29137,10 +32440,13 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
   - ingress_protection_ip_rating
+  - length
   - pattern
   - thermocouple_type
   - tool/utensil_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -29158,9 +32464,12 @@
   - color
   - connectivity_technology
   - display_technology
+  - height
+  - length
   - pattern
   - power_source
   - tool/utensil_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -29215,11 +32524,14 @@
   - display_mode
   - display_technology
   - handle_material
+  - height
   - ingress_protection_ip_rating
+  - length
   - pattern
   - power_source
   - tool/utensil_material
   - units_of_measurement
+  - width
   return_reasons:
   - size
   - color
@@ -29240,11 +32552,14 @@
   - display_mode
   - display_technology
   - handle_material
+  - height
   - ingress_protection_ip_rating
+  - length
   - pattern
   - power_source
   - tool/utensil_material
   - units_of_measurement
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -29264,11 +32579,14 @@
   - display_mode
   - display_technology
   - handle_material
+  - height
   - ingress_protection_ip_rating
+  - length
   - pattern
   - power_source
   - tool/utensil_material
   - units_of_measurement
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -29285,13 +32603,16 @@
   - connectivity_technology
   - display_mode
   - display_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - tool/utensil_material
   - units_of_measurement
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -29311,12 +32632,15 @@
   - display_mode
   - display_technology
   - handle_material
+  - height
   - ingress_protection_ip_rating
+  - length
   - pattern
   - power_source
   - temperature_measurement
   - tool/utensil_material
   - units_of_measurement
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -29336,12 +32660,15 @@
   - display_mode
   - display_technology
   - handle_material
+  - height
   - ingress_protection_ip_rating
+  - length
   - pattern
   - power_source
   - temperature_measurement
   - tool/utensil_material
   - units_of_measurement
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -29377,12 +32704,16 @@
   - cleaning_instructions
   - color
   - display_mode
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
+  - timer_duration
   - timer_mechanism
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -29400,10 +32731,13 @@
   - color
   - flame_adjustment
   - handle_material
+  - height
   - ignition_system
+  - length
   - pattern
   - tool/utensil_material
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -29421,9 +32755,12 @@
   - color
   - cookware/bakeware_features
   - handle_material
+  - height
+  - length
   - pattern
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -29440,10 +32777,13 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - shape
   - tool/utensil_material
+  - width
   - wood_finish
   - wood_grain_orientation
   return_reasons:
@@ -29462,12 +32802,16 @@
   - hg-11-8-22-2
   - hg-11-8-22-3
   attributes:
+  - capacity
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - placement_supported
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -29482,15 +32826,19 @@
   name: Dish Racks
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - features
+  - height
+  - length
   - lumber/wood_type
   - material
   - mounting_type
   - pattern
   - placement_supported
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -29506,15 +32854,19 @@
   name: Drain Boards
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - drain_location
   - features
+  - height
+  - length
   - material
   - pattern
   - placement_supported
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -29553,7 +32905,10 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -29573,8 +32928,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - incompatible
@@ -29592,8 +32950,11 @@
   - cleaning_instructions
   - color
   - edge_type
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -29638,6 +32999,7 @@
   name: Electric Knives
   children: []
   attributes:
+  - amperage
   - battery_size
   - battery_type
   - blade_material
@@ -29646,9 +33008,14 @@
   - construction
   - edge_type
   - handle_material
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - tool/utensil_material
+  - voltage
+  - width
   return_reasons:
   - size
   - color
@@ -29665,8 +33032,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -29683,11 +33053,14 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - shape
   - theme
   - tool/utensil_material
   - usage_type
+  - width
   return_reasons:
   - pattern
   - changed_my_mind
@@ -29727,9 +33100,12 @@
   - color
   - finish
   - handle_material
+  - height
+  - length
   - pattern
   - seafood_utensil_items_included
   - tool/utensil_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -29745,9 +33121,12 @@
   - color
   - finish
   - handle_material
+  - height
+  - length
   - pattern
   - seafood_utensil_items_included
   - tool/utensil_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -29763,9 +33142,12 @@
   - color
   - finish
   - handle_material
+  - height
+  - length
   - pattern
   - seafood_utensil_items_included
   - tool/utensil_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -29787,10 +33169,13 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - power_source
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - color
@@ -29808,11 +33193,14 @@
   - cleaning_instructions
   - color
   - finish
+  - height
+  - length
   - material
   - pattern
   - power_source
   - theme
   - tool/utensil_material
+  - width
   return_reasons:
   - color
   - style
@@ -29826,12 +33214,18 @@
   name: Electric Nutcrackers
   children: []
   attributes:
+  - amperage
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - tool/utensil_material
+  - voltage
+  - width
   return_reasons:
   - color
   - style
@@ -29850,10 +33244,13 @@
   - construction
   - handle_material
   - handle_type
+  - height
   - jewelry_material
+  - length
   - pattern
   - power_source
   - tool/utensil_material
+  - width
   return_reasons:
   - color
   - style
@@ -29870,9 +33267,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - power_source
   - tool/utensil_material
+  - width
   return_reasons:
   - color
   - style
@@ -29889,9 +33289,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tip_style
   - tool/utensil_material
+  - width
   return_reasons:
   - style
   - changed_my_mind
@@ -29908,8 +33311,11 @@
   - color
   - finish
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - color
   - style
@@ -29945,10 +33351,13 @@
   - dispensing_mechanism
   - food_dispenser_type
   - handle_material
+  - height
+  - length
   - lid_type
   - mounting_type
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - color
   - capacity
@@ -29969,8 +33378,11 @@
   - color
   - grating_surface_coarseness
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -29988,9 +33400,12 @@
   - food_grater_type
   - grating_surface_coarseness
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -30010,8 +33425,11 @@
   - grating_surface_coarseness
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -30029,8 +33447,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -30046,8 +33467,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -30065,9 +33489,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - changed_my_mind
@@ -30083,10 +33510,13 @@
   - bag_closure
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - tool/utensil_material
   - usage_type
+  - width
   return_reasons:
   - color
   - capacity
@@ -30105,12 +33535,15 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - shape
   - skewer_tip_type
   - tool/utensil_material
   - usage_type
+  - width
   - wood_finish
   return_reasons:
   - length
@@ -30127,11 +33560,14 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - shape
   - skewer_tip_type
   - tool/utensil_material
   - usage_type
+  - width
   return_reasons:
   - length
   - changed_my_mind
@@ -30147,12 +33583,15 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - shape
   - stick_tip_style
   - tool/utensil_material
   - usage_type
+  - width
   - wood_finish
   return_reasons:
   - length
@@ -30168,10 +33607,14 @@
   attributes:
   - cleaning_instructions
   - color
+  - diameter
   - funnel_type
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -30188,8 +33631,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -30204,9 +33650,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -30221,9 +33670,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -30241,9 +33693,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - nozzle_types_included
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -30273,13 +33728,18 @@
   - blade_construction_method
   - blade_finish
   - blade_material
+  - blade_size
   - cleaning_instructions
   - edge_type
   - handle_color
+  - handle_length
   - handle_material
   - handle_pattern
+  - height
+  - length
   - lumber/wood_type
   - tang_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -30297,13 +33757,18 @@
   - blade_construction_method
   - blade_finish
   - blade_material
+  - blade_size
   - cleaning_instructions
   - edge_type
   - handle_color
+  - handle_length
   - handle_material
   - handle_pattern
+  - height
+  - length
   - lumber/wood_type
   - tang_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -30321,13 +33786,18 @@
   - blade_construction_method
   - blade_finish
   - blade_material
+  - blade_size
   - cleaning_instructions
   - edge_type
   - handle_color
+  - handle_length
   - handle_material
   - handle_pattern
+  - height
+  - length
   - lumber/wood_type
   - tang_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -30345,13 +33815,18 @@
   - blade_construction_method
   - blade_finish
   - blade_material
+  - blade_size
   - blade_type
   - cleaning_instructions
   - edge_type
   - handle_color
+  - handle_length
   - handle_material
   - handle_pattern
+  - height
+  - length
   - tang_type
+  - width
   return_reasons:
   - size
   - color
@@ -30368,12 +33843,17 @@
   - blade_construction_method
   - blade_finish
   - blade_material
+  - blade_size
   - cleaning_instructions
   - edge_type
   - handle_color
+  - handle_length
   - handle_material
   - handle_pattern
+  - height
+  - length
   - tang_type
+  - width
   return_reasons:
   - size
   - color
@@ -30390,13 +33870,18 @@
   - blade_construction_method
   - blade_finish
   - blade_material
+  - blade_size
   - cleaning_instructions
   - edge_type
   - handle_color
+  - handle_length
   - handle_material
   - handle_pattern
+  - height
+  - length
   - lumber/wood_type
   - tang_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -30554,11 +34039,15 @@
   - cleaning_instructions
   - color
   - cookware/bakeware_features
+  - diameter
   - handle_material
+  - height
+  - length
   - pattern
   - shape
   - theme
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -30737,11 +34226,14 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - mounting_type
   - orientation
   - pattern
   - placement_supported
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -30765,10 +34257,13 @@
   - drinkware_holder_style
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - placement_supported
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -30854,12 +34349,15 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - mounting_type
   - pattern
   - placement_supported
   - shape
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -30966,11 +34464,14 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - placement_supported
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - color
   - capacity
@@ -30991,11 +34492,14 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - placement_supported
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -31015,6 +34519,8 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - mounting_type
   - pattern
@@ -31022,6 +34528,7 @@
   - shape
   - tool/utensil_material
   - utensil_holder_features
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -31043,11 +34550,14 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - placement_supported
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -31069,11 +34579,14 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - mounting_type
   - pattern
   - placement_supported
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -31094,12 +34607,15 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - mounting_type
   - orientation
   - pattern
   - placement_supported
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -31120,10 +34636,13 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - placement_supported
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -31146,11 +34665,14 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - placement_supported
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -31172,11 +34694,14 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - placement_supported
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -31197,12 +34722,15 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - mounting_type
   - orientation
   - pattern
   - placement_supported
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -31226,12 +34754,15 @@
   - finish
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - mounting_type
   - orientation
   - pattern
   - placement_supported
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -31255,6 +34786,8 @@
   - fold_type
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - lock_type
   - mounting_type
   - orientation
@@ -31262,6 +34795,7 @@
   - placement_supported
   - power_source
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -31284,12 +34818,15 @@
   - finish
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - mounting_type
   - orientation
   - pattern
   - placement_supported
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -31311,11 +34848,14 @@
   - finish
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - placement_supported
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -31335,12 +34875,15 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - mounting_type
   - pattern
   - placement_supported
   - spice_organizer_features
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -31363,11 +34906,14 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - mounting_type
   - pattern
   - placement_supported
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -31388,11 +34934,14 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - placement_supported
   - straw_dispensing_mechanism
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -31412,11 +34961,14 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - placement_supported
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -31438,13 +34990,16 @@
   - embellishment/trim_material
   - furniture/fixture_features
   - handle_material
+  - height
   - jewelry_material
+  - length
   - lid_type
   - mounting_type
   - pattern
   - placement_supported
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -31466,11 +35021,14 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - placement_supported
   - tool/utensil_material
   - toothpick_dispensing_mechanism
+  - width
   return_reasons:
   - size
   - color
@@ -31490,12 +35048,15 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - placement_supported
   - tool/utensil_material
   - toothpick_dispensing_mechanism
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -31517,13 +35078,16 @@
   - embellishment/trim_material
   - furniture/fixture_features
   - handle_material
+  - height
   - jewelry_material
+  - length
   - lid_type
   - mounting_type
   - pattern
   - placement_supported
   - tool/utensil_material
   - toothpick_dispensing_mechanism
+  - width
   return_reasons:
   - size
   - color
@@ -31547,7 +35111,9 @@
   - embellishment/trim_material
   - furniture/fixture_features
   - handle_material
+  - height
   - jewelry_material
+  - length
   - lumber/wood_type
   - mounting_type
   - pattern
@@ -31555,6 +35121,7 @@
   - shape
   - tool/utensil_material
   - utensil_tray_features
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -31576,12 +35143,15 @@
   - features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - placement_supported
   - shape
   - tool/utensil_material
   - utensil_tray_features
+  - width
   return_reasons:
   - size
   - color
@@ -31601,12 +35171,15 @@
   - drawer_organizer_features
   - furniture/fixture_features
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - placement_supported
   - shape
   - tool/utensil_material
   - utensil_tray_features
+  - width
   return_reasons:
   - size
   - color
@@ -31629,10 +35202,13 @@
   - color
   - edge_type
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - material_firmness
   - pattern
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -31652,8 +35228,11 @@
   - color
   - edge_type
   - handle_material
+  - height
+  - length
   - material_firmness
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -31670,11 +35249,14 @@
   - color
   - edge_type
   - handle_material
+  - height
+  - length
   - material_firmness
   - pattern
   - shape
   - tool/utensil_material
   - utensil_flexibility
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -31691,9 +35273,12 @@
   - color
   - edge_type
   - handle_material
+  - height
+  - length
   - material_firmness
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -31730,7 +35315,10 @@
   - edge_type
   - hand_side
   - handle_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -31751,10 +35339,15 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
+  - maximum_thickness
+  - minimum_thickness
   - pattern
   - power_source
   - slice_style
   - tool/utensil_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -31837,10 +35430,13 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
   - kitchen_utensil_items_included
+  - length
   - lumber/wood_type
   - pattern
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -31858,9 +35454,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -31879,9 +35478,12 @@
   - color
   - handle_material
   - handle_type
+  - height
+  - length
   - masher_head_design
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -31897,12 +35499,16 @@
   - hg-11-8-48-1
   - hg-11-8-48-2
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - system_of_measurement
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -31917,13 +35523,17 @@
   name: Measuring Cups
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - system_of_measurement
   - tool/utensil_material
   - units_of_measurement
+  - width
   return_reasons:
   - color
   - capacity
@@ -31937,13 +35547,17 @@
   name: Measuring Spoons
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - measuring_spoon_features
   - pattern
   - system_of_measurement
   - tool/utensil_material
+  - width
   return_reasons:
   - color
   - capacity
@@ -31960,10 +35574,13 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - meat_tenderizer_face_type
   - meat_tenderizer_mechanism
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -31979,12 +35596,16 @@
   attributes:
   - cleaning_instructions
   - color
+  - diameter
   - handle_material
+  - height
+  - length
   - mixing_bowl_features
   - pattern
   - shape
   - tool/utensil_material
   - units_of_measurement
+  - width
   return_reasons:
   - size
   - color
@@ -32000,11 +35621,15 @@
   attributes:
   - cleaning_instructions
   - color
+  - diameter
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - surface_texture
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -32024,12 +35649,16 @@
   - hg-11-8-52-3
   attributes:
   - bottle/container_closure
+  - capacity
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - pour_spout_style
   - tool/utensil_material
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -32043,14 +35672,18 @@
   children: []
   attributes:
   - bottle/container_closure
+  - capacity
   - cleaning_instructions
   - color
   - dispensing_mechanism
   - handle_material
+  - height
+  - length
   - oil_dispenser_spout_design
   - pattern
   - pour_spout_style
   - tool/utensil_material
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -32064,14 +35697,18 @@
   children: []
   attributes:
   - bottle/container_closure
+  - capacity
   - cleaning_instructions
   - color
   - dispenser_type
   - handle_material
+  - height
+  - length
   - pattern
   - pour_spout_design
   - pour_spout_style
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -32107,9 +35744,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - tool/utensil_material
   - usage_type
+  - width
   return_reasons:
   - size
   - capacity
@@ -32130,9 +35770,12 @@
   - hand_side
   - handle_material
   - handwear_features
+  - height
+  - length
   - pattern
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -32188,9 +35831,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pasta_shape_type
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -32208,9 +35854,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pasta_shape_type
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -32229,10 +35878,13 @@
   - color
   - handle_material
   - handle_type
+  - height
+  - length
   - pasta_shape_type
   - pattern
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -32267,8 +35919,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -32286,8 +35941,11 @@
   - cleaning_instructions
   - color
   - fabric
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -32308,8 +35966,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -32327,8 +35988,11 @@
   - color
   - edge_type
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -32344,9 +36008,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -32390,12 +36057,16 @@
   children: []
   attributes:
   - blade_material
+  - blade_size
   - cleaning_instructions
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - pizza_cutter_design
   - tool/utensil_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -32410,8 +36081,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -32453,8 +36127,11 @@
   - closure_type
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - incompatible
@@ -32473,8 +36150,11 @@
   - closure_type
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - incompatible
@@ -32493,8 +36173,11 @@
   - closure_type
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - incompatible
@@ -32513,9 +36196,12 @@
   - construction
   - embellishment/trim_material
   - handle_material
+  - height
   - jewelry_material
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - incompatible
@@ -32549,9 +36235,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -32572,9 +36261,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - lid_type
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -32593,10 +36285,13 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - lid_type
   - mixing_mechanism
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - color
   - capacity
@@ -32614,10 +36309,13 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - lid_type
   - mixing_mechanism
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - color
   - capacity
@@ -32633,12 +36331,16 @@
   attributes:
   - cleaning_instructions
   - color
+  - diameter
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - power_source
   - salad_spinner_mechanism
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -32684,9 +36386,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - scoop_release_mechanism
   - tool/utensil_material
+  - width
   return_reasons:
   - color
   - capacity
@@ -32703,9 +36408,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - scoop_release_mechanism
   - tool/utensil_material
+  - width
   return_reasons:
   - color
   - capacity
@@ -32723,9 +36431,12 @@
   - color
   - handle_design
   - handle_material
+  - height
+  - length
   - pattern
   - scoop_release_mechanism
   - tool/utensil_material
+  - width
   return_reasons:
   - color
   - capacity
@@ -32746,10 +36457,13 @@
   - hand_side
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
   - scoop_release_mechanism
   - scoop_wall_design
   - tool/utensil_material
+  - width
   return_reasons:
   - color
   - capacity
@@ -32768,11 +36482,14 @@
   - hand_side
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
   - scoop_release_mechanism
   - scoop_surface_design
   - scoop_wall_design
   - tool/utensil_material
+  - width
   return_reasons:
   - color
   - capacity
@@ -32791,10 +36508,13 @@
   - hand_side
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
   - scoop_release_mechanism
   - scoop_wall_design
   - tool/utensil_material
+  - width
   return_reasons:
   - color
   - capacity
@@ -32845,10 +36565,13 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - mounting_type
   - pattern
   - sink_caddy_features
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -32867,10 +36590,13 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - rug/mat_features
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -32889,10 +36615,13 @@
   - color
   - drain_location
   - hardware_finish
+  - height
+  - length
   - pattern
   - rug/mat_features
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -32909,10 +36638,13 @@
   - cleaning_instructions
   - color
   - features
+  - height
+  - length
   - pattern
   - rug/mat_features
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -32929,9 +36661,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -32949,9 +36684,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -32972,8 +36710,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - incompatible
@@ -32990,8 +36731,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -33009,10 +36753,13 @@
   - grind_size
   - grinding_mechanism_material
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - power_source
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -33029,9 +36776,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - shape
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -33046,13 +36796,17 @@
   children: []
   attributes:
   - bottle/container_closure
+  - capacity
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - lid_type
   - pattern
   - sugar_dispenser_mechanism
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -33070,8 +36824,11 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -33088,10 +36845,13 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - pattern
   - shape
   - strainer_style
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - color
@@ -33109,11 +36869,14 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - tip_material
   - tong_type
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -33131,9 +36894,12 @@
   - cleaning_instructions
   - color
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - tool/utensil_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -33218,8 +36984,11 @@
   - finish
   - furniture/fixture_features
   - furniture/fixture_material
+  - height
   - kitchen_layout
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -33268,8 +37037,11 @@
   - cleaning_instructions
   - coffee/tea_set_pieces_included
   - color
+  - height
+  - length
   - pattern
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -33288,8 +37060,11 @@
   - coffee/tea_set_pieces_included
   - color
   - drinkware_material
+  - height
+  - length
   - pattern
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -33308,9 +37083,12 @@
   - coffee/tea_set_pieces_included
   - color
   - drinkware_material
+  - height
+  - length
   - pattern
   - style
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -33327,11 +37105,15 @@
   - hg-11-10-2-1
   - hg-11-10-2-2
   attributes:
+  - capacity
   - cleaning_instructions
   - color
+  - height
+  - length
   - lid_type
   - pattern
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -33347,12 +37129,16 @@
   name: Coffee Servers
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - drinkware_insulation
+  - height
+  - length
   - lid_type
   - pattern
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -33368,13 +37154,17 @@
   name: Teapots
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - compatible_stove_top_type
+  - height
+  - length
   - lid_type
   - pattern
   - tableware_material
   - teapot_spout_style
+  - width
   return_reasons:
   - size
   - color
@@ -33396,10 +37186,13 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - lid_type
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -33417,10 +37210,13 @@
   - cleaning_instructions
   - color
   - grating_surface_coarseness
+  - height
+  - length
   - lid_type
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -33437,10 +37233,13 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - lid_type
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -33457,10 +37256,13 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - lid_type
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -33477,11 +37279,14 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - lid_type
   - pattern
   - shaker_set_pieces_included
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -33502,8 +37307,11 @@
   - cleaning_instructions
   - color
   - finish
+  - height
+  - length
   - pattern
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -33521,11 +37329,15 @@
   - bowl_type
   - cleaning_instructions
   - color
+  - diameter
   - dinnerware_features
   - finish
+  - height
+  - length
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -33545,9 +37357,12 @@
   - dinnerware_pieces_included
   - finish
   - heating_instructions
+  - height
+  - length
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -33564,11 +37379,15 @@
   attributes:
   - cleaning_instructions
   - color
+  - diameter
   - finish
+  - height
+  - length
   - pattern
   - plate_style
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -33591,15 +37410,19 @@
   - hg-11-10-5-7
   - hg-11-10-5-8
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - drinkware_insulation
   - drinkware_material
   - drinkware_shape
   - handle_type
+  - height
+  - length
   - lid_type
   - pattern
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -33615,14 +37438,19 @@
   children: []
   attributes:
   - beer_glass_type
+  - capacity
   - cleaning_instructions
   - color
+  - diameter
   - drinkware_insulation
   - drinkware_material
   - drinkware_shape
   - handle_type
+  - height
+  - length
   - lid_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -33637,15 +37465,20 @@
   name: Coffee & Tea Cups
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
+  - diameter
   - drinkware_insulation
   - drinkware_material
   - drinkware_shape
   - handle_type
+  - height
   - insulation_type
+  - length
   - lid_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -33660,15 +37493,20 @@
   name: Coffee & Tea Saucers
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
+  - diameter
   - drinkware_material
   - drinkware_shape
   - handle_type
+  - height
+  - length
   - lid_type
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -33683,6 +37521,7 @@
   name: Drinkware Sets
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
   - drinkware_insulation
@@ -33690,9 +37529,12 @@
   - drinkware_pieces_included
   - drinkware_shape
   - handle_type
+  - height
+  - length
   - lid_type
   - pattern
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -33707,15 +37549,20 @@
   name: Mugs
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
+  - diameter
   - drinkware_insulation
   - drinkware_material
   - drinkware_shape
   - handle_type
+  - height
+  - length
   - lid_type
   - microwave_compatibility
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -33730,15 +37577,20 @@
   name: Shot Glasses
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
+  - diameter
   - drinkware_insulation
   - drinkware_material
   - drinkware_shape
   - finish
+  - height
+  - length
   - lid_type
   - pattern
   - shot_glass_style
+  - width
   return_reasons:
   - size
   - color
@@ -33758,14 +37610,19 @@
   - hg-11-10-5-7-4
   - hg-11-10-5-7-5
   attributes:
+  - capacity
   - cleaning_instructions
   - color
+  - diameter
   - drinkware_crystal_composition
   - drinkware_insulation
   - drinkware_material
   - drinkware_shape
+  - height
+  - length
   - lid_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -33930,14 +37787,19 @@
   name: Tumblers
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
+  - diameter
   - drinkware_insulation
   - drinkware_material
   - drinkware_shape
   - handle_type
+  - height
+  - length
   - lid_type
   - pattern
+  - width
   return_reasons:
   - size
   - style
@@ -33994,9 +37856,12 @@
   - flatware_material
   - flatware_pieces_included
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - tableware_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -34021,8 +37886,11 @@
   - flatware_material
   - flatware_pieces_included
   - handle_material
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -34044,8 +37912,11 @@
   - flatware_material
   - flatware_pieces_included
   - handle_material
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -34065,9 +37936,12 @@
   - finish
   - flatware_material
   - flatware_pieces_included
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -34089,8 +37963,11 @@
   - finish
   - flatware_material
   - flatware_pieces_included
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -34112,10 +37989,13 @@
   - flatware_material
   - flatware_pieces_included
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - tableware_material
   - usage_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -34139,10 +38019,13 @@
   - flatware_material
   - flatware_pieces_included
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - tableware_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -34175,9 +38058,12 @@
   - flatware_material
   - flatware_pieces_included
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - tableware_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -34388,9 +38274,12 @@
   - finish
   - flatware_material
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - tableware_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -34586,7 +38475,10 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -34658,11 +38550,14 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - lid_type
   - lumber/wood_type
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -34679,11 +38574,15 @@
   attributes:
   - cleaning_instructions
   - color
+  - diameter
   - edge_style
+  - height
+  - length
   - pattern
   - shape
   - tableware_material
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -34700,10 +38599,14 @@
   attributes:
   - cleaning_instructions
   - color
+  - diameter
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -34721,9 +38624,12 @@
   - cleaning_instructions
   - color
   - egg_cup_design
+  - height
+  - length
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -34742,10 +38648,13 @@
   - color
   - construction
   - handle_type
+  - height
   - jewelry_material
+  - length
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -34761,12 +38670,16 @@
   name: Punch Bowls
   children: []
   attributes:
+  - capacity
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - punch_bowl_components_included
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -34784,13 +38697,16 @@
   - cleaning_instructions
   - color
   - construction
+  - height
   - infuser_type
   - jewelry_material
+  - length
   - lid_type
   - pattern
   - pour_spout_design
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -34809,11 +38725,14 @@
   - cleaning_instructions
   - color
   - construction
+  - height
   - jewelry_material
+  - length
   - lumber/wood_type
   - pattern
   - shape
   - tableware_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -34831,12 +38750,16 @@
   attributes:
   - cleaning_instructions
   - color
+  - diameter
   - features
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - shape
   - tableware_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -34856,10 +38779,13 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - lid_type
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - color
   - style
@@ -34875,10 +38801,13 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - lid_type
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -34895,10 +38824,13 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - lid_type
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - color
   - style
@@ -34914,9 +38846,12 @@
   attributes:
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -34990,8 +38925,11 @@
   - cleaning_instructions
   - color
   - finish
+  - height
+  - length
   - pattern
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -35009,9 +38947,12 @@
   - cleaning_instructions
   - color
   - finish
+  - height
+  - length
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -35030,10 +38971,13 @@
   - color
   - finish
   - handle_material
+  - height
+  - length
   - lid_type
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -35051,9 +38995,12 @@
   - cleaning_instructions
   - color
   - finish
+  - height
+  - length
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -35107,9 +39054,12 @@
   - attachment_method
   - cleaning_instructions
   - color
+  - height
+  - length
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -35128,11 +39078,14 @@
   - cleaning_instructions
   - color
   - durability_features
+  - height
+  - length
   - material
   - pattern
   - shape
   - tablecloth_clip_design
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -35151,10 +39104,13 @@
   - attachment_type
   - cleaning_instructions
   - color
+  - height
+  - length
   - material
   - pattern
   - shape
   - tableware_material
+  - width
   return_reasons:
   - size
   - color
@@ -35173,10 +39129,13 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - shape
   - tableware_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -35301,6 +39260,7 @@
   - nutrient_content
   - ph_level
   - suitable_space
+  - volume
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -35315,10 +39275,13 @@
   - color
   - compost_aerator_design
   - handle_material
+  - height
+  - length
   - material
   - pattern
   - power_source
   - suitable_space
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -35331,12 +39294,16 @@
   name: Composters
   children: []
   attributes:
+  - capacity
   - color
   - durability_features
+  - height
+  - length
   - material
   - pattern
   - suitable_location
   - suitable_space
+  - width
   return_reasons:
   - size
   - capacity
@@ -35410,11 +39377,15 @@
   - hg-12-1-4-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - plant_container_size
   - saucer_functionality
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -35490,12 +39461,15 @@
   - hg-12-1-5-1-3
   attributes:
   - color
+  - height
   - height_adjustment
+  - length
   - material
   - outdoor_equipment_features
   - pattern
   - portability
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -35512,13 +39486,16 @@
   attributes:
   - color
   - features
+  - height
   - height_adjustment
+  - length
   - material
   - outdoor_equipment_features
   - pattern
   - portability
   - seat_cushioning
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -35535,7 +39512,9 @@
   attributes:
   - color
   - features
+  - height
   - height_adjustment
+  - length
   - material
   - outdoor_equipment_features
   - pattern
@@ -35543,6 +39522,7 @@
   - seat_type
   - suitable_space
   - wheel_type
+  - width
   return_reasons:
   - size
   - color
@@ -35558,13 +39538,16 @@
   children: []
   attributes:
   - color
+  - height
   - height_adjustment
+  - length
   - material
   - outdoor_equipment_features
   - pattern
   - portability
   - seat_cushioning
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -35584,13 +39567,17 @@
   - bag/case_storage_features
   - bag_closure
   - bag_strap_type
+  - capacity
   - color
   - handle_material
+  - height
+  - length
   - material
   - outdoor_equipment_features
   - pattern
   - suitable_space
   - tote_handle_type
+  - width
   return_reasons:
   - size
   - color
@@ -35609,10 +39596,14 @@
   - durability_features
   - finish
   - furniture/fixture_features
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - outdoor_equipment_features
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -35656,9 +39647,12 @@
   - compatible_gardening_tool
   - handle_material
   - handle_type
+  - height
+  - length
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -35675,9 +39669,12 @@
   - attachment_type
   - color
   - compatible_gardening_tool
+  - height
+  - length
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -35699,9 +39696,12 @@
   - attachment_method
   - color
   - compatible_gardening_tool
+  - height
+  - length
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -35718,9 +39718,12 @@
   - color
   - compatible_gardening_tool
   - handle_grip_texture
+  - height
+  - length
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -35736,12 +39739,16 @@
   - attachment_method
   - color
   - compatible_gardening_tool
+  - height
+  - length
   - material
   - pattern
   - suitable_space
+  - tire_size
   - tire_tread_pattern
   - valve_type
   - wheel_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -35758,9 +39765,12 @@
   - color
   - compatible_gardening_tool
   - finish
+  - height
+  - length
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -35776,10 +39786,13 @@
   - attachment_method
   - color
   - compatible_gardening_tool
+  - height
+  - length
   - material
   - pattern
   - suitable_space
   - valve_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -35795,10 +39808,13 @@
   - attachment_method
   - color
   - compatible_gardening_tool
+  - height
+  - length
   - material
   - pattern
   - suitable_space
   - wheel_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -35888,9 +39904,12 @@
   - handle_material
   - handle_pattern
   - handle_type
+  - height
+  - length
   - suitable_space
   - tool/utensil_material
   - tool_operation
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -35909,10 +39928,13 @@
   - handle_material
   - handle_pattern
   - handle_type
+  - height
+  - length
   - suitable_space
   - tip_style
   - tool/utensil_material
   - tool_operation
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -35932,9 +39954,12 @@
   - handle_material
   - handle_pattern
   - handle_type
+  - height
+  - length
   - suitable_space
   - tool/utensil_material
   - tool_operation
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -35991,9 +40016,12 @@
   - color
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
   - suitable_space
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36012,8 +40040,11 @@
   - handle_material
   - handle_pattern
   - handle_type
+  - height
+  - length
   - suitable_space
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36031,8 +40062,11 @@
   - handle_material
   - handle_pattern
   - handle_type
+  - height
+  - length
   - suitable_space
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36048,12 +40082,17 @@
   - gardening_fork_type
   - handle_color
   - handle_grip_style
+  - handle_length
   - handle_material
   - handle_pattern
   - handle_type
+  - height
+  - length
   - suitable_space
+  - teeth_length
   - teeth_material
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36074,9 +40113,12 @@
   - edge_type
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
   - suitable_space
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36096,10 +40138,13 @@
   - handle_material
   - handle_pattern
   - handle_type
+  - height
+  - length
   - machete_blade_style
   - suitable_space
   - tang_type
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36119,8 +40164,11 @@
   - handle_material
   - handle_pattern
   - handle_type
+  - height
+  - length
   - suitable_space
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36156,8 +40204,11 @@
   - handle_material
   - handle_pattern
   - handle_type
+  - height
+  - length
   - suitable_space
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36172,14 +40223,18 @@
   attributes:
   - battery_size
   - battery_type
+  - capacity
   - color
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
   - power_source
   - sprinkler_head_type
   - suitable_space
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - capacity
@@ -36199,9 +40254,14 @@
   - color
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
+  - roll_diameter
+  - roll_width
   - suitable_space
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36218,9 +40278,14 @@
   - color
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
+  - roll_diameter
+  - roll_width
   - suitable_space
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36237,9 +40302,14 @@
   - color
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
+  - roll_diameter
+  - roll_width
   - suitable_space
   - tool/utensil_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -36259,8 +40329,11 @@
   - handle_material
   - handle_pattern
   - handle_type
+  - height
+  - length
   - suitable_space
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36282,10 +40355,13 @@
   - handle_material
   - handle_pattern
   - handle_type
+  - height
+  - length
   - locking_mechanism
   - spring_type
   - suitable_space
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36299,12 +40375,16 @@
   children: []
   attributes:
   - handle_color
+  - handle_length
   - handle_material
   - handle_pattern
   - handle_type
+  - height
+  - length
   - suitable_space
   - teeth_material
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36323,11 +40403,14 @@
   - color
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
   - shovel_handle_grip_type
   - shovel_head_type
   - suitable_space
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36346,10 +40429,13 @@
   - handle_material
   - handle_pattern
   - handle_type
+  - height
+  - length
   - shovel_handle_grip_type
   - shovel_head_type
   - suitable_space
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36367,10 +40453,13 @@
   - handle_material
   - handle_pattern
   - handle_type
+  - height
+  - length
   - shovel_handle_grip_type
   - shovel_head_type
   - suitable_space
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36389,16 +40478,20 @@
   attributes:
   - battery_size
   - battery_type
+  - capacity
   - color
   - handle_material
   - handle_type
+  - height
   - lawn_spreader_type
+  - length
   - pattern
   - power_source
   - suitable_space
   - suitable_spread_material
   - tank_material
   - tool/utensil_material
+  - width
   return_reasons:
   - size
   - capacity
@@ -36488,14 +40581,18 @@
   name: Wheelbarrows
   children: []
   attributes:
+  - capacity
   - color
   - handle_material
   - handle_type
+  - height
+  - length
   - pattern
   - rib_material
   - suitable_space
   - tool/utensil_material
   - wheel_type
+  - width
   return_reasons:
   - size
   - capacity
@@ -36532,8 +40629,11 @@
   - frame_material
   - frame_pattern
   - glazing_type
+  - height
+  - length
   - screen_material
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -36613,6 +40713,7 @@
   - product_certifications_standards
   - suitable_space
   - targeted_pests
+  - volume
   return_reasons:
   - size
   - changed_my_mind
@@ -36627,9 +40728,12 @@
   attributes:
   - color
   - fabric_structure
+  - height
+  - length
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -36667,12 +40771,15 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - pattern
   - staple/pin_shape
   - staple_coating
   - staple_wire_gauge
   - suitable_space
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36688,6 +40795,8 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - material
   - pattern
   - pin_shape
@@ -36695,6 +40804,7 @@
   - staple_coating
   - staple_wire_gauge
   - suitable_space
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36710,6 +40820,8 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - material
   - pattern
   - shape
@@ -36717,6 +40829,7 @@
   - staple_coating
   - staple_wire_gauge
   - suitable_space
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -36732,10 +40845,12 @@
   - adhesive_type
   - color
   - durability_features
+  - length
   - material
   - pattern
   - suitable_space
   - tape_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -36756,6 +40871,7 @@
   - package_type
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - size
   - color
@@ -36775,6 +40891,7 @@
   - package_type
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - color
   - changed_my_mind
@@ -36796,6 +40913,7 @@
   - plant_name
   - suitable_space
   - sunlight
+  - volume
   return_reasons:
   - color
   - changed_my_mind
@@ -36814,6 +40932,7 @@
   - package_type
   - pattern
   - suitable_space
+  - volume
   return_reasons:
   - color
   - changed_my_mind
@@ -36831,11 +40950,14 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - material
   - pattern
   - plant_support_material
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -36854,12 +40976,15 @@
   - durability_features
   - features
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - plant_support_material
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -36881,6 +41006,8 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - lumber/wood_type
   - material
   - mounting_type
@@ -36888,6 +41015,7 @@
   - plant_support_material
   - shape
   - suitable_space
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -36980,11 +41108,14 @@
   attributes:
   - color
   - furniture/fixture_features
+  - height
+  - length
   - lumber/wood_type
   - material
   - mounting_type
   - pattern
   - suitable_space
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -37001,12 +41132,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - plant_support_material
   - shape
   - suitable_space
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -37025,13 +41159,17 @@
   - hg-12-1-16-2
   attributes:
   - color
+  - height
+  - length
   - lumber/wood_type
   - material
   - mounting_type
   - pattern
+  - plant_container_size
   - plant_support_material
   - shape
   - suitable_space
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -37049,13 +41187,17 @@
   attributes:
   - canopy_shape
   - color
+  - height
+  - length
   - lumber/wood_type
   - material
   - mounting_type
   - pattern
+  - plant_container_size
   - plant_support_material
   - shape
   - suitable_space
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -37072,12 +41214,16 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mounting_type
   - pattern
+  - plant_container_size
   - plant_support_material
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -37092,13 +41238,17 @@
   name: Rain Barrels
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - rain_barrel_design
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -37127,6 +41277,7 @@
   - plant_material
   - product_certifications_standards
   - suitable_space
+  - volume
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -37149,6 +41300,7 @@
   - product_certifications_standards
   - sand_type
   - suitable_space
+  - volume
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -37171,6 +41323,7 @@
   - product_certifications_standards
   - soil_texture
   - suitable_space
+  - volume
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -37993,10 +42146,13 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_hardware
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -38015,11 +42171,14 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - material
   - mounting_hardware
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -38037,9 +42196,12 @@
   - color
   - compatible_awning_rail_type
   - durability_features
+  - height
+  - length
   - material
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -38056,10 +42218,13 @@
   - attachment_method
   - color
   - durability_features
+  - height
+  - length
   - material
   - mesh_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -38077,9 +42242,12 @@
   - color
   - durability_features
   - hardware_material
+  - height
+  - length
   - mounting_hardware
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -38096,11 +42264,14 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_hardware
   - outdoor_equipment_features
   - pattern
   - strap_end_fitting_type
+  - width
   return_reasons:
   - size
   - color
@@ -38119,8 +42290,11 @@
   - durability_features
   - hardware_finish
   - hardware_material
+  - height
+  - length
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -38138,10 +42312,13 @@
   - color
   - cover_material
   - durability_features
+  - height
+  - length
   - mounting_hardware
   - outdoor_equipment_features
   - pattern
   - upf_rating
+  - width
   return_reasons:
   - size
   - color
@@ -38160,9 +42337,12 @@
   - awning_construction_type
   - color
   - durability_features
+  - height
+  - length
   - material
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -38182,8 +42362,11 @@
   - bag_closure
   - color
   - durability_features
+  - height
+  - length
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -38201,12 +42384,15 @@
   - color
   - durability_features
   - finish
+  - height
   - height_adjustment
+  - length
   - material
   - mounting_hardware
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -38261,8 +42447,11 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - mounting_type
   - outdoor_equipment_features
+  - width
   return_reasons:
   - size
   - color
@@ -38281,10 +42470,13 @@
   attributes:
   - color
   - compatible_hammock_design
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -38307,9 +42499,12 @@
   - attachment_type
   - color
   - compatible_hammock_design
+  - height
+  - length
   - material
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -38399,10 +42594,13 @@
   attributes:
   - color
   - compatible_hammock_design
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -38469,9 +42667,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -38495,10 +42697,13 @@
   - color
   - durability_features
   - filler_material
+  - height
+  - length
   - material
   - outdoor_equipment_features
   - pattern
   - season
+  - width
   return_reasons:
   - size
   - color
@@ -38517,11 +42722,14 @@
   - color
   - durability_features
   - filler_material
+  - height
+  - length
   - material
   - outdoor_equipment_features
   - pattern
   - season
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -38541,10 +42749,13 @@
   - color
   - durability_features
   - filler_material
+  - height
+  - length
   - material
   - outdoor_equipment_features
   - pattern
   - season
+  - width
   return_reasons:
   - size
   - color
@@ -38563,10 +42774,13 @@
   - color
   - durability_features
   - filler_material
+  - height
+  - length
   - material
   - outdoor_equipment_features
   - pattern
   - season
+  - width
   return_reasons:
   - size
   - color
@@ -38630,12 +42844,15 @@
   attributes:
   - canopy_material
   - color
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
   - rib_material
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -38652,6 +42869,8 @@
   attributes:
   - canopy_material
   - color
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
@@ -38659,6 +42878,7 @@
   - rib_material
   - shape
   - upf_rating
+  - width
   return_reasons:
   - size
   - color
@@ -38677,12 +42897,15 @@
   - color
   - durability_features
   - gazebo_roof_material
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
   - rib_material
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -38706,11 +42929,14 @@
   - hg-12-2-6-2-8
   attributes:
   - color
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -38727,11 +42953,14 @@
   attributes:
   - attachment_method
   - color
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -38747,12 +42976,15 @@
   children: []
   attributes:
   - color
+  - height
   - height_adjustment
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
   - shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -38767,12 +42999,15 @@
   attributes:
   - attachment_type
   - color
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
   - shape
   - upf_rating
+  - width
   return_reasons:
   - size
   - color
@@ -38790,11 +43025,14 @@
   - color
   - hardware_finish
   - hardware_material
+  - height
   - height_adjustment
+  - length
   - outdoor_equipment_features
   - pattern
   - pole/post_material
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -38812,9 +43050,12 @@
   - attachment_method
   - ballast_material
   - color
+  - height
+  - length
   - outdoor_equipment_features
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - incompatible
@@ -38890,10 +43131,13 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - style
+  - width
   return_reasons:
   - size
   - color
@@ -38912,10 +43156,13 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - style
+  - width
   return_reasons:
   - size
   - color
@@ -38933,10 +43180,13 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - style
+  - width
   return_reasons:
   - size
   - color
@@ -38955,12 +43205,15 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - roof_style
   - shape
   - style
+  - width
   return_reasons:
   - size
   - color
@@ -38978,11 +43231,14 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - shape
   - style
+  - width
   return_reasons:
   - size
   - color
@@ -39000,10 +43256,13 @@
   - bridge_railing_style
   - color
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -39023,12 +43282,15 @@
   attributes:
   - color
   - door_type
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
   - roof_style
   - shingle/tile_material
+  - width
   return_reasons:
   - size
   - color
@@ -39045,12 +43307,15 @@
   attributes:
   - color
   - door_type
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
   - roof_style
   - shingle/tile_material
+  - width
   return_reasons:
   - size
   - color
@@ -39067,12 +43332,15 @@
   attributes:
   - color
   - door_type
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
   - roof_style
   - shingle/tile_material
+  - width
   return_reasons:
   - size
   - color
@@ -39089,12 +43357,15 @@
   attributes:
   - color
   - door_type
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
   - roof_style
   - shingle/tile_material
+  - width
   return_reasons:
   - size
   - color
@@ -39116,10 +43387,13 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - outdoor_equipment_features
   - pattern
   - upf_rating
+  - width
   return_reasons:
   - size
   - color
@@ -39139,10 +43413,13 @@
   - color
   - durability_features
   - fabric
+  - height
+  - length
   - outdoor_equipment_features
   - pattern
   - shape
   - upf_rating
+  - width
   return_reasons:
   - size
   - color
@@ -39159,13 +43436,17 @@
   children: []
   attributes:
   - color
+  - diameter
   - durability_features
+  - height
+  - length
   - material
   - outdoor_equipment_features
   - pattern
   - shape
   - umbrella_base_type
   - upf_rating
+  - width
   return_reasons:
   - size
   - incompatible
@@ -39184,10 +43465,13 @@
   - compatible_umbrella_type
   - cover_features
   - cover_material
+  - height
+  - length
   - outdoor_equipment_features
   - pattern
   - shape
   - upf_rating
+  - width
   return_reasons:
   - size
   - color
@@ -39205,12 +43489,15 @@
   - closure_type
   - color
   - durability_features
+  - height
+  - length
   - material
   - mesh_type
   - outdoor_equipment_features
   - pattern
   - shape
   - upf_rating
+  - width
   return_reasons:
   - size
   - incompatible
@@ -39227,7 +43514,9 @@
   - brightness_levels
   - color
   - durability_features
+  - height
   - ingress_protection_ip_rating
+  - length
   - light_color
   - light_pattern
   - light_source
@@ -39238,6 +43527,7 @@
   - outdoor_equipment_features
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -39259,6 +43549,9 @@
   - canopy_material
   - canopy_venting
   - color
+  - diameter
+  - height
+  - length
   - material
   - outdoor_equipment_features
   - pattern
@@ -39267,6 +43560,7 @@
   - tilt_mechanism
   - umbrella_opening_mechanism
   - upf_rating
+  - width
   return_reasons:
   - size
   - color
@@ -39288,6 +43582,9 @@
   attributes:
   - canopy_material
   - color
+  - diameter
+  - height
+  - length
   - material
   - outdoor_equipment_features
   - pattern
@@ -39296,6 +43593,7 @@
   - tilt_mechanism
   - umbrella_opening_mechanism
   - upf_rating
+  - width
   return_reasons:
   - size
   - color
@@ -39400,6 +43698,9 @@
   attributes:
   - canopy_material
   - color
+  - diameter
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
@@ -39409,6 +43710,7 @@
   - shape
   - umbrella_opening_mechanism
   - upf_rating
+  - width
   return_reasons:
   - size
   - color
@@ -39449,10 +43751,13 @@
   - hg-12-2-9-6
   attributes:
   - color
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -39471,10 +43776,13 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -39491,10 +43799,13 @@
   attributes:
   - color
   - cover_features
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -39513,9 +43824,12 @@
   - color
   - cover_material
   - filler_material
+  - height
+  - length
   - outdoor_equipment_features
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -39532,10 +43846,13 @@
   attributes:
   - color
   - hardware_finish
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -39552,10 +43869,13 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - material
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -39588,11 +43908,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lumber/wood_type
   - material
+  - maximum_load_capacity
   - mounting_type
   - outdoor_equipment_features
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -39628,6 +43952,7 @@
   - color
   - engine_design
   - pattern
+  - power_consumption_typical
   - power_source
   - start_type
   return_reasons:
@@ -39647,11 +43972,17 @@
   attributes:
   - battery_size
   - battery_type
+  - blade_size
   - color
   - engine_design
+  - height
+  - idle_speed
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - start_type
+  - width
   return_reasons:
   - size
   - horsepower
@@ -39669,9 +44000,13 @@
   attributes:
   - color
   - engine_design
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - start_type
+  - width
   return_reasons:
   - size
   - horsepower
@@ -39689,11 +44024,16 @@
   attributes:
   - battery_size
   - battery_type
+  - blade_size
   - color
   - engine_design
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - start_type
+  - width
   return_reasons:
   - size
   - horsepower
@@ -39714,9 +44054,13 @@
   - color
   - engine_design
   - engine_type
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - start_type
+  - width
   return_reasons:
   - size
   - horsepower
@@ -39735,10 +44079,14 @@
   - color
   - engine_design
   - engine_type
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - rib_material
   - start_type
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -39755,11 +44103,15 @@
   - color
   - engine_design
   - engine_type
+  - height
   - lawn_aerator_type
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
   - start_type
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -39781,10 +44133,14 @@
   - color
   - engine_design
   - grass_discharge_type
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - propulsion_type
   - start_type
+  - width
   return_reasons:
   - size
   - horsepower
@@ -39806,12 +44162,16 @@
   - engine_design
   - fuel_supply
   - grass_discharge_type
+  - height
+  - length
   - mower_deck_material
   - pattern
+  - power_consumption_typical
   - power_source
   - propulsion_type
   - start_type
   - transmission_type
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -39875,10 +44235,14 @@
   - connectivity_technology
   - engine_design
   - grass_discharge_type
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - propulsion_type
   - start_type
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -39895,10 +44259,14 @@
   - color
   - engine_design
   - grass_discharge_type
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - propulsion_type
   - start_type
+  - width
   return_reasons:
   - operating_noise
   - incompatible
@@ -39917,10 +44285,14 @@
   - color
   - engine_design
   - grass_discharge_type
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - propulsion_type
   - start_type
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -39954,9 +44326,13 @@
   attributes:
   - color
   - engine_design
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - start_type
+  - width
   return_reasons:
   - size
   - horsepower
@@ -39976,9 +44352,13 @@
   - color
   - compatible_leaf_blower_style
   - engine_design
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - start_type
+  - width
   return_reasons:
   - size
   - horsepower
@@ -39996,10 +44376,14 @@
   - color
   - engine_design
   - engine_type
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - start_type
   - suitable_for_power_equipment_type
+  - width
   return_reasons:
   - size
   - horsepower
@@ -40018,10 +44402,14 @@
   - battery_technology
   - color
   - engine_design
+  - height
+  - length
   - outdoor_power_accessories_included
   - pattern
+  - power_consumption_typical
   - power_source
   - start_type
+  - width
   return_reasons:
   - size
   - horsepower
@@ -40041,10 +44429,14 @@
   - bristle_material
   - color
   - engine_design
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - propulsion_type
   - start_type
+  - width
   return_reasons:
   - size
   - horsepower
@@ -40063,11 +44455,15 @@
   attributes:
   - color
   - engine_design
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
   - start_type
   - tine_position
+  - width
   return_reasons:
   - size
   - horsepower
@@ -40087,10 +44483,14 @@
   - cultivator_type
   - engine_design
   - fuel_supply
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - start_type
   - tine_position
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -40106,11 +44506,15 @@
   attributes:
   - color
   - engine_design
+  - height
+  - length
   - material
   - pattern
+  - power_consumption_typical
   - power_source
   - start_type
   - tine_position
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -40128,10 +44532,17 @@
   - battery_type
   - color
   - engine_design
+  - height
+  - hose_length
+  - length
+  - maximum_flow_rate
+  - maximum_operating_pressure
   - pattern
+  - power_consumption_typical
   - power_source
   - pump_type
   - start_type
+  - width
   return_reasons:
   - horsepower
   - operating_noise
@@ -40148,11 +44559,15 @@
   - color
   - drive_type
   - engine_design
+  - height
+  - length
   - pattern
+  - power_consumption_typical
   - power_source
   - rib_material
   - snow_blower_stage_type
   - start_type
+  - width
   return_reasons:
   - size
   - horsepower
@@ -40174,11 +44589,19 @@
   - drive_type
   - engine_design
   - engine_type
+  - height
+  - length
+  - maximum_cutting_height
+  - minimum_cutting_height
   - pattern
+  - power
+  - power_consumption_typical
   - power_source
   - start_type
   - tractor_accessories_included
   - transmission_type
+  - voltage
+  - width
   return_reasons:
   - size
   - horsepower
@@ -40270,10 +44693,16 @@
   - battery_type
   - color
   - engine_design
+  - head_diameter
+  - height
+  - length
   - pattern
+  - pole_length
+  - power_consumption_typical
   - power_source
   - start_type
   - trimmer_line_feed_system
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -40348,10 +44777,13 @@
   attributes:
   - chainsaw_bar_mount_type
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_power_equipment_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -40365,14 +44797,18 @@
   name: Chainsaw Bars
   children: []
   attributes:
+  - blade_size
   - chainsaw_bar_mount_type
   - chainsaw_bar_nose_type
   - chainsaw_bar_type
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_power_equipment_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40387,11 +44823,17 @@
   attributes:
   - chainsaw_bar_mount_type
   - chainsaw_cutter_type
+  - chainsaw_gauge
+  - chainsaw_pitch
   - color
+  - compatible_bar_size
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_power_equipment_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40443,10 +44885,13 @@
   - hg-12-4-2-5
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_power_equipment_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -40462,10 +44907,13 @@
   attributes:
   - belt_profile
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_power_equipment_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40480,10 +44928,13 @@
   attributes:
   - blade_material
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_power_equipment_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40498,10 +44949,13 @@
   attributes:
   - attachment_method
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_power_equipment_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40515,11 +44969,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - spring_type
   - suitable_for_power_equipment_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40533,11 +44990,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_power_equipment_type
   - wheel_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40557,10 +45017,13 @@
   attributes:
   - blade_material
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_power_equipment_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -40577,10 +45040,13 @@
   - blade_material
   - color
   - edge_type
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_power_equipment_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40596,10 +45062,13 @@
   - attachment_type
   - blade_material
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_power_equipment_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40699,10 +45168,13 @@
   - hg-12-4-4-1-5
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - power_equipment_hitch_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40717,9 +45189,12 @@
   attributes:
   - blade_material
   - color
+  - height
   - lawn_mower_blade_type
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40733,9 +45208,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40749,11 +45227,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - mounting_bolt_pattern
   - pattern
   - thread_direction
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40783,9 +45264,12 @@
   attributes:
   - bag_configuration
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40799,10 +45283,13 @@
   children: []
   attributes:
   - color
+  - height
   - lawn_mower_belt_type
+  - length
   - manufacturer_type
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40818,9 +45305,12 @@
   - blade_material
   - center_hole_shape
   - color
+  - height
   - lawn_mower_blade_type
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40836,10 +45326,13 @@
   - closure_type
   - color
   - durability_features
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - propulsion_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -40853,9 +45346,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40871,9 +45367,12 @@
   - hg-12-4-4-7-2
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40887,10 +45386,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_power_equipment_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40904,10 +45406,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - plate_purpose
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40923,10 +45428,13 @@
   - hg-12-4-4-8-2
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - wheel_bearing_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40940,11 +45448,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - pulley_groove_profile
   - wheel_bearing_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40959,10 +45470,13 @@
   attributes:
   - bore_type
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - wheel_bearing_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40976,11 +45490,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - valve_stem_angle
   - valve_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -40994,11 +45511,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - tire_construction_type
   - tire_tread_pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41012,10 +45532,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - wheel_tread_style
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41030,10 +45553,13 @@
   attributes:
   - color
   - compatible_lawn_mower_type
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - roller_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41047,10 +45573,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - propulsion_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41100,9 +45629,12 @@
   attributes:
   - color
   - compatible_leaf_blower_style
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -41119,10 +45651,14 @@
   - attachment_type
   - color
   - compatible_leaf_blower_style
+  - diameter
+  - height
+  - length
   - manufacturer_type
   - material
   - nozzle_style
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41191,10 +45727,13 @@
   - hg-12-4-6-8
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_power_equipment_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -41211,9 +45750,12 @@
   - attachment_type
   - blade_material
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41227,9 +45769,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41245,9 +45790,12 @@
   - angles_supported
   - blade_type
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41261,9 +45809,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41277,10 +45828,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_power_equipment_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41295,10 +45849,13 @@
   attributes:
   - color
   - cutting_head_type
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - trimmer_line_feed_system
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41343,10 +45900,14 @@
   - battery_features
   - battery_technology
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
+  - power_consumption_typical
   - suitable_for_power_equipment_type
+  - width
   return_reasons:
   - size
   - capacity
@@ -41379,10 +45940,13 @@
   attributes:
   - color
   - connecting_thread
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - pressure_washer_spray_pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41399,9 +45963,12 @@
   - cleaning_surfaces
   - color
   - fragrance
+  - height
+  - length
   - manufacturer_type
   - ph_level
   - product_certifications_standards
+  - width
   return_reasons:
   - scent
   - changed_my_mind
@@ -41416,9 +45983,12 @@
   attributes:
   - color
   - connecting_thread
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41435,10 +46005,13 @@
   - chemical_product_form
   - color
   - connecting_thread
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - pressure_washer_spray_pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -41452,11 +46025,14 @@
   attributes:
   - color
   - connecting_thread
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - pressure_washer_outlet_connector_type
   - pressure_washer_spray_pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41471,10 +46047,13 @@
   attributes:
   - color
   - connecting_thread
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - pressure_washer_outlet_connector_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41490,10 +46069,13 @@
   - bristle_material
   - color
   - connecting_thread
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - scrubber_head_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41508,10 +46090,13 @@
   attributes:
   - color
   - connecting_thread
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - pressure_washer_outlet_connector_type
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -41525,9 +46110,12 @@
   attributes:
   - color
   - connecting_thread
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41542,9 +46130,12 @@
   attributes:
   - color
   - connecting_thread
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41560,9 +46151,12 @@
   - closure_type
   - color
   - connecting_thread
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41577,10 +46171,13 @@
   attributes:
   - color
   - connecting_thread
+  - height
   - hose_material
+  - length
   - manufacturer_type
   - material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41595,10 +46192,13 @@
   attributes:
   - color
   - connecting_thread
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - pressure_washer_spray_pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41614,9 +46214,12 @@
   - abrasive_material
   - color
   - connecting_thread
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -41683,10 +46286,13 @@
   - hg-12-4-9-8
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - snow_blower_stage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -41703,10 +46309,13 @@
   - closure_type
   - color
   - cover_features
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - snow_blower_stage_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -41860,13 +46469,17 @@
   attributes:
   - color
   - compatible_tractor_type
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_vehicle_type
   - tire_construction_type
+  - tire_size
   - tractor_tire_application
   - tractor_tire_tread_classification
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41881,14 +46494,18 @@
   attributes:
   - color
   - compatible_tractor_type
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_vehicle_type
   - tire_construction
   - tire_construction_type
+  - tire_size
   - tire_tread_pattern
   - tractor_tire_tread_classification
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41903,13 +46520,17 @@
   attributes:
   - color
   - compatible_tractor_type
+  - height
   - lawn_tractor_tread_type
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_vehicle_type
   - tire_construction_type
+  - tire_size
   - tractor_tire_tread_classification
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41924,13 +46545,17 @@
   attributes:
   - color
   - compatible_tractor_type
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - suitable_for_vehicle_type
   - tire_construction_type
+  - tire_size
   - tire_tread_pattern
   - tractor_tire_tread_classification
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -41945,11 +46570,15 @@
   attributes:
   - color
   - compatible_tractor_type
+  - diameter
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - rim/wheel_design
   - suitable_for_vehicle_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -42075,10 +46704,13 @@
   - hg-12-4-11-1-3
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - trimmer_line_shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -42093,10 +46725,13 @@
   attributes:
   - blade_material
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - trimmer_line_shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -42110,10 +46745,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - trimmer_line_shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -42144,11 +46782,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - manufacturer_type
   - material
   - pattern
   - trimmer_line_feed_system
   - trimmer_line_shape
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -42324,8 +46965,11 @@
   - color
   - handle_material
   - handle_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -42343,8 +46987,11 @@
   - color
   - handle_material
   - handle_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -42362,8 +47009,11 @@
   - color
   - handle_material
   - handle_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -42382,6 +47032,9 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - weight
@@ -42445,9 +47098,12 @@
   - color
   - connecting_thread
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - incompatible
@@ -42465,9 +47121,12 @@
   - connecting_thread
   - connector_gender
   - garden_hose_fitting_type
+  - height
+  - length
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -42483,10 +47142,13 @@
   - color
   - connecting_thread
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - suitable_space
   - valve_configuration
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -42533,11 +47195,15 @@
   attributes:
   - color
   - connecting_thread
+  - diameter
+  - height
+  - length
   - material
   - pattern
   - sprinkler_head_type
   - suitable_space
   - trigger_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -42553,10 +47219,15 @@
   attributes:
   - color
   - garden_hose_design
+  - height
+  - hose_diameter
+  - hose_length
   - hose_material
+  - length
   - nozzle_material
   - pattern
   - suitable_installation
+  - width
   return_reasons:
   - size
   - incompatible
@@ -42575,10 +47246,13 @@
   attributes:
   - color
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - suitable_space
   - thread_standard
+  - width
   return_reasons:
   - size
   - incompatible
@@ -42596,13 +47270,16 @@
   - connectivity_technology
   - connector_gender
   - control_type
+  - height
   - ingress_protection_ip_rating
+  - length
   - material
   - mounting_type
   - pattern
   - power_source
   - suitable_space
   - thread_standard
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -42617,11 +47294,14 @@
   attributes:
   - color
   - connector_gender
+  - height
+  - length
   - material
   - pattern
   - sprinkler_valve_type
   - suitable_space
   - thread_standard
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -42654,10 +47334,13 @@
   attributes:
   - color
   - connecting_thread
+  - height
+  - length
   - material
   - pattern
   - sprinkler_type
   - suitable_space
+  - width
   return_reasons:
   - size
   - incompatible
@@ -42673,10 +47356,13 @@
   attributes:
   - color
   - connecting_thread
+  - height
+  - length
   - material
   - pattern
   - sprinkler_head_type
   - suitable_space
+  - width
   return_reasons:
   - size
   - incompatible
@@ -42692,11 +47378,14 @@
   attributes:
   - color
   - connecting_thread
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - sprinkler_type
   - suitable_space
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -42714,10 +47403,13 @@
   - attachment_type
   - color
   - connecting_thread
+  - height
+  - length
   - material
   - pattern
   - sprinkler_head_type
   - suitable_space
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -42733,10 +47425,13 @@
   - attachment_type
   - color
   - connecting_thread
+  - height
+  - length
   - material
   - pattern
   - sprinkler_head_type
   - suitable_space
+  - width
   return_reasons:
   - size
   - incompatible
@@ -42753,10 +47448,13 @@
   - attachment_type
   - color
   - connecting_thread
+  - height
+  - length
   - material
   - pattern
   - sprinkler_head_type
   - suitable_space
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -42769,14 +47467,18 @@
   name: Watering Cans
   children: []
   attributes:
+  - capacity
   - color
   - handle_material
   - handle_position
+  - height
+  - length
   - material
   - pattern
   - rose_attachment
   - sprinkler_head_type
   - suitable_space
+  - width
   return_reasons:
   - color
   - capacity
@@ -42793,9 +47495,12 @@
   - hg-12-6-8-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -42809,9 +47514,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - color
   - capacity
@@ -42827,10 +47535,13 @@
   attributes:
   - color
   - flow_control_type
+  - height
+  - length
   - material
   - nozzle_adjustability
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -42924,12 +47635,14 @@
   - hg-13-12
   - hg-13-13
   attributes:
+  - bulb_power
   - bulb_size
   - color
   - energy_efficiency_class
   - light_color
   - light_pattern
   - light_temperature
+  - luminous_flux
   - material
   - mounting_type
   - pattern
@@ -42949,20 +47662,25 @@
   - hg-13-1-1
   - hg-13-1-2
   attributes:
+  - bulb_power
   - bulb_size
   - bulb_type
   - color
   - emergency_lighting_operating_mode
   - energy_efficiency_class
+  - height
   - ingress_protection_ip_rating
+  - length
   - light_color
   - light_pattern
   - light_temperature
+  - luminous_flux
   - material
   - mounting_type
   - pattern
   - power_source
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - brightness
@@ -43021,16 +47739,21 @@
   name: Floating & Submersible Lights
   children: []
   attributes:
+  - bulb_power
   - bulb_size
   - bulb_type
   - color
   - energy_efficiency_class
+  - height
   - ingress_protection_ip_rating
+  - length
   - light_color
   - light_pattern
   - light_temperature
+  - luminous_flux
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -43046,19 +47769,24 @@
   name: Flood & Spot Lights
   children: []
   attributes:
+  - bulb_power
   - bulb_size
   - bulb_type
   - color
   - energy_efficiency_class
+  - height
   - ingress_protection_ip_rating
+  - length
   - light_color
   - light_pattern
   - light_temperature
   - lighting_features
+  - luminous_flux
   - motion_sensor_type
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - brightness
@@ -43072,19 +47800,24 @@
   name: In-Ground Lights
   children: []
   attributes:
+  - bulb_power
   - bulb_size
   - bulb_type
   - color
   - energy_efficiency_class
+  - height
   - ingress_protection_ip_rating
+  - length
   - light_color
   - light_pattern
   - light_temperature
   - lighting_features
+  - luminous_flux
   - material
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - style
@@ -43106,20 +47839,25 @@
   - hg-13-5-5
   attributes:
   - bulb_cap_type
+  - bulb_power
   - bulb_size
   - bulb_type
   - color
   - energy_efficiency_class
   - furniture/fixture_material
   - glazing_material
+  - height
+  - length
   - light_color
   - light_pattern
   - light_temperature
   - lighting_features
+  - luminous_flux
   - mounting_type
   - pattern
   - power_source
   - switch_control_type
+  - width
   return_reasons:
   - size
   - color
@@ -43137,20 +47875,25 @@
   - battery_size
   - battery_type
   - bulb_cap_type
+  - bulb_power
   - bulb_size
   - bulb_type
   - color
   - energy_efficiency_class
   - furniture/fixture_material
   - glazing_material
+  - height
+  - length
   - light_color
   - light_pattern
   - light_temperature
   - lighting_features
+  - luminous_flux
   - material
   - pattern
   - power_source
   - switch_control_type
+  - width
   return_reasons:
   - size
   - color
@@ -43168,21 +47911,26 @@
   - battery_size
   - battery_type
   - bulb_cap_type
+  - bulb_power
   - bulb_size
   - bulb_type
   - color
   - energy_efficiency_class
   - furniture/fixture_material
   - glazing_material
+  - height
+  - length
   - light_color
   - light_pattern
   - light_temperature
   - lighting_features
+  - luminous_flux
   - material
   - mounting_type
   - pattern
   - power_source
   - switch_control_type
+  - width
   return_reasons:
   - size
   - color
@@ -43200,22 +47948,27 @@
   - battery_size
   - battery_type
   - bulb_cap_type
+  - bulb_power
   - bulb_size
   - bulb_type
   - color
   - energy_efficiency_class
   - furniture/fixture_material
   - glazing_material
+  - height
   - height_adjustment
+  - length
   - light_color
   - light_pattern
   - light_temperature
   - lighting_features
+  - luminous_flux
   - material
   - pattern
   - power_source
   - style
   - switch_control_type
+  - width
   return_reasons:
   - size
   - color
@@ -43234,21 +47987,26 @@
   - battery_type
   - brightness_levels
   - bulb_cap_type
+  - bulb_power
   - bulb_size
   - bulb_type
   - color
   - energy_efficiency_class
   - furniture/fixture_material
   - glazing_material
+  - height
   - lamp_arm_style
+  - length
   - light_color
   - light_pattern
   - light_temperature
   - lighting_features
+  - luminous_flux
   - material
   - pattern
   - power_source
   - switch_control_type
+  - width
   return_reasons:
   - size
   - color
@@ -43266,23 +48024,28 @@
   - battery_size
   - battery_type
   - bulb_cap_type
+  - bulb_power
   - bulb_size
   - bulb_type
   - color
   - energy_efficiency_class
   - furniture/fixture_material
   - glazing_material
+  - height
   - lampshade_shape
+  - length
   - light_color
   - light_pattern
   - light_temperature
   - lighting_features
+  - luminous_flux
   - material
   - mounting_type
   - pattern
   - power_source
   - style
   - switch_control_type
+  - width
   return_reasons:
   - size
   - color
@@ -43297,19 +48060,24 @@
   name: Landscape Pathway Lighting
   children: []
   attributes:
+  - bulb_power
   - bulb_size
   - bulb_type
   - color
   - energy_efficiency_class
+  - height
   - ingress_protection_ip_rating
+  - length
   - light_color
   - light_pattern
   - light_temperature
   - lighting_features
+  - luminous_flux
   - material
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - style
@@ -43333,15 +48101,20 @@
   attributes:
   - bulb_cap_type
   - bulb_finish
+  - bulb_power
   - bulb_shape
   - bulb_size
   - color
   - energy_efficiency_class
+  - height
+  - length
   - light_color
   - light_pattern
   - light_temperature
   - lighting_features
+  - luminous_flux
   - pattern
+  - width
   return_reasons:
   - size
   - brightness
@@ -43359,15 +48132,20 @@
   attributes:
   - bulb_cap_type
   - bulb_finish
+  - bulb_power
   - bulb_shape
   - bulb_size
   - color
   - energy_efficiency_class
+  - height
+  - length
   - light_color
   - light_pattern
   - light_temperature
   - lighting_features
+  - luminous_flux
   - pattern
+  - width
   return_reasons:
   - size
   - brightness
@@ -43385,16 +48163,21 @@
   attributes:
   - bulb_cap_type
   - bulb_finish
+  - bulb_power
   - bulb_shape
   - bulb_size
   - color
   - energy_efficiency_class
   - fluorescent_tube_output_type
+  - height
+  - length
   - light_color
   - light_pattern
   - light_temperature
   - lighting_features
+  - luminous_flux
   - pattern
+  - width
   return_reasons:
   - size
   - brightness
@@ -43412,16 +48195,21 @@
   attributes:
   - bulb_cap_type
   - bulb_finish
+  - bulb_power
   - bulb_shape
   - bulb_size
   - color
   - energy_efficiency_class
   - filament_style
+  - height
+  - length
   - light_color
   - light_pattern
   - light_temperature
   - lighting_features
+  - luminous_flux
   - pattern
+  - width
   return_reasons:
   - size
   - brightness
@@ -43441,15 +48229,20 @@
   - battery_type
   - bulb_cap_type
   - bulb_finish
+  - bulb_power
   - bulb_shape
   - bulb_size
   - color
   - energy_efficiency_class
+  - height
+  - length
   - light_color
   - light_pattern
   - light_temperature
   - lighting_features
+  - luminous_flux
   - pattern
+  - width
   return_reasons:
   - size
   - brightness
@@ -43499,11 +48292,14 @@
   - hg-13-8-1
   - hg-13-8-2
   attributes:
+  - bulb_power
   - bulb_size
   - bulb_type
   - color
   - energy_efficiency_class
+  - height
   - ingress_protection_ip_rating
+  - length
   - light_color
   - light_pattern
   - light_temperature
@@ -43512,6 +48308,7 @@
   - plug_type
   - power_source
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -43576,7 +48373,9 @@
   - color
   - energy_efficiency_class
   - finish
+  - height
   - ingress_protection_ip_rating
+  - length
   - light_color
   - light_pattern
   - light_temperature
@@ -43586,6 +48385,7 @@
   - pattern
   - power_source
   - style
+  - width
   return_reasons:
   - size
   - color
@@ -43610,7 +48410,9 @@
   - color
   - energy_efficiency_class
   - finish
+  - height
   - ingress_protection_ip_rating
+  - length
   - light_color
   - light_pattern
   - light_temperature
@@ -43620,6 +48422,7 @@
   - pattern
   - power_source
   - style
+  - width
   return_reasons:
   - size
   - color
@@ -43643,7 +48446,9 @@
   - color
   - energy_efficiency_class
   - finish
+  - height
   - ingress_protection_ip_rating
+  - length
   - light_color
   - light_pattern
   - light_temperature
@@ -43653,6 +48458,7 @@
   - pattern
   - power_source
   - style
+  - width
   return_reasons:
   - size
   - color
@@ -43678,8 +48484,10 @@
   - energy_efficiency_class
   - finish
   - hardware_finish
+  - height
   - ingress_protection_ip_rating
   - jewelry_material
+  - length
   - light_color
   - light_pattern
   - light_temperature
@@ -43689,6 +48497,7 @@
   - pattern
   - power_source
   - style
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -43713,7 +48522,9 @@
   - color
   - energy_efficiency_class
   - finish
+  - height
   - ingress_protection_ip_rating
+  - length
   - light_color
   - light_pattern
   - light_temperature
@@ -43723,6 +48534,7 @@
   - pattern
   - power_source
   - style
+  - width
   return_reasons:
   - size
   - color
@@ -43784,10 +48596,13 @@
   - hg-13-10-3
   attributes:
   - brightness_levels
+  - bulb_power
   - bulb_size
   - bulb_type
   - color
   - energy_efficiency_class
+  - height
+  - length
   - light_color
   - light_pattern
   - light_temperature
@@ -43800,6 +48615,7 @@
   - power_source
   - suitable_location
   - switch_control_type
+  - width
   return_reasons:
   - size
   - brightness
@@ -43879,18 +48695,23 @@
   name: Picture Lights
   children: []
   attributes:
+  - bulb_power
   - bulb_size
   - bulb_type
   - color
   - energy_efficiency_class
+  - height
+  - length
   - light_color
   - light_pattern
   - light_temperature
   - lighting_features
+  - luminous_flux
   - material
   - mounting_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - style
@@ -43908,12 +48729,16 @@
   - hg-13-12-1
   - hg-13-12-2
   attributes:
+  - bulb_power
   - bulb_size
   - color
   - energy_efficiency_class
+  - height
+  - length
   - light_color
   - light_pattern
   - light_temperature
+  - luminous_flux
   - material
   - mounting_type
   - oil_type
@@ -43921,6 +48746,7 @@
   - power_source
   - usage_type
   - wick_material
+  - width
   return_reasons:
   - size
   - color
@@ -43986,6 +48812,7 @@
   - hg-13-13-2
   - hg-13-13-3
   attributes:
+  - bulb_power
   - bulb_size
   - color
   - energy_efficiency_class
@@ -43995,6 +48822,7 @@
   - light_source
   - light_temperature
   - lighting_features
+  - luminous_flux
   - material
   - pattern
   - track_lighting_system_compatibility
@@ -44019,20 +48847,25 @@
   - hg-13-13-1-6
   - hg-13-13-1-7
   attributes:
+  - bulb_power
   - bulb_size
   - color
   - energy_efficiency_class
   - finish
+  - height
   - ingress_protection_ip_rating
+  - length
   - light_color
   - light_pattern
   - light_source
   - light_temperature
   - lighting_features
+  - luminous_flux
   - material
   - mounting_type
   - pattern
   - track_lighting_system_compatibility
+  - width
   return_reasons:
   - size
   - style
@@ -44049,20 +48882,25 @@
   children: []
   attributes:
   - bulb_cap_type
+  - bulb_power
   - bulb_size
   - color
   - energy_efficiency_class
   - finish
+  - height
   - ingress_protection_ip_rating
+  - length
   - light_color
   - light_pattern
   - light_source
   - light_temperature
   - lighting_features
+  - luminous_flux
   - material
   - mounting_type
   - pattern
   - track_lighting_system_compatibility
+  - width
   return_reasons:
   - style
   - finish
@@ -44078,21 +48916,26 @@
   children: []
   attributes:
   - bulb_cap_type
+  - bulb_power
   - bulb_shape
   - bulb_size
   - color
   - energy_efficiency_class
   - finish
+  - height
   - ingress_protection_ip_rating
+  - length
   - light_color
   - light_pattern
   - light_source
   - light_temperature
   - lighting_features
+  - luminous_flux
   - material
   - mounting_type
   - pattern
   - track_lighting_system_compatibility
+  - width
   return_reasons:
   - style
   - finish
@@ -44107,21 +48950,26 @@
   name: Power Feeds
   children: []
   attributes:
+  - bulb_power
   - bulb_size
   - color
   - energy_efficiency_class
   - finish
+  - height
   - ingress_protection_ip_rating
+  - length
   - light_color
   - light_pattern
   - light_source
   - light_temperature
   - lighting_features
+  - luminous_flux
   - material
   - mounting_type
   - pattern
   - track_lighting_system_compatibility
   - track_system_standard
+  - width
   return_reasons:
   - finish
   - incompatible
@@ -44135,21 +48983,26 @@
   name: Suspension Kits
   children: []
   attributes:
+  - bulb_power
   - bulb_size
   - color
   - energy_efficiency_class
   - finish
+  - height
   - height_adjustment
   - ingress_protection_ip_rating
+  - length
   - light_color
   - light_pattern
   - light_source
   - light_temperature
   - lighting_features
+  - luminous_flux
   - material
   - mounting_type
   - pattern
   - track_lighting_system_compatibility
+  - width
   return_reasons:
   - style
   - finish
@@ -44209,19 +49062,24 @@
   children: []
   attributes:
   - bulb_cap_type
+  - bulb_power
   - bulb_size
   - color
   - energy_efficiency_class
   - finish
+  - height
+  - length
   - light_color
   - light_pattern
   - light_source
   - light_temperature
   - lighting_features
+  - luminous_flux
   - material
   - mounting_type
   - pattern
   - track_lighting_system_compatibility
+  - width
   return_reasons:
   - size
   - style
@@ -44238,10 +49096,13 @@
   name: Track Lighting Rails
   children: []
   attributes:
+  - bulb_power
   - bulb_size
   - color
   - energy_efficiency_class
   - finish
+  - height
+  - length
   - light_color
   - light_pattern
   - light_source
@@ -44253,6 +49114,7 @@
   - track_lighting_rail_type
   - track_lighting_system_compatibility
   - track_rail_circuit_configuration
+  - width
   return_reasons:
   - size
   - style
@@ -44277,8 +49139,11 @@
   - hg-14-8
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -44294,10 +49159,13 @@
   attributes:
   - color
   - finish
+  - height
   - lamp_post_base_mounting_type
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - finish
@@ -44315,11 +49183,14 @@
   - color
   - durability_features
   - hardware_finish
+  - height
   - ingress_protection_ip_rating
+  - length
   - mount_material
   - mounting_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - finish
@@ -44335,12 +49206,15 @@
   children: []
   attributes:
   - color
+  - height
   - lamp_shade_fitter_type
   - lamp_shade_shape
   - lamp_shade_translucency
+  - length
   - material
   - pattern
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -44358,12 +49232,15 @@
   attributes:
   - color
   - display_technology
+  - height
   - ingress_protection_ip_rating
+  - length
   - mounting_type
   - pattern
   - plug_type
   - power_source
   - timer_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -44378,9 +49255,13 @@
   attributes:
   - color
   - fragrance
+  - height
+  - length
   - oil_type
   - package_type
   - suitable_space
+  - volume
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -44504,10 +49385,13 @@
   - care_instructions
   - color
   - fabric
+  - height
+  - length
   - light_control
   - mounting_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -44530,8 +49414,11 @@
   - care_instructions
   - color
   - fabric
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - color
@@ -44582,7 +49469,10 @@
   - care_instructions
   - color
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -44606,9 +49496,12 @@
   - color
   - fabric
   - filler_material
+  - height
+  - length
   - pattern
   - season
   - warmth_rating
+  - width
   return_reasons:
   - size
   - color
@@ -44682,7 +49575,10 @@
   - color
   - fabric
   - fabric_weave
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -44703,8 +49599,11 @@
   - closure_type
   - color
   - fabric
+  - height
+  - length
   - mattress_protector_features
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -44722,8 +49621,11 @@
   - closure_type
   - color
   - fabric
+  - height
+  - length
   - mattress_protector_features
   - pattern
+  - width
   return_reasons:
   - size
   - material
@@ -44742,10 +49644,13 @@
   - color
   - fabric
   - filler_material
+  - height
+  - length
   - mattress_features
   - mattress_protector_features
   - pad_type
   - pattern
+  - width
   return_reasons:
   - size
   - too_soft
@@ -44767,9 +49672,12 @@
   - color
   - fabric
   - filler_material
+  - height
+  - length
   - nap_mat_items_included
   - pattern
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -44791,7 +49699,10 @@
   - closure_style
   - color
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -44856,9 +49767,12 @@
   - cover_pattern
   - filler_material
   - filler_support
+  - height
+  - length
   - pattern
   - pillow_shape
   - sleeping_position_suitability
+  - width
   return_reasons:
   - too_soft
   - too_firm
@@ -44979,10 +49893,13 @@
   - care_instructions
   - color
   - fabric
+  - height
+  - length
   - material_treatment
   - pattern
   - quilt_construction_type
   - warmth_level
+  - width
   return_reasons:
   - size
   - color
@@ -45045,8 +49962,11 @@
   - color
   - fabric
   - fabric_structure
+  - height
   - kitchen_linen_items_included
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -45072,9 +49992,12 @@
   - color
   - fabric
   - fabric_structure
+  - height
+  - length
   - occasion
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -45093,10 +50016,13 @@
   - color
   - fabric
   - fabric_structure
+  - height
+  - length
   - napkin_edge_finish
   - occasion
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -45116,9 +50042,12 @@
   - color
   - fabric
   - fabric_structure
+  - height
+  - length
   - occasion
   - pattern
   - shape
+  - width
   return_reasons:
   - pattern
   - changed_my_mind
@@ -45135,9 +50064,12 @@
   - color
   - fabric
   - fabric_structure
+  - height
+  - length
   - occasion
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -45157,10 +50089,13 @@
   - edge_finish
   - fabric
   - fabric_structure
+  - height
+  - length
   - occasion
   - pattern
   - shape
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -45180,11 +50115,14 @@
   - color
   - fabric
   - fabric_structure
+  - height
+  - length
   - occasion
   - pattern
   - shape
   - table_skirt_pleat_style
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -45203,10 +50141,13 @@
   - color
   - fabric
   - fabric_structure
+  - height
+  - length
   - occasion
   - pattern
   - shape
   - tablecloth_features
+  - width
   return_reasons:
   - size
   - color
@@ -45228,8 +50169,11 @@
   attributes:
   - color
   - fabric
+  - height
+  - length
   - pattern
   - towel_weave
+  - width
   return_reasons:
   - size
   - color
@@ -45249,8 +50193,11 @@
   attributes:
   - color
   - fabric
+  - height
+  - length
   - pattern
   - towel_weave
+  - width
   return_reasons:
   - color
   - material
@@ -45267,8 +50214,11 @@
   attributes:
   - color
   - fabric
+  - height
+  - length
   - pattern
   - towel_weave
+  - width
   return_reasons:
   - size
   - color
@@ -45285,8 +50235,11 @@
   attributes:
   - color
   - fabric
+  - height
+  - length
   - pattern
   - towel_weave
+  - width
   return_reasons:
   - size
   - color
@@ -45303,9 +50256,12 @@
   attributes:
   - color
   - fabric
+  - height
+  - length
   - pattern
   - shape
   - towel_weave
+  - width
   return_reasons:
   - size
   - color
@@ -45324,8 +50280,11 @@
   - care_instructions
   - color
   - fabric
+  - height
+  - length
   - pattern
   - towel_weave
+  - width
   return_reasons:
   - size
   - color
@@ -45385,11 +50344,15 @@
   - canopy_material
   - canopy_pattern
   - canopy_shape
+  - diameter
+  - height
+  - length
   - pole_color
   - pole_material
   - pole_pattern
   - rib_material
   - umbrella_opening_mechanism
+  - width
   return_reasons:
   - size
   - color
@@ -45407,6 +50370,9 @@
   - canopy_material
   - canopy_shape
   - color
+  - diameter
+  - height
+  - length
   - outdoor_equipment_features
   - parasol_opening_mechanism
   - pattern
@@ -45415,6 +50381,7 @@
   - shape
   - tilt_mechanism
   - upf_rating
+  - width
   return_reasons:
   - size
   - color
@@ -45432,13 +50399,17 @@
   - canopy_material
   - canopy_shape
   - color
+  - diameter
   - handle_material
+  - height
+  - length
   - pattern
   - pole_material
   - rib_material
   - umbrella_opening_mechanism
   - umbrella_type
   - uv_protection
+  - width
   return_reasons:
   - size
   - color
@@ -45486,12 +50457,16 @@
   - co2_supplementation_requirement
   - flower_color
   - hardiness_zone
+  - height
+  - length
+  - mature_height
   - plant_characteristics
   - plant_class
   - plant_name
   - suitable_for_water_type
   - suitable_space
   - sunlight
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -45508,6 +50483,9 @@
   - color
   - flower_color
   - hardiness_zone
+  - height
+  - length
+  - mature_height
   - occasion
   - plant_characteristics
   - plant_class
@@ -45517,6 +50495,7 @@
   - suitable_space
   - sunlight
   - watering_needs
+  - width
   return_reasons:
   - size
   - color
@@ -45564,6 +50543,8 @@
   attributes:
   - color
   - hardiness_zone
+  - height
+  - length
   - material_treatment
   - pet_safety
   - plant_characteristics
@@ -45575,6 +50556,7 @@
   - suitable_space
   - sunlight
   - watering_needs
+  - width
   return_reasons:
   - size
   - color
@@ -45592,7 +50574,10 @@
   - flower_pattern
   - foliage_color
   - hardiness_zone
+  - height
+  - length
   - material_treatment
+  - mature_height
   - pet_safety
   - plant_characteristics
   - plant_class
@@ -45603,6 +50588,7 @@
   - suitable_space
   - sunlight
   - watering_needs
+  - width
   return_reasons:
   - size
   - color
@@ -45621,7 +50607,10 @@
   - foliage_color
   - growth_habit
   - hardiness_zone
+  - height
+  - length
   - material_treatment
+  - mature_height
   - pet_safety
   - plant_characteristics
   - plant_class
@@ -45632,6 +50621,7 @@
   - suitable_space
   - sunlight
   - watering_needs
+  - width
   return_reasons:
   - size
   - color
@@ -45650,7 +50640,10 @@
   - flower_pattern
   - growth_habit
   - hardiness_zone
+  - height
+  - length
   - material_treatment
+  - mature_height
   - pet_safety
   - plant_characteristics
   - plant_life_cycle
@@ -45661,6 +50654,7 @@
   - suitable_space
   - sunlight
   - watering_needs
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -45677,6 +50671,8 @@
   attributes:
   - color
   - hardiness_zone
+  - height
+  - length
   - material_treatment
   - pet_safety
   - plant_characteristics
@@ -45689,6 +50685,7 @@
   - suitable_space
   - sunlight
   - watering_needs
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -45706,7 +50703,10 @@
   - foliage_color
   - growth_habit
   - hardiness_zone
+  - height
+  - length
   - material_treatment
+  - mature_height
   - pet_safety
   - plant_characteristics
   - plant_class
@@ -45718,6 +50718,7 @@
   - suitable_space
   - sunlight
   - watering_needs
+  - width
   return_reasons:
   - size
   - color
@@ -45736,7 +50737,10 @@
   - flower_pattern
   - growth_habit
   - hardiness_zone
+  - height
+  - length
   - material_treatment
+  - mature_height
   - pet_safety
   - plant_characteristics
   - plant_class
@@ -45748,6 +50752,7 @@
   - suitable_space
   - sunlight
   - watering_needs
+  - width
   return_reasons:
   - size
   - color
@@ -45788,7 +50793,10 @@
   - flower_color
   - flower_pattern
   - hardiness_zone
+  - height
+  - length
   - material_treatment
+  - mature_height
   - pattern
   - pet_safety
   - pet_toxicity
@@ -45803,6 +50811,7 @@
   - suitable_space
   - sunlight
   - watering_needs
+  - width
   return_reasons:
   - size
   - not_pet_friendly
@@ -45881,6 +50890,7 @@
   - flower_pattern
   - growing_medium_type
   - hardiness_zone
+  - mature_height
   - plant_characteristics
   - plant_class
   - plant_name
@@ -45908,6 +50918,7 @@
   - flower_pattern
   - hardiness_zone
   - material_treatment
+  - mature_height
   - plant_characteristics
   - plant_class
   - plant_material
@@ -46004,6 +51015,7 @@
   - flower_pattern
   - hardiness_zone
   - material_treatment
+  - mature_height
   - plant_characteristics
   - plant_class
   - plant_life_cycle
@@ -46031,6 +51043,7 @@
   - flower_color
   - flower_pattern
   - hardiness_zone
+  - mature_height
   - plant_characteristics
   - plant_class
   - plant_name
@@ -46078,6 +51091,7 @@
   - color
   - cultivar_type
   - hardiness_zone
+  - length
   - pattern
   - plant_characteristics
   - plant_class
@@ -46087,6 +51101,7 @@
   - sunlight
   - tape_material
   - watering_needs
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -46105,6 +51120,7 @@
   - flower_pattern
   - hardiness_zone
   - material_treatment
+  - mature_height
   - plant_characteristics
   - plant_class
   - plant_life_cycle
@@ -46201,6 +51217,9 @@
   attributes:
   - flower_color
   - hardiness_zone
+  - height
+  - length
+  - mature_height
   - plant_characteristics
   - plant_class
   - plant_name
@@ -46208,6 +51227,7 @@
   - suitable_space
   - sunlight
   - watering_needs
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -46318,10 +51338,13 @@
   - diving_board_surface_texture
   - durability_features
   - flexibility_rating
+  - height
+  - length
   - material
   - pattern
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - color
@@ -46336,13 +51359,19 @@
   name: Pool & Spa Chlorine Generators
   children: []
   attributes:
+  - amperage
   - color
   - durability_features
+  - height
+  - length
   - material
+  - maximum_pool_capacity
   - pattern
+  - power_consumption_typical
   - power_source
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -46360,11 +51389,14 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - pattern
   - pool_filter_type
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -46416,9 +51448,12 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - pattern
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -46437,10 +51472,13 @@
   - color
   - durability_features
   - handle_material
+  - height
+  - length
   - pattern
   - suitable_for_pool_type
   - suitable_for_water_type
   - suitable_pool_surface_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -46456,10 +51494,13 @@
   attributes:
   - color
   - durability_features
+  - height
   - hose_material
+  - length
   - pattern
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -46475,11 +51516,14 @@
   - chemical_product_form
   - color
   - durability_features
+  - height
+  - length
   - pattern
   - pool_chemical_type
   - power_source
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -46500,11 +51544,14 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - pattern
   - suitable_for_pool_shape
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - color
@@ -46629,11 +51676,14 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - pattern
   - shape
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - color
@@ -46651,11 +51701,14 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - pattern
   - shape
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -46671,11 +51724,14 @@
   - color
   - cover_features
   - durability_features
+  - height
+  - length
   - material
   - pattern
   - shape
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - color
@@ -46694,10 +51750,13 @@
   - color
   - durability_features
   - finish
+  - height
+  - length
   - material
   - pattern
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - color
@@ -46721,12 +51780,15 @@
   - color
   - durability_features
   - features
+  - height
   - inflation_method
+  - length
   - material
   - pattern
   - shape
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - color
@@ -46745,13 +51807,16 @@
   - color
   - durability_features
   - features
+  - height
   - inflation_method
+  - length
   - material
   - pattern
   - recommended_age_group
   - shape
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - color
@@ -46770,14 +51835,17 @@
   - color
   - durability_features
   - features
+  - height
   - inflation_method
+  - length
   - material
   - pattern
+  - pool_lounge_style
   - pool_lounger_features
   - shape
   - suitable_for_pool_type
   - suitable_for_water_type
-  - pool_lounge_style
+  - width
   return_reasons:
   - size
   - color
@@ -46836,13 +51904,21 @@
   name: Pool Heaters
   children: []
   attributes:
+  - amperage
   - color
   - durability_features
+  - heating_power
+  - height
+  - length
   - material
+  - maximum_pool_capacity
+  - minimum_pool_capacity
   - pattern
+  - power_consumption_typical
   - power_source
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - capacity
@@ -46863,11 +51939,14 @@
   - color
   - durability_features
   - handrail_configuration
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - style
@@ -46886,12 +51965,15 @@
   - color
   - durability_features
   - handrail_configuration
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - pool_ladder_design
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - style
@@ -46911,11 +51993,14 @@
   - color
   - durability_features
   - handrail_configuration
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - style
@@ -46934,11 +52019,14 @@
   - color
   - durability_features
   - handrail_configuration
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - style
@@ -46977,12 +52065,15 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - pattern
   - pool_liner_installation_style
   - shape
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - color
@@ -47000,12 +52091,15 @@
   attributes:
   - color
   - durability_features
+  - height
+  - length
   - material
   - net_material
   - pattern
   - pool_skimmer_type
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -47025,10 +52119,13 @@
   - battery_type
   - color
   - durability_features
+  - height
+  - length
   - pattern
   - power_source
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - style
@@ -47045,11 +52142,14 @@
   - booster_pump_requirement
   - color
   - durability_features
+  - height
+  - length
   - pattern
   - power_source
   - suitable_for_pool_type
   - suitable_for_water_type
   - suitable_pool_surface_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -47066,11 +52166,14 @@
   - battery_type
   - color
   - durability_features
+  - height
+  - length
   - pattern
   - pool_vacuum_type
   - power_source
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -47089,13 +52192,16 @@
   attributes:
   - color
   - durability_features
+  - height
   - inflation_method
+  - length
   - material
   - pattern
   - pool_toy_features
   - recommended_age_group
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - color
@@ -47113,13 +52219,16 @@
   - age_group
   - color
   - durability_features
+  - height
   - inflation_method
+  - length
   - material
   - pattern
   - pool_toy_features
   - recommended_age_group
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - color
@@ -47136,7 +52245,9 @@
   attributes:
   - color
   - durability_features
+  - height
   - inflation_method
+  - length
   - mounting_type
   - pattern
   - pool_game_type
@@ -47145,6 +52256,7 @@
   - suitable_for_pool_type
   - suitable_for_water_type
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -47161,7 +52273,9 @@
   attributes:
   - color
   - durability_features
+  - height
   - inflation_method
+  - length
   - material
   - pattern
   - pool_lounge_style
@@ -47169,6 +52283,7 @@
   - recommended_age_group
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - color
@@ -47185,13 +52300,16 @@
   attributes:
   - color
   - durability_features
+  - height
   - inflation_method
+  - length
   - material
   - noodle_core_design
   - pattern
   - recommended_age_group
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - size
   - color
@@ -47209,12 +52327,15 @@
   - age_group
   - color
   - durability_features
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - play_slide_design
   - suitable_for_pool_type
   - suitable_for_water_type
+  - width
   return_reasons:
   - color
   - style
@@ -47308,9 +52429,12 @@
   attributes:
   - color
   - finish
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -47328,10 +52452,13 @@
   - color
   - finish
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - sauna_accessories_included
+  - width
   return_reasons:
   - size
   - color
@@ -47349,9 +52476,12 @@
   - color
   - finish
   - handle_material
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -47366,14 +52496,20 @@
   name: Sauna Heaters
   children: []
   attributes:
+  - amperage
   - color
+  - height
   - housing_material
   - ingress_protection_ip_rating
+  - length
   - material
   - mounting_type
+  - nominal_thermal_power
   - pattern
   - phase_type
+  - power_consumption_typical
   - power_source
+  - width
   return_reasons:
   - size
   - capacity
@@ -47388,6 +52524,8 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - sauna_accessories_included
@@ -47395,6 +52533,7 @@
   - sauna_heater_type
   - suitable_space
   - wall_material
+  - width
   return_reasons:
   - size
   - color
@@ -47485,14 +52624,20 @@
   - hg-18-3-2
   - hg-18-3-3
   attributes:
+  - amperage
   - color
   - heat_source
+  - height
+  - length
+  - maximum_heater_power
   - pattern
+  - power_consumption_typical
   - sauna_accessories_included
   - sauna_form_factor
   - shape
   - suitable_space
   - wall_material
+  - width
   return_reasons:
   - size
   - incompatible
@@ -47556,11 +52701,14 @@
   - hg-18-4-4
   attributes:
   - color
+  - height
+  - length
   - pattern
   - shape
   - shell/frame_material
   - spa_installation_type
   - suitable_space
+  - width
   return_reasons:
   - size
   - incompatible
@@ -47634,11 +52782,15 @@
   - hg-18-5-3
   attributes:
   - color
+  - diameter
+  - height
+  - length
   - material
   - pattern
   - pool_type
   - shape
   - suitable_space
+  - width
   return_reasons:
   - size
   - style
@@ -47731,11 +52883,14 @@
   - ashtray_type
   - cleaning_instructions
   - color
+  - height
+  - length
   - lid_type
   - material
   - mounting_type
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -47753,7 +52908,10 @@
   - bag/case_material
   - closure_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -47773,8 +52931,11 @@
   - blade_material
   - cigar_cutter_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -47792,9 +52953,12 @@
   - blade_material
   - cigar_cutter_type
   - color
+  - height
+  - length
   - material
   - number_of_compartments
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -47812,8 +52976,11 @@
   - blade_material
   - cigar_punch_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -47832,8 +52999,11 @@
   - bag/case_storage_features
   - closure_type
   - color
+  - height
+  - length
   - material_firmness
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -47851,9 +53021,12 @@
   - color
   - compatible_cigarette_size
   - filter_material
+  - height
+  - length
   - material
   - mouthpiece_shape
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -47869,12 +53042,15 @@
   children: []
   attributes:
   - color
+  - height
   - humidity_control
   - humidity_control_method
   - humidor_accessory_type
+  - length
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -47891,13 +53067,16 @@
   - color
   - finish
   - glazing_material
+  - height
   - humidity_control
   - humidity_control_method
   - hygrometer_type
+  - length
   - lock_type
   - material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - color
@@ -48025,7 +53204,10 @@
   - hg-20-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -48044,7 +53226,10 @@
   - bag_closure
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -48061,8 +53246,11 @@
   - closure_type
   - color
   - cover_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -48080,9 +53268,12 @@
   - catalytic_combustor_type
   - color
   - flue_outlet_position
+  - height
+  - length
   - material
   - pattern
   - stove_airflow
+  - width
   return_reasons:
   - size
   - color

--- a/data/categories/lb_luggage_bags.yml
+++ b/data/categories/lb_luggage_bags.yml
@@ -46,12 +46,16 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - luggage/bag_closure
   - pattern
   - target_gender
+  - width
   return_reasons:
   - size
   - color
@@ -70,11 +74,15 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - luggage/bag_closure
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -164,12 +172,16 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - luggage/bag_closure
   - pattern
   - target_gender
+  - width
   return_reasons:
   - size
   - color
@@ -192,12 +204,16 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - luggage/bag_closure
   - pattern
   - target_gender
+  - width
   return_reasons:
   - size
   - color
@@ -216,11 +232,15 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - luggage/bag_closure
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -239,11 +259,15 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - luggage/bag_closure
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -262,11 +286,15 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - luggage/bag_closure
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -284,14 +312,18 @@
   - bag/case_closure
   - bag/case_features
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
   - diaper_bag_additional_features
   - diaper_bag_material
   - diaper_bag_style
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - size
   - color
@@ -312,10 +344,14 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -337,11 +373,15 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - size
   - color
@@ -361,10 +401,14 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -385,11 +429,15 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - size
   - color
@@ -406,11 +454,15 @@
   attributes:
   - accessory_size
   - bag/case_material
+  - capacity
   - care_instructions
   - color
+  - height
+  - length
   - luggage/bag_closure
   - pattern
   - target_gender
+  - width
   return_reasons:
   - size
   - color
@@ -436,7 +488,10 @@
   - bag/case_material
   - care_instructions
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -458,8 +513,11 @@
   - carry_options
   - color
   - fabric
+  - height
+  - length
   - pattern
   - thickness_type
+  - width
   return_reasons:
   - size
   - water_resistance
@@ -477,8 +535,11 @@
   - color
   - cover_features
   - cover_material
+  - height
+  - length
   - luggage/bag_closure
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -496,7 +557,11 @@
   - accessory_size
   - color
   - furniture/fixture_material
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -511,8 +576,11 @@
   attributes:
   - color
   - fabric
+  - height
+  - length
   - luggage/bag_closure
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -526,10 +594,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - shape
   - tag_fastening
+  - width
   return_reasons:
   - size
   - color
@@ -545,8 +616,11 @@
   attributes:
   - color
   - fabric
+  - height
+  - length
   - luggage/bag_closure
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -562,9 +636,13 @@
   children: []
   attributes:
   - bottle/container_closure
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -582,12 +660,16 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - luggage/bag_closure
   - pattern
   - target_gender
+  - width
   return_reasons:
   - size
   - color
@@ -608,11 +690,15 @@
   - bag/case_material
   - bag/case_storage_features
   - bag_strap_type
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - luggage/bag_closure
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -630,14 +716,18 @@
   - accessory_size
   - age_group
   - bag/case_material
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - luggage/bag_closure
   - pattern
   - safety_certifications
   - target_gender
   - tote_handle_type
+  - width
   return_reasons:
   - size
   - color
@@ -660,13 +750,17 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
   - spinner_type
   - suitcase_handle_type
   - target_gender
+  - width
   return_reasons:
   - size
   - color
@@ -686,12 +780,16 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
   - spinner_type
   - suitcase_handle_type
+  - width
   return_reasons:
   - size
   - color
@@ -710,12 +808,16 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
   - spinner_type
   - suitcase_handle_type
+  - width
   return_reasons:
   - size
   - color
@@ -734,12 +836,16 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
   - spinner_type
   - suitcase_handle_type
+  - width
   return_reasons:
   - size
   - color
@@ -758,12 +864,16 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
   - spinner_type
   - suitcase_handle_type
+  - width
   return_reasons:
   - size
   - color
@@ -784,12 +894,16 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
   - target_gender
   - tote_handle_type
+  - width
   return_reasons:
   - size
   - color
@@ -809,11 +923,15 @@
   - bag/case_features
   - bag/case_material
   - bag/case_storage_features
+  - capacity
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - luggage/bag_closure
   - pattern
+  - width
   return_reasons:
   - size
   - color

--- a/data/categories/me_media.yml
+++ b/data/categories/me_media.yml
@@ -44,6 +44,7 @@
   name: Audiobooks
   children: []
   attributes:
+  - duration
   - genre
   - language_version
   - target_audience
@@ -242,6 +243,7 @@
   - me-3-5
   - me-3-6
   attributes:
+  - duration
   - media_format
   - music_genre
   return_reasons:
@@ -257,6 +259,7 @@
   children: []
   attributes:
   - download_format
+  - duration
   - music_genre
   return_reasons:
   - sound_quality
@@ -270,6 +273,7 @@
   name: Music Cassette Tapes
   children: []
   attributes:
+  - duration
   - music_genre
   return_reasons:
   - sound_quality
@@ -283,6 +287,7 @@
   name: Music CDs
   children: []
   attributes:
+  - duration
   - music_genre
   return_reasons:
   - sound_quality
@@ -296,6 +301,7 @@
   name: Records & LPs
   children: []
   attributes:
+  - duration
   - music_genre
   return_reasons:
   - sound_quality
@@ -310,6 +316,7 @@
   name: Spoken Word & Field Recordings
   children: []
   attributes:
+  - duration
   - music_genre
   return_reasons:
   - sound_quality
@@ -324,6 +331,7 @@
   name: Vinyl
   children: []
   attributes:
+  - duration
   - music_genre
   return_reasons:
   - sound_quality
@@ -340,6 +348,7 @@
   - me-4-2
   - me-4-3
   attributes:
+  - duration
   - genre
   - language
   - media_format
@@ -356,6 +365,7 @@
   name: Live Streams
   children: []
   attributes:
+  - duration
   - genre
   - language
   - release_schedule
@@ -374,6 +384,7 @@
   name: Podcasts
   children: []
   attributes:
+  - duration
   - genre
   - language
   - release_schedule
@@ -390,6 +401,7 @@
   name: Radio Shows
   children: []
   attributes:
+  - duration
   - genre
   - language
   - release_schedule
@@ -447,6 +459,7 @@
   - media_content_type
   - media_format
   - mpaa_rating
+  - running_time
   - target_audience
   return_reasons:
   - language
@@ -464,6 +477,7 @@
   - language_version
   - media_content_type
   - mpaa_rating
+  - running_time
   - target_audience
   return_reasons:
   - video_quality
@@ -483,6 +497,7 @@
   - language_version
   - media_content_type
   - mpaa_rating
+  - running_time
   - target_audience
   return_reasons:
   - video_quality
@@ -502,6 +517,7 @@
   - language_version
   - media_content_type
   - mpaa_rating
+  - running_time
   - target_audience
   return_reasons:
   - video_quality
@@ -521,6 +537,7 @@
   - language_version
   - media_content_type
   - mpaa_rating
+  - running_time
   - target_audience
   return_reasons:
   - video_quality

--- a/data/categories/os_office_supplies.yml
+++ b/data/categories/os_office_supplies.yml
@@ -35,8 +35,11 @@
   - os-1-4
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -52,7 +55,10 @@
   - book_cover_material
   - closure_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -67,10 +73,13 @@
   children: []
   attributes:
   - brightness_levels
+  - height
+  - length
   - light_attachment_type
   - light_temperature
   - material
   - power_source
+  - width
   return_reasons:
   - style
   - brightness
@@ -85,8 +94,11 @@
   name: Book Stands & Rests
   children: []
   attributes:
+  - height
+  - length
   - material
   - mount/stand_features
+  - width
   return_reasons:
   - size
   - color
@@ -105,8 +117,11 @@
   - bookmark_design
   - bookmark_shape
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -122,10 +137,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - office_supply_material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -175,8 +193,11 @@
   attributes:
   - book_cover_material
   - color
+  - height
+  - length
   - page_layout
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -215,8 +236,11 @@
   - os-3-2-1-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -232,7 +256,11 @@
   children: []
   attributes:
   - binder_ring_shape
+  - binder_ring_size
+  - height
+  - length
   - office_supply_material
+  - width
   return_reasons:
   - size
   - incompatible
@@ -246,9 +274,12 @@
   name: Index Dividers
   children: []
   attributes:
+  - height
+  - length
   - office_supply_material
   - paper_size
   - tab_style
+  - width
   return_reasons:
   - size
   - color
@@ -263,8 +294,11 @@
   name: Sheet Protectors
   children: []
   attributes:
+  - height
+  - length
   - office_supply_material
   - paper_size
+  - width
   return_reasons:
   - size
   - thickness
@@ -282,9 +316,12 @@
   attributes:
   - binder_ring_shape
   - color
+  - height
+  - length
   - office_supply_material
   - paper_size
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -299,9 +336,13 @@
   name: Binding Combs & Spines
   children: []
   attributes:
+  - binding_comb_size
   - color
+  - height
+  - length
   - office_supply_material
   - pattern
+  - width
   return_reasons:
   - color
   - capacity
@@ -319,6 +360,9 @@
   - os-3-2-4-2
   attributes:
   - binding_style
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - capacity
@@ -333,7 +377,13 @@
   name: Electric Binding Machines
   children: []
   attributes:
+  - amperage
   - binding_style
+  - height
+  - length
+  - power_consumption_typical
+  - voltage
+  - width
   return_reasons:
   - size
   - capacity
@@ -349,6 +399,9 @@
   children: []
   attributes:
   - binding_style
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - capacity
@@ -364,8 +417,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -382,9 +438,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - mount/stand_features
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -405,7 +464,10 @@
   - os-3-5-4
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -424,7 +486,10 @@
   - calendar/organizer_features
   - calendar_format
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -442,7 +507,10 @@
   - calendar/organizer_features
   - calendar_format
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -460,7 +528,10 @@
   - calendar/organizer_features
   - calendar_format
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -478,7 +549,10 @@
   - calendar/organizer_features
   - calendar_format
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -494,8 +568,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -511,8 +588,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -528,8 +608,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -552,7 +635,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -574,8 +660,11 @@
   attributes:
   - color
   - desk_organizer_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -592,8 +681,11 @@
   attributes:
   - color
   - desk_organizer_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -611,8 +703,11 @@
   attributes:
   - color
   - desk_organizer_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -630,8 +725,11 @@
   attributes:
   - color
   - desk_organizer_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -649,8 +747,11 @@
   attributes:
   - color
   - desk_organizer_features
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -666,9 +767,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
   - paper_size
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -684,9 +788,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
   - paper_size
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -705,8 +812,11 @@
   attributes:
   - color
   - folder/report_cover_material
+  - height
+  - length
   - paper_size
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -723,8 +833,11 @@
   attributes:
   - color
   - folder/report_cover_material
+  - height
+  - length
   - paper_size
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -741,8 +854,11 @@
   attributes:
   - color
   - folder/report_cover_material
+  - height
+  - length
   - paper_size
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -758,8 +874,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -775,8 +894,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -799,7 +921,10 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -818,8 +943,11 @@
   - os-3-17-2
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -835,9 +963,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
   - paper_size
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -854,9 +985,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
   - paper_size
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -873,8 +1007,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -917,7 +1054,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -934,6 +1074,9 @@
   - os-4-2-3
   attributes:
   - corrector_features
+  - height
+  - length
+  - width
   return_reasons:
   - coverage
   - changed_my_mind
@@ -947,6 +1090,9 @@
   children: []
   attributes:
   - corrector_features
+  - height
+  - length
+  - width
   return_reasons:
   - applicator
   - consistency
@@ -961,6 +1107,9 @@
   children: []
   attributes:
   - corrector_features
+  - height
+  - length
+  - width
   return_reasons:
   - tip_size
   - consistency
@@ -975,6 +1124,9 @@
   children: []
   attributes:
   - corrector_features
+  - height
+  - length
+  - width
   return_reasons:
   - width
   - incompatible
@@ -992,7 +1144,10 @@
   - os-4-3-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -1006,8 +1161,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -1021,8 +1179,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1037,9 +1198,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -1060,8 +1224,11 @@
   - os-4-4-6
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
   - pattern
+  - width
   return_reasons:
   - size
   - adhesive
@@ -1078,9 +1245,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1095,9 +1265,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -1113,9 +1286,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -1131,9 +1307,11 @@
   children: []
   attributes:
   - color
+  - length
   - pattern
   - tape_material
   - usage_type
+  - width
   return_reasons:
   - size
   - color
@@ -1149,9 +1327,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1166,9 +1347,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
   - pattern
   - usage_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1186,6 +1370,9 @@
   - os-4-5-3
   attributes:
   - finish
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - gauge
@@ -1202,7 +1389,10 @@
   children: []
   attributes:
   - finish
+  - height
+  - length
   - paper_size
+  - width
   return_reasons:
   - size
   - finish
@@ -1219,7 +1409,10 @@
   children: []
   attributes:
   - finish
+  - height
+  - length
   - paper_size
+  - width
   return_reasons:
   - size
   - finish
@@ -1236,7 +1429,10 @@
   children: []
   attributes:
   - finish
+  - height
+  - length
   - paper_size
+  - width
   return_reasons:
   - size
   - finish
@@ -1253,8 +1449,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - adhesive
   - changed_my_mind
@@ -1268,7 +1467,9 @@
   children:
   - os-4-7-1
   - os-4-7-2
-  attributes: []
+  attributes:
+  - length
+  - width
   return_reasons:
   - adhesive
   - width
@@ -1283,7 +1484,9 @@
   children: []
   attributes:
   - color
+  - length
   - pattern
+  - width
   return_reasons:
   - width
   - changed_my_mind
@@ -1297,7 +1500,9 @@
   children: []
   attributes:
   - color
+  - length
   - pattern
+  - width
   return_reasons:
   - width
   - changed_my_mind
@@ -1313,7 +1518,10 @@
   - os-4-8-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -1327,8 +1535,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1343,8 +1554,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1373,7 +1587,10 @@
   - os-4-9-14
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1390,8 +1607,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - paper_size
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -1406,7 +1626,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1423,7 +1646,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1440,7 +1666,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1456,7 +1685,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1472,7 +1704,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1490,7 +1725,10 @@
   attributes:
   - color
   - envelope_features
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1507,7 +1745,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1527,10 +1768,13 @@
   - os-4-9-9-6
   attributes:
   - color
+  - height
+  - length
   - paper_type
   - pattern
   - sheet_color
   - sheet_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1545,11 +1789,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - paper_type
   - pattern
   - sheet_color
   - sheet_pattern
   - target_audience
+  - width
   return_reasons:
   - size
   - color
@@ -1564,10 +1811,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - paper_type
   - pattern
   - sheet_color
   - sheet_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1582,12 +1832,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - notepad_cover_type
   - notepad_design
   - paper_type
   - pattern
   - sheet_color
   - sheet_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1602,10 +1855,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - paper_type
   - pattern
   - sheet_color
   - sheet_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1620,8 +1876,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - theme
+  - width
   return_reasons:
   - size
   - color
@@ -1638,7 +1897,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1654,8 +1916,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - receipt_paper_features
+  - width
   return_reasons:
   - size
   - thickness
@@ -1671,7 +1936,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1688,8 +1956,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -1706,7 +1977,11 @@
   attributes:
   - band_strength
   - color
+  - height
+  - length
   - pattern
+  - rubber_band_size
+  - width
   return_reasons:
   - size
   - strength
@@ -1720,7 +1995,10 @@
   name: Staples
   children: []
   attributes:
+  - height
+  - length
   - staple_wire_gauge
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1736,10 +2014,13 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - office_supply_material
   - pattern
   - point_design
   - tack/pushpin_head_design
+  - width
   return_reasons:
   - size
   - color
@@ -1756,6 +2037,9 @@
   - os-5-2
   attributes:
   - cutter_options
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - speed
@@ -1771,6 +2055,9 @@
   children: []
   attributes:
   - cutter_options
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - speed
@@ -1786,6 +2073,9 @@
   children: []
   attributes:
   - cutter_options
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - speed
@@ -1801,8 +2091,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1820,7 +2113,10 @@
   - os-7-2
   attributes:
   - color
+  - height
+  - length
   - office_supply_material
+  - width
   return_reasons:
   - size
   - color
@@ -1835,8 +2131,11 @@
   name: Desk Name Plates
   children: []
   attributes:
+  - height
+  - length
   - office_supply_material
   - personalization_design
+  - width
   return_reasons:
   - size
   - color
@@ -1851,8 +2150,11 @@
   name: Door Name Plates
   children: []
   attributes:
+  - height
+  - length
   - office_supply_material
   - personalization_design
+  - width
   return_reasons:
   - size
   - color
@@ -1870,8 +2172,11 @@
   - os-8-3
   attributes:
   - color
+  - height
+  - length
   - material
   - rug/mat_material
+  - width
   return_reasons:
   - size
   - color
@@ -1886,8 +2191,11 @@
   name: Anti-Fatigue Mats
   children: []
   attributes:
+  - height
+  - length
   - mat_features
   - rug/mat_material
+  - width
   return_reasons:
   - size
   - color
@@ -1903,8 +2211,11 @@
   name: Chair Mats
   children: []
   attributes:
+  - height
+  - length
   - mat_features
   - rug/mat_material
+  - width
   return_reasons:
   - size
   - color
@@ -1919,8 +2230,11 @@
   name: Office Mats
   children: []
   attributes:
+  - height
+  - length
   - mat_features
   - rug/mat_material
+  - width
   return_reasons:
   - size
   - color
@@ -1940,7 +2254,10 @@
   - os-9-4
   - os-9-5
   attributes:
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - size
   - color
@@ -1956,8 +2273,11 @@
   name: AV Carts
   children: []
   attributes:
+  - height
+  - length
   - material
   - office_cart_features
+  - width
   return_reasons:
   - size
   - style
@@ -1973,8 +2293,11 @@
   name: Book Carts
   children: []
   attributes:
+  - height
+  - length
   - material
   - office_cart_features
+  - width
   return_reasons:
   - size
   - style
@@ -1990,8 +2313,11 @@
   name: File Carts
   children: []
   attributes:
+  - height
+  - length
   - material
   - office_cart_features
+  - width
   return_reasons:
   - size
   - style
@@ -2007,8 +2333,11 @@
   name: Mail Carts
   children: []
   attributes:
+  - height
+  - length
   - material
   - office_cart_features
+  - width
   return_reasons:
   - size
   - style
@@ -2024,8 +2353,11 @@
   name: Utility Carts
   children: []
   attributes:
+  - height
+  - length
   - material
   - office_cart_features
+  - width
   return_reasons:
   - size
   - style
@@ -2050,7 +2382,10 @@
   - os-10-8
   - os-10-9
   - os-10-10
-  attributes: []
+  attributes:
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -2067,7 +2402,10 @@
   attributes:
   - calculator_accessory_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2086,7 +2424,10 @@
   - os-10-2-3
   - os-10-2-4
   - os-10-2-5
-  attributes: []
+  attributes:
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2103,6 +2444,9 @@
   - battery_size
   - battery_type
   - calculator_features
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -2117,6 +2461,9 @@
   children: []
   attributes:
   - calculator_features
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2130,6 +2477,9 @@
   children: []
   attributes:
   - calculator_features
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2143,6 +2493,9 @@
   children: []
   attributes:
   - calculator_features
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2156,6 +2509,9 @@
   children: []
   attributes:
   - calculator_features
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -2168,7 +2524,10 @@
   name: Electronic Dictionaries & Translators
   children: []
   attributes:
+  - height
+  - length
   - supported_language
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2181,7 +2540,10 @@
   name: Label Makers
   children: []
   attributes:
+  - height
+  - length
   - portability
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2195,9 +2557,12 @@
   name: Laminators
   children: []
   attributes:
+  - height
   - lamination_mode
+  - length
   - paper_size
   - portability
+  - width
   return_reasons:
   - size
   - speed
@@ -2212,7 +2577,10 @@
 - id: os-10-6
   name: Office Shredders
   children: []
-  attributes: []
+  attributes:
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - speed
@@ -2228,6 +2596,9 @@
   children: []
   attributes:
   - connectivity_technology
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - capacity
@@ -2245,7 +2616,10 @@
   - authentication_technology
   - connectivity_technology
   - display_technology
+  - height
+  - length
   - power_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2260,8 +2634,12 @@
   attributes:
   - audio_codecs/formats_supported
   - connectivity_technology
+  - height
+  - internal_storage_capacity
+  - length
   - recording_quality
   - transcriber/dictation_system_features
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -2276,8 +2654,11 @@
   children: []
   attributes:
   - compatible_paper_size
+  - height
   - keyboard_layout
+  - length
   - line_spacing_options
+  - width
   return_reasons:
   - size
   - weight
@@ -2317,8 +2698,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
+  - width
   return_reasons:
   - style
   - sound_quality
@@ -2334,8 +2718,11 @@
   attributes:
   - clip_type
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2353,6 +2740,9 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
+  - width
   return_reasons:
   - style
   - changed_my_mind
@@ -2367,8 +2757,11 @@
   attributes:
   - color
   - handle_material
+  - height
+  - length
   - lens_configuration
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -2393,11 +2786,14 @@
   attributes:
   - color
   - customization
+  - height
   - ink_color
   - ink_pattern
+  - length
   - pattern
   - stamp_type
   - text_plate_material
+  - width
   return_reasons:
   - size
   - color
@@ -2414,11 +2810,14 @@
   attributes:
   - color
   - customization
+  - height
   - ink_color
   - ink_pattern
+  - length
   - pattern
   - stamp_type
   - text_plate_material
+  - width
   return_reasons:
   - size
   - color
@@ -2435,11 +2834,14 @@
   attributes:
   - color
   - customization
+  - height
   - ink_color
   - ink_pattern
+  - length
   - pattern
   - stamp_type
   - text_plate_material
+  - width
   return_reasons:
   - size
   - color
@@ -2455,11 +2857,14 @@
   attributes:
   - color
   - customization
+  - height
   - ink_color
   - ink_pattern
+  - length
   - pattern
   - stamp_type
   - text_plate_material
+  - width
   return_reasons:
   - size
   - color
@@ -2476,11 +2881,14 @@
   attributes:
   - color
   - customization
+  - height
   - ink_color
   - ink_pattern
+  - length
   - pattern
   - stamp_type
   - text_plate_material
+  - width
   return_reasons:
   - size
   - color
@@ -2496,11 +2904,14 @@
   attributes:
   - color
   - customization
+  - height
   - ink_color
   - ink_pattern
+  - length
   - pattern
   - stamp_type
   - text_plate_material
+  - width
   return_reasons:
   - size
   - color
@@ -2517,11 +2928,14 @@
   attributes:
   - color
   - customization
+  - height
   - ink_color
   - ink_pattern
+  - length
   - pattern
   - stamp_type
   - text_plate_material
+  - width
   return_reasons:
   - size
   - color
@@ -2538,11 +2952,14 @@
   attributes:
   - color
   - customization
+  - height
   - ink_color
   - ink_pattern
+  - length
   - pattern
   - stamp_type
   - text_plate_material
+  - width
   return_reasons:
   - size
   - color
@@ -2558,11 +2975,14 @@
   attributes:
   - color
   - customization
+  - height
   - ink_color
   - ink_pattern
+  - length
   - pattern
   - stamp_type
   - text_plate_material
+  - width
   return_reasons:
   - size
   - color
@@ -2584,8 +3004,11 @@
   - os-11-6-6
   attributes:
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2599,9 +3022,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
   - pencil_sharpener_design
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2615,9 +3041,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
   - pencil_sharpener_design
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2631,9 +3060,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
   - pencil_sharpener_design
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2646,11 +3078,17 @@
   name: Electric Pencil Sharpeners
   children: []
   attributes:
+  - amperage
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
   - pencil_sharpener_design
+  - power_consumption_typical
   - power_source
+  - voltage
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2665,9 +3103,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
   - pencil_sharpener_design
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2681,9 +3122,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
   - pencil_sharpener_design
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2697,8 +3141,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -2718,7 +3165,10 @@
   - os-11-8-7
   - os-11-8-8
   - os-11-8-9
-  attributes: []
+  attributes:
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - capacity
@@ -2733,9 +3183,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
   - stapler_features
+  - width
   return_reasons:
   - size
   - capacity
@@ -2749,10 +3202,16 @@
   name: Electric Staplers
   children: []
   attributes:
+  - amperage
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
+  - power_consumption_typical
   - stapler_features
+  - voltage
+  - width
   return_reasons:
   - size
   - capacity
@@ -2767,9 +3226,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
   - stapler_features
+  - width
   return_reasons:
   - size
   - capacity
@@ -2784,9 +3246,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
   - stapler_features
+  - width
   return_reasons:
   - size
   - capacity
@@ -2801,9 +3266,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
   - stapler_features
+  - width
   return_reasons:
   - size
   - capacity
@@ -2818,9 +3286,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
   - stapler_features
+  - width
   return_reasons:
   - size
   - capacity
@@ -2835,9 +3306,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
   - stapler_features
+  - width
   return_reasons:
   - size
   - capacity
@@ -2852,9 +3326,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
   - stapler_features
+  - width
   return_reasons:
   - size
   - capacity
@@ -2869,9 +3346,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - office_instrument_material
   - pattern
   - stapler_features
+  - width
   return_reasons:
   - size
   - capacity
@@ -2886,8 +3366,12 @@
   children: []
   attributes:
   - color
+  - compatible_tape_size
+  - height
+  - length
   - office_instrument_material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2922,7 +3406,10 @@
   - os-11-10-1-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -2937,7 +3424,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -2952,7 +3442,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -2968,8 +3461,11 @@
   attributes:
   - alcohol/solvent_content
   - color
+  - height
+  - length
   - pattern
   - pen_tip_design
+  - width
   return_reasons:
   - color
   - incompatible
@@ -2984,8 +3480,12 @@
   children: []
   attributes:
   - color
+  - height
   - lead_grade
+  - lead_size
+  - length
   - pattern
+  - width
   return_reasons:
   - hardness
   - incompatible
@@ -3029,7 +3529,10 @@
   - os-11-11-1-9
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3046,7 +3549,11 @@
   attributes:
   - color
   - hardness
+  - height
+  - lead_size
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - hardness
@@ -3062,7 +3569,10 @@
   attributes:
   - color
   - hardness
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3079,7 +3589,10 @@
   attributes:
   - color
   - hardness
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3096,7 +3609,10 @@
   attributes:
   - color
   - hardness
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3113,7 +3629,10 @@
   attributes:
   - color
   - hardness
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3130,7 +3649,10 @@
   attributes:
   - color
   - hardness
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3147,7 +3669,10 @@
   attributes:
   - color
   - hardness
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - hardness
@@ -3164,7 +3689,10 @@
   attributes:
   - color
   - hardness
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3181,7 +3709,10 @@
   attributes:
   - color
   - hardness
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3197,7 +3728,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -3219,7 +3753,10 @@
   - os-11-11-3-8
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3234,7 +3771,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3249,7 +3789,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3264,7 +3807,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3279,7 +3825,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3294,7 +3843,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3309,7 +3861,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3324,7 +3879,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3339,7 +3897,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3356,7 +3917,10 @@
   - os-11-11-4-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - tip_size
@@ -3372,8 +3936,11 @@
   attributes:
   - alcohol/solvent_content
   - color
+  - height
+  - length
   - marker_tip_design
   - pattern
+  - width
   return_reasons:
   - color
   - tip_size
@@ -3389,8 +3956,11 @@
   attributes:
   - alcohol/solvent_content
   - color
+  - height
+  - length
   - marker_tip_design
   - pattern
+  - width
   return_reasons:
   - color
   - tip_size
@@ -3405,9 +3975,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - pen/pencil_features
   - pen_type
+  - width
   return_reasons:
   - color
   - tip_size
@@ -3428,7 +4001,10 @@
   - os-11-11-6-6
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3444,7 +4020,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3460,7 +4039,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3476,7 +4058,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3492,7 +4077,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3508,7 +4096,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - hardness
@@ -3523,7 +4114,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3542,6 +4136,7 @@
   - os-11-11-7-3
   attributes:
   - color
+  - lead_size
   - pattern
   return_reasons:
   - size
@@ -3557,10 +4152,14 @@
   children: []
   attributes:
   - color
+  - height
+  - lead_size
+  - length
   - pattern
   - pen/pencil_features
   - pen_type
   - pencil_type
+  - width
   return_reasons:
   - color
   - tip_size
@@ -3577,6 +4176,7 @@
   - os-11-11-7-2-2
   attributes:
   - color
+  - lead_size
   - lumber/wood_type
   - pattern
   - pencil_features
@@ -3595,10 +4195,14 @@
   children: []
   attributes:
   - color
+  - height
   - lead_grade
+  - lead_size
+  - length
   - lumber/wood_type
   - pattern
   - pencil_features
+  - width
   - wood_finish
   return_reasons:
   - color
@@ -3615,7 +4219,11 @@
   - os-11-11-7-2-2-1
   - os-11-11-7-2-2-2
   attributes:
+  - height
+  - lead_size
+  - length
   - pencil_features
+  - width
   return_reasons:
   - color
   - hardness
@@ -3630,9 +4238,13 @@
   children: []
   attributes:
   - color
+  - height
+  - lead_size
+  - length
   - lumber/wood_type
   - pattern
   - pencil_features
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -3648,10 +4260,14 @@
   children: []
   attributes:
   - color
+  - height
   - lead_grade
+  - lead_size
+  - length
   - lumber/wood_type
   - pattern
   - pencil_features
+  - width
   - wood_finish
   return_reasons:
   - color
@@ -3671,9 +4287,12 @@
   - os-11-11-7-3-4
   - os-11-11-7-3-5
   attributes:
+  - height
   - ink_color
   - ink_pattern
+  - length
   - lumber/wood_type
+  - width
   - wood_finish
   return_reasons:
   - color
@@ -3688,13 +4307,16 @@
   name: Ballpoint Pens
   children: []
   attributes:
+  - height
   - ink_color
   - ink_pattern
+  - length
   - lumber/wood_type
   - pen_color
   - pen_features
   - pen_pattern
   - pen_tip_design
+  - width
   - wood_finish
   return_reasons:
   - color
@@ -3710,11 +4332,14 @@
   children: []
   attributes:
   - felt_tip_design
+  - height
   - ink_color
   - ink_pattern
+  - length
   - pen_color
   - pen_features
   - pen_pattern
+  - width
   return_reasons:
   - color
   - tip_size
@@ -3728,13 +4353,16 @@
   name: Fountain Pens
   children: []
   attributes:
+  - height
   - ink_color
   - ink_pattern
+  - length
   - lumber/wood_type
   - pen_color
   - pen_features
   - pen_pattern
   - pen_tip_design
+  - width
   - wood_finish
   return_reasons:
   - color
@@ -3750,12 +4378,15 @@
   name: Gel Pens
   children: []
   attributes:
+  - height
   - ink_color
   - ink_pattern
+  - length
   - pen_color
   - pen_features
   - pen_pattern
   - pen_tip_design
+  - width
   return_reasons:
   - color
   - tip_size
@@ -3769,12 +4400,15 @@
   name: Rollerball Pens
   children: []
   attributes:
+  - height
   - ink_color
   - ink_pattern
+  - length
   - pen_color
   - pen_features
   - pen_pattern
   - pen_tip_design
+  - width
   return_reasons:
   - color
   - tip_size
@@ -3793,7 +4427,10 @@
   - os-12-4
   - os-12-5
   - os-12-6
-  attributes: []
+  attributes:
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -3810,7 +4447,10 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3824,7 +4464,11 @@
 - id: os-12-2
   name: Hole Punches
   children: []
-  attributes: []
+  attributes:
+  - height
+  - hole_punch_size
+  - length
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -3840,7 +4484,10 @@
   attributes:
   - feed_system
   - fold_type
+  - height
+  - length
   - paper_size
+  - width
   return_reasons:
   - size
   - speed
@@ -3857,7 +4504,10 @@
   children: []
   attributes:
   - accessory_size
+  - height
+  - length
   - paper_size
+  - width
   return_reasons:
   - size
   - capacity
@@ -3871,9 +4521,12 @@
   name: Paperweights
   children: []
   attributes:
+  - height
+  - length
   - material
   - paperweight_design
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -3888,9 +4541,12 @@
   name: Pencil Boards
   children: []
   attributes:
+  - height
+  - length
   - material
   - paper_size
   - thickness_type
+  - width
   return_reasons:
   - size
   - color
@@ -3933,7 +4589,10 @@
   - board_mounting_type
   - chalkboard_surface
   - frame_design
+  - height
+  - length
   - presentation_supply_features
+  - width
   return_reasons:
   - size
   - color
@@ -3958,6 +4617,9 @@
   - board_surface
   - display_board_features
   - frame_design
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -3974,7 +4636,10 @@
   - os-13-2-1-1
   - os-13-2-1-2
   attributes:
+  - height
+  - length
   - office_supply_material
+  - width
   return_reasons:
   - size
   - color
@@ -3991,8 +4656,11 @@
   attributes:
   - color
   - display_board_features
+  - height
+  - length
   - office_supply_material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4009,8 +4677,11 @@
   attributes:
   - color
   - display_board_features
+  - height
+  - length
   - office_supply_material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4029,7 +4700,10 @@
   - board_mounting_type
   - display_board_features
   - frame_design
+  - height
+  - length
   - lumber/wood_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -4046,6 +4720,9 @@
   attributes:
   - board_mounting_type
   - display_board_features
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -4062,7 +4739,10 @@
   attributes:
   - board_mounting_type
   - display_board_features
+  - height
+  - length
   - lumber/wood_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -4079,7 +4759,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4096,7 +4779,10 @@
   attributes:
   - color
   - connectivity_technology
+  - height
+  - length
   - pattern
+  - width
   - zoom_type
   return_reasons:
   - resolution
@@ -4114,7 +4800,10 @@
   - board_material
   - board_mounting_type
   - frame_design
+  - height
+  - length
   - presentation_supply_features
+  - width
   return_reasons:
   - size
   - color
@@ -4129,8 +4818,11 @@
   name: Easel Pads
   children: []
   attributes:
+  - height
+  - length
   - paper_type
   - presentation_supply_features
+  - width
   return_reasons:
   - size
   - color
@@ -4145,8 +4837,11 @@
   name: Easels
   children: []
   attributes:
+  - height
+  - length
   - material
   - presentation_supply_features
+  - width
   return_reasons:
   - size
   - color
@@ -4163,11 +4858,14 @@
   attributes:
   - battery_size
   - color
+  - height
   - laser_color
   - laser_light_source
   - laser_pattern
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - range
@@ -4183,9 +4881,12 @@
   children: []
   attributes:
   - color
+  - height
   - lectern_mounting_type
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4201,7 +4902,10 @@
   name: Transparencies
   children: []
   attributes:
+  - height
+  - length
   - paper_size
+  - width
   return_reasons:
   - size
   - thickness
@@ -4218,7 +4922,10 @@
   attributes:
   - battery_size
   - connectivity_technology
+  - height
+  - length
   - material
+  - width
   return_reasons:
   - color
   - range
@@ -4237,7 +4944,10 @@
   - os-14-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4253,8 +4963,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - moving/shipping_box_material
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -4268,8 +4981,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - packing_materials_included
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -4283,7 +4999,9 @@
   children: []
   attributes:
   - color
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible

--- a/data/categories/rc_religious_ceremonial.yml
+++ b/data/categories/rc_religious_ceremonial.yml
@@ -5,7 +5,10 @@
   - rc-1
   - rc-2
   - rc-3
-  attributes: []
+  attributes:
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -22,7 +25,10 @@
   - rc-1-1
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -36,7 +42,10 @@
 - id: rc-1-1
   name: Memorial Urns
   children: []
-  attributes: []
+  attributes:
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -58,7 +67,10 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -71,7 +83,10 @@
 - id: rc-2-1
   name: Prayer Beads
   children: []
-  attributes: []
+  attributes:
+  - height
+  - length
+  - width
   return_reasons:
   - color
   - length
@@ -84,7 +99,10 @@
 - id: rc-2-2
   name: Prayer Cards
   children: []
-  attributes: []
+  attributes:
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -99,7 +117,10 @@
 - id: rc-2-3
   name: Religious Altars
   children: []
-  attributes: []
+  attributes:
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - finish
@@ -112,7 +133,10 @@
 - id: rc-2-4
   name: Religious Veils
   children: []
-  attributes: []
+  attributes:
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -128,7 +152,10 @@
 - id: rc-2-5
   name: Tarot Cards
   children: []
-  attributes: []
+  attributes:
+  - height
+  - length
+  - width
   return_reasons:
   - printing
   - finish
@@ -146,7 +173,10 @@
   - rc-3-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -160,7 +190,10 @@
 - id: rc-3-1
   name: Aisle Runners
   children: []
-  attributes: []
+  attributes:
+  - height
+  - length
+  - width
   return_reasons:
   - color
   - length
@@ -175,7 +208,10 @@
 - id: rc-3-2
   name: Flower Girl Baskets
   children: []
-  attributes: []
+  attributes:
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color
@@ -189,7 +225,10 @@
 - id: rc-3-3
   name: Ring Pillows & Holders
   children: []
-  attributes: []
+  attributes:
+  - height
+  - length
+  - width
   return_reasons:
   - size
   - color

--- a/data/categories/sg_sporting_goods.yml
+++ b/data/categories/sg_sporting_goods.yml
@@ -124,9 +124,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - mounting_type
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -143,8 +146,11 @@
   attributes:
   - color
   - compatible_football_kick_type
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - height
@@ -196,10 +202,13 @@
   - american_football_safety_certification
   - color
   - gear_material
+  - height
+  - length
   - pad_coverage_area
   - pattern
   - sports_governing_body_certification
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -228,8 +237,11 @@
   - age_group
   - american_football_safety_certification
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -250,9 +262,12 @@
   - american_football_safety_certification
   - chin_cup_type
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - strap_configuration
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -274,8 +289,11 @@
   - color
   - compatible_helmet_size
   - face_mask_style_code
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -295,8 +313,11 @@
   - age_group
   - american_football_safety_certification
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -316,9 +337,12 @@
   - age_group
   - american_football_safety_certification
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - visor_lens_finish
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -427,9 +451,12 @@
   - chinstrap_type
   - color
   - face_mask_material
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - virginia_tech_helmet_star_rating
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -490,9 +517,12 @@
   - american_football_safety_certification
   - color
   - gear_material
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -513,9 +543,12 @@
   - american_football_safety_certification
   - color
   - gear_material
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -535,8 +568,11 @@
   - age_group
   - american_football_safety_certification
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -663,9 +699,12 @@
   - sg-1-1-5-1-2
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - color
@@ -683,9 +722,12 @@
   attributes:
   - color
   - football_dummy_type
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - color
@@ -702,10 +744,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pad_style
   - pattern
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - color
@@ -785,9 +830,12 @@
   - ball_size
   - color
   - football_ball_type
+  - height
   - lace_type
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -876,9 +924,12 @@
   attributes:
   - baseball_softball_league_certification
   - color
+  - height
+  - length
   - pattern
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - weight
@@ -894,9 +945,12 @@
   attributes:
   - baseball_softball_league_certification
   - color
+  - height
+  - length
   - pattern
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -913,12 +967,15 @@
   attributes:
   - baseball_softball_league_certification
   - color
+  - height
+  - length
   - pattern
   - plate_bottom_design
   - plate_installation_type
   - plate_size_category
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - thickness
@@ -967,6 +1024,7 @@
   - baseball_glove_type
   - baseball_softball_league_certification
   - color
+  - glove_length
   - glove_webbing_style
   - hand_side
   - handwear_material
@@ -995,6 +1053,7 @@
   - baseball_softball_league_certification
   - color
   - fielding_glove_position
+  - glove_length
   - glove_webbing_style
   - hand_side
   - handwear_material
@@ -1023,6 +1082,7 @@
   - baseball_softball_league_certification
   - color
   - fielding_glove_position
+  - glove_length
   - glove_webbing_style
   - hand_side
   - handwear_material
@@ -1047,6 +1107,7 @@
   - baseball_softball_league_certification
   - color
   - fielding_glove_position
+  - glove_length
   - glove_webbing_style
   - hand_side
   - handwear_material
@@ -1068,8 +1129,12 @@
   - age_group
   - baseball_softball_league_certification
   - color
+  - diameter
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -1087,10 +1152,13 @@
   - baseball_softball_league_certification
   - color
   - guideline_markings
+  - height
+  - length
   - mat_backing_type
   - pattern
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -1108,10 +1176,13 @@
   attributes:
   - baseball_softball_league_certification
   - color
+  - height
+  - length
   - mound_usage_type
   - pattern
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - height
@@ -1130,9 +1201,12 @@
   - age_group
   - baseball_softball_league_certification
   - color
+  - height
+  - length
   - pattern
   - pitching_rubber_size_designation
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -1162,8 +1236,11 @@
   - age_group
   - baseball_softball_league_certification
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1184,8 +1261,11 @@
   - baseball_softball_league_certification
   - batting_helmet_accessories_included
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1206,9 +1286,12 @@
   - age_group
   - baseball_softball_league_certification
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1268,9 +1351,12 @@
   - baseball_softball_usage_role
   - color
   - foot_guard_type
+  - height
   - knee_protection_design
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1350,9 +1436,13 @@
   - baseball_softball_league_certification
   - catcher_equipment_included
   - color
+  - height
+  - leg_guard_length
+  - length
   - pattern
   - player_size_category
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1376,10 +1466,13 @@
   - baseball_softball_league_certification
   - catcher_helmet_style
   - color
+  - height
   - intended_player_role
+  - length
   - mask_cage_material
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1575,9 +1668,12 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - height
@@ -1600,10 +1696,13 @@
   - batting_cage_components_included
   - cage_package_type
   - color
+  - height
+  - length
   - net_twine_gauge
   - pattern
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - height
@@ -1682,9 +1781,12 @@
   - age_group
   - baseball_softball_league_certification
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - height
@@ -1702,9 +1804,12 @@
   - age_group
   - baseball_softball_league_certification
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - height
@@ -1722,10 +1827,13 @@
   - age_group
   - baseball_softball_league_certification
   - color
+  - height
+  - length
   - pattern
   - pitching_screen_style
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - height
@@ -1743,10 +1851,13 @@
   - age_group
   - baseball_softball_league_certification
   - color
+  - height
+  - length
   - pattern
   - pitching_target_design
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - height
@@ -1764,9 +1875,14 @@
   - age_group
   - baseball_softball_league_certification
   - color
+  - height
+  - length
   - pattern
+  - speed_measurement_accuracy
+  - speed_range
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - range
@@ -1785,10 +1901,13 @@
   - age_group
   - baseball_softball_league_certification
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - swing_trainer_type
   - training_focus
+  - width
   return_reasons:
   - size
   - weight
@@ -1917,15 +2036,20 @@
   children: []
   attributes:
   - age_group
+  - barrel_size
   - baseball_softball_league_certification
   - bat_construction
+  - bat_length
   - bat_material
   - bat_standard
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - sports_governing_body_certification
   - swing_weighting
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -1948,9 +2072,12 @@
   - baseball/softball_ball_type
   - baseball_softball_league_certification
   - color
+  - height
+  - length
   - pattern
   - seam_type
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -2009,9 +2136,14 @@
   - compatible_ball_type
   - features
   - feed_mechanism
+  - height
+  - length
+  - maximum_ball_speed
+  - minimum_ball_speed
   - pattern
   - pitching_wheel_count
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - speed
@@ -2028,14 +2160,20 @@
   children: []
   attributes:
   - age_group
+  - barrel_length
+  - barrel_size
   - baseball_softball_league_certification
+  - bat_length
   - bat_material
   - bat_standard
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - softball_discipline
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - grip
@@ -2056,9 +2194,13 @@
   - ball_size
   - baseball_softball_league_certification
   - color
+  - height
+  - length
   - pattern
   - softball_certification
+  - softball_circumference
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -2080,6 +2222,7 @@
   - color
   - pattern
   - softball_certification
+  - softball_circumference
   - sports_governing_body_certification
   return_reasons:
   - changed_my_mind
@@ -2098,6 +2241,7 @@
   - color
   - pattern
   - softball_certification
+  - softball_circumference
   - sports_governing_body_certification
   return_reasons:
   - changed_my_mind
@@ -2157,6 +2301,7 @@
   attributes:
   - baseball_softball_league_certification
   - color
+  - glove_length
   - pattern
   - sports_governing_body_certification
   return_reasons:
@@ -2237,8 +2382,11 @@
   - basketball_hoop_accessory_type
   - color
   - compatible_pole_dimensions
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -2256,10 +2404,13 @@
   - basketball_hoop_accessory_type
   - color
   - compatible_pole_dimensions
+  - height
+  - length
   - mounting_type
   - pattern
   - sports_governing_body_certification
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -2281,11 +2432,15 @@
   - basketball_hoop_accessory_type
   - basketball_padding_location
   - color
+  - compatible_backboard_width
   - compatible_pole_dimensions
   - compatible_pole_shape
+  - height
+  - length
   - material
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -2305,6 +2460,7 @@
   - basketball_hoop_accessory_type
   - basketball_padding_location
   - color
+  - compatible_backboard_width
   - compatible_pole_dimensions
   - compatible_pole_shape
   - material
@@ -2326,6 +2482,7 @@
   - basketball_hoop_accessory_type
   - basketball_padding_location
   - color
+  - compatible_backboard_width
   - compatible_pole_dimensions
   - compatible_pole_shape
   - material
@@ -2347,9 +2504,13 @@
   - basketball_hoop_accessory_type
   - color
   - compatible_pole_dimensions
+  - height
+  - length
+  - overhang_length
   - pattern
   - post_material
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -2369,8 +2530,12 @@
   - basketball_hoop_accessory_type
   - color
   - compatible_pole_dimensions
+  - compatible_rim_diameter
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -2390,11 +2555,15 @@
   - basketball_rim_type
   - color
   - compatible_pole_dimensions
+  - diameter
+  - height
+  - length
   - material
   - mounting_type
   - pattern
   - sports_governing_body_certification
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -2479,12 +2648,19 @@
   attributes:
   - age_group
   - backboard_material
+  - backboard_width
+  - base_fill_capacity
   - basketball_equipment_included
   - color
+  - diameter
+  - height
+  - length
   - material
   - pattern
+  - rim_diameter
   - sports_governing_body_certification
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -2501,10 +2677,13 @@
   attributes:
   - age_group
   - backboard_material
+  - backboard_width
+  - base_fill_capacity
   - basketball_equipment_included
   - color
   - material
   - pattern
+  - rim_diameter
   - sports_governing_body_certification
   - suitable_space
   return_reasons:
@@ -2520,10 +2699,13 @@
   attributes:
   - age_group
   - backboard_material
+  - backboard_width
+  - base_fill_capacity
   - basketball_equipment_included
   - color
   - material
   - pattern
+  - rim_diameter
   - sports_governing_body_certification
   - suitable_space
   return_reasons:
@@ -2539,10 +2721,13 @@
   attributes:
   - age_group
   - backboard_material
+  - backboard_width
+  - base_fill_capacity
   - basketball_equipment_included
   - color
   - material
   - pattern
+  - rim_diameter
   - sports_governing_body_certification
   - suitable_space
   return_reasons:
@@ -2558,10 +2743,13 @@
   attributes:
   - age_group
   - backboard_material
+  - backboard_width
+  - base_fill_capacity
   - basketball_equipment_included
   - color
   - material
   - pattern
+  - rim_diameter
   - sports_governing_body_certification
   - suitable_space
   return_reasons:
@@ -2586,9 +2774,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - skill_focus
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -2606,9 +2797,12 @@
   - age_group
   - base_fill_material
   - color
+  - height
+  - length
   - pattern
   - skill_focus
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -2626,9 +2820,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - skill_focus
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -2644,9 +2841,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - skill_focus
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -2668,9 +2868,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - skill_focus
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -2833,8 +3036,11 @@
   - ball_material
   - ball_size
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -2981,8 +3187,11 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -3053,8 +3262,11 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -3138,9 +3350,12 @@
   - age_group
   - color
   - gear_material
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -3277,9 +3492,12 @@
   - age_group
   - color
   - gear_material
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - target_gender
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -3298,10 +3516,13 @@
   - accessory_size
   - age_group
   - color
+  - height
   - instep_coverage
+  - length
   - padding_layers
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -3381,10 +3602,13 @@
   - age_group
   - color
   - handwear_material
+  - height
+  - length
   - padding_material
   - pattern
   - sports_governing_body_certification
   - target_gender
+  - width
   return_reasons:
   - size
   - too_firm
@@ -3404,10 +3628,13 @@
   - color
   - fill_status
   - grappling_dummy_pose
+  - height
+  - length
   - limb_articulation
   - padding_material
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - too_firm
@@ -3433,9 +3660,12 @@
   - age_group
   - color
   - compatible_punching_bag_type
+  - height
+  - length
   - padding_material
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - weight
@@ -3453,9 +3683,12 @@
   - age_group
   - color
   - compatible_punching_bag_type
+  - height
+  - length
   - padding_material
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - weight
@@ -3473,9 +3706,12 @@
   - age_group
   - color
   - compatible_punching_bag_type
+  - height
+  - length
   - padding_material
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - weight_capacity
@@ -3494,9 +3730,12 @@
   - age_group
   - color
   - compatible_punching_bag_type
+  - height
+  - length
   - padding_material
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - width
@@ -3591,10 +3830,14 @@
   attributes:
   - age_group
   - color
+  - diameter
+  - height
+  - length
   - padding_material
   - pattern
   - punching/training_bag_material
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - too_firm
@@ -3612,10 +3855,14 @@
   attributes:
   - age_group
   - color
+  - diameter
+  - height
+  - length
   - padding_material
   - pattern
   - punching/training_bag_material
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - too_firm
@@ -3633,11 +3880,15 @@
   attributes:
   - age_group
   - color
+  - diameter
   - double_end_bag_core_type
+  - height
+  - length
   - padding_material
   - pattern
   - punching/training_bag_material
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - too_firm
@@ -3655,11 +3906,15 @@
   attributes:
   - age_group
   - color
+  - diameter
+  - height
+  - length
   - padding_material
   - pattern
   - punching/training_bag_material
   - punching_training_bag_shape
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - too_firm
@@ -3677,10 +3932,14 @@
   attributes:
   - age_group
   - color
+  - diameter
+  - height
+  - length
   - padding_material
   - pattern
   - punching/training_bag_material
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - too_firm
@@ -3698,11 +3957,15 @@
   attributes:
   - age_group
   - color
+  - diameter
+  - height
+  - length
   - padding_material
   - pattern
   - punching/training_bag_material
   - shock_absorption_system
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - too_firm
@@ -3720,6 +3983,9 @@
   attributes:
   - age_group
   - color
+  - diameter
+  - height
+  - length
   - pad_mounting_or_holding_style
   - pad_shape
   - padding_material
@@ -3727,6 +3993,7 @@
   - punch_pad_type
   - punching/training_bag_material
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - too_firm
@@ -3745,11 +4012,15 @@
   - age_group
   - bag_fill_medium
   - color
+  - diameter
+  - height
+  - length
   - padding_material
   - pattern
   - punching/training_bag_material
   - speed_bag_accessories_included
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - too_firm
@@ -3767,10 +4038,14 @@
   attributes:
   - age_group
   - color
+  - diameter
+  - height
+  - length
   - padding_material
   - pattern
   - punching/training_bag_material
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - too_firm
@@ -3788,10 +4063,14 @@
   attributes:
   - age_group
   - color
+  - diameter
+  - height
+  - length
   - padding_material
   - pattern
   - punching/training_bag_material
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - too_firm
@@ -3809,10 +4088,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - padding_material
   - pattern
   - sports_governing_body_certification
   - strike_shield_shape
+  - width
   return_reasons:
   - size
   - too_firm
@@ -3904,9 +4186,13 @@
   attributes:
   - color
   - compatible_rope_count
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -3923,9 +4209,14 @@
   attributes:
   - color
   - compatible_rope_count
+  - height
+  - length
   - material
+  - maximum_load_capacity
+  - mounting_hole_spacing
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -3943,10 +4234,14 @@
   attributes:
   - color
   - compatible_rope_count
+  - height
+  - length
+  - maximum_load_capacity
   - net_material
   - net_mesh_pattern
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -3964,9 +4259,13 @@
   attributes:
   - color
   - compatible_rope_count
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -4096,9 +4395,13 @@
   attributes:
   - boxing_ring_style
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - height
@@ -4118,10 +4421,13 @@
   - age_group
   - clothing_accessory_material
   - color
+  - height
+  - length
   - martial_arts_belt_rank
   - pattern
   - sports_governing_body_certification
   - target_gender
+  - width
   - wrap_style
   return_reasons:
   - too_long
@@ -4150,8 +4456,11 @@
   - age_group
   - blade_sharpness
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - grip
@@ -4171,8 +4480,11 @@
   - blade_sharpness
   - bo_staff_style
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - grip
@@ -4192,9 +4504,12 @@
   - blade_sharpness
   - color
   - handle_shape
+  - height
+  - length
   - nunchuck_connector_type
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - grip
@@ -4213,8 +4528,11 @@
   - age_group
   - blade_sharpness
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - grip
@@ -4233,9 +4551,12 @@
   - age_group
   - blade_sharpness
   - color
+  - height
+  - length
   - pattern
   - shaft_shape
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - grip
@@ -4339,8 +4660,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -4357,8 +4681,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -4376,8 +4703,11 @@
   - age_group
   - broom_head_material
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - grip
@@ -4395,9 +4725,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - mounting_type
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -4464,8 +4797,11 @@
   - sg-1-6-7
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -4481,10 +4817,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - pom_pom_handle_style
   - sports_governing_body_certification
   - strand_material
+  - width
   return_reasons:
   - color
   - length
@@ -4612,8 +4951,11 @@
   - age_group
   - armband_features
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -4654,8 +4996,11 @@
   attributes:
   - boundary_marker_type
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -4672,6 +5017,7 @@
   attributes:
   - boundary_marker_type
   - color
+  - coverage_area_per_container
   - marking_durability
   - pattern
   - sports_governing_body_certification
@@ -4693,8 +5039,10 @@
   attributes:
   - boundary_marker_type
   - color
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - width
@@ -4773,8 +5121,11 @@
   - sg-1-7-3-2
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -4789,8 +5140,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -4806,8 +5160,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -4829,9 +5186,12 @@
   - sg-1-7-4-6
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -4847,9 +5207,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -4868,9 +5231,12 @@
   - color
   - corner_flag_features
   - flag_base_type
+  - height
+  - length
   - pattern
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - height
@@ -4887,9 +5253,13 @@
   children: []
   attributes:
   - color
+  - flag_dimensions
+  - height
+  - length
   - pattern
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -4921,6 +5291,7 @@
   children: []
   attributes:
   - color
+  - flag_dimensions
   - pattern
   - sport
   - sports_governing_body_certification
@@ -4954,9 +5325,12 @@
   - sg-1-7-5-3
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -4972,11 +5346,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - penalty_card_accessories_included
   - penalty_card_colors_included
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -4993,10 +5370,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - penalty_flag_throw_distance
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -5027,9 +5407,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - metrics_counted
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -5047,9 +5430,12 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - height
@@ -5066,9 +5452,12 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - height
@@ -5085,9 +5474,12 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - height
@@ -5104,10 +5496,13 @@
   attributes:
   - clothing_accessory_material
   - color
+  - height
+  - length
   - pattern
   - referee_wallet_accessories_included
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -5125,11 +5520,15 @@
   - sg-1-7-9-2
   attributes:
   - color
+  - digit_height
+  - height
+  - length
   - pattern
   - scoreboard_features
   - sport
   - sports_governing_body_certification
   - viewing_sides
+  - width
   return_reasons:
   - size
   - color
@@ -5146,11 +5545,15 @@
   children: []
   attributes:
   - color
+  - digit_height
+  - height
+  - length
   - pattern
   - scoreboard_features
   - sport
   - sports_governing_body_certification
   - viewing_sides
+  - width
   return_reasons:
   - size
   - color
@@ -5167,11 +5570,15 @@
   children: []
   attributes:
   - color
+  - digit_height
+  - height
+  - length
   - pattern
   - scoreboard_features
   - sport
   - sports_governing_body_certification
   - viewing_sides
+  - width
   return_reasons:
   - size
   - color
@@ -5193,11 +5600,14 @@
   - sg-1-7-10-6
   attributes:
   - color
+  - height
   - lanyard_type
+  - length
   - material
   - pattern
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -5214,12 +5624,15 @@
   attributes:
   - color
   - finger_grip_adjustability
+  - height
   - lanyard_type
+  - length
   - material
   - mouth_grip_type
   - pattern
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -5235,9 +5648,12 @@
   name: Finger Grip Whistles
   children: []
   attributes:
+  - height
   - lanyard_type
+  - length
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -5254,12 +5670,15 @@
   children: []
   attributes:
   - color
+  - height
   - lanyard_type
+  - length
   - material
   - pattern
   - sport
   - sports_governing_body_certification
   - whistle_purpose
+  - width
   return_reasons:
   - size
   - color
@@ -5310,10 +5729,13 @@
   children: []
   attributes:
   - color
+  - height
   - indicator_functions_tracked
+  - length
   - material
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -5330,6 +5752,7 @@
   children: []
   attributes:
   - color
+  - digit_height
   - pattern
   - sports_governing_body_certification
   return_reasons:
@@ -5377,9 +5800,12 @@
   - color
   - cricket_ball_grade
   - cricket_ball_piece_construction
+  - height
+  - length
   - pattern
   - seam_construction
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -5404,8 +5830,11 @@
   - color
   - cricket_bat_accessory_type
   - cricket_bat_size_compatibility
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -5422,9 +5851,12 @@
   - bat_handle_size_compatibility
   - color
   - cricket_bat_size_compatibility
+  - height
+  - length
   - material
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -5550,10 +5982,13 @@
   - bat_material
   - color
   - cricket_bat_size
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - sports_governing_body_certification
   - sweet_spot_position
+  - width
   - willow_grade
   - willow_type
   - wood_finish
@@ -5575,8 +6010,11 @@
   - color
   - cricket_ball_type
   - cricket_equipment_included
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -5602,8 +6040,11 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -5723,8 +6164,11 @@
   - age_group
   - color
   - cricket_helmet_role
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -5747,8 +6191,11 @@
   - color
   - cricket_leg_guard_type
   - cricket_protection_grade
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -5885,11 +6332,14 @@
   - color
   - cricket_stump_base_type
   - cricket_stump_type
+  - height
+  - length
   - material
   - pattern
   - sports_governing_body_certification
   - stump_mechanism
   - stump_size
+  - width
   return_reasons:
   - size
   - color
@@ -5918,8 +6368,11 @@
   - age_group
   - color
   - cricket_training_focus
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -5938,8 +6391,11 @@
   - batting_tee_base_design
   - color
   - cricket_training_focus
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - height
@@ -5957,8 +6413,12 @@
   - age_group
   - color
   - cricket_training_focus
+  - height
+  - length
   - pattern
+  - rope_length
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - length
@@ -5977,9 +6437,12 @@
   - age_group
   - color
   - cricket_training_focus
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - supported_bowling_delivery_types
+  - width
   return_reasons:
   - size
   - speed
@@ -5997,8 +6460,11 @@
   - age_group
   - color
   - cricket_training_focus
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -6020,8 +6486,11 @@
   - color
   - cricket_training_focus
   - fielding_training_focus
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -6093,8 +6562,11 @@
   - age_group
   - color
   - cricket_training_focus
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -6160,9 +6632,12 @@
   - age_group
   - color
   - cricket_training_focus
+  - height
+  - length
   - pattern
   - pitch_mat_coverage_length
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - width
@@ -6181,9 +6656,12 @@
   - age_group
   - color
   - cricket_training_focus
+  - height
+  - length
   - pattern
   - rebound_surface_configuration
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -6202,9 +6680,12 @@
   - color
   - cricket_stump_target_features
   - cricket_training_focus
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - stump_base_type
+  - width
   return_reasons:
   - size
   - color
@@ -6347,8 +6828,11 @@
   - sg-1-9-7
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -6364,9 +6848,12 @@
   attributes:
   - barre_rail_configuration
   - color
+  - height
+  - length
   - material
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - height
   - length
@@ -6605,8 +7092,11 @@
   - age_group
   - color
   - fencing_discipline
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -6624,8 +7114,11 @@
   - age_group
   - color
   - fencing_discipline
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -6713,9 +7206,12 @@
   - compatible_fencing_weapon
   - fencing_discipline
   - gear_material
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -6774,10 +7270,13 @@
   - age_group
   - color
   - fencing_discipline
+  - height
+  - length
   - lining_type
   - mask_bib_type
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -6795,8 +7294,11 @@
   - age_group
   - color
   - fencing_discipline
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -6856,8 +7358,11 @@
   - color
   - fencing_connector_type
   - fencing_discipline
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -6986,8 +7491,11 @@
   - color
   - fencing_discipline
   - fencing_weapon_type
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - grip
@@ -7007,8 +7515,11 @@
   - color
   - fencing_discipline
   - fencing_weapon_type
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - incompatible
@@ -7026,8 +7537,11 @@
   - color
   - fencing_discipline
   - fencing_weapon_type
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - weight
@@ -7045,8 +7559,11 @@
   - color
   - fencing_discipline
   - fencing_weapon_type
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - width
@@ -7066,8 +7583,11 @@
   - color
   - fencing_discipline
   - fencing_weapon_type
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - grip
   - resistance
@@ -7087,9 +7607,12 @@
   - color
   - fencing_discipline
   - fencing_weapon_type
+  - height
+  - length
   - lunge_trainer_style
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - resistance
@@ -7108,8 +7631,11 @@
   - color
   - fencing_discipline
   - fencing_weapon_type
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - width
@@ -7129,8 +7655,11 @@
   - color
   - fencing_discipline
   - fencing_weapon_type
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - width
@@ -7149,8 +7678,11 @@
   - color
   - fencing_discipline
   - fencing_weapon_type
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - width
@@ -7208,10 +7740,14 @@
   - color
   - fencing_certification
   - fencing_discipline
+  - flex_strength
   - grip_type
   - hand_side
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - grip
   - length
@@ -7232,10 +7768,14 @@
   - epee_point_type
   - fencing_certification
   - fencing_discipline
+  - flex_strength
   - grip_type
   - hand_side
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   - wiring_configuration
   return_reasons:
   - grip
@@ -7257,10 +7797,14 @@
   - color
   - fencing_certification
   - fencing_discipline
+  - flex_strength
   - grip_type
   - hand_side
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - balance
@@ -7280,8 +7824,12 @@
   - color
   - fencing_certification
   - fencing_discipline
+  - flex_strength
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - grip
   - length
@@ -7300,14 +7848,19 @@
   - sg-1-10-4-4-2
   attributes:
   - accessory_size
+  - balance_point
   - blade_size_category
   - color
   - fencing_certification
   - fencing_discipline
+  - flex_strength
   - grip_type
   - hand_side
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - grip
   - length
@@ -7324,10 +7877,12 @@
   children: []
   attributes:
   - accessory_size
+  - balance_point
   - blade_size_category
   - color
   - fencing_certification
   - fencing_discipline
+  - flex_strength
   - grip_type
   - hand_side
   - pattern
@@ -7344,10 +7899,12 @@
   children: []
   attributes:
   - accessory_size
+  - balance_point
   - blade_size_category
   - color
   - fencing_certification
   - fencing_discipline
+  - flex_strength
   - grip_type
   - hand_side
   - pattern
@@ -7367,6 +7924,7 @@
   - color
   - fencing_certification
   - fencing_discipline
+  - flex_strength
   - grip_type
   - hand_side
   - pattern
@@ -7441,9 +7999,12 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - pattern
   - protective_gear_safety_certifications
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -7549,9 +8110,12 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - pattern
   - protective_gear_safety_certifications
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -7572,10 +8136,13 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - mask_goggle_design
   - pattern
   - protective_gear_safety_certifications
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -7635,9 +8202,12 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - pattern
   - protective_gear_safety_certifications
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -7829,8 +8399,11 @@
   - color
   - field_hockey_ball_playing_surface
   - field_hockey_ball_type
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -7848,9 +8421,12 @@
   - age_group
   - color
   - field_hockey_goal_size_standard
+  - height
+  - length
   - mounting_type
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -7869,11 +8445,18 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - stick_balance_point
+  - stick_bow_height
+  - stick_bow_placement
   - stick_bow_profile
   - stick_head_shape
   - stick_material
+  - stick_size
+  - width
   return_reasons:
   - size
   - color
@@ -7893,6 +8476,9 @@
   - color
   - pattern
   - sports_governing_body_certification
+  - stick_balance_point
+  - stick_bow_height
+  - stick_bow_placement
   - stick_bow_profile
   - stick_head_shape
   - stick_material
@@ -7911,6 +8497,9 @@
   - color
   - pattern
   - sports_governing_body_certification
+  - stick_balance_point
+  - stick_bow_height
+  - stick_bow_placement
   - stick_bow_profile
   - stick_head_shape
   - stick_material
@@ -7935,8 +8524,11 @@
   - age_group
   - color
   - field_hockey_training_objective
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -7955,9 +8547,12 @@
   - color
   - field_hockey_training_objective
   - goalkeeper_training_aid_type
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - color
@@ -7976,8 +8571,11 @@
   - color
   - field_hockey_training_objective
   - grip_enhancer_form
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -7995,9 +8593,12 @@
   - age_group
   - color
   - field_hockey_training_objective
+  - height
+  - length
   - pattern
   - rebound_board_face_type
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -8014,9 +8615,13 @@
   attributes:
   - age_group
   - color
+  - compatible_goal_frame_size
   - field_hockey_training_objective
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -8038,8 +8643,11 @@
   - age_group
   - color
   - field_hockey_training_objective
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -8138,9 +8746,12 @@
   - ball_material
   - ball_size
   - color
+  - height
   - lacrosse_ball_certification
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -8157,10 +8768,13 @@
   children: []
   attributes:
   - color
+  - height
   - lacrosse_equipment_included
+  - length
   - pattern
   - play_environment_suitability
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -8179,10 +8793,13 @@
   - age_group
   - color
   - goal_frame_material
+  - height
   - lacrosse_goal_regulation_certification
+  - length
   - mounting_type
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -8205,8 +8822,11 @@
   - sg-1-11-9-7
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -8223,9 +8843,12 @@
   children: []
   attributes:
   - color
+  - height
   - lacrosse_string_type
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - length
@@ -8242,10 +8865,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - player_position
   - recommended_skill_level
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -8263,9 +8889,12 @@
   attributes:
   - color
   - hand_side
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - stick_material
+  - width
   return_reasons:
   - color
   - length
@@ -8341,11 +8970,15 @@
   attributes:
   - age_group
   - color
+  - height
   - lacrosse_pocket_type
+  - length
   - pattern
   - sports_governing_body_certification
   - stick_material
+  - stick_size
   - strung_status
+  - width
   return_reasons:
   - size
   - color
@@ -8404,9 +9037,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_focus_area
+  - width
   return_reasons:
   - size
   - color
@@ -8423,9 +9059,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - rebound_surface_dimensions
   - sports_governing_body_certification
   - training_focus_area
+  - width
   return_reasons:
   - size
   - color
@@ -8442,9 +9082,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_focus_area
+  - width
   return_reasons:
   - size
   - color
@@ -8668,8 +9311,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -8687,8 +9333,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -8706,8 +9355,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - rope_length
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - length
@@ -8725,9 +9378,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - shooting_target_style
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -8745,9 +9401,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - slide_board_accessories_included
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -8765,8 +9424,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - length
@@ -8784,8 +9446,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -8805,9 +9470,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_surface_usage
+  - width
   return_reasons:
   - size
   - color
@@ -8857,8 +9525,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -8876,8 +9547,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -8895,9 +9569,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - rebounding_mechanism_type
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -8914,8 +9591,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -8933,9 +9613,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
+  - measurable_speed_range
   - pattern
   - sports_governing_body_certification
   - training_surface_suitability
+  - width
   return_reasons:
   - size
   - color
@@ -8987,9 +9671,12 @@
   - ball_material
   - ball_size
   - color
+  - height
   - intended_playing_surface
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -9010,10 +9697,13 @@
   - ball_material
   - ball_size
   - color
+  - height
   - intended_playing_surface
+  - length
   - pattern
   - playing_environment
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -9068,11 +9758,14 @@
   attributes:
   - ball_size
   - color
+  - height
   - intended_playing_surface
+  - length
   - material
   - pattern
   - puck_type
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -9109,10 +9802,13 @@
   attributes:
   - age_group
   - color
+  - height
   - hockey_goal_type
+  - length
   - mounting_type
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -9193,8 +9889,11 @@
   attributes:
   - color
   - cut_resistance_rating
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9217,9 +9916,12 @@
   - construction_design
   - cut_resistance_rating
   - fit_profile
+  - height
+  - length
   - level_of_play
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9264,9 +9966,12 @@
   - color
   - cut_resistance_rating
   - goalie_playing_surface
+  - height
   - hockey_equipment_included
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9288,9 +9993,12 @@
   - color
   - cut_resistance_rating
   - face_protection_type
+  - height
+  - length
   - pattern
   - player_position
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9313,6 +10021,8 @@
   - color
   - cut_resistance_rating
   - gear_material
+  - inseam_length
+  - outseam_length
   - pattern
   - sports_governing_body_certification
   - target_gender
@@ -9378,8 +10088,11 @@
   - age_group
   - color
   - cut_resistance_rating
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9470,9 +10183,12 @@
   - age_group
   - color
   - cut_resistance_rating
+  - height
   - hockey_size_segment
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9530,8 +10246,11 @@
   - color
   - cut_resistance_rating
   - fastener_type
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9624,9 +10343,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - runner_configuration
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -9648,9 +10370,12 @@
   - sg-1-12-6-6
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - stick_size_compatibility
+  - width
   return_reasons:
   - size
   - color
@@ -9666,9 +10391,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - stick_size_compatibility
+  - width
   return_reasons:
   - size
   - color
@@ -9684,9 +10412,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - stick_size_compatibility
+  - width
   return_reasons:
   - size
   - color
@@ -9702,11 +10433,13 @@
   children: []
   attributes:
   - color
+  - length
   - pattern
   - sports_governing_body_certification
   - stick_size_compatibility
   - tape_application_area
   - tape_type
+  - width
   return_reasons:
   - color
   - width
@@ -9723,11 +10456,14 @@
   children: []
   attributes:
   - color
+  - height
   - ice_temperature_suitability
+  - length
   - pattern
   - sports_governing_body_certification
   - stick_size_compatibility
   - wax_tackiness_level
+  - width
   return_reasons:
   - size
   - color
@@ -9778,10 +10514,13 @@
   - sg-1-12-7-4
   attributes:
   - color
+  - height
   - hockey_size_category
   - kick_point
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -9805,10 +10544,13 @@
   - blade_size_class
   - color
   - hand_side
+  - height
   - hockey_size_category
   - kick_point
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -9828,11 +10570,14 @@
   - color
   - compatible_blade_hosel
   - hand_side
+  - height
   - hockey_size_category
   - kick_point
+  - length
   - pattern
   - sports_governing_body_certification
   - stick_material
+  - width
   return_reasons:
   - color
   - length
@@ -9886,10 +10631,14 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - stick_construction
   - stick_material
+  - stick_size
+  - width
   return_reasons:
   - color
   - length
@@ -9917,8 +10666,11 @@
   attributes:
   - color
   - compatible_skating_discipline
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -9938,9 +10690,12 @@
   - boot_width_code
   - color
   - compatible_skating_discipline
+  - height
+  - length
   - pattern
   - shoe_size
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9962,11 +10717,17 @@
   - sg-1-12-9-2-3
   - sg-1-12-9-2-4
   attributes:
+  - blade_hollow_radius
+  - blade_rocker_radius
+  - blade_size
   - color
   - compatible_skating_discipline
+  - height
+  - length
   - pattern
   - skate_blade_discipline
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -9982,6 +10743,8 @@
   name: Hockey Skate Blades
   children: []
   attributes:
+  - blade_hollow_radius
+  - blade_rocker_radius
   - color
   - compatible_skating_discipline
   - pattern
@@ -9998,6 +10761,8 @@
   name: Figure Skate Blades
   children: []
   attributes:
+  - blade_hollow_radius
+  - blade_rocker_radius
   - color
   - compatible_skating_discipline
   - pattern
@@ -10014,6 +10779,8 @@
   name: Goalie Skate Blades
   children: []
   attributes:
+  - blade_hollow_radius
+  - blade_rocker_radius
   - color
   - compatible_skating_discipline
   - pattern
@@ -10030,6 +10797,8 @@
   name: Speed Skate Blades
   children: []
   attributes:
+  - blade_hollow_radius
+  - blade_rocker_radius
   - color
   - compatible_skating_discipline
   - pattern
@@ -10052,10 +10821,13 @@
   - color
   - compatible_skating_discipline
   - hardware_material
+  - height
   - ice_skate_sharpener_type
+  - length
   - pattern
   - radius_of_hollow
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - grit
@@ -10128,8 +10900,11 @@
   - color
   - compatible_skating_discipline
   - guard_style
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -10146,9 +10921,12 @@
   attributes:
   - color
   - compatible_skating_discipline
+  - height
   - lace_tightener_style
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -10247,10 +11025,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - shoe_size
   - sports_governing_body_certification
   - target_gender
+  - width
   return_reasons:
   - size
   - color
@@ -10268,10 +11049,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - shoe_size
   - sports_governing_body_certification
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10289,11 +11073,14 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - shoe_size
   - sports_governing_body_certification
   - target_gender
   - toe_pick_style
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10311,10 +11098,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - shoe_size
   - sports_governing_body_certification
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10335,10 +11125,13 @@
   - battery_type
   - boot_support_level
   - color
+  - height
+  - length
   - pattern
   - shoe_size
   - sports_governing_body_certification
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10356,10 +11149,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - shoe_size
   - sports_governing_body_certification
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10380,10 +11176,14 @@
   - age_group
   - blade_attachment_type
   - color
+  - height
+  - length
   - pattern
   - shoe_size
+  - skate_blade_hollow_radius
   - sports_governing_body_certification
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10404,6 +11204,7 @@
   - color
   - pattern
   - shoe_size
+  - skate_blade_hollow_radius
   - sports_governing_body_certification
   - target_gender
   return_reasons:
@@ -10422,6 +11223,7 @@
   - color
   - pattern
   - shoe_size
+  - skate_blade_hollow_radius
   - sports_governing_body_certification
   - target_gender
   return_reasons:
@@ -10506,9 +11308,12 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - pattern
   - resistance_adjustability
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10527,9 +11332,12 @@
   - age_group
   - athletic_cup_size
   - color
+  - height
   - impact_protection_level
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10551,8 +11359,11 @@
   attributes:
   - bag/case_material
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -10569,8 +11380,11 @@
   attributes:
   - bag/case_material
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -10587,8 +11401,11 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -10606,8 +11423,11 @@
   attributes:
   - color
   - fabric
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -10658,8 +11478,11 @@
   attributes:
   - ball_pump_accessory_type
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - gauge
   - incompatible
@@ -10676,8 +11499,11 @@
   - ball_pump_accessory_type
   - color
   - hardware_material
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10740,11 +11566,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - power_source
   - pump_accessories_included
   - sports_governing_body_certification
+  - width
   return_reasons:
   - power_source
   - incompatible
@@ -10762,9 +11591,12 @@
   - sg-1-13-6-3
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -10781,9 +11613,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -10800,10 +11635,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - sports_governing_body_certification
   - wheel_brake_type
+  - width
   return_reasons:
   - size
   - color
@@ -10821,10 +11659,13 @@
   attributes:
   - caster_type
   - color
+  - height
+  - length
   - material
   - pattern
   - rack_side_configuration
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -10842,8 +11683,11 @@
   - age_group
   - color
   - grip_chalk_form
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -10860,9 +11704,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - sports_governing_body_certification
+  - volume
+  - width
   return_reasons:
   - grip
   - texture
@@ -10881,10 +11729,13 @@
   attributes:
   - color
   - exercise_mat_material
+  - height
+  - length
   - mat_installation_method
   - mat_style
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -10955,10 +11806,15 @@
   - sg-1-13-10-3
   attributes:
   - color
+  - height
+  - length
   - mounting_type
   - net_material
+  - net_mesh_size
   - pattern
   - sports_governing_body_certification
+  - twine_thickness
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -10974,8 +11830,10 @@
   - color
   - mounting_type
   - net_material
+  - net_mesh_size
   - pattern
   - sports_governing_body_certification
+  - twine_thickness
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -10990,8 +11848,10 @@
   - color
   - mounting_type
   - net_material
+  - net_mesh_size
   - pattern
   - sports_governing_body_certification
+  - twine_thickness
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -11006,8 +11866,10 @@
   - color
   - mounting_type
   - net_material
+  - net_mesh_size
   - pattern
   - sports_governing_body_certification
+  - twine_thickness
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -11023,8 +11885,12 @@
   - sg-1-13-11-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - rung_spacing
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - length
@@ -11041,6 +11907,7 @@
   attributes:
   - color
   - pattern
+  - rung_spacing
   - sports_governing_body_certification
   return_reasons:
   - changed_my_mind
@@ -11055,6 +11922,7 @@
   attributes:
   - color
   - pattern
+  - rung_spacing
   - sports_governing_body_certification
   return_reasons:
   - changed_my_mind
@@ -11069,6 +11937,7 @@
   attributes:
   - color
   - pattern
+  - rung_spacing
   - sports_governing_body_certification
   return_reasons:
   - changed_my_mind
@@ -11082,9 +11951,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - height
@@ -11102,10 +11974,15 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
+  - maximum_effective_range
   - pattern
+  - power_output_typical
   - power_source
   - sports_governing_body_certification
   - suitable_space
+  - width
   return_reasons:
   - battery_life
   - range
@@ -11125,10 +12002,13 @@
   - age_group
   - braces_compatibility
   - color
+  - height
+  - length
   - mouthgard_design
   - pattern
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - fit
   - color
@@ -11146,8 +12026,11 @@
   - sg-1-13-15-3
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - padding
@@ -11164,8 +12047,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - padding
@@ -11182,8 +12068,12 @@
   children: []
   attributes:
   - color
+  - cushion_thickness
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - padding
@@ -11215,9 +12105,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - numbering_style
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -11362,8 +12255,13 @@
   attributes:
   - color
   - gymnastics_discipline
+  - height
+  - length
+  - maximum_height
+  - minimum_height
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - height
@@ -11431,8 +12329,11 @@
   attributes:
   - color
   - gymnastics_discipline
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -11453,8 +12354,11 @@
   - finger_hole_count
   - gear_material
   - gymnastics_discipline
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -11561,10 +12465,14 @@
   attributes:
   - age_group
   - color
+  - diameter
   - gymnastics_discipline
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - strap_width
+  - width
   return_reasons:
   - size
   - length
@@ -11582,9 +12490,12 @@
   attributes:
   - color
   - gymnastics_discipline
+  - height
+  - length
   - material_hardness
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -11610,8 +12521,11 @@
   - age_group
   - color
   - gymnastics_discipline
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -11629,8 +12543,11 @@
   - age_group
   - color
   - gymnastics_discipline
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - padding
@@ -11651,8 +12568,11 @@
   - age_group
   - color
   - gymnastics_discipline
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -11717,9 +12637,13 @@
   attributes:
   - age_group
   - color
+  - foam_cube_size
   - gymnastics_discipline
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -11740,8 +12664,11 @@
   - age_group
   - color
   - gymnastics_discipline
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -11791,8 +12718,11 @@
   - age_group
   - color
   - gymnastics_discipline
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -11810,8 +12740,11 @@
   - age_group
   - color
   - gymnastics_discipline
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -11830,8 +12763,11 @@
   - age_group
   - color
   - gymnastics_discipline
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -11881,9 +12817,12 @@
   - color
   - features
   - gymnastics_discipline
+  - height
+  - length
   - pattern
   - shape
   - sports_governing_body_certification
+  - width
   return_reasons:
   - height
   - grip
@@ -12006,9 +12945,12 @@
   - ball_size
   - color
   - dynamic_level
+  - height
+  - length
   - pattern
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - bounce
@@ -12068,8 +13010,11 @@
   - eyewear_lens_color
   - eyewear_lens_material
   - eyewear_lens_pattern
+  - height
+  - length
   - protective_eyewear_standard_compliance
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - lens_color
@@ -12118,9 +13063,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - racquetball_squash_training_aid_type
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - weight
@@ -12136,10 +13084,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - racquetball_squash_training_aid_type
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - grip
@@ -12157,9 +13108,12 @@
   - age_group
   - color
   - grip_enhancer_effect
+  - height
+  - length
   - pattern
   - racquetball_squash_training_aid_type
   - sports_governing_body_certification
+  - width
   return_reasons:
   - grip
   - consistency
@@ -12175,9 +13129,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - racquetball_squash_training_aid_type
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -12194,9 +13151,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - racquetball_squash_training_aid_type
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -12214,10 +13174,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - racquetball_squash_training_aid_type
   - sports_governing_body_certification
   - target_trainer_type
+  - width
   return_reasons:
   - size
   - color
@@ -12234,9 +13197,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - racquetball_squash_training_aid_type
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -12256,9 +13222,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - racquetball_squash_training_aid_type
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -12308,9 +13277,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - racquetball_squash_training_aid_type
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -12391,13 +13363,20 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - racket_balance
+  - racket_balance_point
   - racket_head_shape
+  - racket_head_size
+  - racket_length
   - racket_material
   - racket_string_pattern
+  - racquetball_grip_size
   - recommended_skill_level
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - balance
@@ -12415,12 +13394,17 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - racket_balance
   - racket_head_shape
+  - racket_head_size
+  - racket_length
   - racket_material
   - recommended_skill_level
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - balance
@@ -12441,6 +13425,7 @@
   - closure_type
   - color
   - footwear_material
+  - footwear_weight
   - heel_height_type
   - outsole_marking_type
   - pattern
@@ -12522,11 +13507,15 @@
   children: []
   attributes:
   - age_group
+  - bat_length
   - bat_material
   - color
+  - height
+  - length
   - pattern
   - rounders_governing_body_approval
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - grip
@@ -12546,6 +13535,7 @@
   - color
   - handwear_material
   - pattern
+  - rounders_glove_size
   - rounders_governing_body_approval
   - sports_governing_body_certification
   - target_gender
@@ -12571,10 +13561,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - rounders_equipment_included
   - rounders_governing_body_approval
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - height
@@ -12592,10 +13585,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - rounders_equipment_included
   - rounders_governing_body_approval
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - height
@@ -12612,10 +13608,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - rounders_equipment_included
   - rounders_governing_body_approval
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - height
@@ -12634,10 +13633,13 @@
   - age_group
   - base_anchoring_method
   - color
+  - height
+  - length
   - pattern
   - rounders_equipment_included
   - rounders_governing_body_approval
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - length
@@ -12781,10 +13783,13 @@
   - ball_material
   - ball_size
   - color
+  - height
+  - length
   - pattern
   - rugby_variant
   - sports_governing_body_certification
   - stitching_method
+  - width
   return_reasons:
   - size
   - color
@@ -12825,12 +13830,16 @@
   attributes:
   - age_group
   - color
+  - crossbar_height
   - features
   - goal_size_classification
+  - height
+  - length
   - pattern
   - post_material
   - rugby_variant
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -12853,10 +13862,13 @@
   - sg-1-17-4-6
   attributes:
   - color
+  - height
+  - length
   - mouthguard_mold_type
   - pattern
   - rugby_variant
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -12876,11 +13888,14 @@
   - age_group
   - color
   - gear_material
+  - height
+  - length
   - mouthguard_mold_type
   - pattern
   - rugby_headgear_safety_certification
   - rugby_variant
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13007,10 +14022,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - rugby_size
   - rugby_variant
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -13028,11 +14046,14 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - rugby_size
   - rugby_variant
   - sports_governing_body_certification
   - tee_base_style
+  - width
   return_reasons:
   - size
   - height
@@ -13050,10 +14071,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - rugby_size
   - rugby_variant
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -13201,6 +14225,7 @@
   - shoe_size
   - sports_governing_body_certification
   - stud_attachment_type
+  - stud_length
   - stud_material
   - target_gender
   - toe_style
@@ -13252,6 +14277,7 @@
   children: []
   attributes:
   - color
+  - crossbar_height
   - pattern
   - rugby_variant
   - sports_governing_body_certification
@@ -13294,6 +14320,7 @@
   attributes:
   - age_group
   - ball_certification
+  - ball_circumference
   - ball_construction
   - ball_material
   - ball_size
@@ -13301,9 +14328,12 @@
   - battery_type
   - bladder_material
   - color
+  - height
+  - length
   - pattern
   - soccer_ball_type
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -13322,8 +14352,11 @@
   - sg-1-18-2-2
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - height
@@ -13449,8 +14482,11 @@
   - sg-1-18-4-11
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -13467,8 +14503,12 @@
   children: []
   attributes:
   - color
+  - compatible_cord_diameter
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - weight
@@ -13486,8 +14526,11 @@
   - color
   - counterweight_fill_material
   - counterweight_type
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -13504,10 +14547,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - soccer_dummy_base_type
   - soccer_dummy_design
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -13525,9 +14571,12 @@
   children: []
   attributes:
   - color
+  - height
   - kit_components_included
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -13543,9 +14592,14 @@
   name: Soccer Goal Nets
   children: []
   attributes:
+  - bottom_depth
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - top_depth
+  - width
   return_reasons:
   - size
   - color
@@ -13564,9 +14618,12 @@
   - sg-1-18-4-6-2
   attributes:
   - color
+  - height
+  - length
   - pattern
   - soccer_goal_target_style
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -13685,10 +14742,13 @@
   - age_group
   - color
   - goal_size
+  - height
+  - length
   - mounting_type
   - pattern
   - soccer_goal_type
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -13710,6 +14770,7 @@
   attributes:
   - color
   - pattern
+  - shin_guard_length
   - sports_governing_body_certification
   return_reasons:
   - too_big
@@ -13731,9 +14792,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - shin_guard_attachment_method
+  - shin_guard_length
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13753,9 +14818,13 @@
   - ankle_guard_protection_level
   - color
   - foot_side
+  - height
+  - length
   - pattern
   - shin_guard_attachment_method
+  - shin_guard_length
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13773,9 +14842,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - shin_guard_attachment_method
+  - shin_guard_length
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -13795,6 +14868,7 @@
   - color
   - pattern
   - shin_guard_attachment_method
+  - shin_guard_length
   - sports_governing_body_certification
   return_reasons:
   - changed_my_mind
@@ -13811,6 +14885,7 @@
   - color
   - pattern
   - shin_guard_attachment_method
+  - shin_guard_length
   - sports_governing_body_certification
   return_reasons:
   - changed_my_mind
@@ -13827,6 +14902,7 @@
   - color
   - pattern
   - shin_guard_attachment_method
+  - shin_guard_length
   - sports_governing_body_certification
   return_reasons:
   - changed_my_mind
@@ -13843,6 +14919,7 @@
   - color
   - pattern
   - shin_guard_attachment_method
+  - shin_guard_length
   - sports_governing_body_certification
   return_reasons:
   - changed_my_mind
@@ -13859,6 +14936,7 @@
   - color
   - pattern
   - shin_guard_attachment_method
+  - shin_guard_length
   - sports_governing_body_certification
   return_reasons:
   - changed_my_mind
@@ -13880,8 +14958,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -13899,9 +14980,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - pole_anchoring_method
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - height
@@ -13918,9 +15002,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - supported_spin_types
+  - width
   return_reasons:
   - size
   - color
@@ -13939,8 +15026,11 @@
   - age_group
   - color
   - ground_attachment_method
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - height
@@ -13957,10 +15047,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - rebounder_design
   - rebounder_sides
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -13978,9 +15071,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - soccer_ball_compartment_type
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -13998,9 +15094,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - mannequin_style
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -14103,9 +15202,12 @@
   - color
   - handball_ball_type
   - handball_playing_surface
+  - height
+  - length
   - pattern
   - resin_suitability
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -14133,9 +15235,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - color
@@ -14151,9 +15256,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - color
@@ -14171,9 +15279,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - grip
@@ -14190,9 +15301,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - color
@@ -14209,9 +15323,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - color
@@ -14227,9 +15344,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - color
@@ -14247,9 +15367,12 @@
   - age_group
   - color
   - handball_target_type
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - color
@@ -14266,9 +15389,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_focus
+  - width
   return_reasons:
   - size
   - color
@@ -14378,8 +15504,11 @@
   attributes:
   - ball_holder_type
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - capacity
@@ -14439,13 +15568,19 @@
   name: Tennis Ball Machines
   children: []
   attributes:
+  - ball_feed_interval
   - color
+  - height
+  - length
+  - maximum_ball_speed
+  - minimum_ball_speed
   - oscillation_mode
   - pattern
   - power_source
   - spin_types_supported
   - sports_governing_body_certification
   - user_control_method
+  - width
   return_reasons:
   - size
   - speed
@@ -14461,9 +15596,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - pressurization_method
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - capacity
@@ -14482,10 +15620,13 @@
   - ball_size
   - color
   - felt_duty
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - tennis_ball_court_surface
   - tennis_ball_pressure_type
+  - width
   return_reasons:
   - size
   - color
@@ -14502,9 +15643,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - net_mounting_type
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -14549,11 +15693,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - racket_dampener_type
   - sport
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -14569,8 +15716,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -14591,10 +15741,12 @@
   attributes:
   - color
   - grip_tackiness_level
+  - length
   - pattern
   - sport
   - sports_governing_body_certification
   - tape_material
+  - width
   return_reasons:
   - size
   - color
@@ -14612,10 +15764,12 @@
   attributes:
   - color
   - grip_tackiness_level
+  - length
   - pattern
   - sport
   - sports_governing_body_certification
   - tape_material
+  - width
   return_reasons:
   - size
   - color
@@ -14633,10 +15787,12 @@
   attributes:
   - color
   - grip_tackiness_level
+  - length
   - pattern
   - sport
   - sports_governing_body_certification
   - tape_material
+  - width
   return_reasons:
   - size
   - color
@@ -14656,11 +15812,13 @@
   attributes:
   - color
   - grip_tackiness_level
+  - length
   - pattern
   - sport
   - sports_governing_body_certification
   - tape_material
   - tape_purpose
+  - width
   return_reasons:
   - size
   - color
@@ -14712,8 +15870,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -14729,13 +15890,18 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - racket_gauge
   - racket_string_design
+  - racket_string_gauge
   - racket_string_material
   - shape
   - sport
   - sports_governing_body_certification
+  - string_length
+  - width
   return_reasons:
   - color
   - gauge
@@ -14800,14 +15966,19 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - racket_balance
   - racket_head_shape
+  - racket_head_size
+  - racket_length
   - racket_material
   - recommended_skill_level
   - sports_governing_body_certification
   - swing_style
   - tennis_racket_grip_size
+  - width
   return_reasons:
   - size
   - color
@@ -14834,9 +16005,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_objective
+  - width
   return_reasons:
   - size
   - color
@@ -14853,9 +16027,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_objective
+  - width
   return_reasons:
   - size
   - grip
@@ -14872,9 +16049,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_objective
+  - width
   return_reasons:
   - size
   - color
@@ -14891,9 +16071,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_objective
+  - width
   return_reasons:
   - size
   - color
@@ -14913,10 +16096,13 @@
   - age_group
   - base_ballast_method
   - color
+  - height
+  - length
   - pattern
   - rebounder_design_type
   - sports_governing_body_certification
   - training_objective
+  - width
   return_reasons:
   - size
   - color
@@ -14969,9 +16155,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_objective
+  - width
   return_reasons:
   - size
   - color
@@ -14988,9 +16177,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - training_objective
+  - width
   return_reasons:
   - size
   - color
@@ -15064,6 +16256,7 @@
   - shoe_features
   - shoe_fit
   - shoe_size
+  - shoe_weight
   - sports_governing_body_certification
   - target_gender
   - toe_style
@@ -15084,6 +16277,7 @@
   name: Tennis Ball Machine Accessories
   children: []
   attributes:
+  - ball_feed_interval
   - color
   - pattern
   - sports_governing_body_certification
@@ -15135,11 +16329,14 @@
   children: []
   attributes:
   - color
+  - height
   - intended_use
+  - length
   - pattern
   - spin_classification
   - sports_governing_body_certification
   - track_and_field_discipline
+  - width
   return_reasons:
   - size
   - grip
@@ -15157,9 +16354,12 @@
   attributes:
   - color
   - crossbar_style
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - track_and_field_discipline
+  - width
   return_reasons:
   - color
   - length
@@ -15176,11 +16376,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - pit_configuration
   - pit_cover_type
   - sports_governing_body_certification
   - track_and_field_discipline
+  - width
   return_reasons:
   - size
   - color
@@ -15197,10 +16400,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_skill_level
   - sports_governing_body_certification
   - track_and_field_discipline
+  - width
   return_reasons:
   - color
   - length
@@ -15219,9 +16425,12 @@
   - sg-1-21-5-2
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - track_and_field_discipline
+  - width
   return_reasons:
   - size
   - color
@@ -15269,9 +16478,12 @@
   attributes:
   - baton_size_standard
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - track_and_field_discipline
+  - width
   return_reasons:
   - color
   - length
@@ -15288,11 +16500,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - sports_governing_body_certification
   - surface_finish
   - track_and_field_discipline
+  - width
   return_reasons:
   - size
   - grip
@@ -15308,11 +16523,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - starter_pistol_action_type
   - starter_pistol_caliber
   - track_and_field_discipline
+  - width
   return_reasons:
   - grip
   - caliber
@@ -15329,10 +16547,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_skill_level
   - sports_governing_body_certification
   - track_and_field_discipline
+  - width
   return_reasons:
   - length
   - grip
@@ -15358,10 +16579,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - track_and_field_discipline
   - track_field_event_suitability
+  - width
   return_reasons:
   - size
   - color
@@ -15379,10 +16603,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - track_and_field_discipline
   - track_field_event_suitability
+  - width
   return_reasons:
   - length
   - width
@@ -15400,11 +16627,14 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - resistance_band_design
   - sports_governing_body_certification
   - track_and_field_discipline
   - track_field_event_suitability
+  - width
   return_reasons:
   - color
   - length
@@ -15421,10 +16651,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - track_and_field_discipline
   - track_field_event_suitability
+  - width
   return_reasons:
   - size
   - color
@@ -15441,10 +16674,14 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - timing_accuracy
   - track_and_field_discipline
   - track_field_event_suitability
+  - width
   return_reasons:
   - color
   - brightness
@@ -15529,9 +16766,14 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
+  - maximum_height
+  - minimum_height
   - pattern
   - sports_governing_body_certification
   - track_and_field_discipline
+  - width
   return_reasons:
   - color
   - height
@@ -15549,6 +16791,8 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - spike_shape
   - spike_thread_size
@@ -15556,6 +16800,7 @@
   - track_and_field_discipline
   - track_event_specialization
   - track_surface_compatibility
+  - width
   return_reasons:
   - size
   - color
@@ -15572,10 +16817,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - starting_block_anchoring_method
   - track_and_field_discipline
+  - width
   return_reasons:
   - length
   - grip
@@ -15591,9 +16839,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - track_and_field_discipline
+  - width
   return_reasons:
   - length
   - flex
@@ -15693,10 +16944,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - mounting_type
   - pattern
   - regulation_standard
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -15718,9 +16972,12 @@
   - sg-1-22-2-6
   attributes:
   - color
+  - height
+  - length
   - pattern
   - protective_gear_padding_type
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15739,9 +16996,12 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - pattern
   - protective_gear_padding_type
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -15851,8 +17111,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -15870,8 +17133,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - speed
@@ -15888,8 +17154,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -15984,9 +17253,12 @@
   - battery_size
   - battery_type
   - color
+  - height
   - illumination_type
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -16048,8 +17320,11 @@
   - sg-1-23-3
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -16065,8 +17340,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -16083,8 +17361,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - length
   - height
@@ -16100,9 +17381,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - wallyball_equipment_included
+  - width
   return_reasons:
   - size
   - color
@@ -16144,9 +17428,12 @@
   - ball_material
   - ball_size
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
   - water_polo_competition_approval
+  - width
   return_reasons:
   - size
   - color
@@ -16163,8 +17450,11 @@
   attributes:
   - color
   - ear_guard_type
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -16182,10 +17472,13 @@
   - age_group
   - color
   - goal_size_standard
+  - height
+  - length
   - mounting_type
   - pattern
   - sports_governing_body_certification
   - water_polo_goal_type
+  - width
   return_reasons:
   - size
   - color
@@ -16212,8 +17505,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -16230,8 +17526,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -16248,8 +17547,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -16264,8 +17566,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -16282,8 +17587,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -16300,8 +17608,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -16318,8 +17629,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -16337,8 +17651,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -16355,8 +17672,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -16374,8 +17694,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -16446,8 +17769,11 @@
   - sg-1-25-1-8
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - too_tight
@@ -16467,8 +17793,11 @@
   - color
   - gear_material
   - headgear_strap_configuration
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -16487,9 +17816,12 @@
   - accessory_size
   - age_group
   - color
+  - height
   - knee_pad_style
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - color
   - too_tight
@@ -16608,8 +17940,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -16626,8 +17961,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   - wrestling_dummy_design
   return_reasons:
   - size
@@ -16645,8 +17983,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -16663,8 +18004,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   - wrestling_mat_safety_certifications
   return_reasons:
   - size
@@ -16682,8 +18026,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -16700,8 +18047,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -16718,9 +18068,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - singlet_cut_style
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -16738,8 +18091,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -16756,8 +18112,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -16776,8 +18135,11 @@
   - age_group
   - barbell_knurling_pattern
   - color
+  - height
+  - length
   - pattern
   - sports_governing_body_certification
+  - width
   return_reasons:
   - size
   - color
@@ -16889,6 +18251,7 @@
   - shoe_features
   - shoe_fit
   - shoe_size
+  - slider_thickness
   - sports_governing_body_certification
   - target_gender
   - toe_style
@@ -17264,6 +18627,7 @@
   - care_instructions
   - color
   - material
+  - overall_dimensions
   - pattern
   - safety_certifications
   return_reasons:
@@ -17283,7 +18647,11 @@
   attributes:
   - color
   - exercise_equipment_material
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -17300,7 +18668,11 @@
   attributes:
   - color
   - exercise_equipment_material
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -17318,7 +18690,11 @@
   attributes:
   - color
   - exercise_equipment_material
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -17336,7 +18712,12 @@
   - color
   - exercise_equipment_material
   - exercise_machine_features
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - height
@@ -17360,7 +18741,11 @@
   attributes:
   - color
   - floor_surface_compatibility
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -17379,7 +18764,11 @@
   - color
   - difficulty_level
   - floor_surface_compatibility
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -17397,7 +18786,11 @@
   - balance_cushion_accessories_included
   - color
   - floor_surface_compatibility
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -17414,7 +18807,11 @@
   attributes:
   - color
   - floor_surface_compatibility
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -17431,7 +18828,11 @@
   attributes:
   - color
   - floor_surface_compatibility
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -17448,6 +18849,7 @@
   attributes:
   - color
   - floor_surface_compatibility
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -17462,6 +18864,7 @@
   attributes:
   - color
   - floor_surface_compatibility
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -17476,6 +18879,7 @@
   attributes:
   - color
   - floor_surface_compatibility
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -17493,6 +18897,7 @@
   - sg-2-4-4
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - size
@@ -17515,6 +18920,7 @@
   attributes:
   - color
   - compatible_cardio_machine_type
+  - overall_dimensions
   - pattern
   return_reasons:
   - size
@@ -17539,7 +18945,11 @@
   attributes:
   - color
   - elliptical_trainer_part_type
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -17556,8 +18966,12 @@
   attributes:
   - color
   - elliptical_trainer_part_type
+  - height
+  - length
+  - overall_dimensions
   - pattern
   - replacement_part_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17573,7 +18987,11 @@
   attributes:
   - color
   - elliptical_trainer_part_type
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -17590,6 +19008,7 @@
   attributes:
   - color
   - elliptical_trainer_part_type
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -17604,6 +19023,7 @@
   attributes:
   - color
   - elliptical_trainer_part_type
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -17618,6 +19038,7 @@
   attributes:
   - color
   - elliptical_trainer_part_type
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -17632,6 +19053,7 @@
   attributes:
   - color
   - elliptical_trainer_part_type
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -17646,6 +19068,7 @@
   attributes:
   - color
   - elliptical_trainer_part_type
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -17673,7 +19096,11 @@
   - color
   - compatible_exercise_bike_style
   - exercise_bike_accessory_part_type
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -17691,7 +19118,11 @@
   - color
   - compatible_exercise_bike_style
   - exercise_bike_accessory_part_type
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -17710,7 +19141,11 @@
   - compatible_exercise_bike_style
   - exercise_bike_accessory_part_type
   - exercise_bike_metrics_tracked
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - color
   - battery_life
@@ -17729,7 +19164,11 @@
   - compatible_exercise_bike_style
   - compatible_exercise_machine_type
   - exercise_bike_accessory_part_type
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -17748,7 +19187,11 @@
   - compatible_exercise_bike_style
   - exercise_bike_accessory_part_type
   - exercise_bike_cushion_component
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -17770,7 +19213,11 @@
   - exercise_bike_accessory_part_type
   - heart_rate_sensing_technology
   - heart_rate_sensor_placement
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - battery_life
   - incompatible
@@ -17787,7 +19234,11 @@
   - color
   - compatible_exercise_bike_style
   - exercise_bike_accessory_part_type
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -17807,6 +19258,7 @@
   - color
   - compatible_exercise_bike_style
   - exercise_bike_accessory_part_type
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -17824,6 +19276,7 @@
   - color
   - compatible_exercise_bike_style
   - exercise_bike_accessory_part_type
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -17841,6 +19294,7 @@
   - color
   - compatible_exercise_bike_style
   - exercise_bike_accessory_part_type
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -17858,6 +19312,7 @@
   - color
   - compatible_exercise_bike_style
   - exercise_bike_accessory_part_type
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -17878,7 +19333,11 @@
   - sg-2-4-1-3-7
   attributes:
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -17895,8 +19354,12 @@
   attributes:
   - color
   - compatible_equipment_type
+  - height
+  - length
+  - overall_dimensions
   - pattern
   - rowing_machine_part_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -17911,7 +19374,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - adjustability
@@ -17927,6 +19394,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -17940,6 +19408,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -17953,6 +19422,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -17966,6 +19436,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -17979,6 +19450,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -17997,7 +19469,11 @@
   - sg-2-4-1-4-5
   attributes:
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -18013,8 +19489,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - overall_dimensions
   - part_placement
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18029,7 +19509,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - adjustability
@@ -18045,6 +19529,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -18058,6 +19543,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -18071,6 +19557,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -18103,7 +19590,11 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18119,8 +19610,12 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - height
+  - length
   - lubrication_requirement
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -18137,7 +19632,11 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - connectivity
   - incompatible
@@ -18153,7 +19652,11 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - connectivity
@@ -18170,7 +19673,11 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - height
   - incompatible
@@ -18186,8 +19693,12 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - height
+  - length
+  - overall_dimensions
   - pattern
   - treadmill_key_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18203,7 +19714,11 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - adjustability
@@ -18221,7 +19736,11 @@
   - color
   - compatible_treadmill_design
   - controller_function
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - connectivity
   - incompatible
@@ -18235,10 +19754,15 @@
   name: Treadmill Motor Belts
   children: []
   attributes:
+  - belt_pitch
   - color
   - compatible_treadmill_design
+  - height
+  - length
   - motor_belt_type
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18254,7 +19778,13 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - power
+  - voltage
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -18269,8 +19799,12 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - height
+  - length
+  - overall_dimensions
   - pattern
   - rail_side
+  - width
   return_reasons:
   - size
   - grip
@@ -18289,9 +19823,13 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - height
+  - length
+  - overall_dimensions
   - pattern
   - treadmill_part_type
   - treadmill_position
+  - width
   return_reasons:
   - size
   - incompatible
@@ -18307,6 +19845,7 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - overall_dimensions
   - pattern
   - treadmill_part_type
   - treadmill_position
@@ -18323,6 +19862,7 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - overall_dimensions
   - pattern
   - treadmill_part_type
   - treadmill_position
@@ -18339,7 +19879,11 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - length
   - incompatible
@@ -18355,7 +19899,11 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -18370,7 +19918,11 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - connectivity
   - range
@@ -18387,6 +19939,7 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -18401,6 +19954,7 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -18415,6 +19969,7 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -18429,6 +19984,7 @@
   attributes:
   - color
   - compatible_treadmill_design
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -18443,6 +19999,7 @@
   attributes:
   - color
   - compatible_cardio_machine_type
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -18464,6 +20021,8 @@
   - sg-2-4-2-8
   attributes:
   - color
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   return_reasons:
   - size
@@ -18483,7 +20042,14 @@
   - battery_size
   - battery_type
   - color
+  - flywheel_weight
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
+  - stride_length
+  - width
   return_reasons:
   - size
   - stride_length
@@ -18499,7 +20065,14 @@
   children: []
   attributes:
   - color
+  - flywheel_weight
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
+  - stride_length
+  - width
   return_reasons:
   - size
   - stride_length
@@ -18518,8 +20091,15 @@
   attributes:
   - color
   - drive_location
+  - flywheel_weight
+  - height
   - incline_adjustment_type
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
+  - stride_length
+  - width
   return_reasons:
   - size
   - stride_length
@@ -18536,8 +20116,11 @@
   attributes:
   - color
   - drive_location
+  - flywheel_weight
   - incline_adjustment_type
+  - overall_dimensions
   - pattern
+  - stride_length
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -18551,8 +20134,11 @@
   attributes:
   - color
   - drive_location
+  - flywheel_weight
   - incline_adjustment_type
+  - overall_dimensions
   - pattern
+  - stride_length
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -18573,8 +20159,13 @@
   - color
   - drive_mechanism
   - exercise_machine_features
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - resistance_system
+  - width
   return_reasons:
   - size
   - adjustability
@@ -18592,8 +20183,13 @@
   - color
   - drive_mechanism
   - exercise_machine_features
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - resistance_system
+  - width
   return_reasons:
   - size
   - resistance
@@ -18612,8 +20208,13 @@
   - drive_mechanism
   - drive_system
   - exercise_machine_features
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - resistance_system
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -18631,9 +20232,14 @@
   - color
   - drive_mechanism
   - exercise_machine_features
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - pedal_type
   - resistance_system
+  - width
   return_reasons:
   - size
   - resistance
@@ -18651,8 +20257,13 @@
   - color
   - drive_mechanism
   - exercise_machine_features
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - resistance_system
+  - width
   return_reasons:
   - size
   - resistance
@@ -18671,8 +20282,13 @@
   - battery_type
   - color
   - exercise_machine_features
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - resistance_system
+  - width
   return_reasons:
   - size
   - adjustability
@@ -18691,7 +20307,12 @@
   attributes:
   - color
   - console_display_type
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -18708,7 +20329,14 @@
   - color
   - console_display_type
   - heart_rate_monitoring_method
+  - height
+  - length
+  - maximum_load_capacity
+  - minimum_ceiling_height
+  - overall_dimensions
   - pattern
+  - step_height
+  - width
   return_reasons:
   - size
   - resistance
@@ -18726,8 +20354,13 @@
   - color
   - console_display_type
   - handlebar_design
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - stepper_motion_type
+  - width
   return_reasons:
   - size
   - resistance
@@ -18749,8 +20382,17 @@
   - battery_type
   - color
   - exercise_machine_features
+  - height
+  - length
+  - maximum_load_capacity
+  - maximum_speed
+  - minimum_speed
   - motor_type
+  - overall_dimensions
   - pattern
+  - running_surface_length
+  - running_surface_width
+  - width
   return_reasons:
   - size
   - speed
@@ -18770,7 +20412,10 @@
   - color
   - exercise_machine_features
   - motor_type
+  - overall_dimensions
   - pattern
+  - running_surface_length
+  - running_surface_width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -18787,7 +20432,10 @@
   - color
   - exercise_machine_features
   - motor_type
+  - overall_dimensions
   - pattern
+  - running_surface_length
+  - running_surface_width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -18804,7 +20452,10 @@
   - color
   - exercise_machine_features
   - motor_type
+  - overall_dimensions
   - pattern
+  - running_surface_length
+  - running_surface_width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -18817,6 +20468,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -18830,6 +20482,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -18843,6 +20496,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -18859,10 +20513,16 @@
   - battery_size
   - battery_type
   - color
+  - diameter
   - exercise_equipment_material
+  - height
   - jump_rope_design
+  - length
+  - overall_dimensions
   - pattern
+  - rope_length
   - rotation_mechanism_type
+  - width
   return_reasons:
   - length
   - grip
@@ -18879,6 +20539,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -18893,8 +20554,13 @@
   attributes:
   - ball_material
   - color
+  - diameter
   - exercise_equipment_included
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -18914,8 +20580,12 @@
   - sg-2-6-4
   attributes:
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
   - resistance_level
+  - width
   return_reasons:
   - resistance
   - length
@@ -18930,6 +20600,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   - resistance_level
   return_reasons:
@@ -18944,6 +20615,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   - resistance_level
   return_reasons:
@@ -18958,6 +20630,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   - resistance_level
   return_reasons:
@@ -18972,6 +20645,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   - resistance_level
   return_reasons:
@@ -18992,7 +20666,12 @@
   attributes:
   - color
   - compatible_bench_positions
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -19009,6 +20688,7 @@
   attributes:
   - color
   - compatible_bench_positions
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19023,6 +20703,7 @@
   attributes:
   - color
   - compatible_bench_positions
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19037,6 +20718,7 @@
   attributes:
   - color
   - compatible_bench_positions
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19051,6 +20733,7 @@
   attributes:
   - color
   - compatible_bench_positions
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19065,6 +20748,7 @@
   attributes:
   - color
   - compatible_bench_positions
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19084,7 +20768,11 @@
   attributes:
   - color
   - exercise_mat_material
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -19100,7 +20788,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -19116,6 +20808,10 @@
   children: []
   attributes:
   - exercise_mat_material
+  - height
+  - length
+  - overall_dimensions
+  - width
   return_reasons:
   - size
   - thickness
@@ -19133,8 +20829,12 @@
   - color
   - exercise_mat_material
   - floor_mat_format
+  - height
   - installation_method
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -19150,7 +20850,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - thickness
@@ -19166,6 +20870,10 @@
   children: []
   attributes:
   - exercise_mat_material
+  - height
+  - length
+  - overall_dimensions
+  - width
   return_reasons:
   - size
   - thickness
@@ -19182,7 +20890,11 @@
   attributes:
   - color
   - exercise_equipment_included
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -19198,8 +20910,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material_hardness
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - height
@@ -19224,7 +20940,12 @@
   - sg-2-11-9
   attributes:
   - color
+  - compatible_foam_roller_diameter
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -19241,7 +20962,12 @@
   children: []
   attributes:
   - color
+  - compatible_foam_roller_diameter
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -19258,7 +20984,12 @@
   children: []
   attributes:
   - color
+  - compatible_foam_roller_diameter
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -19275,7 +21006,12 @@
   children: []
   attributes:
   - color
+  - compatible_foam_roller_diameter
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -19291,8 +21027,13 @@
   children: []
   attributes:
   - color
+  - compatible_foam_roller_diameter
+  - height
+  - length
+  - overall_dimensions
   - pattern
   - strap_padding
+  - width
   return_reasons:
   - size
   - color
@@ -19309,7 +21050,12 @@
   children: []
   attributes:
   - color
+  - compatible_foam_roller_diameter
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -19325,6 +21071,8 @@
   children: []
   attributes:
   - color
+  - compatible_foam_roller_diameter
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19338,6 +21086,8 @@
   children: []
   attributes:
   - color
+  - compatible_foam_roller_diameter
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19351,6 +21101,8 @@
   children: []
   attributes:
   - color
+  - compatible_foam_roller_diameter
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19364,6 +21116,8 @@
   children: []
   attributes:
   - color
+  - compatible_foam_roller_diameter
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19378,8 +21132,12 @@
   attributes:
   - color
   - exercise_equipment_material
+  - height
+  - length
+  - overall_dimensions
   - pattern
   - roller_technology
+  - width
   return_reasons:
   - size
   - length
@@ -19403,7 +21161,12 @@
   - color
   - counter_type
   - hand_exerciser_style
+  - height
+  - length
+  - minimum_resistance_weight
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -19422,6 +21185,8 @@
   - color
   - counter_type
   - hand_exerciser_style
+  - minimum_resistance_weight
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19437,6 +21202,8 @@
   - color
   - counter_type
   - hand_exerciser_style
+  - minimum_resistance_weight
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19452,6 +21219,8 @@
   - color
   - counter_type
   - hand_exerciser_style
+  - minimum_resistance_weight
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19467,6 +21236,8 @@
   - color
   - counter_type
   - hand_exerciser_style
+  - minimum_resistance_weight
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19482,6 +21253,8 @@
   - color
   - counter_type
   - hand_exerciser_style
+  - minimum_resistance_weight
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19499,8 +21272,15 @@
   - sg-2-14-5
   attributes:
   - color
+  - height
+  - length
+  - maximum_load_capacity
+  - maximum_user_height
+  - minimum_user_height
+  - overall_dimensions
   - pattern
   - therapeutic_features
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -19516,6 +21296,8 @@
   children: []
   attributes:
   - color
+  - minimum_user_height
+  - overall_dimensions
   - pattern
   - therapeutic_features
   return_reasons:
@@ -19530,6 +21312,8 @@
   children: []
   attributes:
   - color
+  - minimum_user_height
+  - overall_dimensions
   - pattern
   - therapeutic_features
   return_reasons:
@@ -19544,6 +21328,8 @@
   children: []
   attributes:
   - color
+  - minimum_user_height
+  - overall_dimensions
   - pattern
   - therapeutic_features
   return_reasons:
@@ -19558,6 +21344,8 @@
   children: []
   attributes:
   - color
+  - minimum_user_height
+  - overall_dimensions
   - pattern
   - therapeutic_features
   return_reasons:
@@ -19578,9 +21366,15 @@
   - sg-2-15-6
   attributes:
   - ball_material
+  - ball_weight
   - bounce_level
   - color
+  - diameter
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -19597,9 +21391,15 @@
   children: []
   attributes:
   - ball_material
+  - ball_weight
   - bounce_level
   - color
+  - diameter
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -19616,9 +21416,15 @@
   children: []
   attributes:
   - ball_material
+  - ball_weight
   - bounce_level
   - color
+  - diameter
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -19635,9 +21441,15 @@
   children: []
   attributes:
   - ball_material
+  - ball_weight
   - bounce_level
   - color
+  - diameter
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -19654,9 +21466,15 @@
   children: []
   attributes:
   - ball_material
+  - ball_weight
   - bounce_level
   - color
+  - diameter
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -19673,9 +21491,15 @@
   children: []
   attributes:
   - ball_material
+  - ball_weight
   - bounce_level
   - color
+  - diameter
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - length
@@ -19692,10 +21516,16 @@
   children: []
   attributes:
   - ball_material
+  - ball_weight
   - bounce_level
   - color
+  - diameter
+  - height
+  - length
+  - overall_dimensions
   - pattern
   - rebound_level
+  - width
   return_reasons:
   - size
   - grip
@@ -19714,7 +21544,12 @@
   - assistance_mechanism
   - color
   - compatible_exercises
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - height
@@ -19734,9 +21569,14 @@
   attributes:
   - bar_mounting_type
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - push_up_bar_design
+  - width
   return_reasons:
   - size
   - grip
@@ -19754,6 +21594,7 @@
   - bar_mounting_type
   - color
   - material
+  - overall_dimensions
   - pattern
   - push_up_bar_design
   return_reasons:
@@ -19770,6 +21611,7 @@
   - bar_mounting_type
   - color
   - material
+  - overall_dimensions
   - pattern
   - push_up_bar_design
   return_reasons:
@@ -19786,6 +21628,7 @@
   - bar_mounting_type
   - color
   - material
+  - overall_dimensions
   - pattern
   - push_up_bar_design
   return_reasons:
@@ -19802,7 +21645,11 @@
   - ball_material
   - ball_size
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -19819,7 +21666,13 @@
   children: []
   attributes:
   - color
+  - diameter
+  - height
+  - length
+  - maximum_resistance_weight
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - resistance
   - changed_my_mind
@@ -19837,10 +21690,14 @@
   - accessory_size
   - activity
   - color
+  - height
+  - length
   - lighting_mode
   - material
   - mounting_location
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - brightness
   - changed_my_mind
@@ -19858,10 +21715,14 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - lighting_mode
   - material
   - mounting_location
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - brightness
   - battery_life
@@ -19884,11 +21745,15 @@
   - accessory_size
   - activity
   - color
+  - height
   - led_light_color
+  - length
   - lighting_mode
   - material
   - mounting_location
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -19911,6 +21776,7 @@
   - lighting_mode
   - material
   - mounting_location
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19930,6 +21796,7 @@
   - lighting_mode
   - material
   - mounting_location
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19949,6 +21816,7 @@
   - lighting_mode
   - material
   - mounting_location
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19968,6 +21836,7 @@
   - lighting_mode
   - material
   - mounting_location
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -19981,8 +21850,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
   - stopwatch_features
+  - timing_precision
+  - width
   return_reasons:
   - size
   - color
@@ -20002,6 +21876,8 @@
   attributes:
   - anchor_configuration
   - color
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - suspension_trainer_accessories_included
   return_reasons:
@@ -20022,8 +21898,13 @@
   attributes:
   - anchor_configuration
   - color
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - suspension_trainer_accessories_included
+  - width
   return_reasons:
   - length
   - grip
@@ -20040,8 +21921,13 @@
   attributes:
   - anchor_configuration
   - color
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - suspension_trainer_accessories_included
+  - width
   return_reasons:
   - size
   - grip
@@ -20058,9 +21944,14 @@
   attributes:
   - anchor_configuration
   - color
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - suspension_trainer_accessories_included
   - suspension_trainer_anchor_type
+  - width
   return_reasons:
   - length
   - grip
@@ -20079,8 +21970,13 @@
   attributes:
   - anchor_configuration
   - color
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - suspension_trainer_accessories_included
+  - width
   return_reasons:
   - size
   - grip
@@ -20099,8 +21995,13 @@
   - anchor_configuration
   - color
   - handle_style
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - suspension_trainer_accessories_included
+  - width
   return_reasons:
   - size
   - grip
@@ -20118,8 +22019,13 @@
   attributes:
   - anchor_configuration
   - color
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - suspension_trainer_accessories_included
+  - width
   return_reasons:
   - length
   - weight_capacity
@@ -20142,8 +22048,13 @@
   attributes:
   - anchor_configuration
   - color
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - suspension_trainer_accessories_included
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -20161,8 +22072,13 @@
   attributes:
   - anchor_configuration
   - color
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - suspension_trainer_accessories_included
+  - width
   return_reasons:
   - length
   - weight_capacity
@@ -20180,8 +22096,14 @@
   attributes:
   - anchor_configuration
   - color
+  - height
+  - length
+  - maximum_compatible_rope_or_band_diameter
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - suspension_trainer_accessories_included
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -20198,9 +22120,15 @@
   children: []
   attributes:
   - anchor_configuration
+  - carabiner_gate_opening_clearance
   - color
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - suspension_trainer_accessories_included
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -20219,8 +22147,14 @@
   - anchor_configuration
   - color
   - connector_type
+  - height
+  - length
+  - maximum_compatible_strap_width
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - suspension_trainer_accessories_included
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -20238,8 +22172,13 @@
   - anchor_configuration
   - color
   - compatible_training_equipment
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - suspension_trainer_accessories_included
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -20258,7 +22197,12 @@
   attributes:
   - color
   - exercise_machine_features
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - intensity
@@ -20275,7 +22219,13 @@
   attributes:
   - color
   - exercise_machine_features
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
+  - vibration_amplitude
+  - width
   return_reasons:
   - size
   - intensity
@@ -20292,7 +22242,12 @@
   attributes:
   - color
   - exercise_machine_features
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - intensity
@@ -20319,6 +22274,8 @@
   - sg-2-24-11
   attributes:
   - color
+  - heel_to_toe_drop
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
   return_reasons:
@@ -20342,8 +22299,13 @@
   - sg-2-24-1-7
   attributes:
   - color
+  - heel_to_toe_drop
+  - height
+  - length
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -20361,15 +22323,23 @@
   attributes:
   - barbell_finish
   - color
+  - heel_to_toe_drop
+  - height
   - knurl_aggressiveness
   - knurl_marking_standard
+  - length
+  - loadable_sleeve_length
   - material
+  - overall_dimensions
   - pattern
   - plate_compatibility_standard
+  - shaft_diameter
   - sleeve_bearing_type
+  - sleeve_diameter
   - weight_bar_activity
   - weight_bar_type
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - length
   - grip
@@ -20392,9 +22362,15 @@
   attributes:
   - color
   - free_weight_rack_type
+  - heel_to_toe_drop
+  - height
+  - length
   - material
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -20411,7 +22387,9 @@
   attributes:
   - color
   - free_weight_rack_type
+  - heel_to_toe_drop
   - material
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
   return_reasons:
@@ -20427,7 +22405,9 @@
   attributes:
   - color
   - free_weight_rack_type
+  - heel_to_toe_drop
   - material
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
   return_reasons:
@@ -20443,7 +22423,9 @@
   attributes:
   - color
   - free_weight_rack_type
+  - heel_to_toe_drop
   - material
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
   return_reasons:
@@ -20459,7 +22441,9 @@
   attributes:
   - color
   - free_weight_rack_type
+  - heel_to_toe_drop
   - material
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
   return_reasons:
@@ -20475,7 +22459,9 @@
   attributes:
   - color
   - free_weight_rack_type
+  - heel_to_toe_drop
   - material
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
   return_reasons:
@@ -20491,10 +22477,16 @@
   attributes:
   - collar_lock_type
   - color
+  - compatible_bar_diameter
   - compatible_weight_lifting_accessory
+  - heel_to_toe_drop
+  - height
+  - length
   - material
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - color
   - diameter
@@ -20511,7 +22503,9 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
   - material
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
   return_reasons:
@@ -20526,7 +22520,9 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
   - material
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
   return_reasons:
@@ -20541,7 +22537,9 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
   - material
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
   return_reasons:
@@ -20556,7 +22554,9 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
   - material
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
   return_reasons:
@@ -20577,10 +22577,15 @@
   - sg-2-24-2-6
   attributes:
   - color
+  - heel_to_toe_drop
+  - height
+  - length
   - material
+  - overall_dimensions
   - pattern
   - weight_adjustability
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -20598,10 +22603,16 @@
   attributes:
   - color
   - dumbbell_style
+  - dumbbell_weight
+  - heel_to_toe_drop
+  - height
+  - length
   - material
+  - overall_dimensions
   - pattern
   - weight_adjustability
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -20617,11 +22628,17 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
+  - height
   - kettlebell_style
+  - kettlebell_weight
+  - length
   - material
+  - overall_dimensions
   - pattern
   - weight_adjustability
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -20640,11 +22657,17 @@
   - sg-2-24-2-3-3
   attributes:
   - color
+  - heel_to_toe_drop
+  - height
+  - length
   - material
+  - overall_dimensions
   - pattern
   - sandbag_style
+  - sandbag_weight
   - weight_adjustability
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -20660,7 +22683,9 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
   - material
+  - overall_dimensions
   - pattern
   - sandbag_style
   - weight_adjustability
@@ -20677,7 +22702,9 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
   - material
+  - overall_dimensions
   - pattern
   - sandbag_style
   - weight_adjustability
@@ -20694,7 +22721,9 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
   - material
+  - overall_dimensions
   - pattern
   - sandbag_style
   - weight_adjustability
@@ -20712,11 +22741,18 @@
   attributes:
   - color
   - color_coding_standard
+  - diameter
   - grip_design
+  - heel_to_toe_drop
+  - height
+  - length
   - material
+  - overall_dimensions
   - pattern
+  - plate_weight
   - weight_adjustability
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -20733,7 +22769,9 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
   - material
+  - overall_dimensions
   - pattern
   - weight_adjustability
   - weightlifting_federation_certification
@@ -20749,7 +22787,9 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
   - material
+  - overall_dimensions
   - pattern
   - weight_adjustability
   - weightlifting_federation_certification
@@ -20768,9 +22808,14 @@
   - age_group
   - belt_profile
   - color
+  - heel_to_toe_drop
+  - height
+  - length
+  - overall_dimensions
   - pattern
   - weightlifting_belt_style
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -20797,6 +22842,8 @@
   - hand_support_level
   - hand_support_size
   - handwear_material
+  - heel_to_toe_drop
+  - overall_dimensions
   - palm_padding_level
   - pattern
   - target_gender
@@ -20823,6 +22870,8 @@
   - hand_support_level
   - hand_support_size
   - handwear_material
+  - heel_to_toe_drop
+  - overall_dimensions
   - palm_padding_level
   - pattern
   - target_gender
@@ -20845,6 +22894,8 @@
   - hand_support_level
   - hand_support_size
   - handwear_material
+  - heel_to_toe_drop
+  - overall_dimensions
   - palm_padding_level
   - pattern
   - target_gender
@@ -20867,6 +22918,8 @@
   - hand_support_level
   - hand_support_size
   - handwear_material
+  - heel_to_toe_drop
+  - overall_dimensions
   - palm_padding_level
   - pattern
   - target_gender
@@ -20889,6 +22942,8 @@
   - hand_support_level
   - hand_support_size
   - handwear_material
+  - heel_to_toe_drop
+  - overall_dimensions
   - palm_padding_level
   - pattern
   - target_gender
@@ -20913,9 +22968,14 @@
   - sg-2-24-5-8
   attributes:
   - color
+  - heel_to_toe_drop
+  - height
+  - length
+  - overall_dimensions
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -20931,10 +22991,16 @@
   name: Cables
   children: []
   attributes:
+  - cable_length
   - color
+  - heel_to_toe_drop
+  - height
+  - length
+  - overall_dimensions
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - length
   - thickness
@@ -20955,9 +23021,14 @@
   attributes:
   - color
   - handle_type
+  - heel_to_toe_drop
+  - height
+  - length
+  - overall_dimensions
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -20975,6 +23046,8 @@
   attributes:
   - color
   - handle_type
+  - heel_to_toe_drop
+  - overall_dimensions
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
@@ -20991,6 +23064,8 @@
   attributes:
   - color
   - handle_type
+  - heel_to_toe_drop
+  - overall_dimensions
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
@@ -21007,6 +23082,8 @@
   attributes:
   - color
   - handle_type
+  - heel_to_toe_drop
+  - overall_dimensions
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
@@ -21024,10 +23101,16 @@
   - sg-2-24-5-3-2
   attributes:
   - color
+  - heel_to_toe_drop
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - plate_weight
   - targeted_muscle_group
   - weight_plate_style
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -21044,6 +23127,8 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
+  - overall_dimensions
   - pattern
   - targeted_muscle_group
   - weight_plate_style
@@ -21060,6 +23145,8 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
+  - overall_dimensions
   - pattern
   - targeted_muscle_group
   - weight_plate_style
@@ -21076,6 +23163,8 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
+  - overall_dimensions
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
@@ -21091,6 +23180,8 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
+  - overall_dimensions
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
@@ -21106,6 +23197,8 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
+  - overall_dimensions
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
@@ -21121,6 +23214,8 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
+  - overall_dimensions
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
@@ -21136,6 +23231,8 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
+  - overall_dimensions
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
@@ -21155,8 +23252,14 @@
   - sg-2-24-6-4
   attributes:
   - color
+  - heel_to_toe_drop
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - size
   - grip
@@ -21176,12 +23279,20 @@
   - color
   - frame_finish
   - frame_steel_gauge
+  - heel_to_toe_drop
+  - height
+  - hole_diameter
+  - hole_spacing
   - j_cup_type
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - power_rack_style
   - pull_up_bar
   - safety_mechanism_type
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - height
   - width
@@ -21199,7 +23310,10 @@
   - color
   - frame_finish
   - frame_steel_gauge
+  - heel_to_toe_drop
+  - hole_spacing
   - j_cup_type
+  - overall_dimensions
   - pattern
   - power_rack_style
   - pull_up_bar
@@ -21219,7 +23333,10 @@
   - color
   - frame_finish
   - frame_steel_gauge
+  - heel_to_toe_drop
+  - hole_spacing
   - j_cup_type
+  - overall_dimensions
   - pattern
   - power_rack_style
   - pull_up_bar
@@ -21237,12 +23354,19 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
+  - height
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - pull_up_bar
   - resistance_loading_type
   - smith_machine_bar_path
+  - starting_bar_weight
   - weight_plate_compatibility
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - size
   - height
@@ -21264,11 +23388,18 @@
   attributes:
   - color
   - compatible_weight_plate_diameter
+  - heel_to_toe_drop
+  - height
   - j_cup_type
+  - length
   - load_mechanism
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - pull_up_bar
+  - weight_stack
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - size
   - height
@@ -21286,10 +23417,13 @@
   attributes:
   - color
   - compatible_weight_plate_diameter
+  - heel_to_toe_drop
   - j_cup_type
   - load_mechanism
+  - overall_dimensions
   - pattern
   - pull_up_bar
+  - weight_stack
   - weightlifting_federation_certification
   return_reasons:
   - changed_my_mind
@@ -21304,10 +23438,13 @@
   attributes:
   - color
   - compatible_weight_plate_diameter
+  - heel_to_toe_drop
   - j_cup_type
   - load_mechanism
+  - overall_dimensions
   - pattern
   - pull_up_bar
+  - weight_stack
   - weightlifting_federation_certification
   return_reasons:
   - changed_my_mind
@@ -21322,10 +23459,13 @@
   attributes:
   - color
   - compatible_weight_plate_diameter
+  - heel_to_toe_drop
   - j_cup_type
   - load_mechanism
+  - overall_dimensions
   - pattern
   - pull_up_bar
+  - weight_stack
   - weightlifting_federation_certification
   return_reasons:
   - changed_my_mind
@@ -21340,10 +23480,13 @@
   attributes:
   - color
   - compatible_weight_plate_diameter
+  - heel_to_toe_drop
   - j_cup_type
   - load_mechanism
+  - overall_dimensions
   - pattern
   - pull_up_bar
+  - weight_stack
   - weightlifting_federation_certification
   return_reasons:
   - changed_my_mind
@@ -21357,10 +23500,16 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
+  - height
   - j_cup_type
+  - length
+  - maximum_load_capacity
+  - overall_dimensions
   - pattern
   - pull_up_bar
   - weightlifting_federation_certification
+  - width
   return_reasons:
   - height
   - width
@@ -21377,6 +23526,8 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
   return_reasons:
@@ -21391,6 +23542,8 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
   return_reasons:
@@ -21405,6 +23558,8 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
   return_reasons:
@@ -21419,6 +23574,8 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
   return_reasons:
@@ -21433,6 +23590,8 @@
   children: []
   attributes:
   - color
+  - heel_to_toe_drop
+  - overall_dimensions
   - pattern
   - weightlifting_federation_certification
   return_reasons:
@@ -21450,7 +23609,11 @@
   - sg-2-25-3
   attributes:
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - too_bulky
@@ -21465,8 +23628,13 @@
   name: Ankle Weights
   children: []
   attributes:
+  - clothing_weight
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - too_bulky
@@ -21482,7 +23650,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - too_bulky
@@ -21498,7 +23670,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - too_bulky
@@ -21525,6 +23701,7 @@
   - sg-2-26-11
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - size
@@ -21546,7 +23723,11 @@
   - sg-2-26-1-5
   attributes:
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - adjustability
@@ -21563,8 +23744,12 @@
   - sg-2-26-1-1-2
   attributes:
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
   - pedal_configuration
+  - width
   return_reasons:
   - size
   - adjustability
@@ -21580,6 +23765,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   - pedal_configuration
   return_reasons:
@@ -21595,7 +23781,11 @@
   - sg-2-26-1-2-2
   attributes:
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - adjustability
@@ -21611,6 +23801,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -21627,8 +23818,12 @@
   - sg-2-26-1-3-3
   attributes:
   - color
+  - height
   - included_components
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - adjustability
@@ -21645,6 +23840,7 @@
   attributes:
   - color
   - included_components
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -21659,6 +23855,7 @@
   attributes:
   - color
   - included_components
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -21673,6 +23870,7 @@
   attributes:
   - color
   - included_components
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -21686,6 +23884,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -21699,6 +23898,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -21712,8 +23912,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -21731,8 +23935,12 @@
   - color
   - exercise_mat_accessories_included
   - exercise_mat_material
+  - height
+  - length
   - mat_base_material
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -21751,7 +23959,11 @@
   - accessory_size
   - color
   - fabric
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -21770,7 +23982,11 @@
   - sg-2-26-5-2
   attributes:
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -21787,7 +24003,14 @@
   children: []
   attributes:
   - color
+  - compatible_mat_length
+  - compatible_mat_thickness
+  - compatible_mat_width
+  - height
+  - length
+  - overall_dimensions
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -21804,8 +24027,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - overall_dimensions
   - pattern
   - strap_functionality
+  - width
   return_reasons:
   - color
   - style
@@ -21822,6 +24049,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -21835,6 +24063,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -21848,6 +24077,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -21861,6 +24091,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -21874,6 +24105,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -21887,6 +24119,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -21900,6 +24133,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -21913,6 +24147,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -21926,6 +24161,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -21939,6 +24175,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -21952,6 +24189,7 @@
   children: []
   attributes:
   - color
+  - overall_dimensions
   - pattern
   return_reasons:
   - changed_my_mind
@@ -21980,6 +24218,7 @@
   - color
   - material
   - pattern
+  - playing_surface_size
   return_reasons:
   - size
   - color
@@ -21999,6 +24238,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - size
   - color
@@ -22017,8 +24257,13 @@
   attributes:
   - air_hockey_items_included
   - color
+  - compatible_table_size
+  - height
+  - length
   - material
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - color
@@ -22036,8 +24281,13 @@
   attributes:
   - air_hockey_items_included
   - color
+  - compatible_table_size
+  - height
+  - length
   - material
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - color
@@ -22055,8 +24305,13 @@
   attributes:
   - air_hockey_items_included
   - color
+  - compatible_table_size
+  - height
+  - length
   - material
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - color
@@ -22082,9 +24337,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - material
   - pattern
+  - playing_surface_size
   - table_hockey_part_type
+  - width
   return_reasons:
   - size
   - color
@@ -22101,9 +24360,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - material
   - pattern
+  - playing_surface_size
   - table_hockey_part_type
+  - width
   return_reasons:
   - size
   - color
@@ -22121,9 +24384,13 @@
   - age_group
   - color
   - fastener_grade
+  - height
+  - length
   - material
   - pattern
+  - playing_surface_size
   - table_hockey_part_type
+  - width
   return_reasons:
   - size
   - color
@@ -22139,10 +24406,15 @@
   children: []
   attributes:
   - age_group
+  - cable_length
   - color
+  - height
+  - length
   - material
   - pattern
+  - playing_surface_size
   - table_hockey_part_type
+  - width
   return_reasons:
   - color
   - length
@@ -22160,9 +24432,13 @@
   - age_group
   - clamp_design
   - color
+  - height
+  - length
   - material
   - pattern
+  - playing_surface_size
   - table_hockey_part_type
+  - width
   return_reasons:
   - size
   - color
@@ -22179,9 +24455,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - material
   - pattern
+  - playing_surface_size
   - table_hockey_part_type
+  - width
   return_reasons:
   - size
   - color
@@ -22200,6 +24480,7 @@
   - color
   - material
   - pattern
+  - playing_surface_size
   - table_hockey_part_type
   return_reasons:
   - changed_my_mind
@@ -22216,6 +24497,7 @@
   - color
   - material
   - pattern
+  - playing_surface_size
   - table_hockey_part_type
   return_reasons:
   - changed_my_mind
@@ -22232,6 +24514,7 @@
   - color
   - material
   - pattern
+  - playing_surface_size
   - table_hockey_part_type
   return_reasons:
   - changed_my_mind
@@ -22246,10 +24529,14 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - lighting_effects
   - material
   - pattern
+  - playing_surface_size
   - scoring_system_type
+  - width
   return_reasons:
   - size
   - color
@@ -22277,6 +24564,7 @@
   - billiards_discipline
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - size
   - color
@@ -22295,9 +24583,14 @@
   - billiard_rack_style
   - billiards_discipline
   - color
+  - compatible_ball_diameter
   - compatible_billiard_game
+  - height
+  - length
   - material
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - color
@@ -22315,7 +24608,11 @@
   - ball_material
   - billiards_discipline
   - color
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - color
@@ -22340,7 +24637,11 @@
   - billiards_discipline
   - color
   - cue_thread_size
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - color
@@ -22361,7 +24662,11 @@
   - color
   - cue_compatibility
   - cue_thread_size
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - color
@@ -22380,7 +24685,11 @@
   - billiards_discipline
   - color
   - cue_thread_size
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - color
@@ -22398,9 +24707,13 @@
   - billiards_discipline
   - color
   - cue_thread_size
+  - height
   - integrated_storage_features
+  - length
   - material
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - color
@@ -22419,6 +24732,7 @@
   - color
   - cue_thread_size
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22434,6 +24748,7 @@
   - color
   - cue_thread_size
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22449,6 +24764,7 @@
   - color
   - cue_thread_size
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22466,10 +24782,15 @@
   - billiards_discipline
   - bridge_head_type
   - color
+  - cue_tip_diameter
   - cue_tip_hardness
+  - height
+  - length
   - material
   - pattern
   - piece_configuration
+  - playing_surface_size
+  - width
   return_reasons:
   - length
   - balance
@@ -22492,9 +24813,13 @@
   - bridge_head_type
   - color
   - cue_tip_hardness
+  - height
+  - length
   - material
   - pattern
   - piece_configuration
+  - playing_surface_size
+  - width
   return_reasons:
   - length
   - grip
@@ -22517,6 +24842,7 @@
   - material
   - pattern
   - piece_configuration
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22536,6 +24862,7 @@
   - material
   - pattern
   - piece_configuration
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22551,6 +24878,7 @@
   - bridge_head_type
   - color
   - cue_construction
+  - cue_size
   - cue_style
   - cue_tip_hardness
   - cue_type
@@ -22561,6 +24889,7 @@
   - material
   - pattern
   - piece_configuration
+  - playing_surface_size
   return_reasons:
   - length
   - balance
@@ -22589,6 +24918,8 @@
   - material
   - pattern
   - piece_configuration
+  - playing_surface_size
+  - shaft_size
   return_reasons:
   - length
   - flex
@@ -22611,6 +24942,7 @@
   - color
   - handwear_material
   - pattern
+  - playing_surface_size
   - target_gender
   return_reasons:
   - too_big
@@ -22629,12 +24961,16 @@
   attributes:
   - billiards_discipline
   - color
+  - height
+  - length
   - light_color
   - light_pattern
   - light_temperature
   - mounting_type
   - pattern
+  - playing_surface_size
   - suitable_table_size
+  - width
   return_reasons:
   - size
   - color
@@ -22663,7 +24999,11 @@
   - color
   - cue_sport_compatibility
   - cushion_rubber_profile
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - color
@@ -22683,7 +25023,12 @@
   - color
   - cue_sport_compatibility
   - cushion_rubber_profile
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - pocket_opening_size
+  - width
   return_reasons:
   - size
   - color
@@ -22704,7 +25049,11 @@
   - color
   - cue_sport_compatibility
   - cushion_rubber_profile
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - color
@@ -22725,9 +25074,13 @@
   - color
   - cue_sport_compatibility
   - cushion_rubber_profile
+  - height
+  - length
   - pattern
+  - playing_surface_size
   - protective_treatment
   - speed_rating
+  - width
   return_reasons:
   - size
   - color
@@ -22750,7 +25103,11 @@
   - cover_material
   - cue_sport_compatibility
   - cushion_rubber_profile
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - color
@@ -22770,6 +25127,7 @@
   - cue_sport_compatibility
   - cushion_rubber_profile
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22786,6 +25144,7 @@
   - cue_sport_compatibility
   - cushion_rubber_profile
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22802,6 +25161,7 @@
   - cue_sport_compatibility
   - cushion_rubber_profile
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22818,6 +25178,7 @@
   - cue_sport_compatibility
   - cushion_rubber_profile
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22834,6 +25195,7 @@
   - cue_sport_compatibility
   - cushion_rubber_profile
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22849,8 +25211,13 @@
   - billiard_table_type
   - billiards_discipline
   - color
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - slate_thickness
   - table_size
+  - width
   return_reasons:
   - size
   - color
@@ -22868,6 +25235,7 @@
   - billiards_discipline
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22882,6 +25250,7 @@
   - billiards_discipline
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22906,7 +25275,11 @@
   - sg-3-3-12
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - color
@@ -22926,7 +25299,11 @@
   - sg-3-3-1-4
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - color
   - style
@@ -22944,6 +25321,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22957,6 +25335,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22970,6 +25349,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -22983,6 +25363,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23000,8 +25381,13 @@
   - bowling_ball_core_type
   - bowling_ball_coverstock_type
   - color
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - radius_of_gyration
   - recommended_lane_condition
+  - width
   return_reasons:
   - color
   - pattern
@@ -23021,6 +25407,7 @@
   - color
   - handwear_material
   - pattern
+  - playing_surface_size
   - target_gender
   return_reasons:
   - too_big
@@ -23040,8 +25427,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - material
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - color
   - weight
@@ -23058,8 +25449,12 @@
   - age_group
   - bowling_set_style
   - color
+  - height
+  - length
   - material
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - color
   - pattern
@@ -23077,9 +25472,13 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - material
   - pattern
+  - playing_surface_size
   - support_brace_features
+  - width
   - wrist_support_style
   return_reasons:
   - too_tight
@@ -23098,6 +25497,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23111,6 +25511,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23124,6 +25525,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23137,6 +25539,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23150,6 +25553,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23163,6 +25567,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23179,6 +25584,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - size
   - color
@@ -23197,7 +25603,11 @@
   - ball_material
   - ball_size
   - color
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -23219,7 +25629,11 @@
   - sg-3-4-2-6
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - color
   - length
@@ -23235,7 +25649,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - color
   - grip
@@ -23252,7 +25670,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - color
@@ -23270,7 +25692,11 @@
   attributes:
   - color
   - foosball_rod_type
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - length
   - grip
@@ -23288,6 +25714,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23301,6 +25728,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23314,6 +25742,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23331,9 +25760,13 @@
   - color
   - foosball_rod_type
   - goalie_configuration
+  - height
+  - length
   - pattern
+  - playing_surface_size
   - scoring_method
   - table_size_category
+  - width
   return_reasons:
   - size
   - color
@@ -23353,6 +25786,7 @@
   - foosball_rod_type
   - goalie_configuration
   - pattern
+  - playing_surface_size
   - scoring_method
   - table_size_category
   return_reasons:
@@ -23371,6 +25805,7 @@
   - foosball_rod_type
   - goalie_configuration
   - pattern
+  - playing_surface_size
   - scoring_method
   - table_size_category
   return_reasons:
@@ -23391,7 +25826,11 @@
   - color
   - furniture/fixture_material
   - games_included
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - color
@@ -23410,9 +25849,15 @@
   attributes:
   - age_group
   - color
+  - compatible_table_length
+  - compatible_table_width
   - furniture/fixture_material
   - games_included
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - length
   - width
@@ -23431,7 +25876,11 @@
   - color
   - furniture/fixture_material
   - games_included
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - weight
@@ -23449,7 +25898,11 @@
   - color
   - furniture/fixture_material
   - games_included
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - length
   - width
@@ -23477,6 +25930,7 @@
   - color
   - pattern
   - ping_pong_certification
+  - playing_surface_size
   return_reasons:
   - size
   - color
@@ -23493,9 +25947,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - ping_pong_certification
   - ping_pong_competition_certification
+  - playing_surface_size
+  - width
   return_reasons:
   - bounce
   - weight
@@ -23512,10 +25970,14 @@
   - sg-3-6-2-2
   attributes:
   - color
+  - height
+  - length
   - mounting_type
   - pattern
   - ping_pong_certification
+  - playing_surface_size
   - table_tennis_certification
+  - width
   return_reasons:
   - length
   - height
@@ -23532,11 +25994,16 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_table_thickness
   - mounting_type
   - net_design
   - pattern
   - ping_pong_certification
+  - playing_surface_size
   - table_tennis_certification
+  - width
   return_reasons:
   - length
   - height
@@ -23553,10 +26020,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - mounting_type
   - pattern
   - ping_pong_certification
+  - playing_surface_size
   - table_tennis_certification
+  - width
   return_reasons:
   - height
   - installation
@@ -23582,10 +26053,14 @@
   - color
   - frame_color
   - frame_pattern
+  - height
+  - length
   - pattern
   - ping_pong_certification
   - ping_pong_rubber_type
+  - playing_surface_size
   - recommended_skill_level
+  - width
   return_reasons:
   - size
   - color
@@ -23604,10 +26079,14 @@
   - color
   - frame_color
   - frame_pattern
+  - height
+  - length
   - pattern
   - ping_pong_certification
   - ping_pong_rubber_type
+  - playing_surface_size
   - recommended_skill_level
+  - width
   return_reasons:
   - size
   - color
@@ -23630,6 +26109,7 @@
   - pattern
   - ping_pong_certification
   - ping_pong_rubber_type
+  - playing_surface_size
   - recommended_skill_level
   return_reasons:
   - changed_my_mind
@@ -23649,6 +26129,7 @@
   - pattern
   - ping_pong_certification
   - ping_pong_rubber_type
+  - playing_surface_size
   - recommended_skill_level
   return_reasons:
   - changed_my_mind
@@ -23668,6 +26149,7 @@
   - pattern
   - ping_pong_certification
   - ping_pong_rubber_type
+  - playing_surface_size
   - recommended_skill_level
   return_reasons:
   - changed_my_mind
@@ -23687,6 +26169,7 @@
   - pattern
   - ping_pong_certification
   - ping_pong_rubber_type
+  - playing_surface_size
   - recommended_skill_level
   return_reasons:
   - changed_my_mind
@@ -23706,6 +26189,7 @@
   - pattern
   - ping_pong_certification
   - ping_pong_rubber_type
+  - playing_surface_size
   - recommended_skill_level
   return_reasons:
   - changed_my_mind
@@ -23725,6 +26209,7 @@
   - pattern
   - ping_pong_certification
   - ping_pong_rubber_type
+  - playing_surface_size
   - recommended_skill_level
   return_reasons:
   - changed_my_mind
@@ -23740,11 +26225,16 @@
   - sg-3-6-4-2
   attributes:
   - color
+  - height
+  - length
   - pattern
   - ping_pong_certification
   - ping_pong_equipment_included
   - ping_pong_paddle_handle_style
   - ping_pong_rubber_surface_type
+  - ping_pong_sponge_thickness
+  - playing_surface_size
+  - width
   return_reasons:
   - color
   - grip
@@ -23766,6 +26256,8 @@
   - ping_pong_equipment_included
   - ping_pong_paddle_handle_style
   - ping_pong_rubber_surface_type
+  - ping_pong_sponge_thickness
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23783,6 +26275,8 @@
   - ping_pong_equipment_included
   - ping_pong_paddle_handle_style
   - ping_pong_rubber_surface_type
+  - ping_pong_sponge_thickness
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23798,9 +26292,13 @@
   - sg-3-6-5-3
   attributes:
   - color
+  - height
+  - length
   - pattern
   - ping_pong_certification
   - ping_pong_robot_accessory_type
+  - playing_surface_size
+  - width
   return_reasons:
   - installation
   - incompatible
@@ -23818,6 +26316,7 @@
   - pattern
   - ping_pong_certification
   - ping_pong_robot_accessory_type
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23833,6 +26332,7 @@
   - pattern
   - ping_pong_certification
   - ping_pong_robot_accessory_type
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23848,6 +26348,7 @@
   - pattern
   - ping_pong_certification
   - ping_pong_robot_accessory_type
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23861,9 +26362,13 @@
   attributes:
   - color
   - connectivity_technology
+  - height
+  - length
   - pattern
   - ping_pong_certification
   - ping_pong_robot_features
+  - playing_surface_size
+  - width
   return_reasons:
   - capacity
   - speed
@@ -23880,9 +26385,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - ping_pong_certification
+  - playing_surface_size
   - table_coverage_position
+  - width
   return_reasons:
   - size
   - color
@@ -23901,11 +26410,15 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - mounting_type
   - pattern
   - ping_pong_certification
   - ping_pong_table_type
+  - playing_surface_size
   - suitable_space
+  - width
   return_reasons:
   - size
   - color
@@ -23926,6 +26439,7 @@
   - pattern
   - ping_pong_certification
   - ping_pong_table_type
+  - playing_surface_size
   - suitable_space
   return_reasons:
   - changed_my_mind
@@ -23944,6 +26458,7 @@
   - pattern
   - ping_pong_certification
   - ping_pong_table_type
+  - playing_surface_size
   - suitable_space
   return_reasons:
   - changed_my_mind
@@ -23959,6 +26474,7 @@
   - color
   - pattern
   - ping_pong_certification
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23973,6 +26489,7 @@
   - color
   - pattern
   - ping_pong_certification
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -23989,8 +26506,12 @@
   - sg-3-7-4
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - playing_surface_size
   - shuffleboard_table_length_compatibility
+  - width
   return_reasons:
   - size
   - color
@@ -24008,9 +26529,15 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - playfield_thickness
+  - playfield_width
+  - playing_surface_size
   - scoring_pattern
   - shuffleboard_table_length_compatibility
+  - width
   return_reasons:
   - length
   - width
@@ -24026,9 +26553,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - playing_surface_size
   - shuffleboard_speed_rating
   - shuffleboard_table_length_compatibility
+  - volume
+  - width
   return_reasons:
   - speed
   - changed_my_mind
@@ -24042,9 +26574,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - playing_surface_size
   - puck_bottom_style
   - shuffleboard_table_length_compatibility
+  - width
   return_reasons:
   - size
   - color
@@ -24061,6 +26597,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   - shuffleboard_table_length_compatibility
   return_reasons:
   - changed_my_mind
@@ -24082,6 +26619,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - size
   - color
@@ -24099,7 +26637,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - color
@@ -24122,7 +26664,11 @@
   - color
   - dart_thread_size
   - dart_tip_compatibility
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - color
   - length
@@ -24141,8 +26687,12 @@
   - dart_thread_size
   - dart_tip_compatibility
   - flight_system_type
+  - height
+  - length
   - material
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - color
   - pattern
@@ -24162,9 +26712,13 @@
   - dart_shaft_thread_type
   - dart_thread_size
   - dart_tip_compatibility
+  - height
+  - length
   - material
   - pattern
+  - playing_surface_size
   - shaft_length_type
+  - width
   return_reasons:
   - color
   - length
@@ -24183,8 +26737,12 @@
   - dart_thread_size
   - dart_tip_compatibility
   - dart_tip_connection_type
+  - height
+  - length
   - material
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - color
   - length
@@ -24204,6 +26762,7 @@
   - dart_tip_compatibility
   - material
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24220,6 +26779,7 @@
   - dart_tip_compatibility
   - material
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24235,7 +26795,12 @@
   - color
   - dartboard_tournament_approval
   - dartboard_type
+  - diameter
+  - height
+  - length
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - size
   - color
@@ -24253,8 +26818,12 @@
   - barrel_profile
   - color
   - dart_barrel_material
+  - height
+  - length
   - material
   - pattern
+  - playing_surface_size
+  - width
   return_reasons:
   - grip
   - length
@@ -24272,6 +26841,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24285,6 +26855,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24298,6 +26869,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24311,6 +26883,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24324,6 +26897,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24337,6 +26911,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24350,6 +26925,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24363,6 +26939,7 @@
   attributes:
   - color
   - pattern
+  - playing_surface_size
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24457,6 +27034,7 @@
   attributes:
   - color
   - pattern
+  - rope_diameter
   return_reasons:
   - size
   - color
@@ -24476,6 +27054,7 @@
   - color
   - handwear_material
   - pattern
+  - rope_diameter
   - target_gender
   return_reasons:
   - too_big
@@ -24498,8 +27077,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - rope_diameter
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -24518,7 +27101,11 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - rope_diameter
+  - width
   return_reasons:
   - size
   - color
@@ -24540,7 +27127,11 @@
   - care_instructions
   - carry_options
   - color
+  - height
+  - length
   - pattern
+  - rope_diameter
+  - width
   return_reasons:
   - size
   - color
@@ -24560,6 +27151,7 @@
   - color
   - lumber/wood_type
   - pattern
+  - rope_diameter
   - wood_finish
   return_reasons:
   - changed_my_mind
@@ -24576,6 +27168,7 @@
   - color
   - lumber/wood_type
   - pattern
+  - rope_diameter
   - wood_finish
   return_reasons:
   - changed_my_mind
@@ -24599,9 +27192,13 @@
   attributes:
   - canoe_construction_type
   - color
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
+  - rope_diameter
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -24619,9 +27216,13 @@
   attributes:
   - canoe_construction_type
   - color
+  - height
+  - length
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
+  - width
   return_reasons:
   - size
   - color
@@ -24638,9 +27239,13 @@
   attributes:
   - canoe_construction_type
   - color
+  - height
+  - length
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
+  - width
   return_reasons:
   - size
   - color
@@ -24659,9 +27264,14 @@
   - canoe_construction_type
   - canoe_stern_design
   - color
+  - height
+  - length
   - material
   - pattern
   - recommended_skill_level
+  - rocker_height
+  - rope_diameter
+  - width
   return_reasons:
   - color
   - weight_capacity
@@ -24680,9 +27290,14 @@
   - canoe_construction_type
   - canoe_hull_shape
   - color
+  - height
+  - hull_rocker_length
+  - length
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
+  - width
   return_reasons:
   - color
   - weight_capacity
@@ -24706,6 +27321,7 @@
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   return_reasons:
   - size
   - color
@@ -24722,9 +27338,13 @@
   attributes:
   - canoe_construction_type
   - color
+  - height
+  - length
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
+  - width
   return_reasons:
   - size
   - color
@@ -24741,10 +27361,14 @@
   attributes:
   - canoe_construction_type
   - color
+  - height
+  - length
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   - sprint_canoe_class
+  - width
   return_reasons:
   - color
   - length
@@ -24765,6 +27389,7 @@
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24782,6 +27407,7 @@
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   - wood_finish
   return_reasons:
   - changed_my_mind
@@ -24800,6 +27426,7 @@
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   - wood_finish
   return_reasons:
   - changed_my_mind
@@ -24818,6 +27445,7 @@
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   - wood_finish
   return_reasons:
   - changed_my_mind
@@ -24836,6 +27464,7 @@
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   - wood_finish
   return_reasons:
   - changed_my_mind
@@ -24863,7 +27492,11 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
+  - rope_diameter
+  - width
   return_reasons:
   - size
   - color
@@ -24879,7 +27512,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - rope_diameter
+  - width
   return_reasons:
   - size
   - color
@@ -24897,9 +27534,13 @@
   attributes:
   - color
   - compatible_kayak_type
+  - height
+  - length
   - pattern
   - reefing_method
+  - rope_diameter
   - sail_shape
+  - width
   return_reasons:
   - size
   - color
@@ -24922,8 +27563,14 @@
   - care_instructions
   - carry_options
   - color
+  - height
   - kayak_storage_bag_type
+  - length
+  - maximum_kayak_width
+  - maximum_supported_kayak_length
   - pattern
+  - rope_diameter
+  - width
   return_reasons:
   - size
   - color
@@ -24946,7 +27593,10 @@
   - carry_options
   - color
   - kayak_storage_bag_type
+  - maximum_kayak_width
+  - maximum_supported_kayak_length
   - pattern
+  - rope_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24965,7 +27615,10 @@
   - carry_options
   - color
   - kayak_storage_bag_type
+  - maximum_kayak_width
+  - maximum_supported_kayak_length
   - pattern
+  - rope_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24981,6 +27634,7 @@
   - battery_type
   - color
   - pattern
+  - rope_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -24996,6 +27650,7 @@
   - battery_type
   - color
   - pattern
+  - rope_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -25011,6 +27666,7 @@
   - battery_type
   - color
   - pattern
+  - rope_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -25026,6 +27682,7 @@
   - battery_type
   - color
   - pattern
+  - rope_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -25041,6 +27698,7 @@
   - battery_type
   - color
   - pattern
+  - rope_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -25056,6 +27714,7 @@
   - battery_type
   - color
   - pattern
+  - rope_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -25071,6 +27730,7 @@
   - battery_type
   - color
   - pattern
+  - rope_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -25086,6 +27746,7 @@
   - battery_type
   - color
   - pattern
+  - rope_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -25101,6 +27762,7 @@
   - battery_type
   - color
   - pattern
+  - rope_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -25125,10 +27787,14 @@
   - sg-4-1-1-5-12
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   - watercraft_propulsion_type
+  - width
   return_reasons:
   - color
   - length
@@ -25143,11 +27809,16 @@
   name: Creekboats
   children: []
   attributes:
+  - cockpit_dimensions
   - color
+  - height
+  - length
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   - watercraft_propulsion_type
+  - width
   return_reasons:
   - color
   - weight_capacity
@@ -25164,12 +27835,16 @@
   children: []
   attributes:
   - color
+  - height
   - kayak_style
+  - length
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   - tracking_aid_type
   - watercraft_propulsion_type
+  - width
   return_reasons:
   - color
   - length
@@ -25185,11 +27860,16 @@
   name: Folding Kayaks
   children: []
   attributes:
+  - assembly_time
   - color
+  - height
+  - length
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   - watercraft_propulsion_type
+  - width
   return_reasons:
   - color
   - weight_capacity
@@ -25206,10 +27886,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   - watercraft_propulsion_type
+  - width
   return_reasons:
   - color
   - length
@@ -25225,9 +27909,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
+  - width
   return_reasons:
   - color
   - weight_capacity
@@ -25244,12 +27932,16 @@
   children: []
   attributes:
   - color
+  - height
   - kayak_construction_type
+  - length
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   - watercraft_drive_mechanism
   - watercraft_propulsion_type
+  - width
   return_reasons:
   - color
   - length
@@ -25266,10 +27958,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   - watercraft_propulsion_type
+  - width
   return_reasons:
   - color
   - maneuverability
@@ -25286,12 +27982,17 @@
   children: []
   attributes:
   - color
+  - height
   - kayak_design_type
   - kayak_hull_design
+  - length
   - material
+  - paddler_weight_range
   - pattern
   - recommended_skill_level
+  - rope_diameter
   - watercraft_propulsion_type
+  - width
   return_reasons:
   - color
   - length
@@ -25308,12 +28009,16 @@
   children: []
   attributes:
   - color
+  - height
   - hull_design
+  - length
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   - watercraft_propulsion_type
   - whitewater_kayak_style
+  - width
   return_reasons:
   - color
   - length
@@ -25333,6 +28038,7 @@
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   - watercraft_propulsion_type
   return_reasons:
   - color
@@ -25353,6 +28059,7 @@
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   - watercraft_propulsion_type
   return_reasons:
   - changed_my_mind
@@ -25369,6 +28076,7 @@
   - material
   - pattern
   - recommended_skill_level
+  - rope_diameter
   - watercraft_propulsion_type
   return_reasons:
   - changed_my_mind
@@ -25382,8 +28090,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - paddle_leash_style
   - pattern
+  - rope_diameter
+  - width
   return_reasons:
   - color
   - length
@@ -25399,9 +28111,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_length
+  - minimum_length
   - paddle/oar_material
   - pattern
+  - rope_diameter
   - suitable_for_boat_type
+  - width
   return_reasons:
   - length
   - grip
@@ -25418,8 +28136,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - rope_diameter
   - watercraft_propulsion_type
+  - width
   return_reasons:
   - size
   - color
@@ -25441,8 +28163,13 @@
   attributes:
   - boat_construction_type
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - rope_diameter
   - watercraft_propulsion_type
+  - width
   return_reasons:
   - size
   - color
@@ -25461,6 +28188,7 @@
   - boat_construction_type
   - color
   - pattern
+  - rope_diameter
   - watercraft_propulsion_type
   return_reasons:
   - changed_my_mind
@@ -25476,6 +28204,7 @@
   - boat_construction_type
   - color
   - pattern
+  - rope_diameter
   - watercraft_propulsion_type
   return_reasons:
   - changed_my_mind
@@ -25491,6 +28220,7 @@
   - boat_construction_type
   - color
   - pattern
+  - rope_diameter
   - watercraft_propulsion_type
   return_reasons:
   - changed_my_mind
@@ -25506,6 +28236,7 @@
   - boat_construction_type
   - color
   - pattern
+  - rope_diameter
   - watercraft_propulsion_type
   return_reasons:
   - changed_my_mind
@@ -25521,6 +28252,7 @@
   - boat_construction_type
   - color
   - pattern
+  - rope_diameter
   - watercraft_propulsion_type
   return_reasons:
   - changed_my_mind
@@ -25537,8 +28269,14 @@
   attributes:
   - color
   - floor_construction_type
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - rope_diameter
+  - tube_diameter
   - whitewater_rating_class
+  - width
   return_reasons:
   - color
   - length
@@ -25556,6 +28294,8 @@
   - color
   - floor_construction_type
   - pattern
+  - rope_diameter
+  - tube_diameter
   - whitewater_rating_class
   return_reasons:
   - changed_my_mind
@@ -25571,6 +28311,8 @@
   - color
   - floor_construction_type
   - pattern
+  - rope_diameter
+  - tube_diameter
   - whitewater_rating_class
   return_reasons:
   - changed_my_mind
@@ -25585,6 +28327,7 @@
   attributes:
   - color
   - pattern
+  - rope_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -25598,6 +28341,7 @@
   attributes:
   - color
   - pattern
+  - rope_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -25640,9 +28384,12 @@
   - color
   - drysuit_footwear_style
   - entry_zipper_location
+  - height
+  - length
   - pattern
   - seal_material
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -25669,8 +28416,12 @@
   - battery_size
   - battery_type
   - color
+  - cylinder_thread_size
+  - height
+  - length
   - marine_safety_standard_compliance
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -25687,8 +28438,12 @@
   attributes:
   - activation_method
   - color
+  - cylinder_thread_size
+  - height
+  - length
   - marine_safety_standard_compliance
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -25705,8 +28460,12 @@
   children: []
   attributes:
   - color
+  - cylinder_thread_size
+  - height
+  - length
   - marine_safety_standard_compliance
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -25722,8 +28481,12 @@
   children: []
   attributes:
   - color
+  - cylinder_thread_size
+  - height
+  - length
   - marine_safety_standard_compliance
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -25742,6 +28505,7 @@
   - battery_size
   - battery_type
   - color
+  - cylinder_thread_size
   - marine_safety_standard_compliance
   - pattern
   return_reasons:
@@ -25758,6 +28522,7 @@
   - battery_size
   - battery_type
   - color
+  - cylinder_thread_size
   - marine_safety_standard_compliance
   - pattern
   return_reasons:
@@ -25774,6 +28539,7 @@
   - battery_size
   - battery_type
   - color
+  - cylinder_thread_size
   - marine_safety_standard_compliance
   - pattern
   return_reasons:
@@ -25790,6 +28556,7 @@
   - battery_size
   - battery_type
   - color
+  - cylinder_thread_size
   - marine_safety_standard_compliance
   - pattern
   return_reasons:
@@ -25806,6 +28573,7 @@
   - battery_size
   - battery_type
   - color
+  - cylinder_thread_size
   - marine_safety_standard_compliance
   - pattern
   return_reasons:
@@ -25821,10 +28589,13 @@
   attributes:
   - accessory_size
   - color
+  - height
   - inflation_method
+  - length
   - life_jacket_certification_standard
   - life_jacket_features
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -25842,10 +28613,13 @@
   attributes:
   - accessory_size
   - age_group
+  - bust/chest_size
   - color
+  - length
   - material
   - pattern
   - target_gender
+  - waist_size
   return_reasons:
   - too_big
   - too_small
@@ -25887,8 +28661,11 @@
   - accessory_size
   - age_group
   - color
+  - height
   - leg_coverage
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -26004,8 +28781,11 @@
   - accessory_size
   - age_group
   - color
+  - height
   - leg_coverage
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -26027,11 +28807,15 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - material
   - pattern
   - target_gender
   - wetsuit_entry_system
   - wetsuit_seam_construction
+  - wetsuit_thickness
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -26049,12 +28833,16 @@
   - accessory_size
   - age_group
   - color
+  - height
   - hood_configuration
+  - length
   - material
   - pattern
   - target_gender
   - wetsuit_entry_system
   - wetsuit_seam_construction
+  - wetsuit_thickness
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -26073,11 +28861,15 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - material
   - pattern
   - target_gender
   - wetsuit_entry_system
   - wetsuit_seam_construction
+  - wetsuit_thickness
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -26180,6 +28972,7 @@
   - sg-4-1-3-15
   attributes:
   - color
+  - maximum_operating_depth
   - pattern
   return_reasons:
   - size
@@ -26196,8 +28989,12 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
+  - maximum_operating_depth
   - pattern
   - weight_integration_system
+  - width
   return_reasons:
   - size
   - color
@@ -26219,9 +29016,13 @@
   - display_technology
   - dive_computer_form_factor
   - dive_computer_items_included
+  - height
+  - length
+  - maximum_operating_depth
   - pattern
   - power_source
   - supported_dive_modes
+  - width
   return_reasons:
   - size
   - color
@@ -26240,9 +29041,13 @@
   attributes:
   - color
   - diving/snorkeling_equipment_included
+  - height
+  - length
+  - maximum_operating_depth
   - pattern
   - snorkel_top_type
   - water_sport
+  - width
   return_reasons:
   - size
   - color
@@ -26266,7 +29071,11 @@
   - fin_material
   - fin_pocket_type
   - fin_strap_type
+  - height
+  - length
+  - maximum_operating_depth
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -26286,7 +29095,11 @@
   - fin_buoyancy
   - fin_material
   - fin_pocket_type
+  - height
+  - length
+  - maximum_operating_depth
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -26306,7 +29119,11 @@
   - fin_buoyancy
   - fin_material
   - fin_pocket_type
+  - height
+  - length
+  - maximum_operating_depth
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -26327,6 +29144,7 @@
   - fin_material
   - fin_pocket_type
   - fin_strap_type
+  - maximum_operating_depth
   - pattern
   return_reasons:
   - changed_my_mind
@@ -26345,6 +29163,7 @@
   - fin_material
   - fin_pocket_type
   - fin_strap_type
+  - maximum_operating_depth
   - pattern
   return_reasons:
   - changed_my_mind
@@ -26366,9 +29185,13 @@
   - eyewear_lens_color
   - eyewear_lens_material
   - eyewear_lens_pattern
+  - height
+  - length
   - mask_skirt_material
   - mask_strap_material
+  - maximum_operating_depth
   - water_sport
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -26386,7 +29209,11 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
+  - maximum_operating_depth
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -26405,7 +29232,11 @@
   attributes:
   - color
   - edge_type
+  - height
+  - length
+  - maximum_operating_depth
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -26423,7 +29254,11 @@
   attributes:
   - color
   - edge_type
+  - height
+  - length
+  - maximum_operating_depth
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -26441,7 +29276,11 @@
   attributes:
   - color
   - edge_type
+  - height
+  - length
+  - maximum_operating_depth
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -26459,7 +29298,11 @@
   attributes:
   - color
   - diving_regulator_style
+  - height
+  - length
+  - maximum_operating_depth
   - pattern
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -26479,10 +29322,14 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
+  - maximum_operating_depth
   - mouthpiece_material
   - pattern
   - snorkel_mount_position
   - snorkel_shape
+  - width
   return_reasons:
   - size
   - color
@@ -26498,10 +29345,14 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
+  - maximum_operating_depth
   - mouthpiece_material
   - pattern
   - snorkel_mount_position
   - snorkel_shape
+  - width
   return_reasons:
   - size
   - color
@@ -26517,10 +29368,14 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
+  - maximum_operating_depth
   - mouthpiece_material
   - pattern
   - snorkel_mount_position
   - snorkel_shape
+  - width
   return_reasons:
   - size
   - color
@@ -26536,10 +29391,14 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
+  - maximum_operating_depth
   - mouthpiece_material
   - pattern
   - snorkel_mount_position
   - snorkel_shape
+  - width
   return_reasons:
   - size
   - color
@@ -26555,6 +29414,7 @@
   attributes:
   - age_group
   - color
+  - maximum_operating_depth
   - mouthpiece_material
   - pattern
   - snorkel_mount_position
@@ -26571,6 +29431,7 @@
   children: []
   attributes:
   - color
+  - maximum_operating_depth
   - pattern
   return_reasons:
   - changed_my_mind
@@ -26584,6 +29445,7 @@
   children: []
   attributes:
   - color
+  - maximum_operating_depth
   - pattern
   return_reasons:
   - changed_my_mind
@@ -26597,6 +29459,7 @@
   children: []
   attributes:
   - color
+  - maximum_operating_depth
   - pattern
   return_reasons:
   - changed_my_mind
@@ -26610,6 +29473,7 @@
   children: []
   attributes:
   - color
+  - maximum_operating_depth
   - pattern
   return_reasons:
   - changed_my_mind
@@ -26623,6 +29487,7 @@
   children: []
   attributes:
   - color
+  - maximum_operating_depth
   - pattern
   return_reasons:
   - changed_my_mind
@@ -26636,6 +29501,7 @@
   children: []
   attributes:
   - color
+  - maximum_operating_depth
   - pattern
   return_reasons:
   - changed_my_mind
@@ -26674,8 +29540,13 @@
   children: []
   attributes:
   - color
+  - compatible_board_length
+  - height
   - kiteboard_bag_style
+  - length
+  - padding_thickness
   - pattern
+  - width
   return_reasons:
   - length
   - padding
@@ -26700,7 +29571,10 @@
   - sg-4-1-4-2-8
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -26717,8 +29591,11 @@
   attributes:
   - color
   - fin_mounting_system
+  - height
   - intended_board_type
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -26734,7 +29611,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -26751,7 +29631,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -26768,8 +29651,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - line_purpose
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -26837,8 +29723,12 @@
   children: []
   attributes:
   - color
+  - height
+  - kiteboard_size
+  - length
   - pattern
   - recommended_skill_level
+  - width
   return_reasons:
   - size
   - color
@@ -26856,8 +29746,11 @@
   - color
   - harness_shell_type
   - harness_style
+  - height
+  - length
   - pattern
   - spreader_bar_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -26875,10 +29768,14 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - kite_area
   - kite_inflation_system
   - kite_type
   - kitesurfing_style
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -26960,8 +29857,11 @@
   attributes:
   - bootie_toe_design
   - color
+  - height
+  - length
   - pattern
   - upf_rating
+  - width
   return_reasons:
   - size
   - color
@@ -26976,11 +29876,15 @@
   children: []
   attributes:
   - bodyboard_features
+  - bodyboard_size
   - bootie_toe_design
   - color
+  - height
+  - length
   - pattern
   - recommended_skill_level
   - upf_rating
+  - width
   return_reasons:
   - color
   - length
@@ -27000,11 +29904,15 @@
   - battery_type
   - bootie_toe_design
   - color
+  - height
+  - length
   - paddleboard_features
   - paddleboard_intended_use
+  - paddleboard_size
   - pattern
   - recommended_skill_level
   - upf_rating
+  - width
   return_reasons:
   - color
   - length
@@ -27023,10 +29931,15 @@
   - age_group
   - bootie_toe_design
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - skimboard_construction
+  - skimboard_size
   - upf_rating
+  - width
   return_reasons:
   - size
   - color
@@ -27045,10 +29958,13 @@
   - bootie_toe_design
   - color
   - cuff_position
+  - height
   - leash_style
+  - length
   - pattern
   - swivel_type
   - upf_rating
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -27065,8 +29981,11 @@
   attributes:
   - bootie_toe_design
   - color
+  - height
+  - length
   - pattern
   - upf_rating
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -27086,11 +30005,15 @@
   - bootie_toe_design
   - color
   - compatible_fin_box_system
+  - fin_base_length
   - fin_flex_rating
   - fin_profile
   - fin_template
+  - height
+  - length
   - pattern
   - upf_rating
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -27108,10 +30031,14 @@
   attributes:
   - bootie_toe_design
   - color
+  - height
+  - length
   - pattern
   - surf_wax_temperature_rating
   - upf_rating
+  - volume
   - wax_coat_type
+  - width
   return_reasons:
   - temperature_rating
   - scent
@@ -27140,12 +30067,17 @@
   - bootie_toe_design
   - color
   - fin_box_system
+  - height
+  - length
   - material
   - pattern
   - surfboard_construction
   - surfboard_features
+  - surfboard_size
   - surfboard_tail_shape
+  - surfboard_volume
   - upf_rating
+  - width
   return_reasons:
   - color
   - length
@@ -27166,12 +30098,16 @@
   - bootie_toe_design
   - color
   - fin_box_system
+  - height
+  - length
   - material
   - pattern
   - surfboard_construction
   - surfboard_features
+  - surfboard_size
   - surfboard_tail_shape
   - upf_rating
+  - width
   return_reasons:
   - color
   - board_volume
@@ -27193,12 +30129,16 @@
   - bootie_toe_design
   - color
   - fin_box_system
+  - height
+  - length
   - material
   - pattern
   - surfboard_construction
   - surfboard_features
+  - surfboard_size
   - surfboard_tail_shape
   - upf_rating
+  - width
   return_reasons:
   - color
   - board_volume
@@ -27219,12 +30159,16 @@
   - bootie_toe_design
   - color
   - fin_box_system
+  - height
+  - length
   - material
   - paddleboard_features
   - pattern
   - surfboard_construction
+  - surfboard_size
   - surfboard_tail_shape
   - upf_rating
+  - width
   return_reasons:
   - color
   - board_volume
@@ -27245,12 +30189,16 @@
   - bootie_toe_design
   - color
   - fin_box_system
+  - height
+  - length
   - material
   - pattern
   - surfboard_construction
   - surfboard_tail_shape
   - upf_rating
   - waveski_features
+  - waveski_size
+  - width
   return_reasons:
   - color
   - length
@@ -27387,13 +30335,18 @@
   attributes:
   - accessory_size
   - age_group
+  - arch_height
   - bootie_toe_design
   - color
   - eco_material_type
+  - height
+  - kicktail_height
+  - length
   - material
   - pattern
   - traction_pattern_type
   - upf_rating
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -27499,7 +30452,10 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -27515,9 +30471,13 @@
   children: []
   attributes:
   - age_group
+  - arm_circumference_range
   - color
+  - height
+  - length
   - pattern
   - swim_armband_construction_type
+  - width
   return_reasons:
   - size
   - color
@@ -27534,8 +30494,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - swim_board_features
+  - swim_board_size
+  - width
   return_reasons:
   - size
   - color
@@ -27552,9 +30516,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - storage_compartment_type
   - swim_buoy_features
+  - width
   return_reasons:
   - size
   - color
@@ -27571,7 +30538,10 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -27588,7 +30558,10 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -27605,8 +30578,11 @@
   attributes:
   - age_group
   - color
+  - height
   - kickboard_handle_style
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -27623,7 +30599,10 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -27641,7 +30620,10 @@
   - age_group
   - canopy_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -27658,9 +30640,13 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - recommended_child_weight_range
   - swim_trainer_features
   - swim_trainer_type
+  - width
   return_reasons:
   - size
   - color
@@ -27677,7 +30663,10 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -27696,9 +30685,12 @@
   - age_group
   - color
   - hand_paddle_strap_type
+  - height
+  - length
   - pattern
   - suitable_for_swim_stroke
   - swim_training_focus
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -27714,8 +30706,11 @@
   children: []
   attributes:
   - color
+  - height
   - kickboard_features
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -27731,8 +30726,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - pull_buoy_style
+  - width
   return_reasons:
   - size
   - color
@@ -27752,8 +30750,11 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - pattern
   - swim_belt_purpose
+  - width
   return_reasons:
   - size
   - color
@@ -27802,9 +30803,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - material
   - pattern
   - swim_cap_style
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -27846,7 +30850,10 @@
   - sg-4-1-6-8-4
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -27863,7 +30870,10 @@
   attributes:
   - color
   - goggle_lens_tint
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - lens_color
@@ -27881,7 +30891,10 @@
   attributes:
   - color
   - compatible_eyewear_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -27934,8 +30947,11 @@
   - eyewear_lens_pattern
   - goggle_gasket_material
   - goggle_strap_material
+  - height
+  - length
   - nose_bridge_type
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -27997,9 +31013,13 @@
   name: Swim Weights
   children: []
   attributes:
+  - clothing_weight
   - color
+  - height
+  - length
   - pattern
   - swim_weight_style
+  - width
   return_reasons:
   - size
   - color
@@ -28017,7 +31037,10 @@
   - sg-4-1-6-11-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -28033,7 +31056,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -28051,7 +31077,10 @@
   - accessory_size
   - blade_length_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -28067,8 +31096,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - speed
@@ -28084,11 +31116,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - nose_clip_accessories_included
   - nose_clip_features
   - pattern
   - water_sport
+  - width
   return_reasons:
   - color
   - fit
@@ -28196,7 +31231,10 @@
   - sg-4-1-7-1-5
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -28213,11 +31251,14 @@
   children: []
   attributes:
   - color
+  - height
   - kneeboard_construction
   - kneeboard_features
   - kneeboard_strap_type
+  - length
   - pattern
   - tow_hook_type
+  - width
   return_reasons:
   - size
   - color
@@ -28302,9 +31343,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - tow_point_configuration
   - towable_tube_style
+  - width
   return_reasons:
   - size
   - color
@@ -28324,6 +31369,7 @@
   - age_group
   - color
   - handwear_material
+  - palm_circumference
   - pattern
   - target_gender
   - towed_water_sport_discipline
@@ -28368,7 +31414,10 @@
   - age_group
   - binding_liner_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -28392,7 +31441,10 @@
   - sg-4-1-7-4-2-7
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -28408,8 +31460,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - wakeboard_binding_mounting_pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -28426,7 +31481,10 @@
   attributes:
   - color
   - fin_position
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - flex
@@ -28444,7 +31502,11 @@
   attributes:
   - color
   - handle_configuration
+  - handle_grip_diameter
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - grip
@@ -28461,10 +31523,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - rope_buoyancy
+  - rope_length
   - rope_stretch_type
+  - width
   return_reasons:
   - color
   - length
@@ -28521,8 +31587,12 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
   - wakeboard_riding_style
+  - wakeboard_size
+  - width
   return_reasons:
   - color
   - length
@@ -28595,7 +31665,10 @@
   - sg-4-1-7-5-4
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -28615,7 +31688,12 @@
   - sg-4-1-7-5-1-4
   attributes:
   - color
+  - height
+  - hydrofoil_mast_length
+  - length
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -28631,6 +31709,7 @@
   children: []
   attributes:
   - color
+  - hydrofoil_mast_length
   - pattern
   return_reasons:
   - changed_my_mind
@@ -28644,6 +31723,7 @@
   children: []
   attributes:
   - color
+  - hydrofoil_mast_length
   - pattern
   return_reasons:
   - changed_my_mind
@@ -28657,6 +31737,7 @@
   children: []
   attributes:
   - color
+  - hydrofoil_mast_length
   - pattern
   return_reasons:
   - changed_my_mind
@@ -28670,6 +31751,7 @@
   children: []
   attributes:
   - color
+  - hydrofoil_mast_length
   - pattern
   return_reasons:
   - changed_my_mind
@@ -28686,7 +31768,10 @@
   - age_group
   - binding_position
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -28703,7 +31788,10 @@
   attributes:
   - bag_padding_level
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -28726,10 +31814,15 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - recommended_speed_range
   - rocker_type
   - ski_construction
   - water_ski_fin_type
+  - water_ski_size
+  - width
   return_reasons:
   - color
   - length
@@ -28746,11 +31839,16 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - recommended_speed_range
   - rocker_type
   - ski_construction
   - water_ski_base_design
   - water_ski_fin_type
+  - water_ski_size
+  - width
   return_reasons:
   - color
   - length
@@ -28767,10 +31865,15 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - recommended_speed_range
   - rocker_type
   - ski_construction
   - water_ski_fin_type
+  - water_ski_size
+  - width
   return_reasons:
   - color
   - length
@@ -28787,10 +31890,15 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - recommended_speed_range
   - rocker_type
   - ski_construction
   - water_ski_fin_type
+  - water_ski_size
+  - width
   return_reasons:
   - color
   - length
@@ -28809,6 +31917,7 @@
   - age_group
   - color
   - pattern
+  - recommended_speed_range
   - rocker_type
   - ski_construction
   - water_ski_fin_type
@@ -28826,6 +31935,7 @@
   - age_group
   - color
   - pattern
+  - recommended_speed_range
   - rocker_type
   - ski_construction
   - water_ski_fin_type
@@ -28845,9 +31955,13 @@
   - sg-4-1-7-6-4
   attributes:
   - anchor_type
+  - cable_length
   - color
   - handle_grip_material
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -28953,8 +32067,11 @@
   - sg-4-1-8-4
   attributes:
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -28971,9 +32088,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -28991,8 +32111,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -29069,7 +32192,11 @@
   - sg-4-1-9-1-5
   attributes:
   - color
+  - foil_wingspan
+  - height
+  - length
   - pattern
+  - width
   - windsurfing_connection_standard
   return_reasons:
   - size
@@ -29087,7 +32214,11 @@
   children: []
   attributes:
   - color
+  - foil_wingspan
+  - height
+  - length
   - pattern
+  - width
   - windsurf_fin_style
   - windsurfing_connection_standard
   return_reasons:
@@ -29106,9 +32237,13 @@
   children: []
   attributes:
   - color
+  - foil_wingspan
+  - height
+  - length
   - mast_bend_curve
   - mast_diameter_type
   - pattern
+  - width
   - windsurfing_connection_standard
   return_reasons:
   - color
@@ -29126,6 +32261,7 @@
   children: []
   attributes:
   - color
+  - foil_wingspan
   - pattern
   - windsurfing_connection_standard
   return_reasons:
@@ -29140,6 +32276,7 @@
   children: []
   attributes:
   - color
+  - foil_wingspan
   - pattern
   - windsurfing_connection_standard
   return_reasons:
@@ -29154,6 +32291,7 @@
   children: []
   attributes:
   - color
+  - foil_wingspan
   - pattern
   - windsurfing_connection_standard
   return_reasons:
@@ -29169,8 +32307,12 @@
   attributes:
   - color
   - foil_mounting_system
+  - height
+  - length
   - pattern
   - recommended_skill_level
+  - width
+  - windsurfing_board_size
   - windsurfing_board_style
   return_reasons:
   - too_big
@@ -29189,7 +32331,11 @@
   attributes:
   - color
   - compatible_mast_type
+  - height
+  - length
+  - luff_length
   - pattern
+  - width
   - windsurfing_sail_style
   return_reasons:
   - size
@@ -29444,6 +32590,7 @@
   children: []
   attributes:
   - color
+  - foil_stabilizer_span
   - material
   - pattern
   - wingfoiling_style
@@ -29603,6 +32750,7 @@
   - material
   - pattern
   - recommended_skill_level
+  - wingfoil_board_length
   - wingfoiling_style
   return_reasons:
   - color
@@ -29678,6 +32826,7 @@
   attributes:
   - color
   - foil_mounting_type
+  - mast_length
   - material
   - pattern
   - recommended_skill_level
@@ -30012,9 +33161,12 @@
   - age_group
   - color
   - ear_coverage
+  - height
   - helmet_liner_material
+  - length
   - pattern
   - visor_brim_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -30123,6 +33275,7 @@
   attributes:
   - color
   - pattern
+  - rope_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -30221,8 +33374,11 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -30243,8 +33399,11 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -30263,10 +33422,13 @@
   - age_group
   - air_mattress_valve_type
   - color
+  - height
+  - length
   - material
   - pattern
   - repair_kit_components
   - repair_method
+  - width
   return_reasons:
   - size
   - color
@@ -30305,9 +33467,12 @@
   - battery_type
   - bedding_size
   - color
+  - height
+  - length
   - material
   - pattern
   - pump_type
+  - width
   return_reasons:
   - size
   - color
@@ -30331,7 +33496,11 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
+  - length
   - lumber/wood_type
+  - maximum_load_capacity
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -30431,8 +33600,11 @@
   - sg-4-2-2-7
   attributes:
   - color
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - color
@@ -30449,9 +33621,12 @@
   attributes:
   - color
   - handle_type
+  - height
   - insulation_type
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - color
@@ -30468,8 +33643,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - color
@@ -30485,8 +33663,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - color
@@ -30505,8 +33686,11 @@
   - sg-4-2-2-4-2
   attributes:
   - color
+  - height
+  - length
   - pattern
   - product_certifications_standards
+  - width
   return_reasons:
   - size
   - color
@@ -30593,12 +33777,16 @@
   attributes:
   - battery_size
   - battery_type
+  - beam_distance
   - color
+  - height
+  - length
   - light_color
   - light_pattern
   - light_temperature
   - pattern
   - power_source
+  - width
   return_reasons:
   - color
   - brightness
@@ -30647,7 +33835,10 @@
   attributes:
   - color
   - fire_starter_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -30667,6 +33858,7 @@
   - color
   - fire_starter_type
   - pattern
+  - volume
   return_reasons:
   - burn_rate
   - scent
@@ -30683,8 +33875,12 @@
   attributes:
   - color
   - fire_starter_type
+  - height
+  - length
   - pattern
   - pen_ink_color
+  - pen_tip_size
+  - width
   return_reasons:
   - size
   - color
@@ -30702,7 +33898,10 @@
   attributes:
   - color
   - fire_starter_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -30720,7 +33919,10 @@
   attributes:
   - color
   - fire_starter_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -30736,7 +33938,10 @@
   attributes:
   - color
   - fire_starter_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -30758,13 +33963,17 @@
   - sg-4-2-4-7-5
   attributes:
   - blade_finish_coating
+  - blade_thickness
   - color
   - fire_starter_type
+  - height
   - hunting/survival_knife_design
   - knife_type
+  - length
   - pattern
   - sheath_material
   - tang_type
+  - width
   return_reasons:
   - size
   - color
@@ -30781,15 +33990,19 @@
   children: []
   attributes:
   - blade_finish_coating
+  - blade_thickness
   - color
   - fire_starter_type
+  - height
   - hunting/survival_knife_design
   - knife_locking_mechanism
   - knife_opening_mechanism
   - knife_type
+  - length
   - pattern
   - sheath_material
   - tang_type
+  - width
   return_reasons:
   - size
   - color
@@ -30806,13 +34019,17 @@
   children: []
   attributes:
   - blade_finish_coating
+  - blade_thickness
   - color
   - fire_starter_type
+  - height
   - hunting/survival_knife_design
   - knife_type
+  - length
   - pattern
   - sheath_material
   - tang_type
+  - width
   return_reasons:
   - size
   - color
@@ -30829,13 +34046,17 @@
   children: []
   attributes:
   - blade_finish_coating
+  - blade_thickness
   - color
   - fire_starter_type
+  - height
   - hunting/survival_knife_design
   - knife_type
+  - length
   - pattern
   - sheath_material
   - tang_type
+  - width
   return_reasons:
   - size
   - color
@@ -30852,6 +34073,7 @@
   children: []
   attributes:
   - blade_finish_coating
+  - blade_thickness
   - color
   - fire_starter_type
   - hunting/survival_knife_design
@@ -30871,6 +34093,7 @@
   children: []
   attributes:
   - blade_finish_coating
+  - blade_thickness
   - color
   - fire_starter_type
   - hunting/survival_knife_design
@@ -30891,7 +34114,10 @@
   attributes:
   - color
   - fire_starter_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31007,8 +34233,13 @@
   attributes:
   - color
   - hand_warmer_type
+  - height
+  - length
+  - maximum_operating_temperature
+  - operating_time
   - pattern
   - usage_type
+  - width
   return_reasons:
   - warmth
   - changed_my_mind
@@ -31022,8 +34253,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31049,7 +34283,10 @@
   - sg-4-2-7-11
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31066,7 +34303,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31083,7 +34323,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31101,7 +34344,10 @@
   attributes:
   - color
   - hand_guard_style
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31118,7 +34364,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31135,7 +34384,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31151,7 +34403,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31168,7 +34423,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31238,8 +34496,11 @@
   - age_group
   - color
   - features
+  - height
+  - length
   - outdoor_walking_activity
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -31261,9 +34522,12 @@
   - sg-4-2-9-5
   attributes:
   - color
+  - height
   - insecticide_treatment
+  - length
   - net_material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31279,9 +34543,12 @@
   children: []
   attributes:
   - color
+  - height
   - insecticide_treatment
+  - length
   - net_material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31298,9 +34565,12 @@
   children: []
   attributes:
   - color
+  - height
   - insecticide_treatment
+  - length
   - net_material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31368,10 +34638,13 @@
   - color
   - compass_illumination_type
   - compass_style
+  - height
+  - length
   - material
   - needle_balance_zone
   - needle_damping_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31390,10 +34663,13 @@
   - color
   - compass_illumination_type
   - compass_style
+  - height
+  - length
   - material
   - needle_balance_zone
   - needle_damping_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31413,10 +34689,13 @@
   - color
   - compass_illumination_type
   - compass_style
+  - height
+  - length
   - material
   - needle_balance_zone
   - needle_damping_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31439,10 +34718,13 @@
   - compass_mounting_style
   - compass_scale_units
   - compass_style
+  - height
+  - length
   - material
   - needle_balance_zone
   - needle_damping_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31466,7 +34748,10 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - capacity
@@ -31485,9 +34770,12 @@
   - sg-4-2-11-1-3
   attributes:
   - color
+  - height
+  - length
   - number_of_compartments
   - pattern
   - water_dispensing_mechanism
+  - width
   return_reasons:
   - size
   - capacity
@@ -31506,10 +34794,13 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - number_of_compartments
   - pattern
   - water_dispensing_mechanism
   - water_heating_method
+  - width
   return_reasons:
   - size
   - capacity
@@ -31527,11 +34818,14 @@
   attributes:
   - color
   - floor_design
+  - height
+  - length
   - material
   - number_of_compartments
   - pattern
   - roof_type
   - water_dispensing_mechanism
+  - width
   return_reasons:
   - size
   - too_bulky
@@ -31547,9 +34841,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - number_of_compartments
   - pattern
   - water_dispensing_mechanism
+  - width
   return_reasons:
   - size
   - coverage
@@ -31573,7 +34870,11 @@
   - sg-4-2-11-2-7
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - waste_tank_capacity
+  - width
   return_reasons:
   - size
   - capacity
@@ -31590,7 +34891,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - waste_tank_capacity
+  - width
   return_reasons:
   - size
   - too_bulky
@@ -31608,8 +34913,12 @@
   - sg-4-2-11-2-2-4
   attributes:
   - color
+  - height
+  - length
   - pattern
   - urination_device_features
+  - waste_tank_capacity
+  - width
   return_reasons:
   - size
   - capacity
@@ -31627,6 +34936,7 @@
   - color
   - pattern
   - urination_device_features
+  - waste_tank_capacity
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -31641,6 +34951,7 @@
   - color
   - pattern
   - urination_device_features
+  - waste_tank_capacity
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -31655,6 +34966,7 @@
   - color
   - pattern
   - urination_device_features
+  - waste_tank_capacity
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -31667,7 +34979,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - waste_tank_capacity
+  - width
   return_reasons:
   - size
   - capacity
@@ -31685,6 +35001,7 @@
   attributes:
   - color
   - pattern
+  - waste_tank_capacity
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -31698,6 +35015,7 @@
   attributes:
   - color
   - pattern
+  - waste_tank_capacity
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -31711,6 +35029,7 @@
   attributes:
   - color
   - pattern
+  - waste_tank_capacity
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -31724,6 +35043,7 @@
   attributes:
   - color
   - pattern
+  - waste_tank_capacity
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -31790,9 +35110,13 @@
   attributes:
   - color
   - contaminant_removal
+  - filter_lifetime_capacity
   - filtration_technology
+  - height
+  - length
   - pattern
   - water_purification_method
+  - width
   return_reasons:
   - size
   - color
@@ -31811,9 +35135,12 @@
   - color
   - contaminant_removal
   - filtration_technology
+  - height
+  - length
   - pathogen_removal_capability
   - pattern
   - water_purification_method
+  - width
   return_reasons:
   - size
   - color
@@ -31832,9 +35159,15 @@
   - color
   - contaminant_removal
   - filtration_technology
+  - height
+  - length
   - pattern
+  - purification_contact_time
   - targeted_contaminants
   - water_purification_method
+  - water_treatment_capacity
+  - water_volume_treated_per_tablet
+  - width
   return_reasons:
   - size
   - taste
@@ -31945,9 +35278,13 @@
   name: Sleeping Bag Liners
   children: []
   attributes:
+  - added_warmth
   - color
+  - height
+  - length
   - liner_shape
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -31964,8 +35301,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - limit_temperature_rating
   - pattern
   - sleeping_bag_shape
+  - width
   - zipper_side
   return_reasons:
   - size
@@ -31985,9 +35326,12 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - material
   - pattern
   - sleeping_pad_type
+  - width
   return_reasons:
   - size
   - color
@@ -32016,7 +35360,10 @@
   - sg-4-2-16-13
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -32035,8 +35382,15 @@
   - color
   - cover_material
   - durability_features
+  - height_packed
+  - height_pitched
   - inner_tent_configuration
+  - length_packed
+  - length_pitched
   - pattern
+  - waterproof_rating_hydrostatic_head
+  - width_packed
+  - width_pitched
   return_reasons:
   - size
   - color
@@ -32053,7 +35407,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -32073,9 +35430,14 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - material
+  - maximum_length
+  - minimum_length
   - pattern
   - stake_shape
+  - width
   return_reasons:
   - size
   - color
@@ -32093,10 +35455,15 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - material
+  - maximum_length
+  - minimum_length
   - pattern
   - pole_connection_system
   - stake_shape
+  - width
   return_reasons:
   - size
   - color
@@ -32114,9 +35481,14 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - material
+  - maximum_length
+  - minimum_length
   - pattern
   - stake_shape
+  - width
   return_reasons:
   - size
   - color
@@ -32135,8 +35507,12 @@
   attributes:
   - color
   - floor_inclusion
+  - height
+  - length
   - pattern
+  - vestibule_floor_area
   - vestibule_type
+  - width
   return_reasons:
   - size
   - color
@@ -32285,9 +35661,16 @@
   - sg-4-2-17-15
   attributes:
   - color
+  - height_packed
+  - height_pitched
+  - length_packed
+  - length_pitched
   - pattern
   - setup_mechanism
   - stove_jack_compatibility
+  - waterproof_rating_hydrostatic_head
+  - width_packed
+  - width_pitched
   return_reasons:
   - size
   - color
@@ -32303,10 +35686,14 @@
   children: []
   attributes:
   - color
+  - floor_area
+  - height
+  - length
   - pattern
   - setup_mechanism
   - stove_jack_compatibility
   - suitable_for_camping_activity
+  - width
   return_reasons:
   - size
   - color
@@ -32323,11 +35710,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - setup_mechanism
   - stove_jack_compatibility
   - suitable_for_camping_activity
   - tent_setup_type
+  - width
   return_reasons:
   - size
   - color
@@ -32344,9 +35734,16 @@
   children: []
   attributes:
   - color
+  - height_packed
+  - height_pitched
+  - length_packed
+  - length_pitched
   - pattern
   - setup_mechanism
   - stove_jack_compatibility
+  - waterproof_rating_hydrostatic_head
+  - width_packed
+  - width_pitched
   return_reasons:
   - size
   - color
@@ -32363,10 +35760,18 @@
   children: []
   attributes:
   - color
+  - height_packed
+  - height_pitched
+  - length_packed
+  - length_pitched
   - pattern
   - season_rating
   - setup_mechanism
   - stove_jack_compatibility
+  - waterproof_rating_hydrostatic_head
+  - weight_packed
+  - width_packed
+  - width_pitched
   return_reasons:
   - size
   - color
@@ -32383,9 +35788,16 @@
   children: []
   attributes:
   - color
+  - height_packed
+  - height_pitched
+  - length_packed
+  - length_pitched
   - pattern
   - setup_mechanism
   - stove_jack_compatibility
+  - waterproof_rating_hydrostatic_head
+  - width_packed
+  - width_pitched
   return_reasons:
   - size
   - color
@@ -32402,10 +35814,17 @@
   children: []
   attributes:
   - color
+  - height_packed
+  - height_pitched
+  - length_packed
+  - length_pitched
   - pattern
   - pole_system_type
   - setup_mechanism
   - stove_jack_compatibility
+  - waterproof_rating_hydrostatic_head
+  - width_packed
+  - width_pitched
   return_reasons:
   - size
   - color
@@ -32422,11 +35841,18 @@
   children: []
   attributes:
   - color
+  - height_packed
+  - height_pitched
+  - length_packed
+  - length_pitched
   - pattern
   - setup_mechanism
   - stove_jack_compatibility
   - tent_fabric_material
   - tent_season_rating
+  - waterproof_rating_hydrostatic_head
+  - width_packed
+  - width_pitched
   return_reasons:
   - size
   - color
@@ -32443,9 +35869,16 @@
   children: []
   attributes:
   - color
+  - height_packed
+  - height_pitched
+  - length_packed
+  - length_pitched
   - pattern
   - setup_mechanism
   - stove_jack_compatibility
+  - waterproof_rating_hydrostatic_head
+  - width_packed
+  - width_pitched
   return_reasons:
   - size
   - color
@@ -32462,9 +35895,16 @@
   children: []
   attributes:
   - color
+  - height_packed
+  - height_pitched
+  - length_packed
+  - length_pitched
   - pattern
   - setup_mechanism
   - stove_jack_compatibility
+  - waterproof_rating_hydrostatic_head
+  - width_packed
+  - width_pitched
   return_reasons:
   - size
   - color
@@ -32482,10 +35922,17 @@
   attributes:
   - color
   - flysheet_material
+  - height_packed
+  - height_pitched
+  - length_packed
+  - length_pitched
   - pattern
   - setup_mechanism
   - stove_jack_compatibility
   - tent_style
+  - waterproof_rating_hydrostatic_head
+  - width_packed
+  - width_pitched
   return_reasons:
   - size
   - color
@@ -32577,9 +36024,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - support_structure_type
+  - width
   - windbreak_purpose
   return_reasons:
   - size
@@ -32727,9 +36177,12 @@
   - climbing_safety_certifications
   - color
   - compatible_rope_type
+  - height
+  - length
   - material
   - number_of_rope_slots
   - pattern
+  - width
   return_reasons:
   - color
   - weight
@@ -32748,9 +36201,12 @@
   - color
   - compatible_rope_type
   - figure_8_device_design
+  - height
+  - length
   - material
   - number_of_rope_slots
   - pattern
+  - width
   return_reasons:
   - color
   - missing_desired_features
@@ -32769,9 +36225,12 @@
   - assisted_braking_technology
   - color
   - compatible_rope_type
+  - height
+  - length
   - material
   - number_of_rope_slots
   - pattern
+  - width
   return_reasons:
   - color
   - missing_desired_features
@@ -32790,10 +36249,13 @@
   - assisted_braking_technology
   - color
   - compatible_rope_type
+  - height
+  - length
   - material
   - number_of_rope_slots
   - pattern
   - rope_strand_compatibility
+  - width
   return_reasons:
   - color
   - missing_desired_features
@@ -32812,8 +36274,12 @@
   - carabiner_gate_type
   - carabiner_shape
   - color
+  - gate_opening_clearance
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -33030,7 +36496,10 @@
   attributes:
   - ascender_descender_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -33075,8 +36544,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - lining_material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -33094,8 +36566,11 @@
   - color
   - crash_pad_size_class
   - folding_style
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -33112,8 +36587,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -33137,8 +36615,11 @@
   - color
   - harness_closure_type
   - harness_type
+  - height
   - leg_loop_type
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -33216,8 +36697,11 @@
   attributes:
   - climbing_protection_device_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -33322,12 +36806,17 @@
   name: Climbing Rope
   children: []
   attributes:
+  - climbing_rope_diameter
+  - climbing_rope_length
   - climbing_rope_middle_marking
   - climbing_rope_treatment
   - climbing_rope_type
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -33345,7 +36834,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_rope_length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -33363,9 +36856,12 @@
   - sg-4-3-12-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - webbing_construction_type
+  - width
   return_reasons:
   - color
   - length
@@ -33383,9 +36879,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - webbing_construction_type
+  - width
   return_reasons:
   - color
   - length
@@ -33401,9 +36900,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - webbing_construction_type
+  - width
   return_reasons:
   - color
   - length
@@ -33425,7 +36927,10 @@
   - sg-4-3-13-5
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -33443,8 +36948,11 @@
   attributes:
   - color
   - head_configuration
+  - height
+  - length
   - pattern
   - shaft_curvature
+  - width
   return_reasons:
   - size
   - color
@@ -33462,7 +36970,10 @@
   attributes:
   - color
   - front_point_configuration
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -33479,7 +36990,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -33522,8 +37036,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -33541,9 +37058,12 @@
   - climbing_hold_mounting_type
   - climbing_hold_type
   - color
+  - height
   - hold_surface_texture
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -33561,8 +37081,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sling_material
+  - sling_width
+  - width
   return_reasons:
   - size
   - color
@@ -33748,8 +37272,11 @@
   - carry_options
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - vehicle_placement
+  - width
   return_reasons:
   - color
   - capacity
@@ -33776,8 +37303,11 @@
   - carry_options
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - vehicle_placement
+  - width
   return_reasons:
   - color
   - capacity
@@ -33884,10 +37414,13 @@
   - carry_options
   - color
   - compatible_bike_type
+  - height
+  - length
   - pannier_configuration
   - pannier_mounting_system
   - pattern
   - vehicle_placement
+  - width
   return_reasons:
   - color
   - capacity
@@ -33910,8 +37443,11 @@
   - carry_options
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - vehicle_placement
+  - width
   return_reasons:
   - color
   - capacity
@@ -33934,8 +37470,11 @@
   - carry_options
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - vehicle_placement
+  - width
   return_reasons:
   - color
   - capacity
@@ -33952,7 +37491,10 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - too_loud
@@ -33974,7 +37516,10 @@
   - bicycle_cage_mounting_position
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - weight
@@ -33993,7 +37538,11 @@
   - bottle_cage_loading_direction
   - color
   - compatible_bike_type
+  - compatible_bottle_volume
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - weight
@@ -34011,7 +37560,10 @@
   - bicycle_cage_mounting_position
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - weight
@@ -34049,7 +37601,10 @@
   - child_seat_accessory_type
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -34143,8 +37698,12 @@
   - color
   - compatible_bike_type
   - footrest_adjustability
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - safety_harness_type
+  - width
   return_reasons:
   - color
   - weight
@@ -34171,7 +37730,10 @@
   - battery_type
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - weight
@@ -34190,7 +37752,10 @@
   - battery_type
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - battery_life
   - incompatible
@@ -34208,9 +37773,12 @@
   - battery_type
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - sensor_measurement_mode
   - sensor_mounting_position
+  - width
   return_reasons:
   - connectivity
   - incompatible
@@ -34226,7 +37794,10 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - weight
@@ -34244,7 +37815,10 @@
   - bicycle_computer_mount_placement
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - weight
@@ -34263,9 +37837,12 @@
   - battery_type
   - color
   - compatible_bike_type
+  - height
+  - length
   - magnet_requirement
   - pattern
   - sensor_functions
+  - width
   return_reasons:
   - connectivity
   - battery_life
@@ -34282,7 +37859,10 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - connectivity
   - battery_life
@@ -34335,8 +37915,12 @@
   - compatible_bike_type
   - connectivity_technology
   - display_features
+  - height
+  - internal_memory
+  - length
   - pattern
   - speed_settings
+  - width
   return_reasons:
   - color
   - battery_life
@@ -34354,7 +37938,10 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - water_resistance
@@ -34373,8 +37960,11 @@
   - compatible_bike_type
   - fender_pieces_included
   - fender_type
+  - height
+  - length
   - pattern
   - vehicle_placement
+  - width
   return_reasons:
   - color
   - coverage
@@ -34396,8 +37986,11 @@
   - color
   - compatible_bike_type
   - compatible_brake_type
+  - height
+  - length
   - pattern
   - vehicle_placement
+  - width
   return_reasons:
   - color
   - weight
@@ -34470,8 +38063,11 @@
   - color
   - compatible_bike_type
   - grip_shape
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - weight
@@ -34562,8 +38158,12 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - shackle_diameter
   - sold_secure_rating
+  - width
   return_reasons:
   - color
   - lock_type
@@ -34581,8 +38181,12 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - shackle_diameter
   - sold_secure_rating
+  - width
   return_reasons:
   - color
   - length
@@ -34600,8 +38204,12 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - shackle_diameter
   - sold_secure_rating
+  - width
   return_reasons:
   - color
   - length
@@ -34620,8 +38228,12 @@
   - color
   - compatible_bike_type
   - disc_lock_accessories_included
+  - height
+  - length
   - pattern
+  - shackle_diameter
   - sold_secure_rating
+  - width
   return_reasons:
   - color
   - lock_type
@@ -34640,8 +38252,12 @@
   - bicycle_lock_security_certification
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - shackle_diameter
   - sold_secure_rating
+  - width
   return_reasons:
   - color
   - length
@@ -34659,8 +38275,12 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - shackle_diameter
   - sold_secure_rating
+  - width
   return_reasons:
   - size
   - color
@@ -34678,9 +38298,13 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - secured_components
+  - shackle_diameter
   - sold_secure_rating
+  - width
   return_reasons:
   - color
   - lock_type
@@ -34698,9 +38322,14 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
   - key_retention_when_unlocked
+  - length
   - pattern
+  - ring_lock_wheel_clearance_width
+  - shackle_diameter
   - sold_secure_rating
+  - width
   return_reasons:
   - color
   - lock_type
@@ -34719,9 +38348,13 @@
   - art_security_rating
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - shackle_diameter
   - sold_secure_certification_level
   - sold_secure_rating
+  - width
   return_reasons:
   - color
   - lock_type
@@ -34739,8 +38372,12 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - shackle_diameter
   - sold_secure_rating
+  - width
   return_reasons:
   - color
   - lock_type
@@ -34758,8 +38395,12 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - shackle_diameter
   - sold_secure_rating
+  - width
   return_reasons:
   - color
   - length
@@ -34776,9 +38417,12 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - mirror_curvature_type
   - mirror_mounting_location
   - pattern
+  - width
   return_reasons:
   - color
   - field_of_view
@@ -34803,8 +38447,11 @@
   - bicycle_pump_type
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - pressure_gauge_type
+  - width
   return_reasons:
   - color
   - pressure
@@ -34912,8 +38559,11 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - shape
+  - width
   return_reasons:
   - color
   - incompatible
@@ -34932,7 +38582,10 @@
   - color
   - compatible_bike_type
   - gauge_style
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - pressure
   - weight
@@ -34949,8 +38602,11 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - spoke_accessory_function
+  - width
   return_reasons:
   - color
   - pattern
@@ -34972,7 +38628,10 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - weight_capacity
@@ -35068,7 +38727,10 @@
   - color
   - compatible_bicycle_tire_type
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -35085,9 +38747,12 @@
   - color
   - compatible_bicycle_tire_type
   - compatible_bike_type
+  - height
   - integrated_tool_functions
+  - length
   - pattern
   - tubeless_compatible
+  - width
   return_reasons:
   - size
   - color
@@ -35103,11 +38768,15 @@
   name: Bicycle Tire Repair Kits
   children: []
   attributes:
+  - co2_cartridge_capacity
   - color
   - compatible_bicycle_tire_type
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - tire_repair_kit_components
+  - width
   return_reasons:
   - size
   - color
@@ -35127,8 +38796,11 @@
   - compatible_bicycle_tire_type
   - compatible_bike_type
   - compatible_tube
+  - height
+  - length
   - patch_adhesion_method
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -35146,7 +38818,10 @@
   - color
   - compatible_bicycle_tire_type
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -35166,9 +38841,13 @@
   - color
   - compatible_bicycle_tire_type
   - compatible_bike_type
+  - height
+  - length
+  - maximum_puncture_diameter_sealed
   - pattern
   - sealant_formulation
   - tire_system_compatibility
+  - width
   return_reasons:
   - size
   - viscosity
@@ -35234,7 +38913,10 @@
   - color
   - compatible_bike_type
   - compatible_pedal_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - weight
@@ -35294,9 +38976,12 @@
   - color
   - compatible_bike_component
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - suitable_riding_conditions
   - tool_functions_included
+  - width
   return_reasons:
   - color
   - grip
@@ -35321,9 +39006,12 @@
   - compatible_bike_type
   - compatible_chain_link_type
   - compatible_chain_size
+  - height
+  - length
   - pattern
   - suitable_riding_conditions
   - tool_functions_included
+  - width
   return_reasons:
   - grip
   - weight
@@ -35401,9 +39089,12 @@
   - color
   - compatible_bike_component
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - suitable_riding_conditions
   - tool_functions_included
+  - width
   return_reasons:
   - color
   - grip
@@ -35552,6 +39243,7 @@
   name: Bicycle Wheel Building Tools
   children: []
   attributes:
+  - axle_spacing_dropout_width
   - battery_size
   - battery_type
   - color
@@ -35576,9 +39268,13 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
   - hitch_type
+  - length
+  - maximum_load_capacity
   - pattern
   - trailer_suspension_type
+  - width
   return_reasons:
   - color
   - capacity
@@ -35652,8 +39348,12 @@
   - battery_type
   - color
   - compatible_bike_type
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - trainer_mounting_type
+  - width
   return_reasons:
   - resistance
   - weight
@@ -35671,8 +39371,13 @@
   - color
   - compatible_bike_type
   - foldability
+  - height
+  - length
+  - maximum_load_capacity
+  - maximum_resistance_power
   - pattern
   - trainer_mounting_type
+  - width
   return_reasons:
   - resistance
   - weight
@@ -35689,8 +39394,12 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - trainer_mounting_type
+  - width
   return_reasons:
   - resistance
   - weight
@@ -35707,8 +39416,13 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
+  - maximum_load_capacity
+  - maximum_power_output
   - pattern
   - trainer_mounting_type
+  - width
   return_reasons:
   - resistance
   - weight
@@ -35726,8 +39440,12 @@
   - color
   - compatible_axle_type
   - compatible_bike_type
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - trainer_mounting_type
+  - width
   return_reasons:
   - resistance
   - weight
@@ -35778,7 +39496,11 @@
   attributes:
   - color
   - compatible_bike_type
+  - diameter
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -35794,8 +39516,11 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - transport_case_type
+  - width
   return_reasons:
   - color
   - weight
@@ -35812,8 +39537,13 @@
   attributes:
   - color
   - compatible_bike_type
+  - compatible_seatpost_diameter
   - compatible_water_sport_board_type
+  - height
+  - length
+  - maximum_board_length
   - pattern
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -35832,7 +39562,10 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -36094,7 +39827,10 @@
   - brake_pad_compound
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -36118,7 +39854,10 @@
   - caliper_mounting_standard
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -36142,10 +39881,13 @@
   - brake_pad_compound
   - color
   - compatible_bike_type
+  - height
   - hydraulic_fluid_type
   - intended_handlebar_style
+  - length
   - pattern
   - reach_adjustment_type
+  - width
   return_reasons:
   - color
   - weight
@@ -36167,9 +39909,12 @@
   - color
   - compatible_bike_type
   - compatible_brake_pad
+  - height
+  - length
   - pattern
   - rotor_construction_type
   - rotor_mounting_interface
+  - width
   return_reasons:
   - size
   - color
@@ -36195,8 +39940,11 @@
   - caliper_mount_type
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - rotor_mounting_standard
+  - width
   return_reasons:
   - color
   - weight
@@ -36296,7 +40044,10 @@
   - cable_housing_liner_type
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -36312,12 +40063,16 @@
   children: []
   attributes:
   - cable_end_type
+  - cable_length
   - cable_surface_treatment
   - cable_type
   - color
   - compatible_bike_type
   - compatible_drivetrain_brand
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -36359,12 +40114,18 @@
   name: Bicycle Bottom Brackets
   children: []
   attributes:
+  - bearing_diameter
   - bearing_material
   - color
   - compatible_bike_type
   - crank_spindle_interface
+  - height
+  - length
   - material
   - pattern
+  - shell_diameter
+  - shell_width
+  - width
   return_reasons:
   - size
   - weight
@@ -36384,7 +40145,10 @@
   - cassette_speed_compatibility
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - range
@@ -36403,7 +40167,10 @@
   - cassette_speed_compatibility
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - range
@@ -36426,7 +40193,10 @@
   - compatible_bike_type
   - compatible_chain_width
   - freewheel_thread_standard
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -36476,11 +40246,17 @@
   name: Bicycle Chainrings
   children: []
   attributes:
+  - bolt_circle_diameter
+  - chainline_offset
   - chainring_shape
   - color
   - compatible_bike_type
+  - diameter
   - drivetrain_speed_compatibility
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -36498,7 +40274,10 @@
   - chain_connection_type
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -36518,8 +40297,12 @@
   - color
   - compatible_bike_type
   - compatible_drivetrain_speeds
+  - height
+  - length
   - number_of_chainrings
   - pattern
+  - q_factor
+  - width
   return_reasons:
   - size
   - color
@@ -36542,8 +40325,11 @@
   - derailleur_cage_length
   - derailleur_mounting_style
   - derailleur_type
+  - height
+  - length
   - pattern
   - vehicle_placement
+  - width
   return_reasons:
   - size
   - weight
@@ -36564,10 +40350,13 @@
   - color
   - compatible_bike_type
   - compatible_cleat_system
+  - height
+  - length
   - material
   - pattern
   - pedal_spindle_material
   - pedal_spindle_thread_size
+  - width
   return_reasons:
   - size
   - color
@@ -36592,9 +40381,12 @@
   - battery_type
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - shifter_mounting_interface
   - shifting_mechanism
+  - width
   return_reasons:
   - size
   - grip
@@ -36755,10 +40547,16 @@
   - brake_mount_type
   - color
   - compatible_bike_type
+  - compatible_wheel_size
+  - fork_offset
   - front_axle_standard
+  - height
+  - length
   - pattern
+  - stanchion_diameter
   - steerer_tube_design
   - suspension_type
+  - width
   return_reasons:
   - color
   - weight
@@ -36778,6 +40576,7 @@
   - compatible_bike_type
   - front_axle_standard
   - pattern
+  - stanchion_diameter
   - steerer_tube_design
   - suspension_type
   return_reasons:
@@ -36796,6 +40595,7 @@
   - compatible_bike_type
   - front_axle_standard
   - pattern
+  - stanchion_diameter
   - steerer_tube_design
   - suspension_type
   return_reasons:
@@ -36819,10 +40619,15 @@
   - bottom_bracket_standard
   - color
   - compatible_bike_type
+  - compatible_wheel_size
   - frame_suspension_type
   - headset_standard
+  - height
+  - length
   - pattern
   - rear_axle_spacing
+  - seatpost_diameter
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -36848,6 +40653,7 @@
   - headset_standard
   - pattern
   - rear_axle_spacing
+  - seatpost_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -36868,6 +40674,7 @@
   - headset_standard
   - pattern
   - rear_axle_spacing
+  - seatpost_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -36888,6 +40695,7 @@
   - headset_standard
   - pattern
   - rear_axle_spacing
+  - seatpost_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -36908,6 +40716,7 @@
   - headset_standard
   - pattern
   - rear_axle_spacing
+  - seatpost_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -36928,6 +40737,7 @@
   - headset_standard
   - pattern
   - rear_axle_spacing
+  - seatpost_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -36943,9 +40753,13 @@
   - battery_type
   - color
   - compatible_bike_type
+  - crank_arm_length
   - groupset_components_included
+  - height
+  - length
   - pattern
   - shifting_actuation_type
+  - width
   return_reasons:
   - size
   - length
@@ -36965,9 +40779,13 @@
   - compatible_bike_type
   - extension_attachment_method
   - extension_bend_type
+  - extension_rise
+  - height
+  - length
   - material
   - pattern
   - shifter_compatibility
+  - width
   return_reasons:
   - color
   - length
@@ -36990,8 +40808,14 @@
   - bicycle_handlebar_type
   - color
   - compatible_bike_type
+  - handlebar_drop
+  - handlebar_rise
+  - height
+  - length
   - material
   - pattern
+  - reach
+  - width
   return_reasons:
   - color
   - width
@@ -37010,8 +40834,11 @@
   - bicycle_handlebar_type
   - color
   - compatible_bike_type
+  - handlebar_drop
+  - handlebar_rise
   - material
   - pattern
+  - reach
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -37026,8 +40853,11 @@
   - bicycle_handlebar_type
   - color
   - compatible_bike_type
+  - handlebar_drop
+  - handlebar_rise
   - material
   - pattern
+  - reach
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -37042,8 +40872,11 @@
   - bicycle_handlebar_type
   - color
   - compatible_bike_type
+  - handlebar_drop
+  - handlebar_rise
   - material
   - pattern
+  - reach
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -37058,8 +40891,11 @@
   - bicycle_handlebar_type
   - color
   - compatible_bike_type
+  - handlebar_drop
+  - handlebar_rise
   - material
   - pattern
+  - reach
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -37079,7 +40915,11 @@
   - color
   - compatible_bike_type
   - compatible_shis
+  - height
+  - length
   - pattern
+  - stack_height
+  - width
   return_reasons:
   - size
   - weight
@@ -37099,7 +40939,12 @@
   - compatible_bike_type
   - compatible_shis
   - contact_angle
+  - diameter
+  - height
+  - length
   - pattern
+  - stack_height
+  - width
   return_reasons:
   - diameter
   - weight
@@ -37117,7 +40962,12 @@
   - color
   - compatible_bike_type
   - compatible_shis
+  - diameter
+  - height
+  - length
   - pattern
+  - stack_height
+  - width
   return_reasons:
   - size
   - color
@@ -37137,6 +40987,7 @@
   - compatible_bike_type
   - compatible_shis
   - pattern
+  - stack_height
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -37152,6 +41003,7 @@
   - compatible_bike_type
   - compatible_shis
   - pattern
+  - stack_height
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -37167,6 +41019,7 @@
   - compatible_bike_type
   - compatible_shis
   - pattern
+  - stack_height
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -37182,7 +41035,11 @@
   - bicycle_headset_configuration
   - color
   - compatible_bike_type
+  - diameter
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -37199,9 +41056,14 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
   - kickstand_mounting_position
   - kickstand_type
+  - length
+  - maximum_length
+  - minimum_length
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -37219,6 +41081,8 @@
   attributes:
   - compatible_bike_type
   - cycling_style
+  - height
+  - length
   - saddle_base_color
   - saddle_base_material
   - saddle_base_pattern
@@ -37227,10 +41091,12 @@
   - saddle_mounting_type
   - saddle_padding_material
   - saddle_rail_material
+  - saddle_rail_size
   - saddle_seat_color
   - saddle_seat_material
   - saddle_seat_pattern
   - target_gender
+  - width
   return_reasons:
   - size
   - color
@@ -37247,8 +41113,11 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - seatpost_clamp_mechanism
+  - width
   return_reasons:
   - size
   - color
@@ -37268,7 +41137,12 @@
   - battery_type
   - color
   - compatible_bike_type
+  - height
+  - length
+  - maximum_length
+  - minimum_length
   - pattern
+  - width
   return_reasons:
   - diameter
   - length
@@ -37292,7 +41166,10 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -37308,7 +41185,10 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -37325,8 +41205,11 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - link_connection_style
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -37341,8 +41224,11 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - spoke_gauge
+  - width
   return_reasons:
   - size
   - color
@@ -37402,7 +41288,13 @@
   attributes:
   - color
   - compatible_bike_type
+  - compatible_handlebar_size
+  - height
+  - length
   - pattern
+  - steerer_tube_diameter
+  - stem_rise
+  - width
   return_reasons:
   - color
   - length
@@ -37421,9 +41313,12 @@
   - adapter_orientation
   - color
   - compatible_bike_type
+  - height
   - input_valve_type
+  - length
   - pattern
   - valve_type
+  - width
   return_reasons:
   - color
   - length
@@ -37440,8 +41335,11 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - valve_type
+  - width
   return_reasons:
   - color
   - style
@@ -37458,10 +41356,13 @@
   attributes:
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - valve_base_shape
   - valve_core_type
   - valve_type
+  - width
   return_reasons:
   - color
   - length
@@ -37482,11 +41383,15 @@
   attributes:
   - color
   - compatible_bike_type
+  - compatible_wheel_size
   - cycling_style
   - e_bike_certification_class
+  - height
+  - length
   - pattern
   - tire_bead_type
   - tread_pattern_type
+  - width
   return_reasons:
   - size
   - width
@@ -37504,11 +41409,15 @@
   attributes:
   - color
   - compatible_bike_type
+  - compatible_wheel_size
   - cycling_style
   - e_bike_certification_class
+  - height
+  - length
   - pattern
   - tire_bead_type
   - tread_pattern_type
+  - width
   return_reasons:
   - width
   - tread_type
@@ -37526,13 +41435,17 @@
   attributes:
   - color
   - compatible_bike_type
+  - compatible_wheel_size
   - cycling_style
   - e_bike_certification_class
   - e_bike_speed_rating
+  - height
+  - length
   - pattern
   - puncture_protection_technology
   - tire_bead_type
   - tread_pattern_type
+  - width
   return_reasons:
   - width
   - tread_type
@@ -37550,11 +41463,15 @@
   - bicycle_tire_tread_pattern
   - color
   - compatible_bike_type
+  - compatible_wheel_size
   - cycling_style
   - e_bike_certification_class
+  - height
+  - length
   - pattern
   - tire_bead_type
   - tread_pattern_type
+  - width
   return_reasons:
   - width
   - tread_type
@@ -37572,13 +41489,17 @@
   - casing_material
   - color
   - compatible_bike_type
+  - compatible_wheel_size
   - cycling_style
   - e_bike_certification_class
+  - height
+  - length
   - pattern
   - tire_bead_type
   - tire_tread_style
   - tread_pattern_type
   - tubular_construction_type
+  - width
   return_reasons:
   - width
   - tread_type
@@ -37596,9 +41517,14 @@
   attributes:
   - color
   - compatible_bike_type
+  - compatible_wheel_size
+  - height
+  - length
   - pattern
   - tube_weight_category
+  - valve_length
   - valve_type
+  - width
   return_reasons:
   - width
   - incompatible
@@ -37622,6 +41548,7 @@
   - sg-4-4-2-23-9
   - sg-4-4-2-23-11
   attributes:
+  - axle_spacing_dropout_width
   - cassette_body_type
   - color
   - compatible_bike_type
@@ -37642,12 +41569,16 @@
   name: Bicycle Foot Pegs
   children: []
   attributes:
+  - axle_spacing_dropout_width
   - cassette_body_type
   - color
   - compatible_axle_size
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - rim_tubeless_compatibility
+  - width
   return_reasons:
   - size
   - color
@@ -37669,12 +41600,16 @@
   - sg-4-4-2-23-2-5
   - sg-4-4-2-23-2-6
   attributes:
+  - axle_spacing_dropout_width
   - cassette_body_type
   - color
   - compatible_bike_type
   - freehub_driver_standard
+  - height
+  - length
   - pattern
   - rim_tubeless_compatibility
+  - width
   return_reasons:
   - size
   - color
@@ -37690,15 +41625,20 @@
   name: Hub Bearings
   children: []
   attributes:
+  - axle_spacing_dropout_width
   - bearing_clearance
   - bearing_construction_type
   - bearing_seal_type
+  - bearing_thickness
   - cassette_body_type
   - color
   - compatible_bike_type
   - freehub_driver_standard
+  - height
+  - length
   - pattern
   - rim_tubeless_compatibility
+  - width
   return_reasons:
   - size
   - incompatible
@@ -37712,12 +41652,16 @@
   name: Hub Cones
   children: []
   attributes:
+  - axle_spacing_dropout_width
   - cassette_body_type
   - color
   - compatible_bike_type
   - freehub_driver_standard
+  - height
+  - length
   - pattern
   - rim_tubeless_compatibility
+  - width
   return_reasons:
   - size
   - incompatible
@@ -37731,12 +41675,16 @@
   name: Quick Releases
   children: []
   attributes:
+  - axle_spacing_dropout_width
   - cassette_body_type
   - color
   - compatible_bike_type
   - freehub_driver_standard
+  - height
+  - length
   - pattern
   - rim_tubeless_compatibility
+  - width
   return_reasons:
   - size
   - color
@@ -37752,6 +41700,7 @@
   name: Hub Axle & End Cap Conversion Kits
   children: []
   attributes:
+  - axle_spacing_dropout_width
   - cassette_body_type
   - color
   - compatible_bike_type
@@ -37769,6 +41718,7 @@
   name: Freehub Bodies
   children: []
   attributes:
+  - axle_spacing_dropout_width
   - cassette_body_type
   - color
   - compatible_bike_type
@@ -37786,6 +41736,7 @@
   name: Hub Guards
   children: []
   attributes:
+  - axle_spacing_dropout_width
   - cassette_body_type
   - color
   - compatible_bike_type
@@ -37803,15 +41754,21 @@
   name: Bicycle Hubs
   children: []
   attributes:
+  - axle_spacing_dropout_width
   - brake_rotor_mount_type
   - cassette_body_type
   - color
   - compatible_bike_type
   - freehub_body_type
+  - height
   - hub_axle_type
+  - hub_size
+  - hub_spacing
+  - length
   - pattern
   - rim_tubeless_compatibility
   - spoke_interface_type
+  - width
   return_reasons:
   - size
   - weight
@@ -37826,12 +41783,17 @@
   name: Bicycle Rim Strips
   children: []
   attributes:
+  - axle_spacing_dropout_width
   - cassette_body_type
   - color
   - compatible_bike_type
+  - compatible_wheel_size
+  - height
+  - length
   - pattern
   - rim_strip_type
   - rim_tubeless_compatibility
+  - width
   return_reasons:
   - size
   - color
@@ -37847,13 +41809,18 @@
   name: Bicycle Spokes
   children: []
   attributes:
+  - axle_spacing_dropout_width
   - cassette_body_type
   - color
   - compatible_bike_type
+  - compatible_wheel_size
+  - height
+  - length
   - pattern
   - rim_tubeless_compatibility
   - spoke_butting_profile
   - spoke_shape
+  - width
   return_reasons:
   - length
   - weight
@@ -37868,12 +41835,16 @@
   name: Bicycle Wheel Axles & Skewers
   children: []
   attributes:
+  - axle_spacing_dropout_width
   - cassette_body_type
   - color
   - compatible_bike_type
+  - height
+  - length
   - pattern
   - rim_tubeless_compatibility
   - vehicle_placement
+  - width
   return_reasons:
   - size
   - color
@@ -37889,13 +41860,18 @@
   name: Bicycle Wheel Nipples
   children: []
   attributes:
+  - axle_spacing_dropout_width
   - cassette_body_type
   - color
   - compatible_bike_type
   - compatible_spoke_gauge
+  - height
+  - length
   - nipple_drive_interface
   - pattern
   - rim_tubeless_compatibility
+  - width
+  - wrench_flat_size
   return_reasons:
   - size
   - color
@@ -37911,11 +41887,16 @@
   name: Bicycle Wheel Rims
   children: []
   attributes:
+  - axle_spacing_dropout_width
   - cassette_body_type
   - color
   - compatible_bike_type
+  - compatible_wheel_size
+  - height
+  - length
   - pattern
   - rim_tubeless_compatibility
+  - width
   return_reasons:
   - size
   - color
@@ -37931,6 +41912,7 @@
   name: Bicycle Wheel Spacers & Shims
   children: []
   attributes:
+  - axle_spacing_dropout_width
   - cassette_body_type
   - color
   - compatible_bike_type
@@ -37947,6 +41929,7 @@
   name: Bicycle Wheel Decal Kits
   children: []
   attributes:
+  - axle_spacing_dropout_width
   - cassette_body_type
   - color
   - compatible_bike_type
@@ -37972,8 +41955,12 @@
   - bicycle_hub_type
   - color
   - compatible_bike_type
+  - height
+  - internal_rim_width
+  - length
   - pattern
   - tubeless_compatible
+  - width
   return_reasons:
   - size
   - color
@@ -37993,8 +41980,12 @@
   - bicycle_hub_type
   - color
   - compatible_bike_type
+  - height
+  - internal_rim_width
+  - length
   - pattern
   - tubeless_compatible
+  - width
   return_reasons:
   - size
   - color
@@ -38014,10 +42005,14 @@
   - bicycle_hub_type
   - color
   - compatible_bike_type
+  - height
   - hub_motor_type
+  - internal_rim_width
+  - length
   - pattern
   - rear_axle_type
   - tubeless_compatible
+  - width
   return_reasons:
   - size
   - color
@@ -38038,9 +42033,14 @@
   - color
   - compatible_bike_type
   - disc_brake_rotor_mount_type
+  - height
+  - internal_rim_width
+  - length
   - pattern
   - rear_axle_standard
+  - rim_internal_width
   - tubeless_compatible
+  - width
   return_reasons:
   - size
   - color
@@ -38060,8 +42060,13 @@
   - bicycle_hub_type
   - color
   - compatible_bike_type
+  - height
+  - internal_rim_width
+  - length
   - pattern
+  - rim_depth
   - tubeless_compatible
+  - width
   return_reasons:
   - size
   - color
@@ -38081,6 +42086,7 @@
   - bicycle_hub_type
   - color
   - compatible_bike_type
+  - internal_rim_width
   - pattern
   - tubeless_compatible
   return_reasons:
@@ -38131,6 +42137,7 @@
   - color
   - compatible_bike_type
   - pattern
+  - stanchion_diameter
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -38147,6 +42154,7 @@
   - color
   - compatible_bike_type
   - pattern
+  - stem_rise
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -38183,10 +42191,16 @@
   - bicycle_features
   - bicycle_suspension_type
   - color
+  - frame_size
   - gearing_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - target_gender
+  - weight
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -38208,10 +42222,17 @@
   - bicycle_features
   - bicycle_suspension_type
   - color
+  - frame_size
   - gearing_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - target_gender
+  - top_tube_length
+  - weight
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -38235,6 +42256,7 @@
   - material
   - pattern
   - target_gender
+  - top_tube_length
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -38254,6 +42276,7 @@
   - material
   - pattern
   - target_gender
+  - top_tube_length
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -38270,11 +42293,17 @@
   - bicycle_suspension_type
   - color
   - electric_assist_type
+  - frame_size
   - gearing_type
   - handlebar_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - target_gender
+  - weight
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -38294,10 +42323,17 @@
   - bicycle_features
   - bicycle_suspension_type
   - color
+  - frame_size
+  - front_suspension_travel
   - gearing_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - target_gender
+  - weight
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -38318,10 +42354,16 @@
   - bicycle_frame_style
   - bicycle_suspension_type
   - color
+  - frame_size
   - gearing_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - target_gender
+  - weight
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -38343,6 +42385,7 @@
   - sg-4-4-3-5-5
   attributes:
   - age_group
+  - amperage
   - battery_size
   - battery_type
   - bicycle_features
@@ -38350,11 +42393,20 @@
   - bicycle_suspension_type
   - color
   - electric_bike_class
+  - frame_size
   - gearing_type
+  - height
+  - length
   - material
+  - maximum_assisted_speed
+  - maximum_load_capacity
   - motor_position
   - pattern
+  - power_consumption_typical
   - target_gender
+  - voltage
+  - weight
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -38381,6 +42433,7 @@
   - electric_bike_class
   - gearing_type
   - material
+  - maximum_assisted_speed
   - motor_position
   - pattern
   - target_gender
@@ -38405,6 +42458,7 @@
   - electric_bike_class
   - gearing_type
   - material
+  - maximum_assisted_speed
   - motor_position
   - pattern
   - target_gender
@@ -38429,6 +42483,7 @@
   - electric_bike_class
   - gearing_type
   - material
+  - maximum_assisted_speed
   - motor_position
   - pattern
   - target_gender
@@ -38453,6 +42508,7 @@
   - electric_bike_class
   - gearing_type
   - material
+  - maximum_assisted_speed
   - motor_position
   - pattern
   - target_gender
@@ -38477,6 +42533,7 @@
   - electric_bike_class
   - gearing_type
   - material
+  - maximum_assisted_speed
   - motor_position
   - pattern
   - target_gender
@@ -38498,10 +42555,16 @@
   - bicycle_propulsion_type
   - bicycle_suspension_type
   - color
+  - frame_size
   - gearing_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - target_gender
+  - weight
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -38522,10 +42585,16 @@
   - bicycle_folding_mechanism
   - bicycle_suspension_type
   - color
+  - frame_size
   - gearing_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - target_gender
+  - weight
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -38550,10 +42619,16 @@
   - cargo_area_configuration
   - color
   - electric_bicycle_motor_position
+  - frame_size
   - gearing_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - target_gender
+  - weight
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -38636,10 +42711,16 @@
   - bicycle_features
   - bicycle_suspension_type
   - color
+  - frame_size
   - gearing_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - target_gender
+  - weight
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -38665,10 +42746,17 @@
   - bicycle_features
   - bicycle_suspension_type
   - color
+  - frame_size
   - gearing_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
+  - rear_suspension_travel
   - target_gender
+  - weight
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -38693,6 +42781,7 @@
   - gearing_type
   - material
   - pattern
+  - rear_suspension_travel
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -38714,6 +42803,7 @@
   - gearing_type
   - material
   - pattern
+  - rear_suspension_travel
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -38735,6 +42825,7 @@
   - gearing_type
   - material
   - pattern
+  - rear_suspension_travel
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -38756,6 +42847,7 @@
   - gearing_type
   - material
   - pattern
+  - rear_suspension_travel
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -38774,10 +42866,16 @@
   - bicycle_features
   - bicycle_suspension_type
   - color
+  - frame_size
   - gearing_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - target_gender
+  - weight
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -38797,10 +42895,16 @@
   - bicycle_features
   - bicycle_suspension_type
   - color
+  - frame_size
   - gearing_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - target_gender
+  - weight
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -38822,10 +42926,17 @@
   - color
   - drivetrain_configuration
   - fork_material
+  - frame_size
   - gearing_type
+  - height
+  - length
   - material
+  - maximum_load_capacity
+  - maximum_tire_clearance
   - pattern
   - target_gender
+  - weight
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -39030,10 +43141,14 @@
   - color
   - compatible_bike_type
   - compatible_cleat_system
+  - diameter
+  - height
+  - length
   - pattern
   - screw_drive_type
   - sun_protection_rating_upf
   - visibility_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -39048,9 +43163,12 @@
   attributes:
   - color
   - compatible_cleat_system
+  - height
+  - length
   - pattern
   - sun_protection_rating_upf
   - visibility_features
+  - width
   return_reasons:
   - color
   - incompatible
@@ -39066,11 +43184,14 @@
   attributes:
   - color
   - compatible_cleat_system
+  - height
+  - length
   - pattern
   - pedal_and_cleat_system_compatibility
   - shim_purpose
   - sun_protection_rating_upf
   - visibility_features
+  - width
   return_reasons:
   - color
   - incompatible
@@ -39740,7 +43861,10 @@
   - sg-4-4-5-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -39757,7 +43881,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -39775,7 +43902,10 @@
   attributes:
   - bell_actuation_mechanism
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - style
@@ -39793,7 +43923,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -39813,12 +43946,15 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - suspension_configuration
   - target_gender
   - tricycle_design
   - tricycle_propulsion_type
   - wheel_type
+  - width
   return_reasons:
   - size
   - color
@@ -39837,7 +43973,10 @@
   - sg-4-4-7-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -39854,7 +43993,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - grip
@@ -39870,7 +44012,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - tread_type
@@ -39887,8 +44032,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -39981,11 +44129,14 @@
   attributes:
   - color
   - equestrian_discipline
+  - height
   - horse_blanket_type
   - horse_care_purpose
+  - length
   - material
   - neck_coverage_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -40099,13 +44250,16 @@
   - color
   - embellishment/trim_material
   - equestrian_discipline
+  - height
   - horse_care_purpose
   - horse_leg_protection_type
+  - length
   - material
   - pattern
   - shoe_size
   - target_gender
   - therapeutic_technology
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -40177,6 +44331,7 @@
   - horse_care_purpose
   - horse_feed_stage
   - pattern
+  - volume
   return_reasons:
   - animal_refused
   - consistency
@@ -40198,6 +44353,7 @@
   - horse_care_purpose
   - horse_feed_stage
   - pattern
+  - volume
   return_reasons:
   - animal_refused
   - consistency
@@ -40235,9 +44391,12 @@
   - color
   - ear_coverage_style
   - equestrian_discipline
+  - height
   - horse_care_purpose
+  - length
   - nose_coverage_style
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -40282,14 +44441,18 @@
   name: Horse Clippers & Trimmers
   children: []
   attributes:
+  - blade_cut_length
   - clipper/trimmer_type
   - clipper_motor_technology
   - color
   - equestrian_discipline
   - equine_application_area
+  - height
   - horse_care_purpose
   - horse_grooming_accessories_included
+  - length
   - pattern
+  - width
   - work_capacity
   return_reasons:
   - grip
@@ -40315,9 +44478,12 @@
   - color
   - equestrian_discipline
   - equine_application_area
+  - height
   - horse_care_purpose
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -40334,12 +44500,16 @@
   name: Horse Grooming Brushes
   children: []
   attributes:
+  - bristle_length
   - color
   - equestrian_discipline
   - equine_application_area
+  - height
   - horse_brush_type
   - horse_care_purpose
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -40366,8 +44536,11 @@
   - comb_type
   - equestrian_discipline
   - equine_application_area
+  - height
   - horse_care_purpose
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -40478,8 +44651,11 @@
   - deshedder_tool_type
   - equestrian_discipline
   - equine_application_area
+  - height
   - horse_care_purpose
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -40523,9 +44699,12 @@
   - color
   - equestrian_discipline
   - equine_application_area
+  - height
   - horse_care_purpose
   - horse_groomer_type
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -40629,8 +44808,11 @@
   - color
   - equestrian_discipline
   - equine_application_area
+  - height
   - horse_care_purpose
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -40700,6 +44882,7 @@
   name: Horse Clipper Blade Sharpeners
   children: []
   attributes:
+  - blade_cut_length
   - color
   - equestrian_discipline
   - equine_application_area
@@ -40718,6 +44901,7 @@
   name: Horse Clipper Blades
   children: []
   attributes:
+  - blade_cut_length
   - color
   - equestrian_discipline
   - equine_application_area
@@ -40736,6 +44920,7 @@
   name: Horse Clipper Parts & Accessories
   children: []
   attributes:
+  - blade_cut_length
   - color
   - equestrian_discipline
   - equine_application_area
@@ -40758,6 +44943,7 @@
   - equestrian_discipline
   - horse_care_purpose
   - pattern
+  - volume
   return_reasons:
   - animal_refused
   - consistency
@@ -40775,6 +44961,7 @@
   - equestrian_discipline
   - horse_care_purpose
   - pattern
+  - volume
   return_reasons:
   - animal_refused
   - consistency
@@ -40791,9 +44978,13 @@
   - administration_method
   - color
   - equestrian_discipline
+  - height
   - horse_care_purpose
+  - length
   - parasite_types_controlled
   - pattern
+  - volume
+  - width
   return_reasons:
   - animal_refused
   - changed_my_mind
@@ -40921,13 +45112,18 @@
   - sg-4-5-2-1-6
   - sg-4-5-2-1-7
   attributes:
+  - bit_length
   - bit_mouthpiece_design
   - bit_ring_style
   - color
   - embellishment/trim_material
   - equestrian_discipline
+  - height
+  - length
   - material
   - pattern
+  - shank_length
+  - width
   return_reasons:
   - size
   - color
@@ -40942,12 +45138,17 @@
   name: Bridle Bit Guards
   children: []
   attributes:
+  - bit_length
   - bit_mouthpiece_design
   - bit_ring_style
   - color
   - compatible_bit_type
   - equestrian_discipline
+  - height
+  - length
   - pattern
+  - shank_length
+  - width
   return_reasons:
   - size
   - color
@@ -40962,15 +45163,22 @@
   name: Bridle Curb Bits
   children: []
   attributes:
+  - bit_length
   - bit_mouthpiece_design
   - bit_ring_style
   - color
   - embellishment/trim_material
   - equestrian_discipline
+  - height
+  - length
   - material
+  - mouthpiece_length
   - mouthpiece_style
   - pattern
+  - port_height
+  - shank_length
   - shank_style
+  - width
   return_reasons:
   - size
   - color
@@ -40985,14 +45193,20 @@
   name: Bridle Snaffle Bits
   children: []
   attributes:
+  - bit_length
   - bit_mouthpiece_design
   - bit_ring_style
   - cheekpiece_style
   - color
   - embellishment/trim_material
   - equestrian_discipline
+  - height
+  - length
   - material
+  - mouthpiece_thickness
   - pattern
+  - shank_length
+  - width
   return_reasons:
   - size
   - thickness
@@ -41006,6 +45220,7 @@
   name: Kimblewick Bits
   children: []
   attributes:
+  - bit_length
   - bit_mouthpiece_design
   - bit_ring_style
   - color
@@ -41013,6 +45228,7 @@
   - equestrian_discipline
   - material
   - pattern
+  - shank_length
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -41024,6 +45240,7 @@
   name: Pelham Bits
   children: []
   attributes:
+  - bit_length
   - bit_mouthpiece_design
   - bit_ring_style
   - color
@@ -41031,6 +45248,7 @@
   - equestrian_discipline
   - material
   - pattern
+  - shank_length
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -41042,6 +45260,7 @@
   name: Gag Bits
   children: []
   attributes:
+  - bit_length
   - bit_mouthpiece_design
   - bit_ring_style
   - color
@@ -41049,6 +45268,7 @@
   - equestrian_discipline
   - material
   - pattern
+  - shank_length
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -41060,6 +45280,7 @@
   name: Weymouth Bits
   children: []
   attributes:
+  - bit_length
   - bit_mouthpiece_design
   - bit_ring_style
   - color
@@ -41067,6 +45288,7 @@
   - equestrian_discipline
   - material
   - pattern
+  - shank_length
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -41083,9 +45305,12 @@
   - bridle_style
   - color
   - equestrian_discipline
+  - height
   - horse_category
+  - length
   - noseband_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -41111,10 +45336,13 @@
   - color
   - embellishment/trim_material
   - equestrian_discipline
+  - height
   - horse_category
+  - length
   - material
   - noseband_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -41235,9 +45463,12 @@
   - color
   - equestrian_discipline
   - headstall_style
+  - height
   - horse_category
+  - length
   - noseband_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -41259,8 +45490,11 @@
   - cinch_liner_material
   - color
   - equestrian_discipline
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -41332,7 +45566,10 @@
   - color
   - equestrian_discipline
   - halter_style
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -41417,8 +45654,11 @@
   - color
   - embellishment/trim_material
   - equestrian_discipline
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -41470,8 +45710,11 @@
   attributes:
   - color
   - equestrian_discipline
+  - height
   - lead_hardware_type
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - style
@@ -41489,10 +45732,13 @@
   attributes:
   - color
   - equestrian_discipline
+  - height
   - horse_category
+  - length
   - material
   - pattern
   - rein_style
+  - width
   return_reasons:
   - size
   - color
@@ -41513,11 +45759,16 @@
   - color
   - equestrian_discipline
   - flap_configuration
+  - gullet_width
+  - height
+  - length
   - material
   - pattern
   - saddle_discipline
+  - saddle_seat_size
   - saddle_tree_material
   - saddle_tree_width
+  - width
   return_reasons:
   - size
   - color
@@ -41536,9 +45787,11 @@
   - color
   - equestrian_discipline
   - flap_configuration
+  - gullet_width
   - material
   - pattern
   - saddle_discipline
+  - saddle_seat_size
   - saddle_tree_material
   - saddle_tree_width
   return_reasons:
@@ -41555,9 +45808,11 @@
   - color
   - equestrian_discipline
   - flap_configuration
+  - gullet_width
   - material
   - pattern
   - saddle_discipline
+  - saddle_seat_size
   - saddle_tree_material
   - saddle_tree_width
   return_reasons:
@@ -41576,11 +45831,14 @@
   - battery_type
   - color
   - equestrian_discipline
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - safety_mechanism_type
   - stirrup_style
   - stirrup_tread_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -41691,8 +45949,11 @@
   attributes:
   - color
   - equestrian_discipline
+  - height
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -41723,8 +45984,11 @@
   - construction
   - embellishment/trim_material
   - equestrian_discipline
+  - height
   - jewelry_material
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -41744,7 +46008,10 @@
   - color
   - compatible_saddle_type
   - equestrian_discipline
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -41763,9 +46030,12 @@
   - color
   - compatible_saddle_type
   - equestrian_discipline
+  - height
+  - length
   - pattern
   - saddle_cover_style
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -41788,9 +46058,12 @@
   - color
   - compatible_saddle_type
   - equestrian_discipline
+  - height
+  - length
   - pattern
   - saddle_pad_shape
   - saddle_pad_style
+  - width
   return_reasons:
   - size
   - color
@@ -41847,9 +46120,13 @@
   - color
   - compatible_saddle_type
   - equestrian_discipline
+  - height
+  - length
   - lumber/wood_type
   - material
+  - maximum_load_capacity
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -42048,7 +46325,10 @@
   attributes:
   - color
   - equestrian_discipline
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -42067,7 +46347,10 @@
   - color
   - equestrian_discipline
   - fabric
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -42085,9 +46368,12 @@
   attributes:
   - color
   - equestrian_discipline
+  - height
+  - length
   - material
   - pattern
   - rein_features
+  - width
   return_reasons:
   - color
   - length
@@ -42105,8 +46391,11 @@
   attributes:
   - color
   - equestrian_discipline
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -42237,9 +46526,12 @@
   - color
   - equestrian_discipline
   - handle_grip_type
+  - height
+  - length
   - material
   - pattern
   - whip_style
+  - width
   return_reasons:
   - length
   - grip
@@ -42563,8 +46855,11 @@
   - sg-4-6-1-5
   attributes:
   - color
+  - height
   - led_indicator_color
+  - length
   - pattern
+  - width
   return_reasons:
   - sensitivity
   - brightness
@@ -42581,9 +46876,12 @@
   attributes:
   - alarm_volume_adjustability
   - color
+  - height
   - led_color_options
   - led_indicator_color
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - sensitivity
@@ -42600,10 +46898,13 @@
   children: []
   attributes:
   - color
+  - height
   - indicator_design
   - led_indicator_color
+  - length
   - mounting_thread_size
   - pattern
+  - width
   return_reasons:
   - color
   - sensitivity
@@ -42621,8 +46922,11 @@
   attributes:
   - color
   - hanger_thread_size
+  - height
   - led_indicator_color
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -42659,10 +46963,13 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - pattern
   - target_gender
   - wader_sole_type
   - wader_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -42679,12 +46986,17 @@
   children: []
   attributes:
   - accessory_size
+  - boot_insulation_weight
   - color
+  - height
+  - length
   - material
   - pattern
   - target_gender
   - wader_sole_type
+  - wader_thickness
   - wader_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -42702,11 +47014,15 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - insulation_weight
+  - length
   - pattern
   - target_gender
   - wader_foot_type
   - wader_sole_type
   - wader_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -42726,10 +47042,13 @@
   - accessory_size
   - color
   - cure_method
+  - height
+  - length
   - pattern
   - target_gender
   - wader_sole_type
   - wader_type
+  - width
   return_reasons:
   - color
   - adhesive_strength
@@ -42785,8 +47104,12 @@
   - aeration_method
   - battery_size
   - battery_type
+  - capacity
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -42864,9 +47187,13 @@
   children: []
   attributes:
   - color
+  - height
+  - hook_gap_size
   - hook_material
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -42905,9 +47232,12 @@
   - sg-4-6-5-23
   attributes:
   - color
+  - height
   - jaw_shape
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - grip
@@ -42924,9 +47254,12 @@
   attributes:
   - color
   - fishing_needle_types_included
+  - height
   - jaw_shape
+  - length
   - needle_material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -42943,9 +47276,12 @@
   attributes:
   - color
   - compatible_bait_type
+  - height
   - jaw_shape
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -42962,9 +47298,12 @@
   children: []
   attributes:
   - color
+  - height
   - jaw_shape
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -42981,9 +47320,12 @@
   children: []
   attributes:
   - color
+  - height
   - jaw_shape
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43000,9 +47342,12 @@
   children: []
   attributes:
   - color
+  - height
   - jaw_shape
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43019,9 +47364,12 @@
   attributes:
   - boilie_shape
   - color
+  - height
   - jaw_shape
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43037,9 +47385,12 @@
   children: []
   attributes:
   - color
+  - height
   - jaw_shape
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43055,9 +47406,13 @@
   children: []
   attributes:
   - color
+  - compatible_boilie_diameter
+  - height
   - jaw_shape
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43073,9 +47428,12 @@
   children: []
   attributes:
   - color
+  - height
   - jaw_shape
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43093,9 +47451,12 @@
   attributes:
   - boilie_stop_buoyancy
   - color
+  - height
   - jaw_shape
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43111,11 +47472,14 @@
   children: []
   attributes:
   - color
+  - height
   - jaw_shape
+  - length
   - material
   - pattern
   - pliers_jaw_style
   - surface_coating_or_finish
+  - width
   return_reasons:
   - size
   - color
@@ -43132,9 +47496,12 @@
   children: []
   attributes:
   - color
+  - height
   - jaw_shape
+  - length
   - needle_material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43151,9 +47518,12 @@
   children: []
   attributes:
   - color
+  - height
   - jaw_shape
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43171,9 +47541,12 @@
   attributes:
   - color
   - fly_tying_tools_included
+  - height
   - jaw_shape
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43190,9 +47563,12 @@
   children: []
   attributes:
   - color
+  - height
   - jaw_shape
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43208,9 +47584,12 @@
   children: []
   attributes:
   - color
+  - height
   - jaw_shape
+  - length
   - needle_material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43227,9 +47606,12 @@
   children: []
   attributes:
   - color
+  - height
   - jaw_shape
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43247,10 +47629,13 @@
   attributes:
   - bait_compatibility
   - color
+  - height
   - jaw_shape
+  - length
   - material
   - pattern
   - pellet_accessory_type
+  - width
   return_reasons:
   - size
   - color
@@ -43267,9 +47652,12 @@
   attributes:
   - color
   - fishing_needle_purpose
+  - height
   - jaw_shape
+  - length
   - needle_material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43286,10 +47674,13 @@
   children: []
   attributes:
   - color
+  - height
   - jaw_shape
+  - length
   - material
   - pattern
   - stick_curvature_type
+  - width
   return_reasons:
   - size
   - color
@@ -43357,9 +47748,13 @@
   - sg-4-6-6-6
   attributes:
   - color
+  - diameter
   - fishing_line_buoyancy_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - diameter
   - length
@@ -43375,10 +47770,14 @@
   children: []
   attributes:
   - color
+  - diameter
   - fishing_line_buoyancy_type
+  - height
+  - length
   - line_buoyancy
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -43396,10 +47795,14 @@
   children: []
   attributes:
   - color
+  - diameter
   - fishing_line_application
   - fishing_line_buoyancy_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - diameter
@@ -43416,9 +47819,13 @@
   children: []
   attributes:
   - color
+  - diameter
   - fishing_line_buoyancy_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - diameter
@@ -43435,10 +47842,14 @@
   children: []
   attributes:
   - color
+  - diameter
   - fishing_line_buoyancy_type
   - fishing_wire_material
+  - height
+  - length
   - pattern
   - strand_configuration
+  - width
   return_reasons:
   - color
   - diameter
@@ -43491,8 +47902,11 @@
   - battery_size
   - battery_type
   - color
+  - height
   - hoop_shape
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -43581,7 +47995,10 @@
   - battery_type
   - color
   - compatible_fishing_reel_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -43601,7 +48018,10 @@
   - color
   - compatible_fishing_reel_type
   - compatible_reel_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43649,8 +48069,11 @@
   attributes:
   - color
   - compatible_fishing_reel_type
+  - height
+  - length
   - lubricant_features
   - pattern
+  - width
   return_reasons:
   - consistency
   - lubrication
@@ -43673,7 +48096,10 @@
   - color
   - compatible_fishing_reel_type
   - compatible_fly_line_weight
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43821,9 +48247,13 @@
   - body_pattern
   - drag_system_type
   - gear_ratio
+  - height
+  - length
+  - maximum_drag
   - spool_color
   - spool_material
   - spool_pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -43844,10 +48274,14 @@
   - drag_system_material
   - drag_system_type
   - gear_ratio
+  - height
+  - length
+  - maximum_drag
   - reel_profile
   - spool_color
   - spool_material
   - spool_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43868,9 +48302,13 @@
   - body_pattern
   - drag_system_type
   - gear_ratio
+  - height
+  - length
+  - maximum_drag
   - spool_color
   - spool_material
   - spool_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43891,10 +48329,14 @@
   - body_pattern
   - drag_system_type
   - gear_ratio
+  - height
+  - length
   - manufacturing_process
+  - maximum_drag
   - spool_color
   - spool_material
   - spool_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43914,9 +48356,13 @@
   - body_pattern
   - drag_system_type
   - gear_ratio
+  - height
+  - length
+  - maximum_drag
   - spool_color
   - spool_material
   - spool_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43936,9 +48382,13 @@
   - body_pattern
   - drag_system_type
   - gear_ratio
+  - height
+  - length
+  - maximum_drag
   - spool_color
   - spool_material
   - spool_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43960,10 +48410,15 @@
   - drag_system_type
   - drag_type
   - gear_ratio
+  - height
+  - length
+  - maximum_drag
+  - reel_knob_diameter
   - reel_size_class
   - spool_color
   - spool_material
   - spool_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -43985,9 +48440,13 @@
   - body_pattern
   - drag_system_type
   - gear_ratio
+  - height
+  - length
+  - maximum_drag
   - spool_color
   - spool_material
   - spool_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -44136,7 +48595,10 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -44151,7 +48613,11 @@
   children: []
   attributes:
   - color
+  - compatible_rod_length
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -44168,8 +48634,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -44255,10 +48724,15 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - material
   - rod_color
   - rod_material
   - rod_pattern
+  - rod_size
+  - weight
+  - width
   return_reasons:
   - length
   - weight
@@ -44283,11 +48757,16 @@
   - handle_material
   - handle_pattern
   - handle_style
+  - height
+  - length
   - reel_seat_material
   - rod_color
   - rod_guide_material
   - rod_material
   - rod_pattern
+  - rod_size
+  - weight
+  - width
   return_reasons:
   - length
   - rod_power
@@ -44312,9 +48791,14 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - rod_color
   - rod_material
   - rod_pattern
+  - rod_size
+  - weight
+  - width
   return_reasons:
   - length
   - rod_power
@@ -44343,10 +48827,15 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - reel_seat_type
   - rod_color
   - rod_material
   - rod_pattern
+  - rod_size
+  - weight
+  - width
   return_reasons:
   - length
   - rod_power
@@ -44449,9 +48938,14 @@
   - handle_material
   - handle_pattern
   - handle_style
+  - height
+  - length
   - rod_color
   - rod_material
   - rod_pattern
+  - rod_size
+  - weight
+  - width
   return_reasons:
   - length
   - rod_power
@@ -44524,11 +49018,16 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - rod_color
   - rod_construction_type
   - rod_handle_type
   - rod_material
   - rod_pattern
+  - rod_size
+  - weight
+  - width
   return_reasons:
   - length
   - rod_power
@@ -44553,9 +49052,14 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - rod_color
   - rod_material
   - rod_pattern
+  - rod_size
+  - weight
+  - width
   return_reasons:
   - length
   - rod_power
@@ -44581,9 +49085,14 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - rod_color
   - rod_material
   - rod_pattern
+  - rod_size
+  - weight
+  - width
   return_reasons:
   - length
   - rod_power
@@ -44610,9 +49119,14 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - rod_color
   - rod_material
   - rod_pattern
+  - rod_size
+  - weight
+  - width
   return_reasons:
   - length
   - rod_power
@@ -44637,9 +49151,14 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - rod_color
   - rod_material
   - rod_pattern
+  - rod_size
+  - weight
+  - width
   return_reasons:
   - length
   - rod_power
@@ -44664,11 +49183,16 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - rod_color
   - rod_material
   - rod_pattern
+  - rod_size
   - tenkara_action_ratio
   - tippet_rating
+  - weight
+  - width
   return_reasons:
   - length
   - rod_power
@@ -44693,11 +49217,16 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - rod_butt_style
   - rod_color
   - rod_guide_type
   - rod_material
   - rod_pattern
+  - rod_size
+  - weight
+  - width
   return_reasons:
   - length
   - rod_power
@@ -44722,9 +49251,14 @@
   - handle_color
   - handle_material
   - handle_pattern
+  - height
+  - length
   - rod_color
   - rod_material
   - rod_pattern
+  - rod_size
+  - weight
+  - width
   return_reasons:
   - length
   - rod_power
@@ -44843,9 +49377,13 @@
   - sg-4-6-12-7
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - spear_size
   - thread_connection_size
   - tip_type
+  - width
   return_reasons:
   - length
   - weight
@@ -44996,8 +49534,11 @@
   - battery_type
   - buoyancy
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -45017,9 +49558,12 @@
   - color
   - decoy_buoyancy
   - decoy_joint_type
+  - height
   - hook_configuration
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -45040,8 +49584,11 @@
   - color
   - fly_pattern_type
   - head_weight_style
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -45062,8 +49609,11 @@
   - battery_type
   - buoyancy
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -45082,11 +49632,14 @@
   - artificial_bait_form
   - buoyancy
   - color
+  - height
+  - length
   - lumber/wood_type
   - lure_buoyancy
   - material
   - pattern
   - rattle_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -45106,8 +49659,11 @@
   - artificial_bait_form
   - buoyancy
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -45128,10 +49684,13 @@
   - artificial_bait_form
   - buoyancy
   - color
+  - height
+  - length
   - material
   - pattern
   - spinner_blade_shape
   - spinner_subtype
+  - width
   return_reasons:
   - size
   - color
@@ -45187,9 +49746,12 @@
   - buoyancy
   - color
   - fishing_hook_type
+  - height
+  - length
   - material
   - pattern
   - spoon_style
+  - width
   return_reasons:
   - size
   - color
@@ -45208,10 +49770,13 @@
   - artificial_bait_form
   - buoyancy
   - color
+  - height
+  - length
   - material
   - pattern
   - swimbait_buoyancy
   - swimbait_style
+  - width
   return_reasons:
   - size
   - color
@@ -45232,8 +49797,11 @@
   - artificial_bait_form
   - buoyancy
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   - wobbler_style
   return_reasons:
   - size
@@ -45291,10 +49859,13 @@
   - artificial_bait_form
   - buoyancy
   - color
+  - height
   - infused_scent
+  - length
   - material
   - pattern
   - soft_bait_style
+  - width
   return_reasons:
   - size
   - color
@@ -45385,9 +49956,12 @@
   - artificial_bait_form
   - buoyancy
   - color
+  - height
+  - length
   - material
   - pattern
   - tackle_components_included
+  - width
   return_reasons:
   - size
   - color
@@ -45498,8 +50072,11 @@
   - color
   - float_attachment_method
   - float_design
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -45519,11 +50096,16 @@
   - barb_type
   - color
   - fishing_hook_size
+  - height
   - hook_eye_type
   - hook_point_type
+  - hook_strength_rating
   - hook_style
+  - hook_wire_diameter
+  - length
   - lumber/wood_type
   - pattern
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -45545,13 +50127,19 @@
   - barb_type
   - color
   - fishing_hook_size
+  - height
   - hook_coating_finish
   - hook_eye_style
   - hook_eye_type
   - hook_point_configuration
   - hook_point_type
+  - hook_strength_rating
   - hook_style
+  - hook_wire_diameter
+  - length
   - pattern
+  - shank_length
+  - width
   return_reasons:
   - size
   - color
@@ -45575,8 +50163,11 @@
   - hook_eye_type
   - hook_point_configuration
   - hook_point_type
+  - hook_strength_rating
   - hook_style
+  - hook_wire_diameter
   - pattern
+  - shank_length
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -45596,8 +50187,11 @@
   - hook_eye_type
   - hook_point_configuration
   - hook_point_type
+  - hook_strength_rating
   - hook_style
+  - hook_wire_diameter
   - pattern
+  - shank_length
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -45613,11 +50207,16 @@
   - color
   - fishing_hook_size
   - fishing_hook_style
+  - height
   - hook_eye_type
   - hook_point_type
   - hook_shank_length
+  - hook_strength_rating
   - hook_style
+  - hook_wire_diameter
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -45646,9 +50245,12 @@
   - sg-4-6-13-4-12
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sinker_finish
   - sinker_material
+  - width
   return_reasons:
   - size
   - color
@@ -45665,10 +50267,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sinker_attachment_style
   - sinker_finish
   - sinker_material
+  - width
   return_reasons:
   - size
   - color
@@ -45685,9 +50290,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sinker_finish
   - sinker_material
+  - width
   return_reasons:
   - size
   - color
@@ -45704,10 +50312,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sinker_finish
   - sinker_material
   - sinker_shape
+  - width
   return_reasons:
   - size
   - color
@@ -45725,9 +50336,13 @@
   attributes:
   - color
   - dipsy_diver_size_designation
+  - height
+  - length
+  - maximum_dive_depth
   - pattern
   - sinker_finish
   - sinker_material
+  - width
   return_reasons:
   - size
   - color
@@ -45744,9 +50359,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sinker_finish
   - sinker_material
+  - width
   return_reasons:
   - size
   - color
@@ -45763,12 +50381,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sinker_finish
   - sinker_material
   - split_shot_cut_type
   - split_shot_shape
   - split_shot_size
+  - width
   return_reasons:
   - size
   - color
@@ -45876,8 +50497,11 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -45914,9 +50538,12 @@
   - sg-4-6-14-5
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - trap_design
+  - width
   return_reasons:
   - size
   - weight
@@ -46004,7 +50631,10 @@
   - sg-4-6-15-13
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -46021,8 +50651,11 @@
   attributes:
   - bead_hole_style
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -46039,8 +50672,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   - yarn_finish_or_effect
+  - yarn_length
   return_reasons:
   - size
   - color
@@ -46202,10 +50839,12 @@
   - sg-4-6-16-3
   - sg-4-6-16-4
   attributes:
+  - bait_length
   - bait_species
   - color
   - live_bait_form
   - pattern
+  - volume
   return_reasons:
   - size
   - changed_my_mind
@@ -46218,6 +50857,7 @@
   name: Live Insects & Larvae
   children: []
   attributes:
+  - bait_length
   - bait_species
   - color
   - live_bait_form
@@ -46233,6 +50873,7 @@
   name: Live Crustaceans
   children: []
   attributes:
+  - bait_length
   - bait_species
   - color
   - live_bait_form
@@ -46248,6 +50889,7 @@
   name: Live Worms
   children: []
   attributes:
+  - bait_length
   - bait_species
   - color
   - live_bait_form
@@ -46263,6 +50905,7 @@
   name: Live Minnows & Suckers
   children: []
   attributes:
+  - bait_length
   - bait_species
   - color
   - live_bait_form
@@ -46281,7 +50924,10 @@
   - sg-4-6-17-2
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -46489,8 +51135,11 @@
   - color
   - divot_tool_prong_configuration
   - divot_tool_style
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -46509,8 +51158,11 @@
   - color
   - golf_accessory_set_purpose
   - golf_equipment_included
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -46535,7 +51187,10 @@
   - sg-4-7-3-9
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -46552,8 +51207,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - maneuverability
@@ -46573,9 +51231,12 @@
   attributes:
   - color
   - compatible_golf_bag_type
+  - height
+  - length
   - pattern
   - protection_level
   - water_resistance
+  - width
   return_reasons:
   - size
   - color
@@ -46720,7 +51381,10 @@
   attributes:
   - color
   - golf_bag_style
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -46793,8 +51457,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -46815,8 +51482,11 @@
   - golf_ball_construction
   - golf_ball_cover_material
   - golf_ball_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - color
   - flight_distance
@@ -46842,7 +51512,10 @@
   - battery_type
   - color
   - golf_club_part_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -46865,9 +51538,12 @@
   - golf_grip_size
   - grip_shape
   - hand_side
+  - height
+  - length
   - material
   - pattern
   - shaft_flex
+  - width
   return_reasons:
   - size
   - color
@@ -46885,8 +51561,11 @@
   attributes:
   - color
   - golf_club_part_type
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -46907,12 +51586,17 @@
   - compatible_adapter_brand
   - golf_club_part_type
   - hand_side
+  - height
   - launch_profile
+  - length
   - material
   - pattern
   - shaft_flex
   - shaft_kick_point
+  - shaft_tip_diameter
   - spin_profile
+  - weight
+  - width
   return_reasons:
   - length
   - flex
@@ -47003,10 +51687,14 @@
   - club_type
   - color
   - hand_side
+  - height
+  - length
   - lie_angle_color_code
   - material
   - pattern
   - shaft_flex
+  - weight
+  - width
   return_reasons:
   - color
   - length
@@ -47092,9 +51780,13 @@
   - color
   - golf_club_number
   - hand_side
+  - height
+  - length
   - material
   - pattern
   - shaft_flex
+  - weight
+  - width
   return_reasons:
   - length
   - flex
@@ -47253,8 +51945,11 @@
   - color
   - flag_attachment_style
   - flag_type
+  - height
+  - length
   - pattern
   - printed_sides
+  - width
   return_reasons:
   - size
   - color
@@ -47292,7 +51987,10 @@
   attributes:
   - color
   - golf_tee_style
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -47309,9 +52007,12 @@
   - accessory_size
   - color
   - fabric
+  - height
+  - length
   - pattern
   - towel_features
   - towel_style
+  - width
   return_reasons:
   - size
   - color
@@ -47340,7 +52041,10 @@
   - age_group
   - color
   - golf_training_focus
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - weight
@@ -47359,7 +52063,10 @@
   - color
   - golf_training_focus
   - golf_training_objective
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -47379,7 +52086,10 @@
   - ball_return_mechanism
   - color
   - golf_training_focus
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -47400,7 +52110,10 @@
   - age_group
   - color
   - golf_training_focus
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -47463,8 +52176,11 @@
   - age_group
   - color
   - golf_training_focus
+  - height
+  - length
   - pattern
   - swing_training_objective
+  - width
   return_reasons:
   - size
   - color
@@ -47653,8 +52369,11 @@
   - sg-4-8-8
   attributes:
   - color
+  - height
+  - length
   - paraglider_certification_rating
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -47675,11 +52394,14 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - material
   - paraglider_certification_rating
   - pattern
   - suit_fit
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -47736,9 +52458,14 @@
   - color
   - glider_certification_rating
   - hang_glider_design
+  - height
+  - length
   - paraglider_certification_rating
   - pattern
   - recommended_skill_level
+  - width
+  - wing_area
+  - wingspan
   return_reasons:
   - size
   - color
@@ -47755,9 +52482,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - parachuting_activity
   - paraglider_certification_rating
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -47832,6 +52562,8 @@
   - color
   - paraglider_certification_rating
   - pattern
+  - wing_area
+  - wingspan
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -47904,6 +52636,7 @@
   - archery_style
   - arrow_component_type
   - color
+  - compatible_arrow_shaft_diameter
   - pattern
   return_reasons:
   - weight
@@ -47926,8 +52659,12 @@
   - arrow_fletching_material
   - arrow_fletching_orientation
   - color
+  - compatible_arrow_shaft_diameter
   - fletching_profile
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -47949,6 +52686,7 @@
   - arrow_fletching_material
   - arrow_fletching_orientation
   - color
+  - compatible_arrow_shaft_diameter
   - fletching_profile
   - pattern
   return_reasons:
@@ -47968,6 +52706,7 @@
   - arrow_fletching_material
   - arrow_fletching_orientation
   - color
+  - compatible_arrow_shaft_diameter
   - fletching_profile
   - pattern
   return_reasons:
@@ -47990,9 +52729,13 @@
   - archery_style
   - arrow_component_type
   - color
+  - compatible_arrow_shaft_diameter
+  - height
+  - length
   - nock_material
   - nock_throat_size
   - pattern
+  - width
   return_reasons:
   - color
   - weight
@@ -48011,9 +52754,13 @@
   - arrow_component_type
   - arrow_nock_groove_size
   - color
+  - compatible_arrow_shaft_diameter
+  - height
+  - length
   - nock_material
   - nock_throat_size
   - pattern
+  - width
   return_reasons:
   - color
   - weight
@@ -48032,10 +52779,14 @@
   - arrow_component_type
   - arrow_shaft_compatibility
   - color
+  - compatible_arrow_shaft_diameter
+  - height
+  - length
   - nock_activation_method
   - nock_material
   - nock_throat_size
   - pattern
+  - width
   return_reasons:
   - color
   - brightness
@@ -48054,10 +52805,14 @@
   - archery_style
   - arrow_component_type
   - color
+  - compatible_arrow_shaft_diameter
+  - height
+  - length
   - nock_material
   - nock_throat_size
   - nock_transparency_level
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -48074,10 +52829,14 @@
   - archery_style
   - arrow_component_type
   - color
+  - compatible_arrow_shaft_diameter
+  - height
+  - length
   - nock_fitment_code
   - nock_material
   - nock_throat_size
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -48094,9 +52853,13 @@
   - archery_style
   - arrow_component_type
   - color
+  - compatible_arrow_shaft_diameter
+  - height
+  - length
   - nock_material
   - nock_throat_size
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -48113,6 +52876,7 @@
   - archery_style
   - arrow_component_type
   - color
+  - compatible_arrow_shaft_diameter
   - nock_material
   - nock_throat_size
   - pattern
@@ -48135,7 +52899,11 @@
   - broadhead_field_point_attachment_style
   - broadhead_thread_size
   - color
+  - compatible_arrow_shaft_diameter
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -48158,7 +52926,11 @@
   - broadhead_thread_size
   - broadhead_tip_type
   - color
+  - compatible_arrow_shaft_diameter
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -48178,9 +52950,13 @@
   - broadhead_field_point_attachment_style
   - broadhead_thread_size
   - color
+  - compatible_arrow_shaft_diameter
   - field_point_attachment_method
   - field_point_tip_style
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - weight
   - incompatible
@@ -48197,6 +52973,7 @@
   - archery_style
   - arrow_component_type
   - color
+  - compatible_arrow_shaft_diameter
   - pattern
   return_reasons:
   - changed_my_mind
@@ -48212,6 +52989,7 @@
   - archery_style
   - arrow_component_type
   - color
+  - compatible_arrow_shaft_diameter
   - pattern
   return_reasons:
   - changed_my_mind
@@ -48227,6 +53005,7 @@
   - archery_style
   - arrow_component_type
   - color
+  - compatible_arrow_shaft_diameter
   - pattern
   return_reasons:
   - changed_my_mind
@@ -48242,6 +53021,7 @@
   - archery_style
   - arrow_component_type
   - color
+  - compatible_arrow_shaft_diameter
   - pattern
   return_reasons:
   - changed_my_mind
@@ -48257,6 +53037,7 @@
   - archery_style
   - arrow_component_type
   - color
+  - compatible_arrow_shaft_diameter
   - pattern
   return_reasons:
   - changed_my_mind
@@ -48275,11 +53056,17 @@
   - age_group
   - archery_style
   - arrow_bolt_point_type
+  - arrow_spine_rating
   - color
   - fletching_orientation
+  - height
+  - length
   - material
   - nock_type
   - pattern
+  - straightness_tolerance
+  - weight
+  - width
   return_reasons:
   - length
   - flex
@@ -48300,10 +53087,17 @@
   - arrow_bolt_point_type
   - arrow_material
   - arrow_nock_type
+  - arrow_spine_rating
+  - arrow_straightness_tolerance
   - color
   - fletching_orientation
+  - height
+  - length
   - nock_type
   - pattern
+  - straightness_tolerance
+  - weight
+  - width
   return_reasons:
   - length
   - flex
@@ -48324,11 +53118,17 @@
   - age_group
   - archery_style
   - arrow_bolt_point_type
+  - arrow_spine_rating
   - bolt_material
   - color
   - fletching_orientation
+  - height
+  - length
   - nock_type
   - pattern
+  - straightness_tolerance
+  - weight
+  - width
   return_reasons:
   - length
   - flex
@@ -48347,11 +53147,13 @@
   - age_group
   - archery_style
   - arrow_bolt_point_type
+  - arrow_spine_rating
   - bolt_material
   - color
   - fletching_orientation
   - nock_type
   - pattern
+  - straightness_tolerance
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -48366,11 +53168,13 @@
   - age_group
   - archery_style
   - arrow_bolt_point_type
+  - arrow_spine_rating
   - bolt_material
   - color
   - fletching_orientation
   - nock_type
   - pattern
+  - straightness_tolerance
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -48386,10 +53190,12 @@
   - archery_style
   - arrow_bolt_point_type
   - arrow_material
+  - arrow_spine_rating
   - color
   - fletching_orientation
   - nock_type
   - pattern
+  - straightness_tolerance
   return_reasons:
   - length
   - flex
@@ -48418,7 +53224,10 @@
   - archery_activity
   - color
   - compatible_bow_crossbow_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -48438,7 +53247,10 @@
   - archery_target_features
   - color
   - compatible_bow_crossbow_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -48764,20 +53576,26 @@
   - sg-4-9-1-7-4
   attributes:
   - archery_style
+  - axle_to_axle_length
   - bow/crossbow_features
   - bow_material
+  - brace_height
   - cam_system
   - core_color
   - core_material
   - core_pattern
+  - draw_length
+  - draw_weight
   - hand_side
   - limb_material
   - riser_color
   - riser_material
   - riser_pattern
+  - speed
   - string_color
   - string_material
   - string_pattern
+  - weight
   return_reasons:
   - size
   - wrong_hand
@@ -48794,19 +53612,28 @@
   children: []
   attributes:
   - archery_style
+  - axle_to_axle_length
   - bow_features
+  - brace_height
   - cam_system
   - core_color
   - core_material
   - core_pattern
+  - draw_length
+  - draw_weight
   - hand_side
+  - height
+  - length
   - limb_material
   - riser_color
   - riser_material
   - riser_pattern
+  - speed
   - string_color
   - string_material
   - string_pattern
+  - weight
+  - width
   return_reasons:
   - wrong_hand
   - draw_weight
@@ -48826,18 +53653,29 @@
   - sg-4-9-1-7-2-3
   attributes:
   - archery_style
+  - axle_to_axle_length
+  - axle_to_axle_width_cocked
+  - axle_to_axle_width_uncocked
+  - brace_height
   - cocking_mechanism
   - core_color
   - core_material
   - core_pattern
   - crossbow_type
+  - draw_length
+  - draw_weight
+  - height
+  - length
   - limb_material
   - riser_color
   - riser_material
   - riser_pattern
+  - speed
   - string_color
   - string_material
   - string_pattern
+  - weight
+  - width
   return_reasons:
   - speed
   - draw_weight
@@ -48854,6 +53692,10 @@
   children: []
   attributes:
   - archery_style
+  - axle_to_axle_length
+  - axle_to_axle_width_cocked
+  - axle_to_axle_width_uncocked
+  - brace_height
   - cocking_mechanism
   - core_color
   - core_material
@@ -48878,6 +53720,10 @@
   children: []
   attributes:
   - archery_style
+  - axle_to_axle_length
+  - axle_to_axle_width_cocked
+  - axle_to_axle_width_uncocked
+  - brace_height
   - cocking_mechanism
   - core_color
   - core_material
@@ -48902,6 +53748,10 @@
   children: []
   attributes:
   - archery_style
+  - axle_to_axle_length
+  - axle_to_axle_width_cocked
+  - axle_to_axle_width_uncocked
+  - brace_height
   - cocking_mechanism
   - core_color
   - core_material
@@ -48928,16 +53778,25 @@
   - sg-4-9-1-7-3-2
   attributes:
   - archery_style
+  - axle_to_axle_length
+  - brace_height
   - core_color
   - core_material
   - core_pattern
+  - draw_length
+  - draw_weight
+  - height
+  - length
   - limb_material
   - riser_color
   - riser_material
   - riser_pattern
+  - speed
   - string_color
   - string_material
   - string_pattern
+  - weight
+  - width
   return_reasons:
   - wrong_hand
   - speed
@@ -48954,16 +53813,25 @@
   children: []
   attributes:
   - archery_style
+  - axle_to_axle_length
+  - brace_height
   - core_color
   - core_material
   - core_pattern
+  - draw_length
+  - draw_weight
+  - height
+  - length
   - limb_material
   - riser_color
   - riser_material
   - riser_pattern
+  - speed
   - string_color
   - string_material
   - string_pattern
+  - weight
+  - width
   return_reasons:
   - wrong_hand
   - length
@@ -48981,19 +53849,28 @@
   attributes:
   - archery_equipment_included
   - archery_style
+  - axle_to_axle_length
   - bow_features
+  - brace_height
   - cam_system
   - core_color
   - core_material
   - core_pattern
+  - draw_length
+  - draw_weight
   - hand_side
+  - height
+  - length
   - limb_material
   - riser_color
   - riser_material
   - riser_pattern
+  - speed
   - string_color
   - string_material
   - string_pattern
+  - weight
+  - width
   return_reasons:
   - wrong_hand
   - speed
@@ -49014,20 +53891,29 @@
   attributes:
   - archery_equipment_included
   - archery_style
+  - axle_to_axle_length
   - bow_features
   - bow_type
+  - brace_height
   - cam_system
   - core_color
   - core_material
   - core_pattern
+  - draw_length
+  - draw_weight
   - hand_side
+  - height
+  - length
   - limb_material
   - riser_color
   - riser_material
   - riser_pattern
+  - speed
   - string_color
   - string_material
   - string_pattern
+  - weight
+  - width
   return_reasons:
   - draw_weight
   - draw_length
@@ -49045,8 +53931,10 @@
   attributes:
   - archery_equipment_included
   - archery_style
+  - axle_to_axle_length
   - bow_features
   - bow_type
+  - brace_height
   - cam_system
   - core_color
   - core_material
@@ -49072,8 +53960,10 @@
   attributes:
   - archery_equipment_included
   - archery_style
+  - axle_to_axle_length
   - bow_features
   - bow_type
+  - brace_height
   - cam_system
   - core_color
   - core_material
@@ -49099,8 +53989,10 @@
   attributes:
   - archery_equipment_included
   - archery_style
+  - axle_to_axle_length
   - bow_features
   - bow_type
+  - brace_height
   - cam_system
   - core_color
   - core_material
@@ -49372,7 +54264,10 @@
   - armguard_style
   - color
   - hand_side
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -49395,11 +54290,14 @@
   - finger_count
   - hand_side
   - handwear_material
+  - height
+  - length
   - pattern
   - release_activation_method
   - release_jaw_style
   - release_strap_type
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -49469,8 +54367,12 @@
   - archery_style
   - archery_target_type
   - color
+  - height
+  - length
   - material
+  - maximum_projectile_speed_rating
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -49492,6 +54394,7 @@
   - archery_target_type
   - color
   - material
+  - maximum_projectile_speed_rating
   - pattern
   return_reasons:
   - changed_my_mind
@@ -49510,6 +54413,7 @@
   - archery_target_type
   - color
   - material
+  - maximum_projectile_speed_rating
   - pattern
   return_reasons:
   - changed_my_mind
@@ -49528,6 +54432,7 @@
   - archery_target_type
   - color
   - material
+  - maximum_projectile_speed_rating
   - pattern
   return_reasons:
   - changed_my_mind
@@ -49542,8 +54447,11 @@
   attributes:
   - color
   - hand_side
+  - height
+  - length
   - pattern
   - quiver_style
+  - width
   return_reasons:
   - size
   - color
@@ -49621,7 +54529,10 @@
   attributes:
   - clay_shooting_discipline
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -49641,9 +54552,13 @@
   - color
   - compatible_clay_target_size
   - features
+  - height
+  - length
   - mounting_method
   - pattern
+  - recycle_time
   - thrower_operation_type
+  - width
   return_reasons:
   - size
   - range
@@ -49661,7 +54576,10 @@
   attributes:
   - clay_shooting_discipline
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -49776,9 +54694,12 @@
   - animal_type
   - capture_method
   - color
+  - height
+  - length
   - map_format
   - pattern
   - trap_spring_configuration
+  - width
   return_reasons:
   - size
   - weight
@@ -49873,9 +54794,12 @@
   - battery_type
   - color
   - hearing_enhancer_style
+  - height
+  - length
   - map_format
   - noise_suppression_technology
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -49898,9 +54822,12 @@
   - color
   - fabric
   - features
+  - height
   - hunting_blind_design
+  - length
   - map_format
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -49922,9 +54849,12 @@
   - camouflage_environment_type
   - color
   - fabric
+  - height
   - hunting_blind_design
+  - length
   - map_format
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -50036,8 +54966,11 @@
   - sg-4-9-3-4-8
   attributes:
   - color
+  - height
+  - length
   - map_format
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -50054,9 +54987,12 @@
   children: []
   attributes:
   - color
+  - height
   - hunting_dog_collar_function
+  - length
   - map_format
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -50072,10 +55008,13 @@
   children: []
   attributes:
   - color
+  - height
   - leash_clip_type
   - leash_type
+  - length
   - map_format
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -50092,10 +55031,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - map_format
   - pattern
   - simulated_game_species
   - training_dummy_shape
+  - width
   return_reasons:
   - size
   - color
@@ -50188,8 +55130,12 @@
   - sg-4-9-3-5-7
   attributes:
   - color
+  - height
+  - length
   - map_format
+  - maximum_load_capacity
   - pattern
+  - width
   return_reasons:
   - color
   - weight_capacity
@@ -50294,8 +55240,11 @@
   - battery_type
   - color
   - feeder_mechanism_type
+  - height
+  - length
   - map_format
   - pattern
+  - width
   return_reasons:
   - color
   - pattern
@@ -50338,10 +55287,14 @@
   - animal_type
   - attractant_scent_profile
   - color
+  - height
+  - length
   - map_format
   - pattern
   - scent_function
   - scent_source
+  - volume
+  - width
   return_reasons:
   - scent
   - longevity
@@ -50360,9 +55313,13 @@
   - animal_type
   - attractant_scent_profile
   - color
+  - height
   - hunting_call_type
+  - length
   - map_format
+  - maximum_sound_output_level
   - pattern
+  - width
   return_reasons:
   - color
   - pattern
@@ -50387,8 +55344,11 @@
   - decoy_posture
   - decoy_size_class
   - decoy_style
+  - height
+  - length
   - map_format
   - pattern
+  - width
   return_reasons:
   - color
   - pattern
@@ -50411,6 +55371,7 @@
   - color
   - map_format
   - pattern
+  - volume
   - wildlife_attractant_scent
   return_reasons:
   - animal_refused
@@ -50431,6 +55392,7 @@
   - color
   - map_format
   - pattern
+  - volume
   - wildlife_attractant_scent
   return_reasons:
   - scent
@@ -50451,6 +55413,7 @@
   - color
   - map_format
   - pattern
+  - volume
   - wildlife_attractant_scent
   return_reasons:
   - animal_refused
@@ -50471,6 +55434,7 @@
   - color
   - map_format
   - pattern
+  - volume
   - wildlife_attractant_scent
   return_reasons:
   - animal_refused
@@ -50621,7 +55585,10 @@
   - sg-4-9-4-7
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -50661,8 +55628,11 @@
   - accessory_size
   - color
   - gear_material
+  - height
+  - length
   - pattern
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -50764,8 +55734,11 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - mounting_rail_type
   - pattern
+  - width
   return_reasons:
   - color
   - caliber
@@ -50786,8 +55759,13 @@
   attributes:
   - color
   - features
+  - height
+  - length
+  - maximum_height
+  - minimum_height
   - pattern
   - shooting_rest_design
+  - width
   return_reasons:
   - color
   - height
@@ -50854,7 +55832,10 @@
   attributes:
   - color
   - head_movement_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - height
@@ -50873,7 +55854,10 @@
   - bipod_mounting_interface
   - color
   - head_movement_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - height
@@ -50891,7 +55875,10 @@
   attributes:
   - color
   - head_movement_type
+  - height
+  - length
   - pattern
+  - width
   - yoke_type
   return_reasons:
   - color
@@ -50910,9 +55897,12 @@
   attributes:
   - color
   - head_movement_type
+  - height
+  - length
   - pattern
   - shooting_stick_yoke_design
   - support_leg_count
+  - width
   return_reasons:
   - color
   - height
@@ -50945,10 +55935,13 @@
   - sg-4-9-6-3-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - shooting_target_type
   - target_resetting_mechanism
+  - width
   return_reasons:
   - color
   - pattern
@@ -51083,6 +56076,7 @@
   attributes:
   - color
   - pattern
+  - projectile_caliber
   return_reasons:
   - size
   - color
@@ -51108,9 +56102,13 @@
   - color
   - compatible_bb_size
   - compatible_gun_platform
+  - height
+  - length
   - pattern
+  - projectile_caliber
   - propellant_type
   - thread_type
+  - width
   return_reasons:
   - color
   - weight
@@ -51131,9 +56129,13 @@
   - color
   - compatible_bb_size
   - compatible_gun_platform
+  - height
+  - length
   - pattern
+  - projectile_caliber
   - propellant_type
   - thread_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -51153,6 +56155,7 @@
   - compatible_bb_size
   - compatible_gun_platform
   - pattern
+  - projectile_caliber
   - propellant_type
   - thread_type
   return_reasons:
@@ -51173,6 +56176,7 @@
   - compatible_bb_size
   - compatible_gun_platform
   - pattern
+  - projectile_caliber
   - propellant_type
   - thread_type
   return_reasons:
@@ -51193,6 +56197,7 @@
   - compatible_bb_size
   - compatible_gun_platform
   - pattern
+  - projectile_caliber
   - propellant_type
   - thread_type
   return_reasons:
@@ -51213,6 +56218,7 @@
   - compatible_bb_size
   - compatible_gun_platform
   - pattern
+  - projectile_caliber
   - propellant_type
   - thread_type
   return_reasons:
@@ -51235,9 +56241,13 @@
   - airsoft_equipment_included
   - color
   - firing_mode
+  - height
   - hop_up_type
+  - length
   - pattern
+  - projectile_caliber
   - rail_system
+  - width
   return_reasons:
   - size
   - color
@@ -51258,6 +56268,7 @@
   - firing_mode
   - hop_up_type
   - pattern
+  - projectile_caliber
   - rail_system
   return_reasons:
   - changed_my_mind
@@ -51275,6 +56286,7 @@
   - firing_mode
   - hop_up_type
   - pattern
+  - projectile_caliber
   - rail_system
   return_reasons:
   - changed_my_mind
@@ -51292,6 +56304,7 @@
   - firing_mode
   - hop_up_type
   - pattern
+  - projectile_caliber
   - rail_system
   return_reasons:
   - changed_my_mind
@@ -51309,6 +56322,7 @@
   - firing_mode
   - hop_up_type
   - pattern
+  - projectile_caliber
   - rail_system
   return_reasons:
   - changed_my_mind
@@ -51326,6 +56340,7 @@
   - firing_mode
   - hop_up_type
   - pattern
+  - projectile_caliber
   - rail_system
   return_reasons:
   - changed_my_mind
@@ -51343,6 +56358,7 @@
   - firing_mode
   - hop_up_type
   - pattern
+  - projectile_caliber
   - rail_system
   return_reasons:
   - changed_my_mind
@@ -51356,8 +56372,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - pellet_grade
+  - pellet_weight
+  - projectile_caliber
+  - width
   return_reasons:
   - size
   - color
@@ -51381,8 +56402,12 @@
   - sg-4-9-7-4-7
   attributes:
   - color
+  - height
+  - length
   - lens_color_tint
   - pattern
+  - projectile_caliber
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -51405,6 +56430,7 @@
   - handwear_material
   - lens_color_tint
   - pattern
+  - projectile_caliber
   - target_gender
   return_reasons:
   - too_big
@@ -51426,8 +56452,12 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - lens_color_tint
   - pattern
+  - projectile_caliber
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -51448,6 +56478,7 @@
   - color
   - lens_color_tint
   - pattern
+  - projectile_caliber
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -51464,6 +56495,7 @@
   - color
   - lens_color_tint
   - pattern
+  - projectile_caliber
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -51477,9 +56509,13 @@
   attributes:
   - color
   - gear_material
+  - height
+  - length
   - lens_color_tint
   - pad_shell_type
   - pattern
+  - projectile_caliber
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -51500,10 +56536,14 @@
   - accessory_size
   - color
   - compatible_plate_size
+  - height
   - hydration_bladder_compatibility
+  - length
   - lens_color_tint
   - magazine_compatibility
   - pattern
+  - projectile_caliber
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -51526,6 +56566,7 @@
   - lens_color_tint
   - magazine_compatibility
   - pattern
+  - projectile_caliber
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -51544,6 +56585,7 @@
   - lens_color_tint
   - magazine_compatibility
   - pattern
+  - projectile_caliber
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -51558,6 +56600,7 @@
   - color
   - lens_color_tint
   - pattern
+  - projectile_caliber
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -51572,6 +56615,7 @@
   - color
   - lens_color_tint
   - pattern
+  - projectile_caliber
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -51586,6 +56630,7 @@
   - color
   - lens_color_tint
   - pattern
+  - projectile_caliber
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -51599,6 +56644,7 @@
   attributes:
   - color
   - pattern
+  - projectile_caliber
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -51612,6 +56658,7 @@
   attributes:
   - color
   - pattern
+  - projectile_caliber
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -51628,9 +56675,12 @@
   attributes:
   - action_type
   - color
+  - height
+  - length
   - pattern
   - projectile_type
   - shot_size
+  - width
   return_reasons:
   - color
   - weight
@@ -51647,9 +56697,12 @@
   attributes:
   - action_type
   - color
+  - height
+  - length
   - pattern
   - projectile_finish
   - projectile_type
+  - width
   return_reasons:
   - color
   - caliber
@@ -51674,9 +56727,12 @@
   - bb_gun_part_type
   - color
   - compatible_powerplant_type
+  - height
+  - length
   - pattern
   - projectile_type
   - rail_mount_standard
+  - width
   return_reasons:
   - color
   - weight
@@ -51787,8 +56843,11 @@
   - bb_gun_action_type
   - bb_gun_caliber
   - color
+  - height
+  - length
   - pattern
   - projectile_type
+  - width
   return_reasons:
   - color
   - range
@@ -51845,7 +56904,10 @@
   - sg-4-9-9-6
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - range
@@ -51862,7 +56924,10 @@
   attributes:
   - color
   - glow_effect
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -51877,7 +56942,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -51899,8 +56967,12 @@
   attributes:
   - blaster_mechanism
   - color
+  - compatible_gel_ball_size
   - gas_propellant_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - range
@@ -51917,6 +56989,7 @@
   attributes:
   - blaster_mechanism
   - color
+  - compatible_gel_ball_size
   - gas_propellant_type
   - pattern
   return_reasons:
@@ -51932,6 +57005,7 @@
   attributes:
   - blaster_mechanism
   - color
+  - compatible_gel_ball_size
   - gas_propellant_type
   - pattern
   return_reasons:
@@ -51947,6 +57021,7 @@
   attributes:
   - blaster_mechanism
   - color
+  - compatible_gel_ball_size
   - gas_propellant_type
   - pattern
   return_reasons:
@@ -51962,6 +57037,7 @@
   attributes:
   - blaster_mechanism
   - color
+  - compatible_gel_ball_size
   - gas_propellant_type
   - pattern
   return_reasons:
@@ -51977,6 +57053,7 @@
   attributes:
   - blaster_mechanism
   - color
+  - compatible_gel_ball_size
   - gas_propellant_type
   - pattern
   return_reasons:
@@ -51992,6 +57069,7 @@
   attributes:
   - blaster_mechanism
   - color
+  - compatible_gel_ball_size
   - gas_propellant_type
   - pattern
   return_reasons:
@@ -52072,9 +57150,12 @@
   children: []
   attributes:
   - color
+  - height
   - launcher_mounting_configuration
+  - length
   - paintball_caliber
   - pattern
+  - width
   return_reasons:
   - color
   - caliber
@@ -52094,9 +57175,13 @@
   - sg-4-9-10-2-3
   attributes:
   - color
+  - fuse_delay_time
   - grenade_effect_type
+  - height
+  - length
   - paintball_caliber
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -52111,6 +57196,7 @@
   children: []
   attributes:
   - color
+  - fuse_delay_time
   - grenade_effect_type
   - paintball_caliber
   - pattern
@@ -52126,6 +57212,7 @@
   children: []
   attributes:
   - color
+  - fuse_delay_time
   - grenade_effect_type
   - paintball_caliber
   - pattern
@@ -52141,6 +57228,7 @@
   children: []
   attributes:
   - color
+  - fuse_delay_time
   - grenade_effect_type
   - paintball_caliber
   - pattern
@@ -52168,8 +57256,11 @@
   - sg-4-9-10-3-12
   attributes:
   - color
+  - height
+  - length
   - paintball_caliber
   - pattern
+  - width
   return_reasons:
   - color
   - weight
@@ -52186,9 +57277,13 @@
   attributes:
   - color
   - compatible_gas_type
+  - height
+  - length
   - paintball_caliber
   - paintball_tank_valve_type
   - pattern
+  - regulator_output_pressure
+  - width
   return_reasons:
   - color
   - capacity
@@ -52204,9 +57299,13 @@
   name: Paintball Gun Barrels
   children: []
   attributes:
+  - barrel_bore_diameter
   - color
+  - height
+  - length
   - paintball_caliber
   - pattern
+  - width
   return_reasons:
   - color
   - caliber
@@ -52224,8 +57323,13 @@
   attributes:
   - asa_mounting_type
   - color
+  - forward_offset
+  - height
+  - length
   - paintball_caliber
   - pattern
+  - vertical_drop_distance
+  - width
   return_reasons:
   - color
   - length
@@ -52244,8 +57348,11 @@
   - sg-4-9-10-3-4-2
   attributes:
   - color
+  - height
+  - length
   - paintball_caliber
   - pattern
+  - width
   return_reasons:
   - color
   - capacity
@@ -52390,6 +57497,7 @@
   - color
   - paintball_caliber
   - pattern
+  - regulator_output_pressure
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -52402,14 +57510,19 @@
   children: []
   attributes:
   - available_firing_modes
+  - barrel_length
   - barrel_thread_standard
   - color
+  - height
+  - length
   - marker_action_type
   - marker_caliber
+  - operating_pressure
   - paintball_caliber
   - paintball_equipment_included
   - paintball_feed_system
   - pattern
+  - width
   return_reasons:
   - color
   - caliber
@@ -52428,9 +57541,12 @@
   - sg-4-9-10-5-2
   attributes:
   - color
+  - height
+  - length
   - paintball_caliber
   - pattern
   - pod_retention_system
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -52477,11 +57593,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - paintball_caliber
   - paintball_fill_color
   - paintball_fill_type
   - paintball_grade
   - pattern
+  - width
   return_reasons:
   - color
   - caliber
@@ -52508,9 +57627,12 @@
   - sg-4-9-10-7-10
   attributes:
   - color
+  - height
+  - length
   - padding_level
   - paintball_caliber
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -52554,11 +57676,14 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - lens_construction
   - padding_level
   - paintball_caliber
   - paintball_mask_coverage_level
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -52617,9 +57742,12 @@
   attributes:
   - color
   - gear_material
+  - height
+  - length
   - padding_level
   - paintball_caliber
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -52684,10 +57812,13 @@
   attributes:
   - accessory_size
   - color
+  - height
+  - length
   - molle_compatibility
   - padding_level
   - paintball_caliber
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -52875,8 +58006,12 @@
   - sg-4-10-14
   attributes:
   - color
+  - compatible_container_capacity
+  - height
+  - length
   - mouthpiece_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -52893,9 +58028,13 @@
   children: []
   attributes:
   - color
+  - compatible_container_capacity
   - drink_tube_insulation
+  - height
+  - length
   - mouthpiece_type
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -52912,11 +58051,16 @@
   attributes:
   - activity
   - bag_attachment_method
+  - capacity
   - color
+  - compatible_container_capacity
   - fabric
+  - height
   - hydration_bag_features
+  - length
   - mouthpiece_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -52933,12 +58077,17 @@
   children: []
   attributes:
   - activity
+  - capacity
   - color
+  - compatible_container_capacity
   - fabric
+  - height
   - hydration_belt_features
   - included_hydration_vessel_type
+  - length
   - mouthpiece_type
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -52956,11 +58105,16 @@
   children: []
   attributes:
   - activity
+  - capacity
   - color
+  - compatible_container_capacity
+  - height
+  - length
   - material
   - mouthpiece_type
   - pattern
   - reservoir_orientation
+  - width
   return_reasons:
   - color
   - capacity
@@ -52976,11 +58130,16 @@
   children: []
   attributes:
   - activity
+  - capacity
   - color
+  - compatible_container_capacity
+  - height
   - hydration_pack_style
+  - length
   - material
   - mouthpiece_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -52997,8 +58156,12 @@
   children: []
   attributes:
   - color
+  - compatible_container_capacity
+  - height
+  - length
   - mouthpiece_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -53014,10 +58177,16 @@
   name: Hydration System Mouthpieces
   children: []
   attributes:
+  - bottle_thread_diameter
   - color
+  - compatible_container_capacity
+  - height
   - hydration_mouthpiece_style
+  - length
   - mouthpiece_type
   - pattern
+  - straw_length
+  - width
   return_reasons:
   - size
   - color
@@ -53034,8 +58203,12 @@
   attributes:
   - color
   - compatible_bottle_mouth
+  - compatible_container_capacity
+  - height
+  - length
   - mouthpiece_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -53051,10 +58224,16 @@
   children: []
   attributes:
   - activity
+  - capacity
   - color
+  - compatible_container_capacity
+  - height
+  - hydration_reservoir_capacity
+  - length
   - material
   - mouthpiece_type
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -53071,10 +58250,15 @@
   children: []
   attributes:
   - activity
+  - capacity
   - color
+  - compatible_container_capacity
+  - height
+  - length
   - material
   - mouthpiece_type
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -53091,6 +58275,7 @@
   children: []
   attributes:
   - color
+  - compatible_container_capacity
   - mouthpiece_type
   - pattern
   return_reasons:
@@ -53105,6 +58290,7 @@
   children: []
   attributes:
   - color
+  - compatible_container_capacity
   - mouthpiece_type
   - pattern
   return_reasons:
@@ -53119,6 +58305,7 @@
   children: []
   attributes:
   - color
+  - compatible_container_capacity
   - mouthpiece_type
   - pattern
   return_reasons:
@@ -53133,6 +58320,7 @@
   children: []
   attributes:
   - color
+  - compatible_container_capacity
   - mouthpiece_type
   - pattern
   return_reasons:
@@ -53147,11 +58335,15 @@
   children: []
   attributes:
   - activity
+  - capacity
   - color
+  - height
   - hydration_system_insulation
   - hydration_valve_type
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -53201,9 +58393,12 @@
   - sg-4-12-1-7
   attributes:
   - color
+  - height
   - helmet_safety_certification
+  - length
   - pattern
   - protective_gear_items_included
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -53224,10 +58419,13 @@
   - accessory_size
   - age_group
   - color
+  - height
   - helmet_safety_certification
+  - length
   - pattern
   - protective_gear_items_included
   - protective_pad_components_included
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -53396,9 +58594,13 @@
   - sg-4-12-2-8
   - sg-4-12-2-9
   attributes:
+  - axle_diameter
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -53414,11 +58616,15 @@
   name: Inline Skate Bearings
   children: []
   attributes:
+  - axle_diameter
   - bearing_lubrication
   - bearing_shield_type
   - bearing_size_code
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - speed
@@ -53433,8 +58639,13 @@
   name: Inline Skate Brakes
   children: []
   attributes:
+  - axle_diameter
   - color
+  - compatible_axle_diameter
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -53448,11 +58659,15 @@
   name: Inline Skate Wheels
   children: []
   attributes:
+  - axle_diameter
   - color
+  - height
+  - length
   - pattern
   - wheel_core_type
   - wheel_illumination
   - wheel_profile
+  - width
   return_reasons:
   - size
   - color
@@ -53467,6 +58682,7 @@
   name: Inline Skate Buckles & Straps
   children: []
   attributes:
+  - axle_diameter
   - color
   - material
   - pattern
@@ -53481,6 +58697,7 @@
   name: Inline Skate Liners
   children: []
   attributes:
+  - axle_diameter
   - color
   - material
   - pattern
@@ -53495,6 +58712,7 @@
   name: Inline Skate Laces
   children: []
   attributes:
+  - axle_diameter
   - color
   - material
   - pattern
@@ -53509,6 +58727,7 @@
   name: Inline Skate Tools
   children: []
   attributes:
+  - axle_diameter
   - color
   - material
   - pattern
@@ -53523,6 +58742,7 @@
   name: Inline Skate Frames
   children: []
   attributes:
+  - axle_diameter
   - color
   - material
   - pattern
@@ -53537,6 +58757,7 @@
   name: Inline Skate Hardware
   children: []
   attributes:
+  - axle_diameter
   - color
   - material
   - pattern
@@ -53562,13 +58783,17 @@
   - footwear_color
   - footwear_material
   - footwear_pattern
+  - height
   - inline_skate_brake_type
   - inline_skating_style
+  - length
   - shell/frame_color
   - shell/frame_material
   - shell/frame_pattern
   - shoe_size
   - target_gender
+  - wheel_size
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -53590,13 +58815,17 @@
   - footwear_color
   - footwear_material
   - footwear_pattern
+  - height
   - inline_skate_brake_type
   - inline_skating_style
+  - length
   - shell/frame_color
   - shell/frame_material
   - shell/frame_pattern
   - shoe_size
   - target_gender
+  - wheel_size
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -53620,13 +58849,17 @@
   - footwear_material
   - footwear_pattern
   - frame_mounting_standard
+  - height
   - inline_skate_brake_type
   - inline_skating_style
+  - length
   - shell/frame_color
   - shell/frame_material
   - shell/frame_pattern
   - shoe_size
   - target_gender
+  - wheel_size
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -53648,13 +58881,17 @@
   - footwear_color
   - footwear_material
   - footwear_pattern
+  - height
   - inline_skate_brake_type
   - inline_skating_style
+  - length
   - shell/frame_color
   - shell/frame_material
   - shell/frame_pattern
   - shoe_size
   - target_gender
+  - wheel_size
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -53676,13 +58913,17 @@
   - footwear_color
   - footwear_material
   - footwear_pattern
+  - height
   - inline_skate_brake_type
   - inline_skating_style
+  - length
   - shell/frame_color
   - shell/frame_material
   - shell/frame_pattern
   - shoe_size
   - target_gender
+  - wheel_size
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -53731,8 +58972,12 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
+  - toe_stop_stem_length
   - toe_stop_stem_thread_size
+  - width
   return_reasons:
   - size
   - color
@@ -53748,8 +58993,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - toe_stop_stem_length
   - toe_stop_stem_thread_size
+  - width
   return_reasons:
   - size
   - color
@@ -53767,11 +59016,16 @@
   - sg-4-12-4-2-1
   - sg-4-12-4-2-2
   attributes:
+  - brake_contact_diameter
   - color
+  - height
+  - length
   - mounting_style
   - pattern
   - roller_skate_brake_shape
+  - toe_stop_stem_length
   - toe_stop_stem_thread_size
+  - width
   return_reasons:
   - size
   - color
@@ -53787,10 +59041,12 @@
   name: Roller Skate Jam Plugs
   children: []
   attributes:
+  - brake_contact_diameter
   - color
   - mounting_style
   - pattern
   - roller_skate_brake_shape
+  - toe_stop_stem_length
   - toe_stop_stem_thread_size
   return_reasons:
   - changed_my_mind
@@ -53803,10 +59059,12 @@
   name: Bolt-On Toe Stops
   children: []
   attributes:
+  - brake_contact_diameter
   - color
   - mounting_style
   - pattern
   - roller_skate_brake_shape
+  - toe_stop_stem_length
   - toe_stop_stem_thread_size
   return_reasons:
   - changed_my_mind
@@ -53820,8 +59078,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - toe_stop_stem_length
   - toe_stop_stem_thread_size
+  - width
   return_reasons:
   - size
   - color
@@ -53840,6 +59102,7 @@
   - battery_type
   - color
   - pattern
+  - toe_stop_stem_length
   - toe_stop_stem_thread_size
   return_reasons:
   - changed_my_mind
@@ -53856,6 +59119,7 @@
   - battery_type
   - color
   - pattern
+  - toe_stop_stem_length
   - toe_stop_stem_thread_size
   return_reasons:
   - changed_my_mind
@@ -53872,6 +59136,7 @@
   - battery_type
   - color
   - pattern
+  - toe_stop_stem_length
   - toe_stop_stem_thread_size
   return_reasons:
   - changed_my_mind
@@ -53897,13 +59162,17 @@
   - footwear_color
   - footwear_material
   - footwear_pattern
+  - height
   - inline_skating_style
+  - length
   - roller_skate_brake_type
   - shell/frame_color
   - shell/frame_material
   - shell/frame_pattern
   - shoe_size
   - target_gender
+  - wheel_size
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -53924,7 +59193,9 @@
   - footwear_color
   - footwear_material
   - footwear_pattern
+  - height
   - inline_skating_style
+  - length
   - roller_skate_brake_type
   - shell/frame_color
   - shell/frame_material
@@ -53932,6 +59203,8 @@
   - shoe_size
   - target_gender
   - wheel_material
+  - wheel_size
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -53951,13 +59224,17 @@
   - footwear_color
   - footwear_material
   - footwear_pattern
+  - height
   - inline_skating_style
+  - length
   - roller_skate_brake_type
   - shell/frame_color
   - shell/frame_material
   - shell/frame_pattern
   - shoe_size
   - target_gender
+  - wheel_size
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -53980,7 +59257,9 @@
   - footwear_color
   - footwear_material
   - footwear_pattern
+  - height
   - inline_skating_style
+  - length
   - roller_skate_brake_type
   - shell/frame_color
   - shell/frame_material
@@ -53988,6 +59267,8 @@
   - shoe_size
   - skate_brake_type
   - target_gender
+  - wheel_size
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -54008,7 +59289,9 @@
   - footwear_color
   - footwear_material
   - footwear_pattern
+  - height
   - inline_skating_style
+  - length
   - roller_skate_brake_type
   - shell/frame_color
   - shell/frame_material
@@ -54016,6 +59299,8 @@
   - shoe_size
   - target_gender
   - wheel_setup_type
+  - wheel_size
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -54130,12 +59415,15 @@
   attributes:
   - age_group
   - color
+  - height
   - inline_skating_style
+  - length
   - pattern
   - rocker_type
   - roller_ski_technique
   - ski_construction
   - target_gender
+  - width
   return_reasons:
   - speed
   - length
@@ -54152,12 +59440,16 @@
   attributes:
   - age_group
   - color
+  - height
   - inline_skating_style
+  - length
   - pattern
   - rocker_type
   - roller_ski_technique
   - ski_construction
   - target_gender
+  - wheel_width
+  - width
   return_reasons:
   - length
   - weight
@@ -54174,12 +59466,15 @@
   attributes:
   - age_group
   - color
+  - height
   - inline_skating_style
+  - length
   - pattern
   - rocker_type
   - roller_ski_technique
   - ski_construction
   - target_gender
+  - width
   return_reasons:
   - speed
   - length
@@ -54196,12 +59491,15 @@
   attributes:
   - age_group
   - color
+  - height
   - inline_skating_style
+  - length
   - pattern
   - rocker_type
   - roller_ski_technique
   - ski_construction
   - target_gender
+  - width
   return_reasons:
   - speed
   - length
@@ -54219,12 +59517,15 @@
   - age_group
   - color
   - cross_country_binding_system
+  - height
   - inline_skating_style
+  - length
   - pattern
   - rocker_type
   - roller_ski_technique
   - ski_construction
   - target_gender
+  - width
   return_reasons:
   - speed
   - length
@@ -54305,7 +59606,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -54325,7 +59629,10 @@
   - sg-4-13-2-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -54342,7 +59649,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -54358,8 +59668,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - tire_compound_type
+  - width
   return_reasons:
   - size
   - not_suitable_for_terrain
@@ -54376,8 +59689,11 @@
   children: []
   attributes:
   - color
+  - height
   - kite_line_configuration
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -54459,8 +59775,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - mounting_type
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -54481,13 +59800,19 @@
   - age_group
   - badminton_set_components_included
   - color
+  - height
+  - length
   - pattern
   - racket_balance
   - racket_grip_size
   - racket_head_shape
+  - racket_head_size
+  - racket_length
   - racket_material
   - racket_weight_class
   - recommended_skill_level
+  - weight
+  - width
   return_reasons:
   - color
   - balance
@@ -54506,12 +59831,17 @@
   - age_group
   - badminton_set_components_included
   - color
+  - height
+  - length
   - pattern
   - racket_balance
   - racket_grip_size
   - racket_head_shape
+  - racket_head_size
+  - racket_length
   - racket_material
   - racket_weight_class
+  - width
   return_reasons:
   - color
   - balance
@@ -54530,14 +59860,21 @@
   - age_group
   - badminton_set_components_included
   - color
+  - height
+  - length
+  - maximum_string_tension
   - pattern
   - racket_balance
   - racket_grip_size
   - racket_head_shape
+  - racket_head_size
+  - racket_length
   - racket_material
   - racket_stringing_status
   - racket_weight_class
   - recommended_skill_level
+  - weight
+  - width
   return_reasons:
   - color
   - balance
@@ -54557,9 +59894,12 @@
   attributes:
   - color
   - feather_source
+  - height
+  - length
   - pattern
   - shuttlecock_base_material
   - shuttlecock_speed_rating
+  - width
   return_reasons:
   - color
   - speed
@@ -54577,11 +59917,14 @@
   attributes:
   - color
   - feather_source
+  - height
+  - length
   - pattern
   - shuttlecock_base_material
   - shuttlecock_feather_material
   - shuttlecock_grade
   - shuttlecock_speed_rating
+  - width
   return_reasons:
   - speed
   - flight_distance
@@ -54598,9 +59941,12 @@
   attributes:
   - color
   - feather_source
+  - height
+  - length
   - pattern
   - shuttlecock_base_material
   - shuttlecock_speed_rating
+  - width
   return_reasons:
   - color
   - speed
@@ -54703,7 +60049,10 @@
   - sg-4-14-2-6
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -54720,8 +60069,11 @@
   attributes:
   - color
   - cue_head_material
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - length
   - grip
@@ -54737,8 +60089,12 @@
   children: []
   attributes:
   - color
+  - diameter
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -54815,8 +60171,11 @@
   - sg-4-14-3-5
   attributes:
   - color
+  - height
+  - length
   - pattern
   - stability_class
+  - width
   return_reasons:
   - size
   - color
@@ -54832,8 +60191,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - stability_class
+  - width
   return_reasons:
   - size
   - color
@@ -54853,8 +60215,11 @@
   attributes:
   - chain_tier_configuration
   - color
+  - height
+  - length
   - pattern
   - stability_class
+  - width
   return_reasons:
   - size
   - color
@@ -54968,7 +60333,10 @@
   - sg-4-14-4-9
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -54985,7 +60353,10 @@
   attributes:
   - ball_surface_texture
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -55007,7 +60378,10 @@
   - board_size_classification
   - color
   - cornhole_league_certification
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -55071,10 +60445,14 @@
   name: Croquet Sets
   children: []
   attributes:
+  - ball_diameter
   - color
   - croquet_set_components_included
+  - height
+  - length
   - pattern
   - set_classification
+  - width
   return_reasons:
   - size
   - color
@@ -55090,7 +60468,12 @@
   children: []
   attributes:
   - color
+  - height
+  - horseshoe_weight
+  - length
   - pattern
+  - stake_length
+  - width
   return_reasons:
   - size
   - color
@@ -55171,8 +60554,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - paddle_equipment_included
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -55196,7 +60582,10 @@
   - sg-4-14-6-7
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -55212,8 +60601,13 @@
   children: []
   attributes:
   - color
+  - grip_circumference
+  - height
+  - length
   - paddle_shape
   - pattern
+  - weight
+  - width
   return_reasons:
   - color
   - grip
@@ -55230,8 +60624,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - pickleball_construction_type
+  - width
   return_reasons:
   - size
   - color
@@ -55318,7 +60715,10 @@
   - sg-4-14-7-6
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -55336,7 +60736,11 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
+  - paddle_grip_circumference
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -55355,7 +60759,10 @@
   - ball_size
   - ball_speed_rating
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - speed
@@ -55426,7 +60833,10 @@
   - sg-4-14-8-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -55443,7 +60853,10 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - height
@@ -55460,8 +60873,12 @@
   attributes:
   - color
   - game_variation
+  - height
+  - length
   - pattern
+  - pole_diameter
   - tetherball_equipment_included
+  - width
   return_reasons:
   - size
   - color
@@ -55481,7 +60898,10 @@
   - ball_size
   - ball_surface_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -55555,7 +60975,10 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -55577,8 +61000,14 @@
   attributes:
   - battery_size
   - battery_type
+  - charging_time
   - color
+  - distance_per_charge
+  - height
+  - length
+  - maximum_speed
   - pattern
+  - width
   return_reasons:
   - color
   - range
@@ -55594,6 +61023,7 @@
   name: Commuter E-Scooters
   children: []
   attributes:
+  - charging_time
   - color
   - features
   - pattern
@@ -55613,6 +61043,7 @@
   name: Off-Road E-Scooters
   children: []
   attributes:
+  - charging_time
   - color
   - features
   - motor_configuration
@@ -55633,6 +61064,7 @@
   name: Performance E-Scooters
   children: []
   attributes:
+  - charging_time
   - color
   - features
   - pattern
@@ -55652,6 +61084,7 @@
   name: Youth E-Scooters
   children: []
   attributes:
+  - charging_time
   - color
   - features
   - pattern
@@ -55676,9 +61109,12 @@
   - battery_type
   - color
   - features
+  - height
+  - length
   - pattern
   - range_type
   - wheel_type
+  - width
   return_reasons:
   - size
   - color
@@ -56165,7 +61601,12 @@
   - battery_size
   - battery_type
   - color
+  - length
+  - nose_size
   - pattern
+  - tail_size
+  - wheel_base
+  - width
   return_reasons:
   - color
   - length
@@ -56182,7 +61623,12 @@
   children: []
   attributes:
   - color
+  - length
+  - nose_size
   - pattern
+  - tail_size
+  - wheel_base
+  - width
   return_reasons:
   - color
   - length
@@ -56200,7 +61646,13 @@
   attributes:
   - color
   - deck_material
+  - length
+  - nose_size
   - pattern
+  - tail_size
+  - truck_axle_width
+  - wheel_base
+  - width
   return_reasons:
   - color
   - length
@@ -56218,8 +61670,13 @@
   attributes:
   - color
   - deck_flex_rating
+  - length
+  - nose_size
   - pattern
+  - tail_size
   - truck_mounting_style
+  - wheel_base
+  - width
   return_reasons:
   - color
   - length
@@ -56236,8 +61693,13 @@
   children: []
   attributes:
   - color
+  - length
   - mountainboard_truck_type
+  - nose_size
   - pattern
+  - tail_size
+  - wheel_base
+  - width
   return_reasons:
   - color
   - length
@@ -56254,7 +61716,12 @@
   children: []
   attributes:
   - color
+  - length
+  - nose_size
   - pattern
+  - tail_size
+  - wheel_base
+  - width
   return_reasons:
   - color
   - length
@@ -56271,7 +61738,12 @@
   children: []
   attributes:
   - color
+  - length
+  - nose_size
   - pattern
+  - tail_size
+  - wheel_base
+  - width
   return_reasons:
   - color
   - length
@@ -56303,8 +61775,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - rail_style
+  - width
   return_reasons:
   - length
   - height
@@ -56322,9 +61797,12 @@
   - color
   - compatible_ride_equipment
   - features
+  - height
+  - length
   - pattern
   - ramp_surface_texture
   - ramp_type
+  - width
   return_reasons:
   - size
   - color
@@ -56369,10 +61847,13 @@
   - board_type
   - color
   - deck_concave_level
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
   - truck_mounting_hole_pattern
+  - width
   - wood_finish
   return_reasons:
   - color
@@ -56400,7 +61881,10 @@
   - sg-4-16-4-2-9
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -56417,8 +61901,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -56433,7 +61920,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - height
@@ -56451,7 +61941,9 @@
   attributes:
   - color
   - grip_tape_form
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -56472,8 +61964,11 @@
   attributes:
   - bolt_drive_style
   - color
+  - height
+  - length
   - pattern
   - skateboard_nut_thread_size
+  - width
   return_reasons:
   - size
   - color
@@ -56534,8 +62029,12 @@
   children: []
   attributes:
   - color
+  - durometer_hardness_shore_a
+  - height
+  - length
   - pattern
   - pivot_piece_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -56550,7 +62049,10 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -56566,8 +62068,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - riser_pad_type
+  - width
   return_reasons:
   - height
   - incompatible
@@ -56607,13 +62112,17 @@
   name: Skateboard Trucks
   children: []
   attributes:
+  - axle_width
   - baseplate_construction
   - color
+  - height
   - kingpin_design
   - kingpin_orientation
+  - length
   - material
   - pattern
   - truck_profile
+  - width
   return_reasons:
   - size
   - color
@@ -56630,11 +62139,15 @@
   children: []
   attributes:
   - color
+  - diameter
+  - height
+  - length
   - material
   - pattern
   - skateboarding_style
   - wheel_hardness
   - wheel_hub_placement
+  - width
   return_reasons:
   - size
   - color
@@ -56676,7 +62189,10 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -56697,7 +62213,10 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -56739,9 +62258,12 @@
   - accessory_size
   - age_group
   - color
+  - height
   - impact_protection_rating
+  - length
   - pad_components_included
   - pattern
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -56924,7 +62446,10 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -56941,8 +62466,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
+  - probe_length
+  - width
   return_reasons:
   - color
   - length
@@ -56959,8 +62488,14 @@
   children: []
   attributes:
   - color
+  - height
+  - inflation_time
+  - length
   - material
+  - maximum_pressure
   - pattern
+  - volume
+  - width
   return_reasons:
   - size
   - color
@@ -57082,7 +62617,10 @@
   - sg-4-17-2-1-4
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - style
@@ -57159,7 +62697,10 @@
   attributes:
   - color
   - goggle_accessory_type
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - lens_color
@@ -57182,6 +62723,9 @@
   - eyewear_lens_pattern
   - goggle_accessory_type
   - goggle_lens_shape
+  - height
+  - length
+  - width
   return_reasons:
   - lens_color
   - incompatible
@@ -57329,6 +62873,9 @@
   - eyewear_lens_pattern
   - eyewear_lens_shape
   - goggle_features
+  - height
+  - length
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -57347,10 +62894,13 @@
   - accessory_size
   - age_group
   - color
+  - height
+  - length
   - pattern
   - snow_sports_helmet_safety_certification
   - ventilation_control_type
   - visor_configuration
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -57367,7 +62917,11 @@
   children: []
   attributes:
   - color
+  - compatible_ski_width
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - color
   - length
@@ -57383,9 +62937,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - supported_equipment_type
+  - width
   return_reasons:
   - size
   - color
@@ -57414,8 +62971,11 @@
   - sg-4-17-2-7-12
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sport
+  - width
   return_reasons:
   - size
   - grit
@@ -57431,8 +62991,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sport
+  - width
   return_reasons:
   - color
   - burn_rate
@@ -57450,8 +63013,11 @@
   - brush_format
   - brush_shape
   - color
+  - height
+  - length
   - pattern
   - sport
+  - width
   return_reasons:
   - size
   - bristles_too_coarse
@@ -57467,8 +63033,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sport
+  - width
   return_reasons:
   - size
   - grit
@@ -57486,8 +63055,11 @@
   attributes:
   - color
   - edge_tuner_type
+  - height
+  - length
   - pattern
   - sport
+  - width
   return_reasons:
   - size
   - grit
@@ -57504,10 +63076,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - p_tex_application_method
   - p_tex_form
   - pattern
   - sport
+  - width
   return_reasons:
   - color
   - thickness
@@ -57523,8 +63098,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sport
+  - width
   return_reasons:
   - size
   - grip
@@ -57541,9 +63119,13 @@
   attributes:
   - color
   - compatible_equipment
+  - height
+  - jaw_width
+  - length
   - pattern
   - sport
   - vise_configuration
+  - width
   return_reasons:
   - size
   - grip
@@ -57559,8 +63141,11 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - sport
+  - width
   return_reasons:
   - size
   - scent
@@ -57575,10 +63160,14 @@
   name: Ski & Snowboard Waxing Irons
   children: []
   attributes:
+  - base_plate_thickness
   - color
+  - height
+  - length
   - pattern
   - sport
   - temperature_control_type
+  - width
   return_reasons:
   - size
   - temperature
@@ -57643,12 +63232,15 @@
   - application_method
   - color
   - fluorocarbon_content
+  - height
+  - length
   - pattern
   - skiing_style
   - snow_condition_suitability
   - sport
   - wax_application_method
   - wax_hardness
+  - width
   return_reasons:
   - temperature_rating
   - application
@@ -57665,12 +63257,15 @@
   - application_method
   - color
   - fluorocarbon_content
+  - height
+  - length
   - pattern
   - skiing_style
   - snow_condition_suitability
   - sport
   - wax_application_method
   - wax_hardness
+  - width
   return_reasons:
   - temperature_rating
   - application
@@ -57688,6 +63283,8 @@
   - color
   - fluorocarbon_content
   - grip_wax_form
+  - height
+  - length
   - pattern
   - skiing_style
   - snow_condition_suitability
@@ -57695,6 +63292,7 @@
   - suitable_snow_conditions
   - wax_application_method
   - wax_hardness
+  - width
   return_reasons:
   - temperature_rating
   - application
@@ -57754,8 +63352,11 @@
   - sg-4-17-2-9-5
   attributes:
   - color
+  - height
+  - length
   - pattern
   - ski_binding_part_type
+  - width
   return_reasons:
   - color
   - width
@@ -57772,8 +63373,11 @@
   attributes:
   - binding_strap_position
   - color
+  - height
+  - length
   - pattern
   - ski_binding_part_type
+  - width
   return_reasons:
   - color
   - length
@@ -57856,10 +63460,14 @@
   - age_group
   - binding_mounting_system
   - boot_sole_compatibility
+  - brake_width
   - color
+  - height
+  - length
   - pattern
   - riding_style
   - ski_binding_mechanism
+  - width
   return_reasons:
   - size
   - incompatible
@@ -57876,6 +63484,7 @@
   - age_group
   - binding_mounting_system
   - boot_sole_compatibility
+  - brake_width
   - color
   - pattern
   - riding_style
@@ -57894,6 +63503,7 @@
   - age_group
   - binding_mounting_system
   - boot_sole_compatibility
+  - brake_width
   - color
   - pattern
   - riding_style
@@ -57912,6 +63522,7 @@
   - age_group
   - binding_mounting_system
   - boot_sole_compatibility
+  - brake_width
   - color
   - pattern
   - riding_style
@@ -57930,6 +63541,7 @@
   - age_group
   - binding_mounting_system
   - boot_sole_compatibility
+  - brake_width
   - color
   - pattern
   - riding_style
@@ -57952,10 +63564,14 @@
   - binding_compatibility_standard
   - color
   - fit_volume_classification
+  - height
+  - last_width
+  - length
   - pattern
   - shoe_size
   - skiing_style
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -57976,11 +63592,15 @@
   - binding_compatibility_standard
   - color
   - fit_volume_classification
+  - height
+  - last_width
+  - length
   - pattern
   - shoe_size
   - ski_boot_sole_standard
   - skiing_style
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -57999,12 +63619,17 @@
   attributes:
   - age_group
   - binding_compatibility_standard
+  - boot_last_width
   - color
   - fit_volume_classification
+  - height
+  - last_width
+  - length
   - pattern
   - shoe_size
   - skiing_style
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -58025,10 +63650,14 @@
   - binding_compatibility_standard
   - color
   - fit_volume_classification
+  - height
+  - last_width
+  - length
   - pattern
   - shoe_size
   - skiing_style
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -58047,11 +63676,15 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - material
+  - maximum_length
   - pattern
   - pole_basket_type
   - skiing_style
   - target_gender
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -58071,7 +63704,13 @@
   - sg-4-17-2-13-3
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - ski_size
+  - ski_waist_width
+  - turn_radius
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -58091,12 +63730,18 @@
   - binding_interface
   - color
   - edge_construction
+  - height
   - kick_zone_grip_system
+  - length
   - pattern
   - rocker_type
   - ski_construction
+  - ski_size
+  - ski_waist_width
   - skiing_style
   - target_gender
+  - turn_radius
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -58115,11 +63760,17 @@
   - age_group
   - binding_inclusion
   - color
+  - height
+  - length
   - pattern
   - rocker_type
   - ski_construction
+  - ski_size
+  - ski_waist_width
   - skiing_style
   - target_gender
+  - turn_radius
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -58140,8 +63791,10 @@
   - pattern
   - rocker_type
   - ski_construction
+  - ski_waist_width
   - skiing_style
   - target_gender
+  - turn_radius
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -58161,7 +63814,10 @@
   - sg-4-17-2-14-7
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -58179,8 +63835,11 @@
   - ankle_strap_padding_type
   - ankle_strap_type
   - color
+  - height
+  - length
   - pattern
   - strap_side
+  - width
   return_reasons:
   - size
   - color
@@ -58197,9 +63856,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - screw_thread_size
+  - width
   return_reasons:
   - size
   - color
@@ -58216,8 +63878,11 @@
   children: []
   attributes:
   - color
+  - height
   - highback_style
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -58292,11 +63957,14 @@
   - binding_mount
   - color
   - flexibility_rating
+  - height
+  - length
   - material
   - pattern
   - riding_style
   - shoe_binding_type
   - toe_strap_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -58357,11 +64025,14 @@
   - age_group
   - boot_liner_type
   - color
+  - height
+  - length
   - pattern
   - shoe_size
   - snowboarding_style
   - stiffness
   - target_gender
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -58383,14 +64054,20 @@
   attributes:
   - age_group
   - color
+  - effective_edge_length
+  - height
+  - length
   - pattern
   - recommended_skill_level
+  - sidecut_radius
   - snowboard_base_material
   - snowboard_construction
   - snowboard_design
+  - snowboard_size
   - snowboard_width_class
   - snowboarding_style
   - target_gender
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -58408,8 +64085,10 @@
   attributes:
   - age_group
   - color
+  - effective_edge_length
   - pattern
   - recommended_skill_level
+  - sidecut_radius
   - snowboard_base_material
   - snowboard_construction
   - snowboard_design
@@ -58429,8 +64108,10 @@
   attributes:
   - age_group
   - color
+  - effective_edge_length
   - pattern
   - recommended_skill_level
+  - sidecut_radius
   - snowboard_base_material
   - snowboard_construction
   - snowboard_design
@@ -58503,11 +64184,14 @@
   - sg-4-17-3-10
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - runner_material
   - sled_brake_type
   - sled_towing_method
+  - width
   return_reasons:
   - size
   - color
@@ -58523,11 +64207,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - runner_material
   - sled_brake_type
   - sled_towing_method
+  - width
   return_reasons:
   - size
   - color
@@ -58544,11 +64231,14 @@
   attributes:
   - color
   - handle_style
+  - height
+  - length
   - material
   - pattern
   - runner_material
   - sled_brake_type
   - sled_towing_method
+  - width
   return_reasons:
   - size
   - color
@@ -58566,11 +64256,14 @@
   - sg-4-17-3-3-2
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - runner_material
   - sled_brake_type
   - sled_towing_method
+  - width
   return_reasons:
   - size
   - color
@@ -58620,11 +64313,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - runner_material
   - sled_brake_type
   - sled_towing_method
+  - width
   return_reasons:
   - size
   - color
@@ -58640,11 +64336,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - material
   - pattern
   - runner_material
   - sled_brake_type
   - sled_towing_method
+  - width
   return_reasons:
   - size
   - color
@@ -58663,11 +64362,14 @@
   attributes:
   - brake_type
   - color
+  - height
+  - length
   - material
   - pattern
   - runner_material
   - sled_brake_type
   - sled_towing_method
+  - width
   return_reasons:
   - size
   - color
@@ -58774,7 +64476,10 @@
   - sg-4-17-4-4
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -58796,11 +64501,14 @@
   - color
   - compatible_snowshoe_deck_type
   - flexibility_rating
+  - height
+  - length
   - material
   - pattern
   - riding_style
   - shoe_binding_type
   - toe_strap_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -58818,12 +64526,16 @@
   attributes:
   - age_group
   - color
+  - height
+  - length
   - material
+  - maximum_load_capacity
   - pattern
   - shoe_binding_type
   - suitable_for_snowshoeing_activity
   - target_gender
   - terrain
+  - width
   return_reasons:
   - too_big
   - too_small

--- a/data/categories/tg_toys_games.yml
+++ b/data/categories/tg_toys_games.yml
@@ -28,12 +28,16 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - playing_time
   - recommended_age_group
   - timer_count_mode
   - timer_display_type
   - timer_features
   - toy/game_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -62,6 +66,7 @@
   attributes:
   - color
   - pattern
+  - playing_time
   - recommended_age_group
   - safety_certifications
   - toy/game_material
@@ -78,9 +83,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -101,9 +109,12 @@
   - color
   - compatible_battle_top_system
   - game_features
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -124,9 +135,12 @@
   - bingo_set_features
   - color
   - game_features
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -146,10 +160,13 @@
   - casino_set_layout_included
   - color
   - game_features
+  - height
+  - length
   - pattern
   - recommended_age_group
   - storage_case_type
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -168,10 +185,13 @@
   - chip_denomination
   - color
   - game_features
+  - height
+  - length
   - pattern
   - recommended_age_group
   - storage_case_type
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -190,10 +210,13 @@
   - color
   - craps_accessories_included
   - game_features
+  - height
+  - length
   - pattern
   - recommended_age_group
   - storage_case_type
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -209,12 +232,17 @@
   attributes:
   - board_game_features
   - board_game_mechanics
+  - board_game_set_up_time
   - board_game_theme
   - color
   - gameplay_skills
+  - height
+  - length
   - pattern
+  - playing_time
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - difficulty_level
   - changed_my_mind
@@ -231,9 +259,12 @@
   - card_game_accessory_features
   - card_sleeve_size_format_compatibility
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -250,10 +281,14 @@
   attributes:
   - color
   - condition
+  - height
+  - length
   - pattern
+  - playing_time
   - recommended_age_group
   - theme
   - toy/game_material
+  - width
   return_reasons:
   - difficulty_level
   - changed_my_mind
@@ -269,9 +304,13 @@
   - color
   - dexterity_skills
   - game_features
+  - height
+  - length
   - pattern
+  - playing_time
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -289,9 +328,13 @@
   - color
   - dice_shape
   - dice_sides
+  - height
+  - length
   - pattern
+  - playing_time
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -308,11 +351,15 @@
   - tg-2-10-1
   attributes:
   - color
+  - compatible_poker_chip_diameter
+  - height
+  - length
   - pattern
   - poker_accessory_storage_included
   - poker_chip_tray_rack_configuration
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -328,11 +375,15 @@
   attributes:
   - color
   - compatible_chip_denomination
+  - compatible_poker_chip_diameter
+  - height
+  - length
   - pattern
   - poker_accessory_storage_included
   - poker_chip_tray_rack_configuration
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - capacity
@@ -349,9 +400,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - color
   - weight
@@ -369,10 +423,14 @@
   - color
   - connectivity_technology
   - electronic_game_genre
+  - height
+  - length
   - pattern
+  - playing_time
   - portable_electronic_game_features
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - battery_life
   - video_quality
@@ -389,12 +447,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - roulette_set_components_included
   - roulette_wheel_ball_track_type
   - roulette_wheel_numbering_system
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -409,10 +470,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - slot_machine_type
   - toy/game_material
+  - width
   return_reasons:
   - size
   - too_loud
@@ -428,10 +492,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - playing_time
   - recommended_age_group
   - tile_game_type
   - toy/game_material
+  - width
   return_reasons:
   - difficulty_level
   - changed_my_mind
@@ -480,9 +548,13 @@
   attributes:
   - color
   - compatible_valve_type
+  - height
+  - length
   - pattern
   - recommended_age_group
+  - repair_patch_size
   - toy/game_material
+  - width
   return_reasons:
   - size
   - incompatible
@@ -497,10 +569,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - outdoor_equipment_features
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -516,11 +592,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - recommended_age_group
   - safety_restraint_type
   - swing_attachment_connection_type
   - toy/game_material
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -535,11 +615,16 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - outdoor_equipment_features
   - pattern
   - recommended_age_group
   - setup_type
   - toy/game_material
+  - tunnel_diameter
+  - width
   return_reasons:
   - size
   - color
@@ -555,11 +640,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - outdoor_equipment_features
   - pattern
   - playhouse_design
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -575,11 +664,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - pogo_stick_footrest_type
   - pogo_stick_suspension_type
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -598,6 +691,8 @@
   attributes:
   - color
   - furniture/fixture_material
+  - height
+  - length
   - outdoor_equipment_features
   - pattern
   - recommended_age_group
@@ -605,6 +700,7 @@
   - sandbox_drainage_type
   - sandbox_seating_type
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -621,13 +717,17 @@
   attributes:
   - battery_size
   - battery_type
+  - capacity
   - color
   - furniture/fixture_material
+  - height
+  - length
   - outdoor_equipment_features
   - pattern
   - recommended_age_group
   - sandbox_seating_type
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -644,10 +744,13 @@
   - color
   - cover_features
   - cover_material
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sandbox_seating_type
   - shape
+  - width
   return_reasons:
   - size
   - color
@@ -663,11 +766,16 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - outdoor_equipment_features
   - pattern
   - recommended_age_group
   - recommended_use_location
+  - see_saw_weight_capacity_per_seat
   - toy/game_material
+  - width
   return_reasons:
   - height
   - length
@@ -683,14 +791,20 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - outdoor_equipment_features
   - pattern
   - play_slide_design
   - recommended_age_group
+  - slide_chute_length
   - slide_installation_type
+  - slide_platform_height_compatibility
   - slide_safety_features
   - slide_water_use_capability
   - toy/game_material
+  - width
   return_reasons:
   - color
   - style
@@ -708,11 +822,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - outdoor_equipment_features
   - pattern
   - recommended_age_group
   - stilt_foot_attachment_type
   - toy/game_material
+  - width
   return_reasons:
   - height
   - weight_capacity
@@ -727,9 +845,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -746,12 +867,18 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - outdoor_equipment_features
   - pattern
   - playset_activities_included
+  - playset_deck_height
   - playset_installation_type
   - recommended_age_group
+  - required_safety_clearance
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -769,10 +896,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - shape
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -792,15 +922,20 @@
   - frame_color
   - frame_material
   - frame_pattern
+  - height
   - jumping_surface_color
   - jumping_surface_material
   - jumping_surface_pattern
+  - length
+  - maximum_load_capacity
   - outdoor_equipment_features
   - recommended_age_group
   - shape
   - trampoline_design
   - trampoline_enclosure_type
+  - trampoline_padding_thickness
   - trampoline_safety_certifications
+  - width
   return_reasons:
   - size
   - shape
@@ -819,9 +954,12 @@
   - tg-3-15-3
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -836,12 +974,17 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - play_sprinkler_mounting_type
+  - play_sprinkler_spray_coverage_diameter
   - recommended_age_group
   - sprinkler_shape
   - toy/game_material
   - water_supply_type
+  - width
   return_reasons:
   - size
   - color
@@ -859,10 +1002,14 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - recommended_age_group
   - toy/game_material
   - water_play_features
+  - width
   return_reasons:
   - size
   - color
@@ -877,13 +1024,17 @@
   name: Water Tables
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
   - water_table_feature_set
   - water_table_items_included
   - water_table_water_source_type
+  - width
   return_reasons:
   - size
   - color
@@ -906,12 +1057,18 @@
   attributes:
   - color
   - difficulty_level
+  - finished_puzzle_height
+  - finished_puzzle_length
+  - finished_puzzle_width
+  - height
+  - length
   - pattern
   - puzzle_theme
   - puzzle_type
   - recommended_age_group
   - safety_certifications
   - toy/game_material
+  - width
   return_reasons:
   - size
   - difficulty_level
@@ -927,11 +1084,16 @@
   attributes:
   - color
   - difficulty_level
+  - finished_puzzle_height
+  - finished_puzzle_length
+  - height
+  - length
   - pattern
   - puzzle_accessory_features
   - puzzle_theme
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -946,12 +1108,17 @@
   attributes:
   - color
   - difficulty_level
+  - finished_puzzle_height
+  - finished_puzzle_length
+  - height
   - jigsaw_puzzle_piece_shape
+  - length
   - pattern
   - puzzle_theme
   - puzzle_type
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - pattern
@@ -969,6 +1136,10 @@
   attributes:
   - color
   - difficulty_level
+  - finished_puzzle_height
+  - finished_puzzle_length
+  - height
+  - length
   - mechanical_puzzle_primary_mechanism
   - mechanical_puzzle_solution_format
   - pattern
@@ -976,6 +1147,7 @@
   - puzzle_type
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - difficulty_level
   - changed_my_mind
@@ -990,10 +1162,15 @@
   attributes:
   - color
   - difficulty_level
+  - finished_puzzle_height
+  - finished_puzzle_length
+  - height
+  - length
   - pattern
   - puzzle_theme
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - difficulty_level
@@ -1010,6 +1187,8 @@
   attributes:
   - color
   - difficulty_level
+  - finished_puzzle_height
+  - finished_puzzle_length
   - pattern
   - puzzle_theme
   - puzzle_type
@@ -1104,9 +1283,12 @@
   attributes:
   - ball_cup_game_included_pieces
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1122,11 +1304,15 @@
   attributes:
   - battery_size
   - battery_type
+  - bouncy_ball_bounce_height
   - bouncy_ball_surface_finish
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1141,9 +1327,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - volume
+  - width
   return_reasons:
   - consistency
   - scent
@@ -1164,9 +1354,12 @@
   - battery_type
   - bubble_toy_included_accessories
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1184,9 +1377,12 @@
   - bubble_output_rate
   - bubble_toy_included_accessories
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1207,9 +1403,12 @@
   - bubble_solution_container_type
   - bubble_toy_included_accessories
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1229,9 +1428,12 @@
   - bubble_machine_items_included
   - bubble_toy_included_accessories
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - battery_life
   - bubble_output
@@ -1248,9 +1450,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1265,10 +1470,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - marble_size
   - pattern
   - recommended_age_group
   - safety_warning
   - toy/game_material
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1285,11 +1494,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - paddle_ball_attachment_type
   - paddle_shape
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1305,9 +1517,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - color
   - length
@@ -1324,11 +1539,15 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
+  - spin_time
   - spinning_top_features
   - spinning_top_launch_mechanism
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1342,11 +1561,16 @@
   name: Toy Jacks
   children: []
   attributes:
+  - ball_diameter
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - toy_jack_size
   - toy_jacks_set_items_included
+  - width
   return_reasons:
   - size
   - color
@@ -1361,10 +1585,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   - yo_yo_accessory_part_type
+  - yo_yo_axle_length
   - yo_yo_response_system
   - yo_yo_string_material
   return_reasons:
@@ -1382,10 +1610,13 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   - wood_finish
   - yo_yo_axle_system_type
   - yo_yo_bearing_size_class
@@ -1436,14 +1667,18 @@
   attributes:
   - battery_size
   - battery_type
+  - bead_diameter
   - color
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
   - kit_tools_included
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1459,9 +1694,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - content
   - changed_my_mind
@@ -1480,10 +1718,13 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1500,9 +1741,13 @@
   - color
   - easel_art_desk_features
   - easel_art_desk_surface_type
+  - easel_art_desk_working_surface_dimensions
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1517,10 +1762,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - paint_by_number_surface_type
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - color
   - pattern
@@ -1541,10 +1789,13 @@
   - tg-5-2-6-6
   attributes:
   - color
+  - height
+  - length
   - pattern
   - play_dough_putty_kit_contents
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - color
   - texture
@@ -1562,10 +1813,13 @@
   - dough_extruder_accessories_included
   - dough_extruder_operation_type
   - dough_extruder_shape_disc_included
+  - height
+  - length
   - pattern
   - play_dough_putty_kit_contents
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - pattern
@@ -1580,6 +1834,8 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - play_dough_putty_kit_contents
   - putty_glow_activation_method
@@ -1588,6 +1844,7 @@
   - putty_texture
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - color
   - texture
@@ -1602,10 +1859,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - play_dough_putty_kit_contents
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - color
   - texture
@@ -1620,10 +1880,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - play_dough_putty_kit_contents
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - color
   - texture
@@ -1640,11 +1903,14 @@
   attributes:
   - color
   - compatible_dough_type
+  - height
+  - length
   - pattern
   - play_dough_putty_kit_contents
   - play_dough_tool_set_items_included
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1661,11 +1927,14 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - play_dough_putty_kit_contents
   - recommended_age_group
   - slime_putty_kit_components_included
   - toy/game_material
+  - width
   return_reasons:
   - color
   - texture
@@ -1681,9 +1950,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - color
   - changed_my_mind
@@ -1697,11 +1969,14 @@
   children: []
   attributes:
   - color
+  - height
   - ink_colors_included
+  - length
   - pattern
   - recommended_age_group
   - stamp_set_pieces_included
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1717,10 +1992,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - paper_opacity
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - color
   - pattern
@@ -1738,10 +2016,13 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - theme
   - toy/game_material
+  - width
   return_reasons:
   - color
   - style
@@ -1758,6 +2039,8 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
@@ -1765,6 +2048,7 @@
   - toy_drawing_tablet_erase_method
   - toy_drawing_tablet_screen_type
   - toy_drawing_tablet_writing_drawing_instrument
+  - width
   return_reasons:
   - size
   - color
@@ -1780,9 +2064,12 @@
   - tg-5-3-1
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1798,10 +2085,14 @@
   attributes:
   - ball_pit_ball_surface_finish
   - color
+  - height
+  - length
   - pattern
+  - pit_ball_size
   - recommended_age_group
   - shape
   - toy/game_material
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1818,10 +2109,13 @@
   attributes:
   - ball_pit_safety_features
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - shape
   - toy/game_material
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -1849,9 +2143,12 @@
   - bath_toy_molded_drain_design
   - bath_toy_water_play_function
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1870,9 +2167,12 @@
   - bath_toy_molded_drain_design
   - bath_toy_water_play_function
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1891,10 +2191,13 @@
   - bath_toy_molded_drain_design
   - bath_toy_water_play_function
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
   - water_exposure_protection_level
+  - width
   return_reasons:
   - size
   - battery_life
@@ -1912,9 +2215,12 @@
   - bath_toy_molded_drain_design
   - bath_toy_water_play_function
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - color
   - washability
@@ -1931,9 +2237,12 @@
   - bath_toy_molded_drain_design
   - bath_toy_water_play_function
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1951,9 +2260,12 @@
   - bath_toy_molded_drain_design
   - bath_toy_water_play_function
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1973,9 +2285,12 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -1995,9 +2310,12 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -2015,12 +2333,15 @@
   - bath_toy_molded_drain_design
   - bath_toy_water_play_function
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - rubber_ducky_character_theme
   - rubber_ducky_features
   - rubber_ducky_size_class
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -2037,9 +2358,12 @@
   - bath_toy_molded_drain_design
   - bath_toy_water_play_function
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -2056,9 +2380,12 @@
   - bath_toy_molded_drain_design
   - bath_toy_water_play_function
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -2085,10 +2412,13 @@
   - tg-5-6-11
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
   - toy_game_features
+  - width
   return_reasons:
   - size
   - color
@@ -2104,10 +2434,13 @@
   attributes:
   - beach_ball_features
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
   - toy_game_features
+  - width
   return_reasons:
   - size
   - color
@@ -2125,10 +2458,13 @@
   - beach_bucket_features
   - beach_sand_toy_items_included
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
   - toy_game_features
+  - width
   return_reasons:
   - size
   - color
@@ -2145,11 +2481,14 @@
   attributes:
   - color
   - float_raft_use_environment
+  - height
   - inflatable_raft_float_features
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
   - toy_game_features
+  - width
   return_reasons:
   - size
   - color
@@ -2165,12 +2504,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sand_water_mill_items_included
   - suitable_play_location
   - toy/game_material
   - toy_game_features
+  - width
   return_reasons:
   - size
   - color
@@ -2185,10 +2527,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
   - toy_game_features
+  - width
   return_reasons:
   - size
   - color
@@ -2204,11 +2549,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sand_cup_features
   - toy/game_material
   - toy_game_features
+  - width
   return_reasons:
   - size
   - color
@@ -2223,10 +2571,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
+  - rake_head_width
   - recommended_age_group
   - toy/game_material
   - toy_game_features
+  - width
   return_reasons:
   - size
   - color
@@ -2241,11 +2593,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sand_shovel_handle_style
   - toy/game_material
   - toy_game_features
+  - width
   return_reasons:
   - size
   - color
@@ -2260,10 +2615,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
+  - sieve_opening_size
   - toy/game_material
   - toy_game_features
+  - width
   return_reasons:
   - size
   - color
@@ -2278,11 +2637,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sand_toy_set_pieces_included
   - toy/game_material
   - toy_game_features
+  - width
   return_reasons:
   - size
   - color
@@ -2297,6 +2659,8 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
@@ -2304,6 +2668,7 @@
   - water_gun_features
   - water_gun_operating_mechanism
   - water_gun_spray_pattern
+  - width
   return_reasons:
   - size
   - color
@@ -2327,9 +2692,12 @@
   - building_toy_type
   - color
   - compatible_building_toy_system
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -2348,9 +2716,12 @@
   - color
   - compatible_construction_set_system
   - construction_set_theme
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - theme
@@ -2368,9 +2739,12 @@
   - color
   - foam_blocks_size_class
   - foam_blocks_surface_texture
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -2388,10 +2762,13 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - material
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -2409,10 +2786,13 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - marble_track_set_feature_modules
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -2429,10 +2809,13 @@
   attributes:
   - block_edge_style
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   - wood_finish
   - wooden_block_special_features
   return_reasons:
@@ -2487,11 +2870,14 @@
   - battery_type
   - color
   - dollhouse_scale
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
   - toy_figure_features
   - toy_figure_theme
+  - width
   return_reasons:
   - size
   - color
@@ -2510,10 +2896,13 @@
   - battery_type
   - color
   - dollhouse_scale
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
   - toy_figure_features
+  - width
   return_reasons:
   - size
   - color
@@ -2532,6 +2921,8 @@
   - battery_type
   - color
   - dollhouse_scale
+  - height
+  - length
   - lumber/wood_type
   - material
   - pattern
@@ -2539,6 +2930,7 @@
   - toy/game_material
   - toy_figure_features
   - toy_figure_sound_feature
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2558,12 +2950,15 @@
   - bobble_mechanism
   - color
   - dollhouse_scale
+  - height
+  - length
   - packaging_type
   - pattern
   - recommended_age_group
   - toy/game_material
   - toy_figure_features
   - toy_figure_theme
+  - width
   return_reasons:
   - size
   - color
@@ -2585,12 +2980,15 @@
   - doll_accessory_type
   - dollhouse_scale
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - lumber/wood_type
   - pattern
   - recommended_age_group
   - toy/game_material
   - toy_figure_features
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2612,10 +3010,13 @@
   - color
   - dollhouse_room_type
   - dollhouse_scale
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -2640,10 +3041,13 @@
   - dollhouse_lighting_type
   - dollhouse_scale
   - dollhouse_style_theme
+  - height
+  - length
   - material
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -2664,11 +3068,15 @@
   - doll_eye_type
   - doll_features
   - doll_hair_fiber_type
+  - doll_size
   - doll_type
   - dollhouse_scale
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -2686,14 +3094,18 @@
   attributes:
   - color
   - doll_features
+  - doll_size
   - doll_type
   - dollhouse_scale
+  - height
+  - length
   - outfit_attachment_mechanism
   - paper_and_magnetic_doll_format
   - paper_magnetic_doll_set_contents
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -2713,10 +3125,13 @@
   attributes:
   - color
   - dollhouse_scale
+  - height
+  - length
   - pattern
   - puppet_puppet_theater_accessory_type
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -2766,10 +3181,13 @@
   attributes:
   - color
   - dollhouse_scale
+  - height
+  - length
   - pattern
   - puppet_theme
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -2785,12 +3203,16 @@
   attributes:
   - color
   - dollhouse_scale
+  - height
+  - length
   - pattern
   - puppet_features
+  - puppet_size
   - puppet_theme
   - puppet_type
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -2809,10 +3231,14 @@
   - battery_type
   - color
   - dollhouse_scale
+  - height
+  - length
   - pattern
   - recommended_age_group
   - stuffed_animal_features
+  - stuffed_animal_size
   - toy/game_material
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -2844,12 +3270,15 @@
   - battery_type
   - color
   - dollhouse_scale
+  - height
+  - length
   - pattern
   - playset_features
   - recommended_age_group
   - toy/game_material
   - toy_playset_assembly_required
   - toy_playset_items_included
+  - width
   return_reasons:
   - size
   - color
@@ -2867,12 +3296,15 @@
   - battery_type
   - color
   - dollhouse_scale
+  - height
+  - length
   - pattern
   - playset_features
   - recommended_age_group
   - toy/game_material
   - toy_playset_assembly_required
   - toy_playset_items_included
+  - width
   return_reasons:
   - size
   - color
@@ -2893,12 +3325,15 @@
   - color
   - compatible_toy_vehicle_scale
   - dollhouse_scale
+  - height
+  - length
   - pattern
   - playset_features
   - recommended_age_group
   - toy/game_material
   - toy_playset_assembly_required
   - toy_playset_items_included
+  - width
   return_reasons:
   - size
   - color
@@ -2915,12 +3350,15 @@
   - castle_playset_included_items
   - color
   - dollhouse_scale
+  - height
+  - length
   - pattern
   - playset_features
   - recommended_age_group
   - toy/game_material
   - toy_playset_assembly_required
   - toy_playset_items_included
+  - width
   return_reasons:
   - size
   - color
@@ -2940,6 +3378,8 @@
   - dinosaur_playset_scale_figure_size_class
   - dinosaur_species_included
   - dollhouse_scale
+  - height
+  - length
   - material
   - pattern
   - playset_features
@@ -2947,6 +3387,7 @@
   - toy/game_material
   - toy_playset_assembly_required
   - toy_playset_items_included
+  - width
   return_reasons:
   - size
   - color
@@ -2967,12 +3408,15 @@
   - doctor_playset_role_play_setting
   - doctor_playset_wearable_items_included
   - dollhouse_scale
+  - height
+  - length
   - pattern
   - playset_features
   - recommended_age_group
   - toy/game_material
   - toy_playset_assembly_required
   - toy_playset_items_included
+  - width
   return_reasons:
   - size
   - color
@@ -2989,12 +3433,15 @@
   - color
   - dollhouse_scale
   - electronic_lights_and_sound
+  - height
+  - length
   - pattern
   - playset_features
   - recommended_age_group
   - toy/game_material
   - toy_playset_assembly_required
   - toy_playset_items_included
+  - width
   return_reasons:
   - size
   - color
@@ -3012,12 +3459,15 @@
   attributes:
   - color
   - dollhouse_scale
+  - height
+  - length
   - pattern
   - playset_features
   - recommended_age_group
   - toy/game_material
   - toy_playset_assembly_required
   - toy_playset_items_included
+  - width
   return_reasons:
   - size
   - color
@@ -3031,18 +3481,23 @@
   name: Kitchen Playsets
   children: []
   attributes:
+  - assembled_toy_kitchen_dimensions
   - color
   - dollhouse_scale
+  - height
   - interactive_effects
+  - length
   - pattern
   - play_food_items_included
   - playset_features
   - recommended_age_group
   - toy/game_material
   - toy_kitchen_appliances_included
+  - toy_kitchen_counter_height
   - toy_playset_assembly_required
   - toy_playset_items_included
   - toy_tableware_pieces_included
+  - width
   return_reasons:
   - size
   - color
@@ -3058,6 +3513,8 @@
   attributes:
   - color
   - dollhouse_scale
+  - height
+  - length
   - pattern
   - playset_features
   - playset_items_included
@@ -3065,6 +3522,7 @@
   - toy/game_material
   - toy_playset_assembly_required
   - toy_playset_items_included
+  - width
   return_reasons:
   - size
   - color
@@ -3172,10 +3630,13 @@
   - ant_farm_lighting_type
   - color
   - educational_topic
+  - height
+  - length
   - observation_window_material
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -3196,9 +3657,12 @@
   - tg-5-9-2-7
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -3214,9 +3678,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - difficulty_level
@@ -3232,9 +3699,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -3249,11 +3719,15 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - planetarium_content_theme
   - planetarium_projection_content_format
+  - projection_coverage_area
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - brightness
   - too_loud
@@ -3269,12 +3743,15 @@
   attributes:
   - color
   - educational_guide_included
+  - height
+  - length
   - pattern
   - recommended_age_group
   - rotation_motion_features
   - solar_system_model_included_bodies
   - solar_system_model_scaling
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -3290,12 +3767,15 @@
   children: []
   attributes:
   - color
+  - height
   - hemisphere_compatibility
+  - length
   - map_coverage_sky_planet_body
   - map_size_sheet
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -3311,9 +3791,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - magnification
@@ -3331,9 +3814,12 @@
   attributes:
   - bug_collecting_kit_items_included
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -3351,9 +3837,12 @@
   - color
   - flash_card_included_features
   - flash_card_theme
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - theme
@@ -3371,12 +3860,15 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - phonics_focus
   - reading_toy_type
   - recommended_age_group
   - recommended_reading_level
   - toy/game_material
+  - width
   return_reasons:
   - difficulty_level
   - changed_my_mind
@@ -3393,9 +3885,12 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - too_complex
   - too_simple
@@ -3411,9 +3906,12 @@
   attributes:
   - abacus_bead_material
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -3459,9 +3957,12 @@
   - tg-5-10-2
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -3476,12 +3977,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - magnet_toy_storage_included
   - pattern
   - play_pattern
   - recommended_age_group
   - toy/game_material
   - toy_safety_certification
+  - width
   return_reasons:
   - size
   - color
@@ -3496,9 +4000,14 @@
   children: []
   attributes:
   - color
+  - height
+  - kite_line_length
+  - kite_line_strength_rating
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -3520,9 +4029,12 @@
   - tg-5-12-10
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -3539,9 +4051,12 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - battery_life
   - range
@@ -3556,9 +4071,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -3574,10 +4092,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - model_aircraft_assembly_level
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
+  - wingspan
   return_reasons:
   - size
   - color
@@ -3595,12 +4117,16 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - model_rocket_motor_mount_size
+  - model_rocket_predicted_maximum_altitude
   - model_rocket_recovery_system_type
   - model_rocket_staging
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -3620,10 +4146,13 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
   - toy_glider_launch_method
+  - width
   return_reasons:
   - size
   - color
@@ -3677,9 +4206,12 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -3696,10 +4228,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - toy_parachute_canopy_diameter
   - toy_parachute_launch_method
+  - width
   return_reasons:
   - size
   - color
@@ -3718,9 +4254,13 @@
   - air_water_rocket_kit_items_included
   - air_water_rocket_launch_method
   - color
+  - height
+  - length
+  - maximum_launch_height
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -3747,10 +4287,13 @@
   - tg-5-13-15
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - too_loud
   - sound_quality
@@ -3765,10 +4308,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - sound_quality
   - too_loud
@@ -3784,11 +4330,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - percussion_instruments_included
   - power_source
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -3805,12 +4354,15 @@
   children: []
   attributes:
   - color
+  - height
   - interaction_mode
+  - length
   - pattern
   - power_source
   - recommended_age_group
   - sound_type
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -3830,6 +4382,8 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - lyrics_display_type
   - microphone_type
   - pattern
@@ -3837,6 +4391,7 @@
   - recommended_age_group
   - toy/game_material
   - voice_effects
+  - width
   return_reasons:
   - sound_quality
   - connectivity
@@ -3853,11 +4408,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - microphone_toy_feature_set
   - pattern
   - power_source
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - sound_quality
   - too_loud
@@ -3874,10 +4432,13 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - power_source
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - sound_quality
   - too_loud
@@ -3894,11 +4455,14 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - musical_box_mechanism_type
   - pattern
   - power_source
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - color
   - sound_quality
@@ -3916,6 +4480,8 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - power_source
@@ -3924,6 +4490,7 @@
   - toy_keyboard_learning_mode
   - toy_keyboard_sound_theme
   - toy_piano_and_keyboard_accessories_included
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -3946,10 +4513,13 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - power_source
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -4018,10 +4588,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -4038,10 +4611,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - color
   - sound_quality
@@ -4059,9 +4635,12 @@
   - color
   - compatible_play_vehicle_scale
   - compatible_play_vehicle_type
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -4086,12 +4665,15 @@
   - tg-5-15-9
   attributes:
   - color
+  - height
+  - length
   - pattern
   - play_vehicle_propulsion
   - play_vehicle_scale
   - recommended_age_group
   - remote_technology
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -4108,6 +4690,8 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - play_vehicle_propulsion
   - play_vehicle_scale
@@ -4117,6 +4701,7 @@
   - toy_airplane_control_type
   - toy_airplane_features
   - toy_airplane_flight_capability
+  - width
   return_reasons:
   - size
   - color
@@ -4131,6 +4716,8 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - play_vehicle_propulsion
   - play_vehicle_scale
@@ -4139,6 +4726,7 @@
   - toy/game_material
   - toy_boat_play_features
   - toy_boat_recommended_play_environment
+  - width
   return_reasons:
   - size
   - color
@@ -4155,6 +4743,8 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - material
   - pattern
   - play_vehicle_propulsion
@@ -4163,6 +4753,7 @@
   - remote_technology
   - toy/game_material
   - toy_car_features
+  - width
   return_reasons:
   - size
   - color
@@ -4177,6 +4768,8 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - play_vehicle_propulsion
   - play_vehicle_scale
@@ -4185,6 +4778,7 @@
   - toy/game_material
   - toy_helicopter_control_type
   - toy_helicopter_features
+  - width
   return_reasons:
   - size
   - color
@@ -4201,6 +4795,8 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - play_vehicle_propulsion
   - play_vehicle_scale
@@ -4209,6 +4805,7 @@
   - toy/game_material
   - toy_motorcycle_feature_set
   - toy_motorcycle_scale
+  - width
   return_reasons:
   - size
   - color
@@ -4222,9 +4819,12 @@
   name: Toy Race Car & Track Sets
   children: []
   attributes:
+  - assembled_track_length
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - play_vehicle_propulsion
   - play_vehicle_scale
@@ -4232,6 +4832,7 @@
   - remote_technology
   - toy/game_material
   - track_set_special_features
+  - width
   return_reasons:
   - size
   - color
@@ -4249,6 +4850,8 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - play_vehicle_propulsion
   - play_vehicle_scale
@@ -4257,6 +4860,7 @@
   - toy/game_material
   - toy_spaceship_features
   - toy_spaceship_size_class
+  - width
   return_reasons:
   - size
   - color
@@ -4273,6 +4877,8 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - play_vehicle_propulsion
   - play_vehicle_scale
@@ -4281,6 +4887,7 @@
   - toy/game_material
   - toy_train_scale
   - toy_train_track_layout_type
+  - width
   return_reasons:
   - size
   - color
@@ -4298,6 +4905,8 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - play_vehicle_lights_and_sounds
   - play_vehicle_propulsion
@@ -4305,6 +4914,7 @@
   - recommended_age_group
   - remote_technology
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -4354,6 +4964,8 @@
   - battery_type
   - color
   - electronic_features
+  - height
+  - length
   - pattern
   - play_money_set_components_included
   - pretend_play_electronic_features
@@ -4361,6 +4973,7 @@
   - pretend_play_set_theme
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -4466,6 +5079,8 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - pretend_electronics_toy_type
   - pretend_play_electronic_features
@@ -4474,6 +5089,7 @@
   - recommended_age_group
   - toy/game_material
   - toy_audio_features
+  - width
   return_reasons:
   - size
   - color
@@ -4490,6 +5106,8 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - pretend_housekeeping_set_items_included
   - pretend_housekeeping_toy_type
@@ -4498,6 +5116,7 @@
   - pretend_play_set_theme
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -4512,12 +5131,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - pretend_play_electronic_features
   - pretend_play_set_pieces_included
   - pretend_play_set_theme
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -4534,12 +5156,15 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - pretend_play_electronic_features
   - pretend_play_set_pieces_included
   - pretend_play_set_theme
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -4554,12 +5179,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - pretend_play_electronic_features
   - pretend_play_set_pieces_included
   - pretend_play_set_theme
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -4578,6 +5206,8 @@
   - tg-5-16-7-4
   attributes:
   - color
+  - height
+  - length
   - pattern
   - pretend_play_electronic_features
   - pretend_play_set_pieces_included
@@ -4586,6 +5216,7 @@
   - toy/game_material
   - toy_kitchen_assembly_requirement
   - toy_kitchen_interactive_features
+  - width
   return_reasons:
   - size
   - color
@@ -4600,6 +5231,8 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - play_food_features
   - play_food_size_scale
@@ -4610,6 +5243,7 @@
   - toy/game_material
   - toy_kitchen_assembly_requirement
   - toy_kitchen_interactive_features
+  - width
   return_reasons:
   - size
   - color
@@ -4624,6 +5258,8 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - pretend_play_electronic_features
   - pretend_play_set_pieces_included
@@ -4632,6 +5268,7 @@
   - toy/game_material
   - toy_kitchen_assembly_requirement
   - toy_kitchen_interactive_features
+  - width
   return_reasons:
   - size
   - color
@@ -4649,6 +5286,8 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - lumber/wood_type
   - pattern
   - pretend_play_electronic_features
@@ -4658,6 +5297,7 @@
   - toy/game_material
   - toy_kitchen_assembly_requirement
   - toy_kitchen_interactive_features
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -4673,6 +5313,8 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - pretend_play_electronic_features
   - pretend_play_set_pieces_included
@@ -4681,6 +5323,7 @@
   - toy/game_material
   - toy_kitchen_assembly_requirement
   - toy_kitchen_interactive_features
+  - width
   return_reasons:
   - size
   - color
@@ -4697,6 +5340,8 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - pretend_play_electronic_features
   - pretend_play_set_pieces_included
@@ -4706,6 +5351,7 @@
   - toy_tool_electronic_features
   - toy_tool_set_components_included
   - toy_tool_type
+  - width
   return_reasons:
   - size
   - color
@@ -4721,9 +5367,12 @@
   attributes:
   - color
   - compatible_rc_scale
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -4747,11 +5396,16 @@
   - tg-5-18-8
   attributes:
   - color
+  - height
+  - length
+  - maximum_battery_life
   - pattern
   - recommended_age_group
+  - signal_range
   - skill_level
   - suitable_space
   - toy/game_material
+  - width
   return_reasons:
   - battery_life
   - range
@@ -4767,13 +5421,18 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_battery_life
   - pattern
   - rc_airship_lifting_gas_type
   - recommended_age_group
   - remote_control_airship_envelope_material
+  - signal_range
   - skill_level
   - suitable_space
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -4792,14 +5451,19 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
+  - maximum_battery_life
   - pattern
   - recommended_age_group
   - remote_control_watercraft_features
   - remote_control_watercraft_propulsion_drive_type
   - remote_control_watercraft_water_environment
+  - signal_range
   - skill_level
   - suitable_space
   - toy/game_material
+  - width
   return_reasons:
   - size
   - battery_life
@@ -4818,14 +5482,19 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
+  - maximum_battery_life
   - pattern
   - rc_vehicle_controller_type
   - rc_vehicle_scale
   - rc_vehicle_terrain_type
   - recommended_age_group
+  - signal_range
   - skill_level
   - suitable_space
   - toy/game_material
+  - width
   return_reasons:
   - size
   - battery_life
@@ -4844,14 +5513,19 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
+  - maximum_battery_life
   - pattern
   - rc_helicopter_control_frequency
   - rc_helicopter_stabilization_features
   - recommended_age_group
   - rotor_configuration_type
+  - signal_range
   - skill_level
   - suitable_space
   - toy/game_material
+  - width
   return_reasons:
   - size
   - battery_life
@@ -4868,15 +5542,20 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_battery_life
   - pattern
   - rc_motorcycle_controller_type
   - recommended_age_group
   - remote_control_motorcycle_scale
   - remote_control_motorcycle_terrain_suitability
   - remote_control_motorcycle_water_resistance
+  - signal_range
   - skill_level
   - suitable_space
   - toy/game_material
+  - width
   return_reasons:
   - color
   - battery_life
@@ -4895,15 +5574,20 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
+  - maximum_battery_life
   - pattern
   - rc_plane_takeoff_launch_method
   - recommended_age_group
   - remote_control_plane_kit_completion_level
   - remote_control_plane_landing_gear_type
   - remote_control_plane_power_type
+  - signal_range
   - skill_level
   - suitable_space
   - toy/game_material
+  - width
   return_reasons:
   - color
   - battery_life
@@ -4922,11 +5606,16 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
+  - maximum_battery_life
   - pattern
   - recommended_age_group
+  - signal_range
   - skill_level
   - suitable_space
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -4943,11 +5632,16 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_battery_life
   - pattern
   - recommended_age_group
+  - signal_range
   - skill_level
   - suitable_space
   - toy/game_material
+  - width
   return_reasons:
   - size
   - battery_life
@@ -4964,9 +5658,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -4987,11 +5684,15 @@
   - tg-5-20-5
   attributes:
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - recommended_age_group
   - riding_toy_features
   - riding_toy_propulsion_type
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5006,15 +5707,22 @@
   name: Electric Riding Vehicles
   children: []
   attributes:
+  - amperage
   - battery_size
   - battery_type
   - color
   - electric_riding_vehicle_control_options
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
+  - power_consumption_typical
   - recommended_age_group
   - riding_toy_features
   - riding_toy_propulsion_type
   - toy/game_material
+  - voltage
+  - width
   return_reasons:
   - color
   - battery_life
@@ -5031,13 +5739,17 @@
   children: []
   attributes:
   - color
+  - height
   - hobby_horse_handle_type
   - hobby_horse_sound_features
+  - length
+  - maximum_load_capacity
   - pattern
   - recommended_age_group
   - riding_toy_features
   - riding_toy_propulsion_type
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5054,11 +5766,15 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - recommended_age_group
   - riding_toy_features
   - riding_toy_propulsion_type
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5075,11 +5791,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - recommended_age_group
   - riding_toy_features
   - riding_toy_propulsion_type
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5095,11 +5815,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
+  - maximum_load_capacity
   - pattern
   - recommended_age_group
   - riding_toy_features
   - riding_toy_propulsion_type
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5116,8 +5840,11 @@
   name: Robotic Toys
   children: []
   attributes:
+  - charging_time
   - color
+  - height
   - included_accessories
+  - length
   - pattern
   - recommended_age_group
   - robotic_toy_interaction_mode
@@ -5126,6 +5853,7 @@
   - robotic_toy_skill_level
   - robotic_toy_sound_features
   - toy/game_material
+  - width
   return_reasons:
   - color
   - battery_life
@@ -5142,9 +5870,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5195,10 +5926,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5215,10 +5949,13 @@
   attributes:
   - baseball_toy_set_components_included
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5240,11 +5977,14 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5259,10 +5999,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - width
   - wing_count
   return_reasons:
   - color
@@ -5278,13 +6021,17 @@
   name: Bowling Toys
   children: []
   attributes:
+  - bowling_pin_height
   - color
+  - height
   - indoor_outdoor_use
+  - length
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
   - toy_bowling_equipment_included
+  - width
   return_reasons:
   - size
   - color
@@ -5303,11 +6050,17 @@
   - battery_type
   - color
   - fingerboard_bearing_type
+  - fingerboard_deck_length
+  - fingerboard_deck_width
   - fingerboard_grip_type
+  - fingerboard_truck_width
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5323,10 +6076,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5350,11 +6106,14 @@
   - color
   - construction
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5370,12 +6129,15 @@
   children: []
   attributes:
   - color
+  - height
   - hula_hoop_construction_type
   - hula_hoop_features
+  - length
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5394,12 +6156,16 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - jump_rope_size
   - jump_rope_style
+  - length
   - length_adjustment_method
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - width
   return_reasons:
   - too_long
   - too_short
@@ -5416,10 +6182,15 @@
   children: []
   attributes:
   - color
+  - exercise_ball_maximum_user_weight
+  - exercise_ball_size
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -5435,10 +6206,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5455,10 +6229,14 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - trampoline_size
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -5478,10 +6256,13 @@
   - battery_type
   - color
   - flying_disc_feature_set
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5499,10 +6280,13 @@
   attributes:
   - color
   - footbag_play_style
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5518,10 +6302,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - width
   return_reasons:
   - color
   - length
@@ -5537,10 +6324,13 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5559,10 +6349,13 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5578,12 +6371,15 @@
   children: []
   attributes:
   - color
+  - height
   - impact_surface_material
+  - length
   - pattern
   - racquet_toy_set_equipment_included
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5633,10 +6429,13 @@
   attributes:
   - color
   - gift_message_option
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
   - toy_gift_basket_items_included
+  - width
   return_reasons:
   - size
   - color
@@ -5651,9 +6450,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   return_reasons:
   - size
   - color
@@ -5672,11 +6474,15 @@
   - tg-5-26-3
   attributes:
   - color
+  - height
+  - length
+  - maximum_range
   - pattern
   - projectile_ammunition_type
   - recommended_age_group
   - toy/game_material
   - toy_weapon_gadget_features
+  - width
   return_reasons:
   - size
   - color
@@ -5693,6 +6499,7 @@
   children: []
   attributes:
   - color
+  - maximum_range
   - pattern
   - projectile_ammunition_type
   - recommended_age_group
@@ -5710,6 +6517,7 @@
   children: []
   attributes:
   - color
+  - maximum_range
   - pattern
   - projectile_ammunition_type
   - recommended_age_group
@@ -5727,6 +6535,7 @@
   children: []
   attributes:
   - color
+  - maximum_range
   - pattern
   - projectile_ammunition_type
   - recommended_age_group
@@ -5748,10 +6557,14 @@
   - tg-5-27-4
   attributes:
   - color
+  - height
+  - length
   - optical_toy_features
   - pattern
   - recommended_age_group
   - toy/game_material
+  - toy_dimensions
+  - width
   return_reasons:
   - size
   - color
@@ -5767,11 +6580,15 @@
   children: []
   attributes:
   - color
+  - height
   - kaleidoscope_viewing_type
+  - length
   - optical_toy_features
   - pattern
   - recommended_age_group
   - toy/game_material
+  - toy_dimensions
+  - width
   return_reasons:
   - color
   - pattern
@@ -5787,11 +6604,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - optical_toy_features
   - pattern
   - prism_material
   - recommended_age_group
   - toy/game_material
+  - toy_dimensions
+  - width
   return_reasons:
   - size
   - color
@@ -5811,6 +6632,7 @@
   - pattern
   - recommended_age_group
   - toy/game_material
+  - toy_dimensions
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -5827,6 +6649,7 @@
   - pattern
   - recommended_age_group
   - toy/game_material
+  - toy_dimensions
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -5839,9 +6662,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - recommended_age_group
   - toy/game_material
+  - width
   - wind_up_mechanism_type
   - wind_up_toy_movement_pattern
   return_reasons:
@@ -5864,6 +6690,7 @@
   - sensory_modality
   - sensory_toy_fidget_mechanism
   - sensory_toy_light_features
+  - sensory_toy_size
   - sensory_toy_texture_type
   - toy/game_material
   return_reasons:

--- a/data/categories/vp_vehicles_parts.yml
+++ b/data/categories/vp_vehicles_parts.yml
@@ -50,7 +50,10 @@
   - aircraft_system_application
   - airworthiness_approval_basis
   - compatible_aircraft_type
+  - height
+  - length
   - part_condition
+  - width
   return_reasons:
   - size
   - incompatible
@@ -88,8 +91,11 @@
   attributes:
   - battery_management_features
   - compatible_battery_technology
+  - height
   - item_condition
+  - length
   - manufacturer_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -103,11 +109,16 @@
   name: Charging Cables
   children: []
   attributes:
+  - cable_length
   - charging_cable_type
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - power_rating
+  - width
   return_reasons:
   - size
   - incompatible
@@ -123,11 +134,15 @@
   attributes:
   - charging_level
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - phase_type
+  - power_output_typical
   - station_type
+  - width
   return_reasons:
   - size
   - power_output
@@ -145,9 +160,13 @@
   - color
   - ev_connector/adapter_type
   - ev_connector_adapter_direction
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - power_output_typical
+  - width
   return_reasons:
   - size
   - incompatible
@@ -170,9 +189,14 @@
   - ev_conversion_kit_components
   - ev_conversion_kit_drivetrain_configuration
   - ev_conversion_kit_voltage_class
+  - height
   - installation_fabrication_level
   - item_condition
+  - length
   - manufacturer_type
+  - power
+  - voltage
+  - width
   return_reasons:
   - size
   - incompatible
@@ -191,9 +215,14 @@
   - ev_conversion_kit_components
   - ev_conversion_kit_drivetrain_configuration
   - ev_conversion_kit_voltage_class
+  - height
   - installation_fabrication_level
   - item_condition
+  - length
   - manufacturer_type
+  - power
+  - voltage
+  - width
   return_reasons:
   - size
   - range
@@ -212,9 +241,14 @@
   - ev_conversion_kit_components
   - ev_conversion_kit_drivetrain_configuration
   - ev_conversion_kit_voltage_class
+  - height
   - installation_fabrication_level
   - item_condition
+  - length
   - manufacturer_type
+  - power
+  - voltage
+  - width
   return_reasons:
   - size
   - range
@@ -234,11 +268,16 @@
   - ev_conversion_kit_components
   - ev_conversion_kit_drivetrain_configuration
   - ev_conversion_kit_voltage_class
+  - height
   - installation_fabrication_level
   - item_condition
+  - length
   - manufacturer_type
   - motor_mounting_configuration
+  - power
   - throttle_type_scooter_conversion
+  - voltage
+  - width
   return_reasons:
   - size
   - range
@@ -259,9 +298,14 @@
   - ev_conversion_kit_components
   - ev_conversion_kit_drivetrain_configuration
   - ev_conversion_kit_voltage_class
+  - height
   - installation_fabrication_level
   - item_condition
+  - length
   - manufacturer_type
+  - power
+  - voltage
+  - width
   return_reasons:
   - size
   - range
@@ -280,9 +324,14 @@
   - ev_conversion_kit_components
   - ev_conversion_kit_drivetrain_configuration
   - ev_conversion_kit_voltage_class
+  - height
   - installation_fabrication_level
   - item_condition
+  - length
   - manufacturer_type
+  - power
+  - voltage
+  - width
   return_reasons:
   - size
   - range
@@ -300,13 +349,20 @@
   - vp-1-2-6-2
   - vp-1-2-6-3
   attributes:
+  - amperage
+  - battery_pack_operating_voltage_nominal
   - battery_size
   - battery_type
   - battery_voltage_class
   - ev_battery_features
   - ev_battery_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
+  - power_consumption_typical
+  - voltage
+  - width
   return_reasons:
   - size
   - capacity
@@ -321,6 +377,7 @@
   name: EV Battery Cells
   children: []
   attributes:
+  - battery_pack_operating_voltage_nominal
   - battery_size
   - battery_type
   - battery_voltage_class
@@ -339,6 +396,7 @@
   name: EV Battery Packs
   children: []
   attributes:
+  - battery_pack_operating_voltage_nominal
   - battery_size
   - battery_type
   - battery_voltage_class
@@ -357,6 +415,7 @@
   name: EV Battery Modules
   children: []
   attributes:
+  - battery_pack_operating_voltage_nominal
   - battery_size
   - battery_type
   - battery_voltage_class
@@ -376,10 +435,14 @@
   children: []
   attributes:
   - color
+  - height
   - inverter_type
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - voltage
+  - width
   return_reasons:
   - size
   - inverter_type
@@ -409,11 +472,14 @@
   - care_instructions
   - carry_options
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - protective_case_interior_protection_type
   - protective_case_shell_type
+  - width
   return_reasons:
   - size
   - style
@@ -429,6 +495,9 @@
   children: []
   attributes:
   - accessory_size
+  - adapter_case_interior_height
+  - adapter_case_interior_length
+  - adapter_case_interior_width
   - bag/case_closure
   - bag/case_features
   - bag/case_material
@@ -436,11 +505,14 @@
   - care_instructions
   - carry_options
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - protective_case_interior_protection_type
   - protective_case_shell_type
+  - width
   return_reasons:
   - size
   - style
@@ -465,11 +537,14 @@
   - care_instructions
   - carry_options
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - protective_case_interior_protection_type
   - protective_case_shell_type
+  - width
   return_reasons:
   - size
   - style
@@ -492,11 +567,14 @@
   - care_instructions
   - carry_options
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - protective_case_interior_protection_type
   - protective_case_shell_type
+  - width
   return_reasons:
   - size
   - style
@@ -518,12 +596,17 @@
   - care_instructions
   - carry_options
   - color
+  - connector_case_internal_dimensions
   - connector_case_style
+  - height
   - item_condition
+  - length
   - manufacturer_type
+  - maximum_cable_length_supported
   - pattern
   - protective_case_interior_protection_type
   - protective_case_shell_type
+  - width
   return_reasons:
   - size
   - style
@@ -546,12 +629,15 @@
   - care_instructions
   - carry_options
   - color
+  - height
   - interior_padding_type
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - protective_case_interior_protection_type
   - protective_case_shell_type
+  - width
   return_reasons:
   - size
   - style
@@ -574,12 +660,15 @@
   - care_instructions
   - carry_options
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - protective_case_interior_protection_type
   - protective_case_shell_type
   - tool_case_form_factor
+  - width
   return_reasons:
   - size
   - style
@@ -594,11 +683,14 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - regenerative_braking_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -644,12 +736,15 @@
   - battery_type
   - color
   - compatible_operating_system
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - motor_vehicle_a_v_integration_features
   - pattern
   - player/recorder_specialized_features
   - power_source
+  - width
   return_reasons:
   - size
   - incompatible
@@ -665,12 +760,17 @@
   attributes:
   - amplifier_class
   - amplifier_configuration
+  - amplifier_fuse_rating
   - color
   - crossover_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - power_output_typical
   - power_source
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -688,10 +788,13 @@
   - color
   - compatible_player
   - faceplate_design
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - length
   - sound_quality
@@ -711,10 +814,13 @@
   attributes:
   - color
   - faceplate_design
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -731,10 +837,13 @@
   - color
   - faceplate_design
   - faceplate_security_features
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -751,10 +860,13 @@
   - cassette_deck_feature_set
   - color
   - faceplate_design
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -770,10 +882,13 @@
   attributes:
   - color
   - faceplate_design
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - power_source
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -794,11 +909,14 @@
   attributes:
   - color
   - connectivity_technology
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - power_source
   - vehicle_audio_system_features
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -814,11 +932,14 @@
   attributes:
   - color
   - connectivity_technology
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - power_source
   - vehicle_audio_system_features
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -834,12 +955,15 @@
   attributes:
   - color
   - connectivity_technology
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - power_source
   - vehicle_audio_dsp_form_factor
   - vehicle_audio_system_features
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -855,12 +979,16 @@
   attributes:
   - color
   - connectivity_technology
+  - height
   - item_condition
+  - length
   - manufacturer_type
+  - maximum_preamp_output_voltage
   - mounting_location
   - pattern
   - power_source
   - vehicle_audio_system_features
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -877,11 +1005,15 @@
   - audio_channel_configuration
   - color
   - connectivity_technology
+  - height
   - item_condition
+  - length
   - manufacturer_type
+  - maximum_boost_and_cut_per_band
   - pattern
   - power_source
   - vehicle_audio_system_features
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -899,11 +1031,14 @@
   - connectivity_technology
   - crossover_component_type
   - crossover_configuration
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - power_source
   - vehicle_audio_system_features
+  - width
   return_reasons:
   - sound_quality
   - incompatible
@@ -920,7 +1055,9 @@
   - vp-1-3-6-2
   attributes:
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - parking_camera_features
   - parking_camera_mounting_location
@@ -929,6 +1066,7 @@
   - pattern
   - power_source
   - video_signal_standard
+  - width
   return_reasons:
   - field_of_view
   - installation
@@ -945,7 +1083,9 @@
   attributes:
   - camera_mounting_location_vehicle_exterior
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - parking_camera_features
   - parking_camera_mounting_location
@@ -954,6 +1094,7 @@
   - pattern
   - power_source
   - video_signal_standard
+  - width
   return_reasons:
   - field_of_view
   - installation
@@ -968,10 +1109,13 @@
   name: Backup Cameras
   children: []
   attributes:
+  - backup_camera_minimum_illumination
   - backup_camera_mounting_location
   - backup_camera_video_interface
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - parking_camera_features
   - parking_camera_mounting_location
@@ -980,6 +1124,7 @@
   - pattern
   - power_source
   - video_signal_standard
+  - width
   return_reasons:
   - field_of_view
   - installation
@@ -995,13 +1140,16 @@
   children: []
   attributes:
   - color
+  - height
   - included_mounting_accessories
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - power_source
   - speaker_features
   - speakerphone_type
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -1023,10 +1171,15 @@
   - vp-1-3-8-7
   attributes:
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
+  - motor_vehicle_speaker_mounting_depth
   - pattern
   - power_source
+  - speaker_mounting_cutout_diameter
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -1042,12 +1195,19 @@
   children: []
   attributes:
   - color
+  - height
+  - impedance
   - item_condition
+  - length
   - manufacturer_type
+  - motor_vehicle_speaker_mounting_depth
   - pattern
   - power_source
+  - rms_rated_power
   - speaker_cone_material
+  - speaker_mounting_cutout_diameter
   - vehicle_coaxial_speaker_nominal_size
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -1064,12 +1224,19 @@
   attributes:
   - color
   - crossover_type
+  - height
+  - impedance
   - item_condition
+  - length
   - manufacturer_type
+  - motor_vehicle_speaker_mounting_depth
   - pattern
   - power_source
+  - rms_rated_power
+  - speaker_mounting_cutout_diameter
   - speaker_size
   - tweeter_material
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -1085,10 +1252,17 @@
   children: []
   attributes:
   - color
+  - height
+  - impedance
   - item_condition
+  - length
   - manufacturer_type
+  - motor_vehicle_speaker_mounting_depth
   - pattern
   - power_source
+  - rms_rated_power
+  - speaker_mounting_cutout_diameter
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -1104,11 +1278,18 @@
   children: []
   attributes:
   - color
+  - height
+  - impedance
   - item_condition
+  - length
   - manufacturer_type
+  - motor_vehicle_speaker_mounting_depth
   - motor_vehicle_speaker_mounting_type
   - pattern
   - power_source
+  - rms_rated_power
+  - speaker_mounting_cutout_diameter
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -1124,12 +1305,20 @@
   children: []
   attributes:
   - color
+  - height
+  - impedance
   - item_condition
+  - length
   - manufacturer_type
+  - motor_vehicle_speaker_mounting_depth
   - pattern
   - power_source
+  - rms_rated_power
+  - speaker_mounting_cutout_diameter
   - tweeter_crossover_type
   - tweeter_mount_type
+  - tweeter_sensitivity
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -1145,12 +1334,25 @@
   children: []
   attributes:
   - color
+  - height
+  - impedance
   - item_condition
+  - length
   - manufacturer_type
+  - motor_vehicle_speaker_mounting_depth
   - pattern
+  - peak_power_handling
   - power_source
+  - rms_rated_power
+  - speaker_mounting_cutout_diameter
   - voice_coil_configuration
+  - voice_coil_diameter
+  - width
+  - woofer_diameter
+  - woofer_mounting_cutout_diameter
+  - woofer_mounting_depth
   - woofer_mounting_type
+  - woofer_sensitivity
   - woofer_surround_material
   return_reasons:
   - size
@@ -1169,14 +1371,21 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - impedance
   - item_condition
+  - length
   - manufacturer_type
+  - motor_vehicle_subwoofer_sensitivity
   - motor_vehicle_subwoofer_size
   - motor_vehicle_subwoofer_voice_coil_configuration
   - motor_vehicle_subwoofer_voice_coil_impedance_per_coil
   - pattern
   - power_source
+  - rms_rated_power
   - subwoofer_installation_type
+  - subwoofer_mounting_depth
+  - width
   return_reasons:
   - size
   - sound_quality
@@ -1199,12 +1408,16 @@
   - vp-1-3-10-7
   attributes:
   - color
+  - compatible_monitor_size
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - mount_attachment_method
   - mount_material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - style
@@ -1220,12 +1433,16 @@
   children: []
   attributes:
   - color
+  - compatible_monitor_size
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - mount_attachment_method
   - mount_material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - style
@@ -1242,13 +1459,17 @@
   attributes:
   - color
   - compatible_device_type
+  - compatible_monitor_size
   - headrest_mount_attachment_method
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - mount_attachment_method
   - mount_material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - style
@@ -1264,13 +1485,17 @@
   children: []
   attributes:
   - color
+  - compatible_monitor_size
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - mount_attachment_method
   - mount_material
   - overhead_mount_installation_method
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - style
@@ -1286,13 +1511,17 @@
   children: []
   attributes:
   - color
+  - compatible_monitor_size
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - mount_attachment_method
   - mount_material
   - pattern
   - power_source
   - rearview_mirror_mount_attachment_type
+  - width
   return_reasons:
   - size
   - style
@@ -1308,12 +1537,16 @@
   children: []
   attributes:
   - color
+  - compatible_monitor_size
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - mount_attachment_method
   - mount_material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - style
@@ -1329,12 +1562,16 @@
   children: []
   attributes:
   - color
+  - compatible_monitor_size
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - mount_attachment_method
   - mount_material
   - pattern
   - power_source
+  - width
   return_reasons:
   - size
   - style
@@ -1350,12 +1587,17 @@
   children: []
   attributes:
   - color
+  - compatible_monitor_size
+  - height
   - item_condition
+  - length
   - manufacturer_type
+  - maximum_arm_reach
   - mount_attachment_method
   - mount_material
   - pattern
   - power_source
+  - width
   - windshield_mount_attachment_method
   return_reasons:
   - size
@@ -1455,10 +1697,13 @@
   - brake_position
   - color
   - compatible_brake_service_system
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - vehicle_braking_features
+  - width
   return_reasons:
   - programming
   - incompatible
@@ -1473,16 +1718,21 @@
   children: []
   attributes:
   - brake_booster_assist_type
+  - brake_booster_body_diameter
   - brake_booster_diaphragm_configuration
+  - brake_booster_hose_port_size
   - brake_fluid_dot_specification
   - brake_position
   - color
   - compatible_brake_service_system
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - pushrod_end_type
   - vehicle_braking_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1500,15 +1750,20 @@
   - brake_caliper_finish
   - brake_caliper_included_hardware
   - brake_caliper_mount_type
+  - brake_caliper_mounting_bolt_spacing
+  - brake_caliper_piston_bore_diameter
   - brake_fluid_dot_specification
   - brake_position
   - color
   - compatible_brake_service_system
   - compatible_parking_brake_mechanism
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - vehicle_braking_features
+  - width
   return_reasons:
   - color
   - incompatible
@@ -1523,9 +1778,11 @@
   children: []
   attributes:
   - brake_fluid_dot_specification
+  - brake_fluid_wet_boiling_point
   - brake_position
   - color
   - compatible_brake_service_system
+  - dry_boiling_point
   - pattern
   return_reasons:
   - incompatible
@@ -1543,10 +1800,13 @@
   - brake_position
   - color
   - compatible_brake_service_system
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - vehicle_braking_features
+  - width
   return_reasons:
   - length
   - incompatible
@@ -1569,11 +1829,14 @@
   - compatible_abs_system
   - compatible_brake_fluid
   - compatible_brake_service_system
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - outlet_thread_type
   - pattern
   - vehicle_braking_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1596,10 +1859,13 @@
   - brake_position
   - color
   - compatible_brake_service_system
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - vehicle_braking_features
+  - width
   return_reasons:
   - operating_noise
   - incompatible
@@ -1617,10 +1883,15 @@
   - brake_position
   - color
   - compatible_brake_service_system
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - rotor_diameter
+  - rotor_weight
   - vehicle_braking_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -1634,8 +1905,12 @@
   name: Brake Drums
   children: []
   attributes:
+  - brake_drum_center_bore_diameter
   - brake_drum_finish_coating
+  - brake_drum_inside_diameter
+  - brake_drum_maximum_discard_diameter
   - brake_drum_type
+  - brake_drum_width
   - brake_fluid_dot_specification
   - brake_position
   - color
@@ -1684,6 +1959,8 @@
   - brake_shoe_set_contents
   - color
   - compatible_brake_service_system
+  - compatible_brake_shoe_width
+  - compatible_drum_inside_diameter
   - item_condition
   - manufacturer_type
   - pattern
@@ -1780,9 +2057,12 @@
   - color
   - durability_features
   - fabric
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1801,9 +2081,12 @@
   - color
   - durability_features
   - fabric
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1819,12 +2102,17 @@
   name: Carpet Kits
   children: []
   attributes:
+  - carpet_kit_thickness
+  - carpet_pile_height
   - color
   - durability_features
   - fabric
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1845,9 +2133,12 @@
   - console_cover_installation_method
   - cover_features
   - cover_material
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - color
   - style
@@ -1867,9 +2158,12 @@
   - cover_material
   - dash_cover_construction_type
   - dash_cover_cutout_configuration
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1888,9 +2182,12 @@
   - color
   - durability_features
   - fabric
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1910,10 +2207,14 @@
   - color
   - durability_features
   - fabric
+  - headliner_backing_thickness
   - headliner_product_form
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1932,9 +2233,12 @@
   - color
   - durability_features
   - fabric
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -1954,12 +2258,15 @@
   - durability_features
   - fabric
   - flammability_compliance
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - stretch_type
   - upholstery_fabric_backing_type
   - upholstery_fabric_water_resistance
+  - width
   return_reasons:
   - size
   - color
@@ -1985,10 +2292,13 @@
   attributes:
   - color
   - durability_features
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2005,10 +2315,13 @@
   - ac_compressor_oil_type
   - color
   - durability_features
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2022,11 +2335,16 @@
   children: []
   attributes:
   - color
+  - condenser_inlet_port_diameter
+  - condenser_outlet_port_diameter
   - durability_features
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2044,10 +2362,15 @@
   - compatible_refrigerant_type
   - durability_features
   - evaporator_core_type
+  - height
+  - inlet_port_diameter
   - item_condition
   - item_material
+  - length
   - manufacturer_type
+  - outlet_port_diameter
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2062,10 +2385,13 @@
   attributes:
   - color
   - durability_features
+  - height
   - hose_material
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - length
   - material
@@ -2082,12 +2408,18 @@
   attributes:
   - blower_motor_bearing_type
   - blower_motor_mounting_position
+  - blower_motor_rotational_speed
   - color
   - durability_features
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
+  - power
+  - voltage
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2103,10 +2435,13 @@
   - climate_control_module_function
   - color
   - durability_features
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2123,11 +2458,14 @@
   - durability_features
   - heater_control_actuation_method
   - heater_control_electrical_connector_type
+  - height
   - hvac_control_functions
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2142,10 +2480,13 @@
   attributes:
   - color
   - durability_features
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2170,12 +2511,15 @@
   attributes:
   - color
   - handbrake_actuation_type
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - steering_component_drive_type
   - vehicle_steering_assist_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2190,11 +2534,14 @@
   attributes:
   - color
   - handbrake_orientation
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - mounting_position
   - pattern
+  - width
   return_reasons:
   - length
   - incompatible
@@ -2210,11 +2557,14 @@
   attributes:
   - color
   - grip_surface_type
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - pedal_mounting_style
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2229,14 +2579,20 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - steering_column_adjustability_features
   - steering_column_ignition_provision
+  - steering_column_mounting_pattern_bolt_spacing
+  - steering_column_overall_length
+  - steering_column_shaft_diameter
   - steering_column_shaft_end_interface_type
   - steering_column_shift_type
+  - width
   return_reasons:
   - length
   - incompatible
@@ -2251,11 +2607,15 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
+  - maximum_operating_pressure
   - pattern
   - steering_pump_pulley_type
+  - width
   return_reasons:
   - pressure_rating
   - flow_rate
@@ -2271,12 +2631,16 @@
   children: []
   attributes:
   - color
+  - height
+  - input_shaft_diameter
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - steering_rack_finish_coating
   - steering_rack_position
+  - width
   return_reasons:
   - length
   - incompatible
@@ -2293,11 +2657,16 @@
   - color
   - compatible_steering_wheel_airbag
   - compatible_steering_wheel_control_button
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
+  - steering_wheel_dish_depth
   - steering_wheel_rim_material_grip_surface
+  - steering_wheel_size
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2399,12 +2768,15 @@
   - vp-1-4-5-11
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - oil_system_connection_thread_standard
   - pattern
   - vehicle_oil_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2418,13 +2790,16 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - oil_cooler_core_type
   - oil_cooler_mounting_style
   - pattern
   - vehicle_oil_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2438,14 +2813,18 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - oil_dipstick_component_type
   - oil_dipstick_measurement_markings
+  - oil_dipstick_tube_inner_diameter
   - oil_dipstick_tube_mounting_type
   - pattern
   - vehicle_oil_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2459,13 +2838,16 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - oil_drain_plug_head_drive_type
   - oil_drain_plug_magnet_type
   - pattern
   - vehicle_oil_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2480,16 +2862,20 @@
   attributes:
   - cap_seal_type
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - oil_filler_cap_attachment_type
+  - oil_filler_cap_diameter
   - oil_filler_cap_installation_position
   - oil_filler_cap_locking_type
   - oil_filler_cap_tether_type
   - oil_filler_cap_venting_type
   - pattern
   - vehicle_oil_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2503,12 +2889,16 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
+  - oil_filter_gasket_outer_diameter
   - oil_filter_style
   - pattern
   - vehicle_oil_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2523,13 +2913,17 @@
   attributes:
   - color
   - compatible_sensor_port_type
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - oil_pan_baffle_windage_features
+  - oil_pan_capacity
   - oil_pan_finish_coating
   - pattern
   - vehicle_oil_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2543,14 +2937,17 @@
   children: []
   attributes:
   - color
+  - height
   - installation_location
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - oil_pressure_sensor_function_type
   - oil_pressure_sensor_signal_output_type
   - pattern
   - vehicle_oil_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2564,13 +2961,18 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
+  - maximum_operating_pressure
   - oil_pump_drive_method
+  - oil_pump_inlet_port_diameter
   - oil_pump_mounting_style
   - pattern
   - vehicle_oil_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2647,11 +3049,14 @@
   - vp-1-4-6-9
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - vehicle_engine/part_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2664,16 +3069,23 @@
   name: Camshafts
   children: []
   attributes:
+  - camshaft_base_circle_diameter
   - camshaft_construction
+  - camshaft_journal_diameter
+  - camshaft_lobe_lift
   - camshaft_material
   - camshaft_position
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - usage
+  - valve_lift
   - vehicle_engine/part_features
+  - width
   return_reasons:
   - horsepower
   - incompatible
@@ -2690,12 +3102,17 @@
   - color
   - crankshaft_balance_type
   - crankshaft_bolt_pattern
+  - crankshaft_main_bearing_journal_diameter
   - crankshaft_sensor_reluctor_type
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
+  - rod_journal_diameter
   - vehicle_engine/part_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2712,11 +3129,16 @@
   - cylinder_head_assembly
   - cylinder_head_material_grade
   - cylinder_head_position
+  - exhaust_runner_volume
+  - height
+  - intake_valve_diameter
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - vehicle_engine/part_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2733,11 +3155,14 @@
   - engine_bearing_coating
   - engine_bearing_position
   - engine_bearing_size
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - vehicle_engine/part_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2757,11 +3182,14 @@
   - vp-1-4-6-5-5
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - vehicle_engine/part_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2776,6 +3204,8 @@
   attributes:
   - glow_plug_connector_type
   - glow_plug_heating_element_type
+  - glow_plug_reach_length
+  - glow_plug_voltage
   - hex_size
   - item_condition
   - item_material
@@ -2851,6 +3281,7 @@
   name: Distributor Parts
   children: []
   attributes:
+  - distributor_cap_diameter
   - distributor_cap_terminal_type
   - item_condition
   - item_material
@@ -2869,14 +3300,19 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - piston_application_type
   - piston_crown_dish_style
   - piston_pin_retention_type
   - vehicle_engine/part_features
+  - width
+  - wrist_pin_diameter
+  - wrist_pin_length
   return_reasons:
   - size
   - incompatible
@@ -2892,14 +3328,17 @@
   attributes:
   - color
   - components_included
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - timing_belt_construction_material_rubber_compound
   - timing_belt_profile
   - timing_belt_reinforcement_cord_material
   - vehicle_engine/part_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2913,13 +3352,16 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
   - item_material
   - kit_components_included
+  - length
   - manufacturer_type
   - number_of_timing_chain_rows
   - pattern
   - vehicle_engine/part_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2934,14 +3376,18 @@
   attributes:
   - color
   - engine_valve_coating
+  - engine_valve_length
   - engine_valve_position
   - engine_valve_stem_tip_type
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - valve_design
   - vehicle_engine/part_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -2964,18 +3410,26 @@
   attributes:
   - aspiration_type
   - color
+  - cylinder_bore
+  - dry_weight
   - emissions_compliance_standard
   - engine_configuration
   - engine_cooling_type
   - engine_design
   - engine_type
   - fuel_system_type
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - primary_component_material
+  - stroke
   - valvetrain_configuration
   - vehicle_engine_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -2990,15 +3444,23 @@
   children: []
   attributes:
   - color
+  - cylinder_bore
+  - dry_weight
   - emissions_compliance_standard
   - engine_design
   - engine_type
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - primary_component_material
+  - stroke
   - valvetrain_configuration
   - vehicle_engine_features
+  - width
   return_reasons:
   - size
   - horsepower
@@ -3015,16 +3477,25 @@
   attributes:
   - color
   - crate_engine_assembly_level
+  - cylinder_bore
+  - dry_weight
   - emissions_compliance_standard
   - engine_design
   - engine_type
   - engine_valvetrain_type
+  - fuel_tank_capacity
+  - height
+  - horsepower
+  - horsepower_rpm
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - primary_component_material
+  - stroke
   - valvetrain_configuration
   - vehicle_engine_features
+  - width
   return_reasons:
   - size
   - horsepower
@@ -3044,12 +3515,15 @@
   - engine_design
   - engine_mount_type
   - engine_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - primary_component_material
   - valvetrain_configuration
   - vehicle_engine_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -3067,13 +3541,16 @@
   - engine_design
   - engine_rebuild_kit_contents
   - engine_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - oversize_or_undersize_grade
   - pattern
   - primary_component_material
   - valvetrain_configuration
   - vehicle_engine_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -3093,13 +3570,16 @@
   - engine_design
   - engine_timing_system_drive_type
   - engine_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - primary_component_material
   - timing_component_material
   - valvetrain_configuration
   - vehicle_engine_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -3113,11 +3593,14 @@
   name: Engine Valve Covers
   children: []
   attributes:
+  - breather_port_diameter
   - color
   - emissions_compliance_standard
   - engine_design
   - engine_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - oil_fill_cap_type
   - pattern
@@ -3126,6 +3609,7 @@
   - valve_cover_material
   - valvetrain_configuration
   - vehicle_engine_features
+  - width
   return_reasons:
   - color
   - incompatible
@@ -3140,16 +3624,24 @@
   children: []
   attributes:
   - color
+  - cylinder_bore
+  - dry_weight
   - emissions_compliance_standard
   - engine_design
   - engine_type
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
   - long_block_completeness
   - manufacturer_type
   - pattern
   - primary_component_material
+  - stroke
   - valvetrain_configuration
   - vehicle_engine_features
+  - width
   return_reasons:
   - size
   - horsepower
@@ -3165,18 +3657,26 @@
   children: []
   attributes:
   - color
+  - cylinder_bore
+  - dry_weight
   - emissions_compliance_standard
   - engine_design
   - engine_type
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - primary_component_material
   - short_block_assembly_balance_type
   - short_block_intended_use
   - short_block_rotating_assembly_included
+  - stroke
   - valvetrain_configuration
   - vehicle_engine_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -3200,12 +3700,15 @@
   - color
   - exhaust_installation_position
   - exhaust_outlet_configuration
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - motor_vehicle_type
   - pattern
   - vehicle_exhaust_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -3344,12 +3847,15 @@
   attributes:
   - color
   - fit_type
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - vehicle_frame/body_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -3367,11 +3873,14 @@
   - bumper_finish
   - bumper_sensor_cutouts
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - vehicle_frame/body_features
+  - width
   return_reasons:
   - size
   - color
@@ -3389,11 +3898,14 @@
   - color
   - door_assembly_type
   - door_window_operation
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - vehicle_frame/body_features
+  - width
   return_reasons:
   - size
   - color
@@ -3410,11 +3922,14 @@
   attributes:
   - color
   - fender_finish_state
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - vehicle_frame/body_features
+  - width
   return_reasons:
   - size
   - color
@@ -3432,12 +3947,16 @@
   - color
   - grille_emblem_provision
   - grille_mounting_method
+  - grille_opening_dimensions
   - grille_style
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - vehicle_frame/body_features
+  - width
   return_reasons:
   - size
   - color
@@ -3453,11 +3972,14 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - vehicle_frame/body_features
+  - width
   return_reasons:
   - size
   - color
@@ -3474,13 +3996,16 @@
   attributes:
   - body_panel_finish_state
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - quarter_panel_coverage_type
   - quarter_panel_set_contents
   - vehicle_frame/body_features
+  - width
   return_reasons:
   - color
   - incompatible
@@ -3495,12 +4020,16 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - spoiler_adjustability
+  - spoiler_width
   - vehicle_frame/body_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -3514,12 +4043,15 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - trunk_part_type
   - vehicle_frame/body_features
+  - width
   return_reasons:
   - size
   - color
@@ -3554,6 +4086,7 @@
   attributes:
   - color
   - end_fitting_type
+  - gas_strut_compressed_length
   - item_condition
   - item_material
   - manufacturer_type
@@ -3652,10 +4185,13 @@
   attributes:
   - color
   - fuel_supply
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -3668,12 +4204,16 @@
   name: Carburetors
   children: []
   attributes:
+  - carburetor_airflow_rating
   - carburetor_barrel_count
   - carburetor_choke_type
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - size
   - incompatible
@@ -3689,13 +4229,17 @@
   attributes:
   - color
   - compatible_evap_system
+  - compatible_fuel_cap_neck_outer_diameter
   - fuel_cap_gasket_seal_material
   - fuel_cap_locking_mechanism
   - fuel_cap_type
   - fuel_cap_venting
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - color
   - incompatible
@@ -3713,9 +4257,12 @@
   - fuel_filter_features
   - fuel_filter_media_material
   - fuel_filter_mounting_connection_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - flow_rate
   - incompatible
@@ -3731,14 +4278,18 @@
   attributes:
   - color
   - fuel_injector_electrical_connector_type
+  - fuel_injector_o_ring_size
   - fuel_injector_seat_type
   - fuel_injector_spray_pattern
   - fuel_supply
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - mounting_type
   - operating_voltage
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -3752,9 +4303,12 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -3771,12 +4325,15 @@
   - color
   - fuel_pressure_regulator_body_material
   - fuel_pressure_regulator_mounting_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - regulator_diaphragm_material
   - regulator_port_thread_standard
   - vacuum_boost_reference_port
+  - width
   return_reasons:
   - pressure_rating
   - incompatible
@@ -3794,10 +4351,15 @@
   - fuel_pump_inlet_type
   - fuel_pump_mounting_location
   - fuel_pump_outlet_connection_type
+  - fuel_pump_outlet_diameter
   - fuel_system_application
+  - height
   - item_condition
+  - length
   - manufacturer_type
+  - maximum_operating_pressure
   - pattern
+  - width
   return_reasons:
   - flow_rate
   - incompatible
@@ -3814,9 +4376,12 @@
   - color
   - fuel_tank_installation_position
   - fuel_tank_shape
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -3909,12 +4474,15 @@
   - battery_type
   - color
   - fit_type
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - motor_vehicle_type
   - pattern
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -3932,11 +4500,14 @@
   - battery_type
   - color
   - fit_type
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - motor_vehicle_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3955,10 +4526,13 @@
   - color
   - fabric
   - fit_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - motor_vehicle_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -3981,10 +4555,13 @@
   - floor_mat_edge_style
   - floor_mat_retention_system
   - floor_mat_set_configuration
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - motor_vehicle_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4002,12 +4579,15 @@
   attributes:
   - color
   - fit_type
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - motor_vehicle_type
   - pattern
   - pedal_set_components
+  - width
   return_reasons:
   - size
   - color
@@ -4026,13 +4606,16 @@
   - color
   - cover_material
   - fit_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - motor_vehicle_type
   - pattern
   - seat_cover_placement
   - seat_cover_securement_method
   - seat_cover_set_contents
+  - width
   return_reasons:
   - size
   - color
@@ -4053,10 +4636,13 @@
   - color
   - cover_material
   - fit_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - motor_vehicle_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4076,12 +4662,15 @@
   - color
   - fabric
   - fit_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - motor_vehicle_type
   - pattern
   - sun_shade_attachment_method
   - sun_shade_style
+  - width
   return_reasons:
   - size
   - color
@@ -4108,11 +4697,14 @@
   - battery_type
   - color
   - fit_type
+  - height
   - item_condition
+  - length
   - light_source
   - lighting_features
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - color
   - brightness
@@ -4129,11 +4721,14 @@
   attributes:
   - color
   - fit_type
+  - height
   - item_condition
+  - length
   - light_source
   - lighting_features
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - size
   - color
@@ -4151,11 +4746,14 @@
   attributes:
   - color
   - fit_type
+  - height
   - item_condition
+  - length
   - light_source
   - lighting_features
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - color
   - brightness
@@ -4176,7 +4774,9 @@
   - color
   - compliance_certification
   - fit_type
+  - height
   - item_condition
+  - length
   - light_bar_housing_material
   - light_bar_lens_material
   - light_bar_mounting_location
@@ -4184,6 +4784,7 @@
   - lighting_features
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - color
   - brightness
@@ -4202,13 +4803,16 @@
   - battery_type
   - color
   - fit_type
+  - height
   - item_condition
+  - length
   - light_source
   - lighting_features
   - manufacturer_type
   - motor_vehicle_bulb_application_position
   - motor_vehicle_bulb_approval_standard
   - pattern
+  - width
   return_reasons:
   - color
   - brightness
@@ -4225,10 +4829,13 @@
   attributes:
   - color
   - fit_type
+  - height
   - item_condition
+  - length
   - light_source
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - color
   - brightness
@@ -4245,7 +4852,9 @@
   attributes:
   - color
   - fit_type
+  - height
   - item_condition
+  - length
   - light_source
   - light_switch_function
   - lighting_features
@@ -4254,6 +4863,7 @@
   - number_of_switch_throws
   - pattern
   - switch_electrical_positions
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4269,11 +4879,14 @@
   attributes:
   - color
   - fit_type
+  - height
   - item_condition
+  - length
   - light_source
   - lighting_features
   - manufacturer_type
   - pattern
+  - width
   return_reasons:
   - color
   - brightness
@@ -4290,13 +4903,16 @@
   attributes:
   - color
   - fit_type
+  - height
   - item_condition
+  - length
   - light_source
   - lighting_features
   - manufacturer_type
   - pattern
   - turn_signal_lens_color
   - turn_signal_lighting_style
+  - width
   return_reasons:
   - color
   - brightness
@@ -4312,7 +4928,9 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - vehicle_mirror_adjustment_type
@@ -4320,6 +4938,7 @@
   - vehicle_mirror_features
   - vehicle_mirror_glass_type
   - vehicle_mirror_type
+  - width
   return_reasons:
   - size
   - style
@@ -4344,12 +4963,17 @@
   - vp-1-4-14-9
   - vp-1-4-14-10
   attributes:
+  - amperage
   - battery_size
   - battery_type
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - voltage
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -4366,11 +4990,16 @@
   - alternator_mounting_configuration
   - alternator_pulley_type
   - alternator_regulator_type
+  - amperage
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - vehicle_electrical_connector_type
+  - voltage
+  - width
   return_reasons:
   - power_output
   - incompatible
@@ -4384,14 +5013,20 @@
   name: Batteries
   children: []
   attributes:
+  - amperage
   - battery_group_size
   - battery_polarity
   - battery_size
   - battery_type
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - reserve_capacity_rc
+  - voltage
+  - width
   return_reasons:
   - capacity
   - incompatible
@@ -4405,14 +5040,19 @@
   name: Fuses
   children: []
   attributes:
+  - amperage
   - color
   - fuse_form_factor
   - fuse_terminal_or_mount_style
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - time_current_characteristic
+  - voltage
   - voltage_rating_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -4425,10 +5065,15 @@
   name: Relays
   children: []
   attributes:
+  - amperage
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - voltage
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -4441,15 +5086,20 @@
   name: Spark Plugs
   children: []
   attributes:
+  - amperage
   - battery_size
   - battery_type
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - spark_plug_electrode_material
   - spark_plug_seat_type
   - spark_plug_terminal_type
+  - voltage
+  - width
   return_reasons:
   - tip_style
   - incompatible
@@ -4463,12 +5113,17 @@
   name: Starters
   children: []
   attributes:
+  - amperage
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - starter_drive_type
   - starter_terminal_type
+  - voltage
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -4481,16 +5136,21 @@
   name: Voltage Regulators
   children: []
   attributes:
+  - amperage
   - battery_size
   - battery_type
   - color
   - compatible_ground_polarity
   - electrical_system_voltage
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - motor_vehicle_voltage_regulator_type
   - pattern
+  - voltage
   - voltage_regulator_connector_type
+  - width
   return_reasons:
   - power_output
   - incompatible
@@ -4504,10 +5164,15 @@
   name: Wiring Harnesses
   children: []
   attributes:
+  - amperage
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
+  - voltage
+  - width
   - wire_gauge_awg
   - wire_insulation_material
   return_reasons:
@@ -4559,10 +5224,13 @@
   attributes:
   - color
   - fabric
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - vehicle_seating_features
+  - width
   return_reasons:
   - size
   - color
@@ -4582,7 +5250,9 @@
   - compatible_seat_airbag
   - fabric
   - front_seat_position
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - occupant_classification_sensor_support
   - pattern
@@ -4590,6 +5260,7 @@
   - seat_belt_integration
   - seat_mounting_type
   - vehicle_seating_features
+  - width
   return_reasons:
   - size
   - color
@@ -4608,7 +5279,9 @@
   - color
   - fabric
   - headrest_provision
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - mounting_hardware_included_for_installation
   - pattern
@@ -4616,6 +5289,7 @@
   - seat_belt_provision
   - vehicle_seat_row
   - vehicle_seating_features
+  - width
   return_reasons:
   - size
   - color
@@ -4654,10 +5328,13 @@
   - battery_type
   - color
   - gauge_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - sensor_or_gauge_mounting_location
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -4675,10 +5352,13 @@
   - fuel_level_sensor_mounting_type
   - fuel_level_sensor_sensing_mechanism
   - gauge_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - sensor_or_gauge_mounting_location
+  - width
   return_reasons:
   - length
   - incompatible
@@ -4694,11 +5374,15 @@
   attributes:
   - color
   - gauge_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
+  - panel_cutout_diameter
   - pattern
   - sensor_or_gauge_mounting_location
   - signal_source
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -4713,15 +5397,19 @@
   attributes:
   - color
   - gauge_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - motor_vehicle_oxygen_sensor_bank
   - motor_vehicle_oxygen_sensor_number_of_wires
   - motor_vehicle_oxygen_sensor_position
   - motor_vehicle_oxygen_sensor_sensor_number
   - motor_vehicle_oxygen_sensor_type
+  - oxygen_sensor_hex_size
   - pattern
   - sensor_or_gauge_mounting_location
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -4739,13 +5427,16 @@
   - color
   - electrical_connector_type
   - gauge_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - pressure_measurement_unit
   - pressure_sensor_application
   - pressure_sensor_port_thread_standard
   - sensor_or_gauge_mounting_location
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -4760,10 +5451,13 @@
   attributes:
   - color
   - gauge_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - sensor_or_gauge_mounting_location
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -4778,13 +5472,16 @@
   attributes:
   - color
   - gauge_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - sensor_or_gauge_mounting_location
   - speedometer_backlight_type
   - speedometer_display_type
   - speedometer_unit_of_measure
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4800,10 +5497,13 @@
   attributes:
   - color
   - gauge_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - sensor_or_gauge_mounting_location
+  - width
   return_reasons:
   - size
   - incompatible
@@ -4819,10 +5519,13 @@
   attributes:
   - color
   - gauge_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - sensor_or_gauge_mounting_location
+  - width
   return_reasons:
   - temperature_rating
   - incompatible
@@ -4860,6 +5563,7 @@
   - item_condition
   - manufacturer_type
   - parking_sensor_finish
+  - parking_sensor_hole_diameter
   - parking_sensor_type
   - pattern
   - sensor_or_gauge_mounting_location
@@ -4916,6 +5620,7 @@
   children: []
   attributes:
   - color
+  - coolant_temperature_sensor_hex_size
   - coolant_temperature_sensor_seal_type
   - gauge_type
   - item_condition
@@ -5062,12 +5767,15 @@
   - vp-1-4-17-11
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - motor_vehicle_placement
   - pattern
   - vehicle_suspension_features
+  - width
   return_reasons:
   - height
   - incompatible
@@ -5082,11 +5790,14 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - motor_vehicle_placement
   - pattern
   - vehicle_suspension_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -5101,13 +5812,19 @@
   attributes:
   - coil_spring_design
   - coil_spring_finish_coating
+  - coil_spring_free_length
+  - coil_spring_lift_height
   - coil_spring_material
+  - coil_spring_wire_diameter
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - motor_vehicle_placement
   - pattern
   - vehicle_suspension_features
+  - width
   return_reasons:
   - height
   - firmness
@@ -5130,11 +5847,14 @@
   - control_arm_material
   - control_arm_position
   - control_arm_style
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - motor_vehicle_placement
   - pattern
   - vehicle_suspension_features
+  - width
   return_reasons:
   - height
   - length
@@ -5150,12 +5870,21 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
+  - leaf_spring_bushing_inside_diameter
+  - leaf_spring_center_bolt_diameter
+  - leaf_spring_eye_to_eye_length
+  - leaf_spring_free_arch_height
   - leaf_spring_material
+  - leaf_spring_width
+  - length
   - manufacturer_type
   - motor_vehicle_placement
   - pattern
+  - suspension_lift_amount
   - vehicle_suspension_features
+  - width
   return_reasons:
   - height
   - firmness
@@ -5172,16 +5901,20 @@
   attributes:
   - color
   - damping_adjustability
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - motor_vehicle_placement
   - pattern
   - shock_absorber_bushing_material
   - shock_absorber_charge_type
+  - shock_absorber_compressed_length
   - shock_absorber_mount_type_lower
   - shock_absorber_mount_type_upper
   - shock_absorber_position
   - vehicle_suspension_features
+  - width
   return_reasons:
   - height
   - firmness
@@ -5198,12 +5931,17 @@
   attributes:
   - adjustability_type
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - motor_vehicle_placement
   - pattern
+  - strut_extended_length
   - strut_placement
+  - strut_travel
   - vehicle_suspension_features
+  - width
   return_reasons:
   - height
   - firmness
@@ -5219,13 +5957,16 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
+  - length
   - lubrication_type
   - manufacturer_type
   - motor_vehicle_placement
   - pattern
   - suspension_bushing_type
   - vehicle_suspension_features
+  - width
   return_reasons:
   - firmness
   - incompatible
@@ -5240,14 +5981,18 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - motor_vehicle_placement
   - pattern
   - sway_bar_adjustability
   - sway_bar_coating
+  - sway_bar_diameter
   - sway_bar_fitment_front_rear_kit
   - vehicle_suspension_features
+  - width
   return_reasons:
   - length
   - incompatible
@@ -5324,14 +6069,23 @@
   - vp-1-4-18-8
   attributes:
   - color
+  - height
   - hitch_ball_diameter
+  - hitch_ball_threaded_shank_diameter
+  - hitch_ball_threaded_shank_length
+  - hitch_mount_drop
+  - hitch_mount_rise
   - item_condition
   - item_material
+  - length
   - manufacturer_type
+  - maximum_load_capacity
   - pattern
+  - tow_strap_width
   - trailer_light_function
   - trailer_wiring_connector_type
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5346,13 +6100,21 @@
   children: []
   attributes:
   - color
+  - height
   - hitch_ball_mounting_style
+  - hitch_ball_threaded_shank_diameter
+  - hitch_ball_tongue_weight_rating
+  - hitch_ball_weight_rating_gtw
+  - hitch_mount_rise
   - item_condition
   - item_material
+  - length
   - manufacturer_type
+  - maximum_load_capacity
   - pattern
   - trailer_light_function
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - size
   - material
@@ -5369,12 +6131,18 @@
   children: []
   attributes:
   - color
+  - height
+  - hitch_ball_threaded_shank_diameter
+  - hitch_mount_rise
   - item_condition
+  - length
   - manufacturer_type
+  - maximum_load_capacity
   - mount_material
   - pattern
   - trailer_light_function
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5390,12 +6158,18 @@
   children: []
   attributes:
   - color
+  - height
+  - hitch_ball_threaded_shank_diameter
+  - hitch_mount_rise
   - item_condition
   - item_material
+  - length
   - manufacturer_type
+  - maximum_load_capacity
   - pattern
   - trailer_light_function
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5412,14 +6186,20 @@
   attributes:
   - color
   - end_type
+  - height
+  - hitch_ball_threaded_shank_diameter
+  - hitch_mount_rise
   - item_condition
   - item_material
+  - length
   - manufacturer_type
+  - maximum_load_capacity
   - pattern
   - tow_strap_protective_features
   - tow_strap_type
   - trailer_light_function
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5436,12 +6216,18 @@
   - brake_mounting_flange_bolt_pattern
   - color
   - compatible_axle_weight_rating
+  - height
+  - hitch_ball_threaded_shank_diameter
+  - hitch_mount_rise
   - item_condition
   - item_material
+  - length
   - manufacturer_type
+  - maximum_load_capacity
   - pattern
   - trailer_light_function
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5457,13 +6243,19 @@
   children: []
   attributes:
   - color
+  - height
+  - hitch_ball_threaded_shank_diameter
+  - hitch_mount_rise
   - item_condition
   - item_material
+  - length
   - manufacturer_type
+  - maximum_load_capacity
   - pattern
   - trailer_hitch_mounting_location_method
   - trailer_light_function
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -5479,12 +6271,18 @@
   children: []
   attributes:
   - color
+  - height
+  - hitch_ball_threaded_shank_diameter
+  - hitch_mount_rise
   - item_condition
   - item_material
+  - length
   - manufacturer_type
+  - maximum_load_capacity
   - pattern
   - trailer_light_function
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5499,13 +6297,19 @@
   children: []
   attributes:
   - color
+  - height
+  - hitch_ball_threaded_shank_diameter
+  - hitch_mount_rise
   - item_condition
   - item_material
+  - length
   - manufacturer_type
+  - maximum_load_capacity
   - pattern
   - trailer_light_function
   - trailer_wiring_circuit
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - size
   - length
@@ -5560,14 +6364,19 @@
   name: Axles
   children: []
   attributes:
+  - axle_shaft_diameter
+  - axle_shaft_length
   - color
   - gear_oil_api_classification
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - transmission_cooler_construction
   - transmission_type
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5583,12 +6392,15 @@
   attributes:
   - color
   - gear_oil_api_classification
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - transmission_cooler_construction
   - transmission_type
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -5603,12 +6415,15 @@
   attributes:
   - color
   - gear_oil_api_classification
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - transmission_cooler_construction
   - transmission_type
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -5623,16 +6438,20 @@
   attributes:
   - balance_type
   - color
+  - drive_shaft_length
   - drive_shaft_material
   - gear_oil_api_classification
+  - height
   - intended_use
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - transmission_cooler_construction
   - transmission_type
   - u_joint_series_size
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -5648,12 +6467,15 @@
   attributes:
   - color
   - gear_oil_api_classification
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - transmission_cooler_construction
   - transmission_type
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -5673,6 +6495,7 @@
   - transmission_cooler_construction
   - transmission_type
   - vehicle_drive/handling_features
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -5687,7 +6510,9 @@
   attributes:
   - color
   - gear_oil_api_classification
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - transmission_cooler_construction
@@ -5695,6 +6520,7 @@
   - transmission_mount_type
   - transmission_type
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -5710,12 +6536,15 @@
   - bellhousing_bolt_pattern
   - color
   - gear_oil_api_classification
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - pattern
   - transmission_cooler_construction
   - transmission_type
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -5728,6 +6557,7 @@
   name: Clutch Master Cylinders
   children: []
   attributes:
+  - clutch_master_cylinder_bore_diameter
   - color
   - gear_oil_api_classification
   - item_condition
@@ -5797,8 +6627,11 @@
   - color
   - cv_boot_clamp_type
   - cv_boot_kit_contents
+  - cv_boot_large_end_inner_diameter
+  - cv_boot_length
   - cv_boot_material
   - cv_boot_position
+  - cv_boot_small_end_inner_diameter
   - gear_oil_api_classification
   - item_condition
   - manufacturer_type
@@ -5819,8 +6652,12 @@
   children: []
   attributes:
   - color
+  - compatible_clutch_disc_diameter
   - compatible_clutch_type
   - flywheel_balance_type
+  - flywheel_outer_diameter
+  - flywheel_thickness
+  - flywheel_weight
   - friction_surface_included
   - gear_oil_api_classification
   - item_condition
@@ -5863,6 +6700,8 @@
   children: []
   attributes:
   - clutch_pressure_plate_actuation_type
+  - clutch_pressure_plate_bolt_circle_diameter_bcd
+  - clutch_pressure_plate_diameter
   - clutch_pressure_plate_release_mechanism_type
   - clutch_pressure_plate_surface_type
   - color
@@ -5985,6 +6824,7 @@
   - pattern
   - tire_speed_rating
   - vehicle_drive/handling_features
+  - wheel_offset
   - wheel_system_finish
   return_reasons:
   - size
@@ -6006,14 +6846,21 @@
   attributes:
   - color
   - compatible_tpms_sensor_type
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - rim/wheel_design
   - tire_speed_rating
   - vehicle_drive/handling_features
+  - vehicle_wheel_backspacing
+  - vehicle_wheel_load_rating
+  - vehicle_wheel_offset
   - vehicle_wheel_valve_stem_type
+  - wheel_size
+  - width
   return_reasons:
   - size
   - color
@@ -6031,16 +6878,23 @@
   attributes:
   - color
   - compatible_tpms_sensor_type
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - number_of_wheel_pieces
   - pattern
   - rim/wheel_design
   - tire_speed_rating
   - vehicle_drive/handling_features
+  - vehicle_wheel_backspacing
+  - vehicle_wheel_load_rating
+  - vehicle_wheel_offset
   - vehicle_wheel_valve_stem_type
   - wheel_construction_type
+  - wheel_size
+  - width
   return_reasons:
   - size
   - color
@@ -6058,14 +6912,21 @@
   attributes:
   - color
   - compatible_tpms_sensor_type
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - rim/wheel_design
   - tire_speed_rating
   - vehicle_drive/handling_features
+  - vehicle_wheel_backspacing
+  - vehicle_wheel_load_rating
+  - vehicle_wheel_offset
   - vehicle_wheel_valve_stem_type
+  - wheel_size
+  - width
   return_reasons:
   - size
   - color
@@ -6084,15 +6945,22 @@
   - beadlock_type
   - color
   - compatible_tpms_sensor_type
+  - height
   - item_condition
   - item_material
+  - length
   - lug_nut_seat_profile
   - manufacturer_type
   - pattern
   - rim/wheel_design
   - tire_speed_rating
   - vehicle_drive/handling_features
+  - vehicle_wheel_backspacing
+  - vehicle_wheel_load_rating
+  - vehicle_wheel_offset
   - vehicle_wheel_valve_stem_type
+  - wheel_size
+  - width
   return_reasons:
   - size
   - color
@@ -6111,13 +6979,16 @@
   - battery_size
   - battery_type
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - tire_speed_rating
   - tpms_sensor_frequency_band
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -6135,15 +7006,22 @@
   - vp-1-4-20-3-3
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - tire_construction_type
   - tire_position
+  - tire_profile
+  - tire_rim
   - tire_speed_rating
+  - tire_tread_depth
   - tire_tube_type
+  - tire_width
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - size
   - tread_type
@@ -6159,20 +7037,29 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - tire_construction_type
   - tire_load_range
+  - tire_outside_diameter
   - tire_position
+  - tire_profile
+  - tire_rim
+  - tire_section_width
   - tire_sidewall_type
   - tire_speed_rating
   - tire_temperature_rating_utqg
   - tire_traction_rating_utqg
+  - tire_tread_depth
   - tire_tube_type
+  - tire_width
   - vehicle_drive/handling_features
   - vehicle_tire_type
+  - width
   return_reasons:
   - size
   - tread_type
@@ -6188,17 +7075,25 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
+  - motorcycle_tire_overall_diameter
   - motorcycle_tire_speed_rating
   - motorcycle_tire_type
   - pattern
   - tire_construction_type
   - tire_position
+  - tire_profile
+  - tire_rim
   - tire_speed_rating
+  - tire_tread_depth
   - tire_tube_type
+  - tire_width
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - size
   - tread_type
@@ -6215,15 +7110,22 @@
   attributes:
   - atv/off_road_tire_type
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - tire_construction_type
   - tire_position
+  - tire_profile
+  - tire_rim
   - tire_speed_rating
+  - tire_tread_depth
   - tire_tube_type
+  - tire_width
   - vehicle_drive/handling_features
+  - width
   return_reasons:
   - size
   - tread_type
@@ -6243,14 +7145,18 @@
   - vp-1-4-20-4-4
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
   - tire_speed_rating
   - vehicle_drive/handling_features
   - wheel_fastener_seat_type
   - wheel_part_type
+  - wheel_spacer_thickness
+  - width
   return_reasons:
   - size
   - color
@@ -6275,6 +7181,7 @@
   - vehicle_drive/handling_features
   - wheel_fastener_seat_type
   - wheel_part_type
+  - wheel_spacer_thickness
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -6295,6 +7202,7 @@
   - vehicle_drive/handling_features
   - wheel_fastener_seat_type
   - wheel_part_type
+  - wheel_spacer_thickness
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -6315,6 +7223,7 @@
   - vehicle_drive/handling_features
   - wheel_fastener_seat_type
   - wheel_part_type
+  - wheel_spacer_thickness
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -6335,6 +7244,7 @@
   - vehicle_drive/handling_features
   - wheel_fastener_seat_type
   - wheel_part_type
+  - wheel_spacer_thickness
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -6351,14 +7261,18 @@
   - vp-1-4-21-4
   attributes:
   - color
+  - height
   - item_condition
   - item_material
+  - length
   - manufacturer_type
   - pattern
+  - width
   - window_component_location
   - window_glass_finish
   - window_regulator_operation
   - wiper_blade_attachment_type
+  - wiper_blade_length
   return_reasons:
   - size
   - incompatible
@@ -6516,6 +7430,7 @@
   - window_component_location
   - window_glass_finish
   - wiper_arm_finish
+  - wiper_arm_length
   - wiper_arm_pivot_mount_type
   - wiper_blade_attachment_type
   return_reasons:
@@ -6586,6 +7501,7 @@
   - manufacturer_type
   - motor_vehicle_type
   - radiator_cap_gasket_material
+  - radiator_cap_neck_depth
   - radiator_cap_pressure_relief_style
   - radiator_expansion_tank_cap_application
   return_reasons:
@@ -6622,6 +7538,7 @@
   - item_material
   - manufacturer_type
   - motor_vehicle_type
+  - thermostat_flange_diameter
   - thermostat_type
   return_reasons:
   - temperature_rating
@@ -6678,6 +7595,7 @@
   - item_material
   - manufacturer_type
   - motor_vehicle_type
+  - radiator_overflow_tank_hose_port_diameter
   - radiator_overflow_tank_level_sensor_provision
   - radiator_overflow_tank_shape
   return_reasons:
@@ -6790,6 +7708,7 @@
   attributes:
   - bearing_type
   - cooling_system_component_included
+  - inlet_port_inner_diameter
   - item_condition
   - item_material
   - manufacturer_type
@@ -6798,6 +7717,7 @@
   - water_pump_housing_material
   - water_pump_impeller_material
   - water_pump_mounting_type
+  - water_pump_outlet_port_diameter
   return_reasons:
   - flow_rate
   - incompatible
@@ -6888,10 +7808,14 @@
   name: Portable Fuel Cans
   children: []
   attributes:
+  - capacity
   - color
+  - height
+  - length
   - material
   - pattern
   - vehicle_type
+  - width
   return_reasons:
   - capacity
   - changed_my_mind
@@ -6930,8 +7854,11 @@
   - battery_size
   - battery_type
   - bristle_material
+  - brush_head_width
   - brush_type
   - color
+  - height
+  - length
   - paint_safe_bristles
   - pattern
   - recommended_vehicle_surfaces
@@ -6939,6 +7866,7 @@
   - vehicle_application_area
   - vehicle_type
   - water_fed_design
+  - width
   return_reasons:
   - size
   - too_soft
@@ -6966,6 +7894,7 @@
   - vehicle_application_area
   - vehicle_fluid_type
   - vehicle_type
+  - volume
   - wheel_cleaner_formula_type
   return_reasons:
   - incompatible
@@ -6987,6 +7916,7 @@
   - pattern
   - vehicle_application_area
   - vehicle_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7008,6 +7938,7 @@
   - product_form
   - vehicle_application_area
   - vehicle_type
+  - volume
   return_reasons:
   - residue
   - incompatible
@@ -7028,6 +7959,7 @@
   - pattern
   - vehicle_application_area
   - vehicle_type
+  - volume
   return_reasons:
   - residue
   - incompatible
@@ -7050,6 +7982,7 @@
   - pattern
   - vehicle_application_area
   - vehicle_type
+  - volume
   - wheel_cleaner_acidity_ph_category
   - wheel_contaminant_target
   return_reasons:
@@ -7072,6 +8005,7 @@
   - pattern
   - vehicle_application_area
   - vehicle_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7090,6 +8024,7 @@
   - pattern
   - vehicle_application_area
   - vehicle_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7109,6 +8044,7 @@
   - stain_remover_format
   - vehicle_application_area
   - vehicle_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7127,6 +8063,7 @@
   - pattern
   - vehicle_application_area
   - vehicle_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7143,11 +8080,14 @@
   - color
   - fuel_injection_cleaning_method
   - fuel_system_connection_type
+  - height
+  - length
   - package_type
   - pattern
   - vehicle_application_area
   - vehicle_cleaning_item_features
   - vehicle_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -7161,12 +8101,15 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - package_type
   - pattern
   - vehicle_application_area
   - vehicle_cleaning_item_features
   - vehicle_glass_cleaner_form
   - vehicle_type
+  - width
   return_reasons:
   - residue
   - incompatible
@@ -7194,6 +8137,7 @@
   - vehicle_cleaning_item_features
   - vehicle_type
   - vehicle_wax_polish_product_form
+  - volume
   return_reasons:
   - finish
   - incompatible
@@ -7215,6 +8159,7 @@
   - vehicle_cleaning_item_features
   - vehicle_type
   - vehicle_wax_polish_product_form
+  - volume
   return_reasons:
   - finish
   - incompatible
@@ -7238,6 +8183,7 @@
   - vehicle_polish_application_method
   - vehicle_type
   - vehicle_wax_polish_product_form
+  - volume
   return_reasons:
   - finish
   - incompatible
@@ -7261,6 +8207,7 @@
   - vehicle_cleaning_item_features
   - vehicle_type
   - vehicle_wax_polish_product_form
+  - volume
   return_reasons:
   - finish
   - incompatible
@@ -7283,6 +8230,7 @@
   - vehicle_cleaning_item_features
   - vehicle_type
   - vehicle_wax_polish_product_form
+  - volume
   return_reasons:
   - finish
   - incompatible
@@ -7331,9 +8279,12 @@
   - enclosure_panel_configuration
   - enclosure_window_material
   - golf_cart_enclosure_fit_type
+  - height
+  - length
   - pattern
   - vehicle_application_area
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7352,10 +8303,13 @@
   - color
   - cover_features
   - cover_material
+  - height
+  - length
   - pattern
   - season_condition_protection
   - vehicle_application_area
   - vehicle_type
+  - width
   - windshield_coverage_area
   return_reasons:
   - size
@@ -7373,13 +8327,17 @@
   children: []
   attributes:
   - color
+  - compatible_truck_bed_length
   - cover_features
   - cover_material
   - cover_type
+  - height
+  - length
   - pattern
   - tonneau_cover_mounting_style
   - vehicle_application_area
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7401,9 +8359,12 @@
   - hardtop_finish_type
   - hardtop_shell_material
   - hardtop_window_configuration
+  - height
+  - length
   - pattern
   - vehicle_application_area
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7422,6 +8383,8 @@
   - color
   - cover_features
   - cover_material
+  - height
+  - length
   - pattern
   - soft_top_attachment_type
   - soft_top_includes_frame_hardware
@@ -7429,6 +8392,7 @@
   - soft_top_window_configuration
   - vehicle_application_area
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7453,9 +8417,12 @@
   - cover_features
   - cover_material
   - cover_type
+  - height
+  - length
   - pattern
   - vehicle_application_area
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7475,9 +8442,12 @@
   - cover_features
   - cover_material
   - cover_type
+  - height
+  - length
   - pattern
   - vehicle_application_area
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7499,10 +8469,13 @@
   - cover_material
   - cover_type
   - golf_cart_cover_climate_use
+  - height
+  - length
   - pattern
   - vehicle_application_area
   - vehicle_type
   - venting_design
+  - width
   return_reasons:
   - size
   - color
@@ -7522,10 +8495,13 @@
   - cover_features
   - cover_material
   - cover_type
+  - height
+  - length
   - motorcycle_cover_size_class
   - pattern
   - vehicle_application_area
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7545,9 +8521,12 @@
   - cover_features
   - cover_material
   - cover_type
+  - height
+  - length
   - pattern
   - vehicle_application_area
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7562,13 +8541,17 @@
   children: []
   attributes:
   - color
+  - compatible_beam_width
   - cover_features
   - cover_fit_type
   - cover_material
   - cover_type
+  - height
+  - length
   - pattern
   - vehicle_application_area
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7608,11 +8591,14 @@
   - construction
   - decoration_material
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - pattern
   - vehicle_application_area
   - vehicle_decor_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7631,10 +8617,13 @@
   - accessory_size
   - color
   - decoration_material
+  - height
+  - length
   - pattern
   - vehicle_application_area
   - vehicle_decor_features
   - vehicle_type
+  - width
   return_reasons:
   - color
   - style
@@ -7654,11 +8643,14 @@
   - car_freshener_fragrance
   - color
   - decoration_material
+  - height
+  - length
   - pattern
   - scent
   - vehicle_application_area
   - vehicle_decor_features
   - vehicle_type
+  - width
   return_reasons:
   - scent
   - incompatible
@@ -7676,11 +8668,14 @@
   - antenna_fit_type
   - color
   - decoration_material
+  - height
+  - length
   - pattern
   - reflective_or_glow_effect
   - vehicle_application_area
   - vehicle_decor_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7700,10 +8695,13 @@
   - color
   - dashboard_accessory_position
   - decoration_material
+  - height
+  - length
   - pattern
   - vehicle_application_area
   - vehicle_decor_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7727,10 +8725,13 @@
   - decal_placement_type
   - decal_visibility_property
   - decoration_material
+  - height
+  - length
   - pattern
   - vehicle_application_area
   - vehicle_decor_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7752,12 +8753,15 @@
   - construction
   - decoration_material
   - embellishment/trim_material
+  - height
   - jewelry_material
+  - length
   - pattern
   - vehicle_application_area
   - vehicle_decor_features
   - vehicle_decor_set_items_included
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7778,10 +8782,13 @@
   - decoration_material
   - flag_design_theme
   - flag_mounting_method
+  - height
+  - length
   - pattern
   - vehicle_application_area
   - vehicle_decor_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7800,10 +8807,13 @@
   - accessory_size
   - color
   - decoration_material
+  - height
+  - length
   - pattern
   - vehicle_application_area
   - vehicle_decor_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7823,11 +8833,14 @@
   - color
   - cover_features
   - cover_material
+  - height
+  - length
   - pattern
   - vehicle_application_area
   - vehicle_hitch_cover_illumination_type
   - vehicle_hitch_cover_mounting_type
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7847,10 +8860,13 @@
   - color
   - cover_features
   - cover_material
+  - height
+  - length
   - license_plate_cover_style
   - pattern
   - vehicle_application_area
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7869,6 +8885,8 @@
   - accessory_size
   - color
   - decoration_material
+  - height
+  - length
   - pattern
   - vehicle_application_area
   - vehicle_decor_features
@@ -7876,6 +8894,7 @@
   - vehicle_license_plate_frame_plate_standard
   - vehicle_license_plate_frame_profile
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7897,11 +8916,14 @@
   - compatible_license_plate_hole_pattern
   - compatible_license_plate_size
   - corrosion_resistance
+  - height
+  - length
   - mount_material
   - pattern
   - vehicle_application_area
   - vehicle_decor_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -7918,6 +8940,8 @@
   - accessory_size
   - color
   - decoration_material
+  - height
+  - length
   - license_plate_personalization_type
   - pattern
   - vehicle_application_area
@@ -7930,6 +8954,7 @@
   - vehicle_license_plate_text_style
   - vehicle_license_plate_theme
   - vehicle_type
+  - width
   return_reasons:
   - color
   - style
@@ -7947,12 +8972,15 @@
   - accessory_size
   - color
   - decoration_material
+  - height
+  - length
   - pattern
   - vehicle_application_area
   - vehicle_decor_features
   - vehicle_magnet_attachment_type
   - vehicle_magnet_intended_use
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -7973,7 +9001,10 @@
   - construction
   - decoration_material
   - embellishment/trim_material
+  - hanging_drop_length
+  - height
   - jewelry_material
+  - length
   - lumber/wood_type
   - pattern
   - personalization_type
@@ -7981,6 +9012,7 @@
   - vehicle_application_area
   - vehicle_decor_features
   - vehicle_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -8001,12 +9033,16 @@
   - color
   - compatible_shifter_type
   - decoration_material
+  - height
+  - length
   - pattern
   - shift_boot_attachment_method
+  - shift_boot_inner_opening_diameter
   - shift_boot_installation_hardware_included
   - vehicle_application_area
   - vehicle_decor_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -8025,6 +9061,8 @@
   - accessory_size
   - color
   - decoration_material
+  - height
+  - length
   - pattern
   - shift_knob_illumination
   - shift_knob_installation_method
@@ -8033,6 +9071,7 @@
   - vehicle_application_area
   - vehicle_decor_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -8052,10 +9091,13 @@
   - color
   - cover_features
   - cover_material
+  - height
+  - length
   - pattern
   - steering_wheel_cover_installation_type
   - vehicle_application_area
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -8076,11 +9118,15 @@
   - construction
   - decoration_material
   - embellishment/trim_material
+  - height
+  - length
   - material
   - pattern
   - vehicle_application_area
   - vehicle_decor_features
   - vehicle_type
+  - width
+  - wrap_coverage_area
   return_reasons:
   - size
   - color
@@ -8111,6 +9157,7 @@
   - color
   - pattern
   - vehicle_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8127,9 +9174,12 @@
   - color
   - coolant_base_fluid
   - coolant_technology
+  - freeze_protection_temperature_minimum
+  - maximum_boiling_protection_temperature
   - mix_ratio
   - pattern
   - vehicle_type
+  - volume
   return_reasons:
   - temperature_rating
   - incompatible
@@ -8150,6 +9200,7 @@
   - pattern
   - vehicle_fluid_features
   - vehicle_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8169,6 +9220,7 @@
   - pattern
   - vehicle_fluid_features
   - vehicle_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8187,6 +9239,7 @@
   - pattern
   - vehicle_fluid_features
   - vehicle_type
+  - volume
   return_reasons:
   - temperature_rating
   - incompatible
@@ -8206,6 +9259,7 @@
   - pattern
   - vehicle_fluid_features
   - vehicle_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8224,6 +9278,7 @@
   - seals_leak_type
   - vehicle_fluid_features
   - vehicle_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8242,6 +9297,7 @@
   - pattern
   - vehicle_fluid_features
   - vehicle_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8262,6 +9318,7 @@
   - pattern
   - vehicle_fluid_features
   - vehicle_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8282,6 +9339,7 @@
   - vehicle_fluid_features
   - vehicle_type
   - voc_compliance_standard
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8299,6 +9357,7 @@
   - pattern
   - vehicle_fluid_features
   - vehicle_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8315,9 +9374,11 @@
   - compatible_fuel_system_type
   - compatible_injection_type
   - delivery_form
+  - fuel_volume_treated
   - pattern
   - vehicle_fluid_features
   - vehicle_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8337,6 +9398,7 @@
   - pattern
   - vehicle_fluid_features
   - vehicle_type
+  - volume
   return_reasons:
   - viscosity
   - incompatible
@@ -8353,9 +9415,12 @@
   - brake_clutch_fluid_base_chemistry
   - brake_clutch_fluid_dot_specification
   - color
+  - dry_boiling_point
   - pattern
   - vehicle_fluid_features
   - vehicle_type
+  - volume
+  - wet_boiling_point
   return_reasons:
   - viscosity
   - incompatible
@@ -8378,6 +9443,7 @@
   - vehicle_oil_features
   - vehicle_type
   - viscosity
+  - volume
   return_reasons:
   - viscosity
   - incompatible
@@ -8398,6 +9464,7 @@
   - vehicle_oil_features
   - vehicle_type
   - viscosity
+  - volume
   return_reasons:
   - viscosity
   - incompatible
@@ -8416,6 +9483,7 @@
   - vehicle_oil_features
   - vehicle_type
   - viscosity
+  - volume
   return_reasons:
   - viscosity
   - incompatible
@@ -8434,6 +9502,7 @@
   - vehicle_oil_features
   - vehicle_type
   - viscosity
+  - volume
   return_reasons:
   - viscosity
   - incompatible
@@ -8453,6 +9522,7 @@
   - vehicle_oil_features
   - vehicle_type
   - viscosity
+  - volume
   return_reasons:
   - viscosity
   - incompatible
@@ -8470,6 +9540,7 @@
   - pattern
   - vehicle_fluid_features
   - vehicle_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8488,6 +9559,7 @@
   - power_steering_fluid_formulation
   - vehicle_fluid_features
   - vehicle_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8504,6 +9576,7 @@
   - pattern
   - vehicle_fluid_features
   - vehicle_type
+  - volume
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8522,6 +9595,7 @@
   - vehicle_fluid_features
   - vehicle_type
   - vehicle_windshield_fluid_formula
+  - volume
   - windshield_washer_fluid_seasonality
   return_reasons:
   - temperature_rating
@@ -8546,6 +9620,7 @@
   - vehicle_paint_chemistry_base
   - vehicle_paint_type
   - vehicle_type
+  - volume
   return_reasons:
   - color
   - finish
@@ -8564,6 +9639,7 @@
   - color
   - compatible_substrate_material
   - motor_vehicle_paint_application_method
+  - motor_vehicle_paint_coverage_area
   - motor_vehicle_paint_system_step
   - paint_finish
   - pattern
@@ -8573,6 +9649,7 @@
   - vehicle_paint_type
   - vehicle_type
   - voc_regulatory_class
+  - volume
   return_reasons:
   - color
   - finish
@@ -8589,8 +9666,10 @@
   attributes:
   - brake_caliper_paint_base_chemistry
   - brake_caliper_paint_kit_contents
+  - brake_caliper_paint_maximum_temperature_resistance
   - color
   - paint_application_method
+  - paint_dry_to_touch_time
   - paint_finish
   - pattern
   - vehicle_application_area
@@ -8598,6 +9677,7 @@
   - vehicle_paint_chemistry_base
   - vehicle_paint_type
   - vehicle_type
+  - volume
   return_reasons:
   - color
   - finish
@@ -8647,10 +9727,13 @@
   - brake_bleeding_method
   - brake_service_kit_components_included
   - color
+  - height
+  - length
   - material
   - pattern
   - power_source
   - vehicle_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8664,9 +9747,12 @@
   children: []
   attributes:
   - color
+  - height
+  - length
   - pattern
   - power_source
   - vehicle_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8681,10 +9767,13 @@
   attributes:
   - charger_type
   - color
+  - height
+  - length
   - pattern
   - power_source
   - vehicle_battery_charger_features
   - vehicle_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8699,10 +9788,13 @@
   attributes:
   - battery_standards_supported
   - color
+  - height
+  - length
   - pattern
   - power_source
   - test_result_output_method
   - vehicle_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8717,10 +9809,14 @@
   attributes:
   - color
   - filler_type
+  - height
+  - length
   - pattern
   - power_source
   - vehicle_body_filler_form
   - vehicle_type
+  - volume
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8738,10 +9834,13 @@
   - color
   - communication_protocols
   - diagnostic_functions_supported
+  - height
+  - length
   - pattern
   - power_source
   - update_method
   - vehicle_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8757,9 +9856,12 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - power_source
   - vehicle_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -8772,10 +9874,14 @@
   name: Vehicle Jumper Cables
   children: []
   attributes:
+  - cable_length
   - color
+  - height
+  - length
   - pattern
   - power_source
   - vehicle_type
+  - width
   return_reasons:
   - length
   - incompatible
@@ -8817,10 +9923,13 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - pattern
   - power_source
   - tire_changer_operation_type
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8837,11 +9946,14 @@
   - color
   - compatible_tire_application
   - features
+  - height
+  - length
   - mounting_style
   - pattern
   - power_source
   - tire_changer_operation_type
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8858,12 +9970,16 @@
   - bead_breaker_type
   - color
   - features
+  - height
+  - length
+  - maximum_tire_diameter_supported
   - pattern
   - power_source
   - rim_clamping_method
   - tire_changer_operation_type
   - tire_changer_type
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8879,10 +9995,13 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - pattern
   - power_source
   - tire_changer_operation_type
   - vehicle_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8897,10 +10016,13 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - pattern
   - power_source
   - tire_changer_operation_type
   - vehicle_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8915,12 +10037,15 @@
   attributes:
   - color
   - features
+  - height
+  - length
   - pattern
   - power_source
   - tip_finish_coating
   - tire_changer_operation_type
   - tire_spoon_type
   - vehicle_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -8969,11 +10094,16 @@
   attributes:
   - color
   - features
+  - height
   - inflation_method_included
   - intended_repair_location
+  - length
+  - maximum_puncture_size_supported
   - pattern
   - power_source
+  - sealant_volume
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -8989,9 +10119,14 @@
   attributes:
   - color
   - damage_type
+  - height
+  - length
   - pattern
   - power_source
   - vehicle_type
+  - width
+  - windshield_repair_kit_maximum_crack_length
+  - windshield_repair_kit_maximum_repair_diameter
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -9128,12 +10263,15 @@
   - accessory_size
   - compatible_protective_gear_integration
   - gear_material
+  - height
+  - length
   - motorcycle_armor_certification_standard
   - motorcycle_protective_gear_size_system
   - protective_gear_features
   - protector_coverage_area
   - target_gender
   - vehicle_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9151,11 +10289,14 @@
   - gear_material
   - guard_construction_type
   - guard_size_measurement_basis
+  - height
+  - length
   - motorcycle_guard_coverage_area
   - motorcycle_protective_gear_size_system
   - protective_gear_features
   - target_gender
   - vehicle_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9202,12 +10343,15 @@
   - frame_color
   - frame_pattern
   - gear_material
+  - height
+  - length
   - lens_color
   - lens_pattern
   - motorcycle_protective_gear_size_system
   - protective_gear_features
   - target_gender
   - vehicle_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9230,10 +10374,13 @@
   - hand_guard_mounting_type
   - hand_guard_set_configuration
   - hand_guard_weather_protection
+  - height
+  - length
   - motorcycle_protective_gear_size_system
   - protective_gear_features
   - target_gender
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9255,12 +10402,15 @@
   - compatible_helmet_certification_standard
   - compatible_helmet_shell_size
   - gear_material
+  - height
+  - length
   - motorcycle_protective_gear_size_system
   - pattern
   - protective_gear_features
   - replacement_part_purpose
   - target_gender
   - vehicle_type
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -9285,6 +10435,7 @@
   - color
   - compatible_visor_system
   - gear_material
+  - height
   - helmet_communication_system_readiness
   - helmet_interior_liner_type
   - helmet_safety_certification_standard
@@ -9293,11 +10444,13 @@
   - helmet_vehicle_fit
   - helmet_ventilation_configuration
   - helmet_visor_shield_type
+  - length
   - motorcycle_protective_gear_size_system
   - pattern
   - protective_gear_features
   - target_gender
   - vehicle_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9320,6 +10473,7 @@
   - color
   - compatible_visor_system
   - gear_material
+  - height
   - helmet_communication_system_readiness
   - helmet_fit_head_shape
   - helmet_interior_liner_type
@@ -9329,11 +10483,13 @@
   - helmet_vehicle_fit
   - helmet_ventilation_configuration
   - helmet_visor_shield_type
+  - length
   - motorcycle_protective_gear_size_system
   - pattern
   - protective_gear_features
   - target_gender
   - vehicle_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9354,6 +10510,7 @@
   - color
   - compatible_visor_system
   - gear_material
+  - height
   - helmet_communication_system_readiness
   - helmet_interior_liner_type
   - helmet_safety_certification_standard
@@ -9362,11 +10519,13 @@
   - helmet_vehicle_fit
   - helmet_ventilation_configuration
   - helmet_visor_shield_type
+  - length
   - motorcycle_protective_gear_size_system
   - pattern
   - protective_gear_features
   - target_gender
   - vehicle_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9389,6 +10548,7 @@
   - color
   - compatible_visor_system
   - gear_material
+  - height
   - helmet_communication_system_readiness
   - helmet_interior_liner_type
   - helmet_safety_certification_standard
@@ -9399,11 +10559,13 @@
   - helmet_ventilation_configuration
   - helmet_visor_shield_optical_features
   - helmet_visor_shield_type
+  - length
   - motorcycle_protective_gear_size_system
   - pattern
   - protective_gear_features
   - target_gender
   - vehicle_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9424,6 +10586,7 @@
   - compatible_visor_system
   - gear_material
   - goggle_integration
+  - height
   - helmet_communication_system_readiness
   - helmet_interior_liner_type
   - helmet_safety_certification_standard
@@ -9433,12 +10596,14 @@
   - helmet_ventilation_configuration
   - helmet_visor_peak_adjustability
   - helmet_visor_shield_type
+  - length
   - motorcycle_protective_gear_size_system
   - pattern
   - protective_gear_features
   - target_gender
   - vehicle_type
   - ventilation_configuration
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9459,6 +10624,7 @@
   - color
   - compatible_visor_system
   - gear_material
+  - height
   - helmet_communication_system_readiness
   - helmet_interior_liner_type
   - helmet_liner_material
@@ -9468,11 +10634,14 @@
   - helmet_vehicle_fit
   - helmet_ventilation_configuration
   - helmet_visor_shield_type
+  - helmet_weight
+  - length
   - motorcycle_protective_gear_size_system
   - pattern
   - protective_gear_features
   - target_gender
   - vehicle_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9520,14 +10689,18 @@
   children: []
   attributes:
   - accessory_size
+  - height
   - item_material
+  - kidney_belt_panel_height
   - kidney_belt_support_level
+  - length
   - motorcycle_kidney_belt_construction_type
   - motorcycle_kidney_belt_purpose
   - motorcycle_protective_gear_size_system
   - protective_gear_features
   - target_gender
   - vehicle_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9545,10 +10718,13 @@
   attributes:
   - accessory_size
   - gear_material
+  - height
+  - length
   - motorcycle_protective_gear_size_system
   - protective_gear_features
   - target_gender
   - vehicle_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9565,6 +10741,8 @@
   - accessory_size
   - compatible_protective_gear
   - gear_material
+  - height
+  - length
   - motorcycle_protective_gear_size_system
   - motorcycle_riding_discipline
   - neck_brace_fit_system
@@ -9572,6 +10750,7 @@
   - protective_gear_features
   - target_gender
   - vehicle_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -9612,11 +10791,14 @@
   name: Automotive Alarm Accessories
   children: []
   attributes:
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - power_source
   - vehicle_alarm/lock_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9632,11 +10814,14 @@
   attributes:
   - battery_size
   - battery_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - power_source
   - vehicle_alarm/lock_features
   - vehicle_type
+  - width
   return_reasons:
   - range
   - incompatible
@@ -9650,13 +10835,18 @@
   name: Motorcycle Alarms & Locks
   children: []
   attributes:
+  - alarm_siren_loudness
   - battery_size
   - battery_type
+  - height
   - item_condition
+  - length
+  - locking_bolt_diameter
   - manufacturer_type
   - power_source
   - vehicle_alarm/lock_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9673,12 +10863,15 @@
   - vp-1-6-3-4-2
   - vp-1-6-3-4-3
   attributes:
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - material
   - power_source
   - vehicle_alarm/lock_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9692,7 +10885,9 @@
   name: Vehicle Door Lock Actuators
   children: []
   attributes:
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - material
   - power_source
@@ -9700,6 +10895,7 @@
   - vehicle_door_lock_actuator_kit_contents
   - vehicle_door_lock_actuator_wiring_configuration
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9714,12 +10910,15 @@
   children: []
   attributes:
   - door_lock_knob_attachment_method
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - material
   - power_source
   - vehicle_alarm/lock_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9734,7 +10933,9 @@
   children: []
   attributes:
   - electrical_connector_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - material
   - power_source
@@ -9742,6 +10943,7 @@
   - vehicle_door_lock_actuation_method
   - vehicle_door_lock_included_components
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9755,13 +10957,16 @@
   name: Vehicle Hitch Locks
   children: []
   attributes:
+  - height
   - hitch_class
   - item_condition
+  - length
   - manufacturer_type
   - material
   - power_source
   - vehicle_alarm/lock_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9777,15 +10982,18 @@
   attributes:
   - battery_size
   - battery_type
+  - height
   - immobilizer_installation_type
   - immobilizer_type
   - immobilizer_unlock_method
   - item_condition
+  - length
   - manufacturer_type
   - material
   - power_source
   - vehicle_alarm/lock_features
   - vehicle_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -9800,12 +11008,15 @@
   attributes:
   - battery_size
   - battery_type
+  - height
   - item_condition
+  - length
   - manufacturer_type
   - power_source
   - remote_keyless_system_programming_method
   - vehicle_alarm/lock_features
   - vehicle_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -9818,14 +11029,18 @@
   name: Vehicle Steering Wheel Locks
   children: []
   attributes:
+  - height
   - item_condition
+  - length
   - lock_cylinder_type
   - manufacturer_type
   - material
+  - maximum_extended_length
   - power_source
   - vehicle_alarm/lock_features
   - vehicle_steering_wheel_lock_form_factor
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9839,7 +11054,9 @@
   name: Vehicle Wheel Clamps
   children: []
   attributes:
+  - height
   - item_condition
+  - length
   - lock_security_level
   - manufacturer_type
   - material
@@ -9847,6 +11064,7 @@
   - vehicle_alarm/lock_features
   - vehicle_type
   - visibility_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9873,12 +11091,15 @@
   - battery_size
   - battery_type
   - color
+  - height
+  - length
   - pattern
   - product_certifications_standards
   - safety_equipment_material
   - vehicle_safety_equipment_position
   - vehicle_safety_equipment_visibility_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9892,15 +11113,19 @@
   name: Car Window Nets
   children: []
   attributes:
+  - height
+  - length
   - motorsport_window_net_certification
   - net_material
   - product_certifications_standards
   - vehicle_safety_equipment_position
   - vehicle_safety_equipment_visibility_features
   - vehicle_type
+  - width
   - window_net_latch_mechanism
   - window_net_mounting_hardware
   - window_net_opening_direction
+  - window_net_strap_width
   return_reasons:
   - size
   - color
@@ -9918,12 +11143,15 @@
   - flare_color
   - flare_type
   - hazard_signal_mode
+  - height
+  - length
   - mounting_method
   - product_certifications_standards
   - safety_equipment_material
   - vehicle_safety_equipment_position
   - vehicle_safety_equipment_visibility_features
   - vehicle_type
+  - width
   return_reasons:
   - brightness
   - burn_time
@@ -9939,11 +11167,14 @@
   attributes:
   - airbag_position
   - compatible_airbag_system_type
+  - height
+  - length
   - product_certifications_standards
   - safety_equipment_material
   - vehicle_safety_equipment_position
   - vehicle_safety_equipment_visibility_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -9958,13 +11189,17 @@
   children: []
   attributes:
   - cage_type
+  - height
   - installation_method
+  - length
   - product_certifications_standards
   - roll_cage_tubing_material
+  - roll_cage_tubing_wall_thickness
   - safety_equipment_material
   - vehicle_safety_equipment_position
   - vehicle_safety_equipment_visibility_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -9979,6 +11214,9 @@
   name: Vehicle Seat Belt Buckles
   children: []
   attributes:
+  - compatible_seat_belt_tongue_width
+  - height
+  - length
   - product_certifications_standards
   - safety_equipment_material
   - seat_belt_buckle_electrical_connector_type
@@ -9987,6 +11225,7 @@
   - vehicle_safety_equipment_position
   - vehicle_safety_equipment_visibility_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10002,11 +11241,14 @@
   attributes:
   - cover_features
   - cover_material
+  - height
+  - length
   - product_certifications_standards
   - seat_belt_cover_placement
   - vehicle_safety_equipment_position
   - vehicle_safety_equipment_visibility_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - comfort
@@ -10021,14 +11263,19 @@
   children: []
   attributes:
   - compatible_strap_retractor
+  - height
   - intended_seating_position
+  - length
   - product_certifications_standards
   - safety_equipment_material
   - seat_belt_attachment_type
   - seat_belt_strap_installation_location
+  - seat_belt_strap_thickness
+  - seat_belt_strap_width
   - vehicle_safety_equipment_position
   - vehicle_safety_equipment_visibility_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10044,10 +11291,13 @@
   attributes:
   - belt_type
   - fabric
+  - height
+  - length
   - product_certifications_standards
   - vehicle_safety_equipment_position
   - vehicle_safety_equipment_visibility_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10061,11 +11311,15 @@
   name: Vehicle Warning Whips
   children: []
   attributes:
+  - height
+  - length
   - product_certifications_standards
   - safety_equipment_material
   - vehicle_safety_equipment_position
   - vehicle_safety_equipment_visibility_features
   - vehicle_type
+  - whip_diameter
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10079,12 +11333,15 @@
   name: Vehicle Wheel Chocks
   children: []
   attributes:
+  - height
+  - length
   - product_certifications_standards
   - safety_equipment_material
   - vehicle_safety_equipment_position
   - vehicle_safety_equipment_visibility_features
   - vehicle_type
   - wheel_chock_grip_features
+  - width
   return_reasons:
   - size
   - incompatible
@@ -10301,6 +11558,7 @@
   name: Distress Beacons and EPIRBs
   children: []
   attributes:
+  - battery_service_life
   - color
   - distress_transmission_frequency
   - floatation
@@ -10341,6 +11599,8 @@
   - color
   - life_raft_certification_standard
   - life_raft_container_type
+  - life_raft_packed_dimensions
+  - life_raft_packed_weight
   - material
   - pattern
   - service_interval
@@ -10361,6 +11621,7 @@
   - color
   - lifebuoy_approval_standard
   - lifebuoy_features
+  - lifebuoy_weight
   - pattern
   - watercraft_safety_equipment_activation_type
   return_reasons:
@@ -10375,6 +11636,7 @@
   name: Man Overboard Systems
   children: []
   attributes:
+  - battery_life_active_transmission
   - color
   - compatible_watercraft_communication_standard
   - man_overboard_system_type
@@ -10427,9 +11689,12 @@
   - vp-1-6-7-14
   - vp-1-6-7-15
   attributes:
+  - height
+  - length
   - protective_gear_certification_standard
   - protective_gear_features
   - vehicle_type
+  - width
   return_reasons:
   - too_big
   - too_small
@@ -10446,8 +11711,11 @@
   children: []
   attributes:
   - bar_pad_style
+  - height
+  - length
   - protective_gear_certification_standard
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -10694,6 +11962,7 @@
   - color
   - compatible_helmet_type
   - gear_material
+  - neck_support_circumference
   - neck_support_size_system
   - pattern
   - protective_gear_certification_standard
@@ -10847,9 +12116,13 @@
   - cargo_net_adjustability
   - cargo_net_style
   - features
+  - height
   - item_condition
+  - length
+  - mesh_opening_size
   - net_material
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -10868,10 +12141,14 @@
   - cargo_net_adjustability
   - cargo_net_style
   - features
+  - height
   - item_condition
+  - length
+  - mesh_opening_size
   - net_material
   - roof_cargo_net_hook_fastener_style
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -10890,10 +12167,14 @@
   - cargo_net_adjustability
   - cargo_net_style
   - features
+  - height
   - item_condition
+  - length
+  - mesh_opening_size
   - net_material
   - truck_bed_length_class
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -10914,9 +12195,13 @@
   - cargo_net_stretch_type
   - cargo_net_style
   - features
+  - height
   - item_condition
+  - length
+  - mesh_opening_size
   - net_material
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -10937,9 +12222,12 @@
   - vp-1-7-2-5
   attributes:
   - compatible_hitch_receiver_size
+  - height
   - item_condition
+  - length
   - material
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -10955,9 +12243,12 @@
   children: []
   attributes:
   - compatible_hitch_receiver_size
+  - height
   - item_condition
+  - length
   - material
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -10974,9 +12265,12 @@
   attributes:
   - carrying_capacity_pairs_boards
   - compatible_hitch_receiver_size
+  - height
   - item_condition
+  - length
   - material
   - vehicle_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11046,10 +12340,13 @@
   attributes:
   - color
   - features
+  - height
   - item_condition
+  - length
   - material
   - pattern
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -11067,9 +12364,12 @@
   - compatible_roof_rail_type
   - crossbar_shape_profile
   - features
+  - height
   - item_condition
+  - length
   - material
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -11089,11 +12389,16 @@
   - bike_rack_tilt_function
   - features
   - foldability_stow
+  - height
   - integrated_locking
   - item_condition
+  - length
   - material
+  - maximum_tire_width_supported
+  - maximum_wheelbase_supported
   - rack_type
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -11111,10 +12416,13 @@
   - carrier_style
   - compatible_crossbar
   - features
+  - height
   - item_condition
+  - length
   - material
   - rack_type
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -11132,10 +12440,13 @@
   attributes:
   - cargo_rack_finish
   - features
+  - height
   - item_condition
+  - length
   - material
   - mounting_receiver_size
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -11152,10 +12463,13 @@
   children: []
   attributes:
   - features
+  - height
   - item_condition
+  - length
   - material
   - rack_type
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -11171,10 +12485,13 @@
   children: []
   attributes:
   - features
+  - height
   - item_condition
+  - length
   - material
   - rack_type
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -11190,12 +12507,15 @@
   children: []
   attributes:
   - features
+  - height
   - item_condition
+  - length
   - material
   - motorcycle_rack_carrier_style
   - rack_type
   - tie_down_points_straps_included
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -11212,10 +12532,13 @@
   children: []
   attributes:
   - features
+  - height
   - item_condition
+  - length
   - material
   - rack_type
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -11232,10 +12555,13 @@
   attributes:
   - compatible_water_board_type
   - features
+  - height
   - item_condition
+  - length
   - material
   - rack_type
   - vehicle_type
+  - width
   return_reasons:
   - style
   - incompatible
@@ -11250,10 +12576,13 @@
   children: []
   attributes:
   - features
+  - height
   - item_condition
+  - length
   - loading_ramp_type
   - material
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -11273,13 +12602,17 @@
   - vp-1-7-5-4
   attributes:
   - features
+  - height
   - item_condition
+  - length
   - material
   - number_of_trailer_axles
   - trailer_construction
   - trailer_coupler_size
+  - trailer_interior_width
   - trailer_type
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -11296,14 +12629,18 @@
   attributes:
   - boat_trailer_construction_type
   - features
+  - height
   - item_condition
+  - length
   - lighting_type
   - material
   - number_of_trailer_axles
   - trailer_construction
   - trailer_coupler_size
+  - trailer_interior_width
   - trailer_type
   - vehicle_type
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -11319,15 +12656,19 @@
   children: []
   attributes:
   - features
+  - height
   - interior_stall_configuration
   - item_condition
+  - length
   - material
   - number_of_trailer_axles
   - ramp_type
   - trailer_construction
   - trailer_coupler_size
+  - trailer_interior_width
   - trailer_type
   - vehicle_type
+  - width
   return_reasons:
   - size
   - capacity
@@ -11344,16 +12685,20 @@
   children: []
   attributes:
   - features
+  - height
   - item_condition
+  - length
   - material
   - number_of_trailer_axles
   - trailer_construction
   - trailer_coupler_size
+  - trailer_interior_width
   - trailer_type
   - travel_trailer_appliances_fuel_type
   - travel_trailer_holding_tank_type
   - travel_trailer_power_hookup_shore_power
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -11370,13 +12715,17 @@
   children: []
   attributes:
   - features
+  - height
   - item_condition
+  - length
   - material
   - number_of_trailer_axles
   - trailer_construction
   - trailer_coupler_size
+  - trailer_interior_width
   - trailer_type
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -11400,12 +12749,15 @@
   - care_instructions
   - carry_options
   - color
+  - height
   - item_condition
+  - length
   - motorcycle_luggage_capacity_class
   - motorcycle_luggage_mounting_system
   - motorcycle_luggage_side
   - pattern
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -11423,10 +12775,14 @@
   attributes:
   - box_type
   - features
+  - height
   - item_condition
+  - length
   - lumber/wood_type
   - material
   - vehicle_type
+  - volume
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -11442,9 +12798,12 @@
   name: Vehicle Headrest Hangers & Hooks
   children: []
   attributes:
+  - height
   - item_condition
+  - length
   - material
   - vehicle_type
+  - width
   return_reasons:
   - size
   - style
@@ -11460,13 +12819,16 @@
   children: []
   attributes:
   - color
+  - height
   - item_condition
+  - length
   - material
   - number_of_compartments
   - organizer_type
   - pattern
   - vehicle_organizer_features
   - vehicle_type
+  - width
   return_reasons:
   - size
   - color
@@ -11521,9 +12883,12 @@
   - battery_type
   - control_technology
   - durability_features
+  - height
   - item_condition
   - item_material
+  - length
   - watercraft_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11540,9 +12905,12 @@
   - chain_type
   - control_technology
   - durability_features
+  - height
   - item_condition
   - item_material
+  - length
   - watercraft_type
+  - width
   return_reasons:
   - size
   - length
@@ -11557,15 +12925,19 @@
   name: Anchor Lines & Ropes
   children: []
   attributes:
+  - anchor_line_diameter
   - control_technology
   - durability_features
+  - height
   - item_condition
   - item_material
+  - length
   - line/rope_type
   - rope_construction
   - splice_termination_type
   - suitable_for_anchoring_use
   - watercraft_type
+  - width
   return_reasons:
   - size
   - length
@@ -11586,10 +12958,13 @@
   - compatible_windlass_rode
   - control_technology
   - durability_features
+  - height
   - item_condition
   - item_material
+  - length
   - power_source
   - watercraft_type
+  - width
   - windlass_control_station_type
   - windlass_design
   - windlass_mount_type
@@ -11606,13 +12981,18 @@
   name: Anchors
   children: []
   attributes:
+  - anchor_shank_length
   - anchor_type
+  - anchor_weight
   - bottom_type_suitability
   - control_technology
   - durability_features
+  - height
   - item_condition
   - item_material
+  - length
   - watercraft_type
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -11629,10 +13009,13 @@
   - boat_hook_flotation
   - control_technology
   - durability_features
+  - height
   - hook_type
   - item_condition
   - item_material
+  - length
   - watercraft_type
+  - width
   return_reasons:
   - size
   - length
@@ -11649,11 +13032,14 @@
   - boat_ladder_stowage_style
   - control_technology
   - durability_features
+  - height
   - item_condition
   - item_material
   - ladder_type
+  - length
   - step_surface_texture
   - watercraft_type
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -11674,9 +13060,13 @@
   - cleat_type
   - control_technology
   - durability_features
+  - fastener_hole_spacing
+  - height
   - item_condition
   - item_material
+  - length
   - watercraft_type
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -11693,10 +13083,14 @@
   - compatible_dock_structure_type
   - control_technology
   - durability_features
+  - height
   - item_condition
   - item_material
+  - length
   - step_type
+  - step_width
   - watercraft_type
+  - width
   return_reasons:
   - size
   - weight_capacity
@@ -11711,10 +13105,13 @@
   name: Sailboat Parts
   children: []
   attributes:
+  - height
   - item_condition
   - item_material
+  - length
   - lumber/wood_type
   - watercraft_type
+  - width
   - wood_finish
   return_reasons:
   - size
@@ -11731,11 +13128,16 @@
   - vp-1-8-3-1
   - vp-1-8-3-2
   attributes:
+  - height
   - item_material
+  - length
   - product_form
   - vehicle_cleaning_item_features
+  - volume
   - watercraft_care_application_area
+  - watercraft_care_coverage_area
   - watercraft_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -11750,11 +13152,16 @@
   attributes:
   - alcohol/solvent_content
   - cleaner_purpose
+  - height
   - item_material
+  - length
   - product_form
   - vehicle_cleaning_item_features
+  - volume
   - watercraft_care_application_area
+  - watercraft_care_coverage_area
   - watercraft_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -11768,12 +13175,17 @@
   children: []
   attributes:
   - alcohol/solvent_content
+  - height
   - item_material
+  - length
   - polish_type
   - product_form
   - vehicle_cleaning_item_features
+  - volume
   - watercraft_care_application_area
+  - watercraft_care_coverage_area
   - watercraft_type
+  - width
   return_reasons:
   - finish
   - incompatible
@@ -11799,12 +13211,17 @@
   - battery_size
   - battery_type
   - compatible_watercraft_engine_type
+  - height
+  - impeller_height
   - item_condition
   - item_material
+  - length
+  - piston_oversize
   - propeller_hub_type
   - propeller_rotation
   - vehicle_engine/part_features
   - watercraft_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -11819,13 +13236,19 @@
   attributes:
   - alternator_marine_ignition_protection_rating
   - alternator_terminal_connection_type
+  - amperage
   - compatible_watercraft_engine_type
+  - height
   - item_condition
   - item_material
+  - length
+  - piston_oversize
+  - power_output_typical
   - propeller_hub_type
   - propeller_rotation
   - vehicle_engine/part_features
   - watercraft_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -11840,12 +13263,16 @@
   attributes:
   - carburetor_mounting_flange_type
   - compatible_watercraft_engine_type
+  - height
   - item_condition
   - item_material
+  - length
+  - piston_oversize
   - propeller_hub_type
   - propeller_rotation
   - vehicle_engine/part_features
   - watercraft_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -11860,15 +13287,19 @@
   attributes:
   - compatible_watercraft_engine_type
   - control_cable_connector_type
+  - height
   - item_condition
   - item_material
+  - length
   - lever_configuration
   - number_of_control_stations
+  - piston_oversize
   - propeller_hub_type
   - propeller_rotation
   - vehicle_engine/part_features
   - watercraft_engine_control_type
   - watercraft_type
+  - width
   return_reasons:
   - length
   - incompatible
@@ -11885,13 +13316,17 @@
   - battery_size
   - battery_type
   - compatible_watercraft_engine_type
+  - height
   - item_condition
   - item_material
+  - length
+  - piston_oversize
   - propeller_hub_type
   - propeller_rotation
   - vehicle_engine/part_features
   - watercraft_ignition_part_voltage
   - watercraft_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -11905,14 +13340,20 @@
   children: []
   attributes:
   - compatible_watercraft_engine_type
+  - height
   - item_condition
   - item_material
+  - length
+  - piston_oversize
   - propeller_hub_type
   - propeller_rotation
   - vehicle_engine/part_features
   - watercraft_impeller_material_grade
+  - watercraft_impeller_outer_diameter
+  - watercraft_impeller_thickness_overall_width
   - watercraft_pump_stage_impeller_role
   - watercraft_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -11926,13 +13367,18 @@
   children: []
   attributes:
   - compatible_watercraft_engine_type
+  - height
   - item_condition
   - item_material
+  - length
   - lock_placement
+  - piston_oversize
   - propeller_hub_type
   - propeller_rotation
   - vehicle_engine/part_features
+  - watercraft_motor_lock_shackle_bolt_diameter
   - watercraft_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -11947,14 +13393,18 @@
   attributes:
   - compatible_watercraft_engine_type
   - corrosion_resistance_level
+  - height
   - item_condition
+  - length
   - mount_material
+  - piston_oversize
   - propeller_hub_type
   - propeller_rotation
   - vehicle_engine/part_features
   - watercraft_motor_mount_adjustment_features
   - watercraft_motor_mounting_type
   - watercraft_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -11968,13 +13418,18 @@
   children: []
   attributes:
   - compatible_watercraft_engine_type
+  - height
   - item_condition
   - item_material
+  - length
+  - piston_oversize
+  - piston_ring_thickness
   - propeller_hub_type
   - propeller_rotation
   - vehicle_engine/part_features
   - watercraft_piston_part_type
   - watercraft_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -11989,16 +13444,22 @@
   children: []
   attributes:
   - compatible_watercraft_engine_type
+  - height
   - item_condition
   - item_material
+  - length
+  - piston_oversize
   - propeller_blade_cup
   - propeller_blade_design
   - propeller_hub_type
   - propeller_rotation
   - vehicle_engine/part_features
   - watercraft_propeller_blade_rake
+  - watercraft_propeller_diameter
+  - watercraft_propeller_pitch
   - watercraft_propeller_rotation_direction
   - watercraft_type
+  - width
   return_reasons:
   - pitch
   - incompatible
@@ -12017,12 +13478,20 @@
   attributes:
   - battery_size
   - battery_type
+  - cylinder_bore
+  - dry_weight
   - engine_type
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
   - item_material
+  - length
+  - stroke
   - vehicle_engine_features
   - watercraft_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12037,14 +13506,22 @@
   children: []
   attributes:
   - cooling_system_type
+  - cylinder_bore
+  - dry_weight
   - engine_rotation_direction
   - engine_type
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
   - item_material
+  - length
   - marine_transmission_type
+  - stroke
   - vehicle_engine_features
   - watercraft_type
+  - width
   return_reasons:
   - size
   - horsepower
@@ -12061,15 +13538,24 @@
   attributes:
   - battery_size
   - battery_type
+  - cylinder_bore
+  - dry_weight
   - engine_type
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
   - item_material
+  - length
+  - outboard_motor_alternator_output
   - outboard_motor_shaft_type
   - outboard_motor_steering_type
+  - stroke
   - trim_tilt_type
   - vehicle_engine_features
   - watercraft_type
+  - width
   return_reasons:
   - size
   - shaft_length
@@ -12087,12 +13573,17 @@
   attributes:
   - battery_size
   - battery_type
+  - dry_weight
   - engine_type
   - fuel_supply
+  - height
   - item_condition
   - item_material
+  - length
   - vehicle_engine_features
+  - voltage
   - watercraft_type
+  - width
   return_reasons:
   - size
   - shaft_length
@@ -12114,10 +13605,13 @@
   attributes:
   - compliance_certifications
   - exhaust_cooling_type
+  - height
   - item_condition
   - item_material
+  - length
   - mounting_location
   - watercraft_type
+  - width
   return_reasons:
   - size
   - incompatible
@@ -12133,10 +13627,13 @@
   attributes:
   - compliance_certifications
   - exhaust_cooling_type
+  - height
   - item_condition
   - item_material
+  - length
   - mounting_location
   - watercraft_type
+  - width
   return_reasons:
   - operating_noise
   - incompatible
@@ -12152,10 +13649,13 @@
   attributes:
   - compliance_certifications
   - exhaust_cooling_type
+  - height
   - item_condition
   - item_material
+  - length
   - mounting_location
   - watercraft_type
+  - width
   return_reasons:
   - size
   - operating_noise
@@ -12210,9 +13710,12 @@
   - vp-1-8-7-5
   - vp-1-8-7-6
   attributes:
+  - height
   - item_condition
   - item_material
+  - length
   - watercraft_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12227,9 +13730,12 @@
   attributes:
   - fuel_line_compliance_standard
   - fuel_line_connector_interface_type
+  - height
   - item_condition
   - item_material
+  - length
   - watercraft_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12243,11 +13749,15 @@
   children: []
   attributes:
   - display_backlight_color
+  - gauge_cutout_diameter
   - gauge_mounting_type
+  - height
   - item_condition
   - item_material
+  - length
   - meter_type
   - watercraft_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12260,9 +13770,13 @@
   name: Watercraft Fuel Pumps & Parts
   children: []
   attributes:
+  - height
   - item_condition
   - item_material
+  - length
+  - maximum_operating_pressure
   - watercraft_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12275,12 +13789,19 @@
   name: Watercraft Fuel Tanks & Parts
   children: []
   attributes:
+  - fuel_tank_capacity
   - fuel_tank_orientation
+  - height
   - item_condition
   - item_material
+  - length
+  - watercraft_fuel_tank_feed_connection_diameter
+  - watercraft_fuel_tank_fill_neck_diameter
   - watercraft_fuel_tank_sending_unit_pattern
   - watercraft_fuel_tank_shape
+  - watercraft_fuel_tank_vent_connection_diameter
   - watercraft_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12323,13 +13844,16 @@
   attributes:
   - battery_size
   - battery_type
+  - height
   - item_condition
   - item_material
+  - length
   - light_type
   - lighting_features
   - power_source
   - watercraft_lighting_certification_compliance
   - watercraft_type
+  - width
   return_reasons:
   - color
   - brightness
@@ -12348,9 +13872,12 @@
   attributes:
   - battery_size
   - battery_type
+  - height
   - item_condition
   - item_material
+  - length
   - watercraft_type
+  - width
   return_reasons:
   - incompatible
   - changed_my_mind
@@ -12363,13 +13890,18 @@
   name: Watercraft Steering Cables
   children: []
   attributes:
+  - cable_length
+  - height
   - item_condition
   - item_material
+  - length
   - steering_cable_end_fitting_type
   - watercraft_steering_cable_core_material
   - watercraft_steering_cable_hardware_included
+  - watercraft_steering_cable_stroke
   - watercraft_steering_cable_system_type
   - watercraft_type
+  - width
   return_reasons:
   - length
   - incompatible
@@ -12383,13 +13915,16 @@
   name: Watercraft Steering Wheels
   children: []
   attributes:
+  - height
   - item_condition
   - item_material
+  - length
   - steering_wheel_grip_material
   - steering_wheel_mounting_pattern
   - watercraft_steering_wheel_hub_bore_type
   - watercraft_steering_wheel_type
   - watercraft_type
+  - width
   return_reasons:
   - color
   - incompatible
@@ -12427,12 +13962,18 @@
   - vp-2-1-1
   - vp-2-1-2
   attributes:
+  - airframe_total_time
   - body_color
   - body_pattern
   - fuel_supply
+  - height
   - item_condition
+  - length
+  - maximum_takeoff_weight_mtow
   - upholstery_color
   - upholstery_pattern
+  - width
+  - wingspan
   return_reasons:
   - size
   - performance
@@ -12459,12 +14000,15 @@
   - vp-2-1-1-12
   attributes:
   - aircraft_airframe_material
+  - aircraft_service_ceiling
+  - airframe_total_time
   - body_color
   - body_pattern
   - fuel_supply
   - item_condition
   - upholstery_color
   - upholstery_pattern
+  - wingspan
   return_reasons:
   - size
   - performance
@@ -12481,6 +14025,8 @@
   - aircraft_airframe_material
   - aircraft_engine_configuration
   - aircraft_engine_type
+  - aircraft_service_ceiling
+  - airframe_total_time
   - body_color
   - body_pattern
   - cockpit_type
@@ -12490,6 +14036,7 @@
   - item_condition
   - upholstery_color
   - upholstery_pattern
+  - wingspan
   return_reasons:
   - performance
   - changed_my_mind
@@ -12503,6 +14050,8 @@
   children: []
   attributes:
   - aircraft_airframe_material
+  - aircraft_service_ceiling
+  - airframe_total_time
   - battery_size
   - battery_type
   - color
@@ -12512,6 +14061,7 @@
   - item_condition
   - pattern
   - video_resolution_supported
+  - wingspan
   return_reasons:
   - performance
   - changed_my_mind
@@ -12527,6 +14077,8 @@
   - aircraft_airframe_material
   - aircraft_engine_configuration
   - aircraft_engine_type
+  - aircraft_service_ceiling
+  - airframe_total_time
   - body_color
   - body_pattern
   - cockpit_type
@@ -12535,6 +14087,7 @@
   - ultralight_aircraft_wing_configuration
   - upholstery_color
   - upholstery_pattern
+  - wingspan
   return_reasons:
   - performance
   - changed_my_mind
@@ -12548,8 +14101,13 @@
   children: []
   attributes:
   - aircraft_airframe_material
+  - aircraft_empty_weight
   - aircraft_landing_gear_type
+  - aircraft_service_ceiling
+  - airframe_total_time
   - autogyro_cockpit_enclosure
+  - autogyro_landing_distance
+  - autogyro_rotor_diameter
   - body_color
   - body_pattern
   - cockpit_type
@@ -12557,6 +14115,7 @@
   - item_condition
   - upholstery_color
   - upholstery_pattern
+  - wingspan
   return_reasons:
   - performance
   - changed_my_mind
@@ -12570,6 +14129,8 @@
   children: []
   attributes:
   - aircraft_airframe_material
+  - aircraft_service_ceiling
+  - airframe_total_time
   - body_color
   - body_pattern
   - cockpit_type
@@ -12580,6 +14141,7 @@
   - item_condition
   - upholstery_color
   - upholstery_pattern
+  - wingspan
   return_reasons:
   - size
   - performance
@@ -12596,6 +14158,8 @@
   - aircraft_airframe_material
   - aircraft_engine_configuration
   - aircraft_engine_type
+  - aircraft_service_ceiling
+  - airframe_total_time
   - body_color
   - body_pattern
   - cockpit_type
@@ -12603,6 +14167,7 @@
   - item_condition
   - upholstery_color
   - upholstery_pattern
+  - wingspan
   return_reasons:
   - size
   - performance
@@ -12620,6 +14185,8 @@
   - aircraft_airframe_material
   - aircraft_engine_configuration
   - aircraft_engine_type
+  - aircraft_service_ceiling
+  - airframe_total_time
   - body_color
   - body_pattern
   - cockpit_type
@@ -12627,6 +14194,7 @@
   - item_condition
   - upholstery_color
   - upholstery_pattern
+  - wingspan
   return_reasons:
   - performance
   - changed_my_mind
@@ -12641,9 +14209,13 @@
   attributes:
   - aircraft_airframe_material
   - aircraft_engine_configuration
+  - aircraft_engine_time_since_overhaul_tso
   - aircraft_engine_type
   - aircraft_galley_configuration
+  - aircraft_maximum_payload
   - aircraft_operational_certification
+  - aircraft_service_ceiling
+  - airframe_total_time
   - body_color
   - body_pattern
   - cockpit_type
@@ -12651,6 +14223,7 @@
   - item_condition
   - upholstery_color
   - upholstery_pattern
+  - wingspan
   return_reasons:
   - performance
   - changed_my_mind
@@ -12669,6 +14242,8 @@
   - aircraft_internet_connection
   - aircraft_lavatory_configuration
   - aircraft_maintenance_program_enrollment
+  - aircraft_service_ceiling
+  - airframe_total_time
   - body_color
   - body_pattern
   - cockpit_type
@@ -12676,6 +14251,7 @@
   - item_condition
   - upholstery_color
   - upholstery_pattern
+  - wingspan
   return_reasons:
   - size
   - performance
@@ -12693,6 +14269,8 @@
   - aircraft_cabin_configuration
   - aircraft_engine_configuration
   - aircraft_engine_type
+  - aircraft_service_ceiling
+  - airframe_total_time
   - body_color
   - body_pattern
   - cockpit_type
@@ -12700,6 +14278,7 @@
   - item_condition
   - upholstery_color
   - upholstery_pattern
+  - wingspan
   return_reasons:
   - performance
   - changed_my_mind
@@ -12715,6 +14294,8 @@
   - aircraft_airframe_material
   - aircraft_engine_configuration
   - aircraft_engine_type
+  - aircraft_service_ceiling
+  - airframe_total_time
   - body_color
   - body_pattern
   - cockpit_type
@@ -12722,6 +14303,7 @@
   - item_condition
   - upholstery_color
   - upholstery_pattern
+  - wingspan
   return_reasons:
   - performance
   - changed_my_mind
@@ -12737,6 +14319,8 @@
   - aircraft_airframe_material
   - aircraft_engine_configuration
   - aircraft_engine_type
+  - aircraft_service_ceiling
+  - airframe_total_time
   - body_color
   - body_pattern
   - cockpit_type
@@ -12744,6 +14328,7 @@
   - item_condition
   - upholstery_color
   - upholstery_pattern
+  - wingspan
   return_reasons:
   - size
   - performance
@@ -12759,11 +14344,13 @@
   - vp-2-1-2-1
   - vp-2-1-2-2
   attributes:
+  - airframe_total_time
   - body_color
   - body_pattern
   - item_condition
   - upholstery_color
   - upholstery_pattern
+  - wingspan
   return_reasons:
   - size
   - performance
@@ -12777,6 +14364,7 @@
   name: Hot Air Balloons
   children: []
   attributes:
+  - airframe_total_time
   - body_color
   - body_pattern
   - hot_air_balloon_basket_type
@@ -12785,6 +14373,7 @@
   - item_condition
   - upholstery_color
   - upholstery_pattern
+  - wingspan
   return_reasons:
   - performance
   - changed_my_mind
@@ -12799,6 +14388,7 @@
   attributes:
   - aircraft_engine_configuration
   - aircraft_engine_type
+  - airframe_total_time
   - airship_envelope_material
   - ballonet_configuration
   - body_color
@@ -12809,6 +14399,7 @@
   - lifting_gas_type
   - upholstery_color
   - upholstery_pattern
+  - wingspan
   return_reasons:
   - size
   - performance
@@ -12833,8 +14424,12 @@
   attributes:
   - body_color
   - body_pattern
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - horsepower
   - item_condition
+  - maximum_speed
   - transmission_type
   - upholstery_color
   - upholstery_pattern
@@ -12860,8 +14455,14 @@
   - body_color
   - body_pattern
   - drive_type
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - horsepower
   - item_condition
+  - maximum_speed
+  - odometer_unit
+  - towing_capacity
   - transmission_type
   - upholstery_color
   - upholstery_pattern
@@ -12887,8 +14488,14 @@
   - body_color
   - body_pattern
   - drive_type
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - horsepower
   - item_condition
+  - maximum_speed
+  - odometer_unit
+  - towing_capacity
   - transmission_type
   - upholstery_color
   - upholstery_pattern
@@ -12908,18 +14515,28 @@
   - vp-2-2-1-1-1-1
   - vp-2-2-1-1-1-2
   attributes:
+  - ac_onboard_charger_power
   - bidirectional_charging_capability
   - body_color
   - body_pattern
   - car_type
   - charging_port_location
   - drive_type
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
+  - odometer_unit
+  - towing_capacity
   - transmission_type
   - upholstery_color
   - upholstery_pattern
   - vehicle_features
+  - width
   return_reasons:
   - range
   - performance
@@ -12933,18 +14550,28 @@
   name: Battery Electric Vehicles (BEV)
   children: []
   attributes:
+  - ac_onboard_charger_power
   - bidirectional_charging_capability
   - body_color
   - body_pattern
   - car_type
   - drive_type
   - electric_vehicle_drivetrain_layout
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
+  - odometer_unit
+  - towing_capacity
   - transmission_type
   - upholstery_color
   - upholstery_pattern
   - vehicle_features
+  - width
   return_reasons:
   - range
   - performance
@@ -12958,18 +14585,29 @@
   name: Plug-In Hybrid Electric Vehicles (PHEV)
   children: []
   attributes:
+  - ac_onboard_charger_power
   - bidirectional_charging_capability
   - body_color
   - body_pattern
   - car_type
   - drive_type
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - hybrid_drivetrain_configuration
   - item_condition
+  - length
+  - maximum_speed
+  - odometer_unit
+  - phev_charging_time
+  - towing_capacity
   - transmission_type
   - upholstery_color
   - upholstery_pattern
   - vehicle_features
+  - width
   return_reasons:
   - range
   - performance
@@ -12987,13 +14625,22 @@
   - body_color
   - body_pattern
   - drive_type
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
+  - odometer_unit
+  - towing_capacity
   - transmission_type
   - truck_type
   - upholstery_color
   - upholstery_pattern
   - vehicle_features
+  - width
   return_reasons:
   - size
   - performance
@@ -13014,13 +14661,22 @@
   - drive_type
   - electric_van_body_length_class
   - electric_van_roof_height_class
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
+  - odometer_unit
+  - towing_capacity
   - transmission_type
   - upholstery_color
   - upholstery_pattern
   - van_type
   - vehicle_features
+  - width
   return_reasons:
   - range
   - performance
@@ -13041,12 +14697,23 @@
   - body_pattern
   - drive_type
   - emissions_standard
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
+  - odometer_unit
+  - payload_capacity
+  - towing_capacity
   - transmission_type
   - upholstery_color
   - upholstery_pattern
+  - vehicle_curb_weight
   - vehicle_features
+  - width
   return_reasons:
   - color
   - performance
@@ -13065,12 +14732,23 @@
   - car_type
   - drive_type
   - emissions_standard
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
+  - odometer_unit
+  - payload_capacity
+  - towing_capacity
   - transmission_type
   - upholstery_color
   - upholstery_pattern
+  - vehicle_curb_weight
   - vehicle_features
+  - width
   return_reasons:
   - color
   - performance
@@ -13088,13 +14766,24 @@
   - body_pattern
   - drive_type
   - emissions_standard
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
+  - odometer_unit
+  - payload_capacity
+  - towing_capacity
   - transmission_type
   - truck_type
   - upholstery_color
   - upholstery_pattern
+  - vehicle_curb_weight
   - vehicle_features
+  - width
   return_reasons:
   - size
   - performance
@@ -13113,13 +14802,24 @@
   - body_pattern
   - drive_type
   - emissions_standard
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
+  - odometer_unit
+  - payload_capacity
+  - towing_capacity
   - transmission_type
   - upholstery_color
   - upholstery_pattern
   - van_type
+  - vehicle_curb_weight
   - vehicle_features
+  - width
   return_reasons:
   - color
   - performance
@@ -13140,12 +14840,16 @@
   - body_pattern
   - drive_type
   - fuel_supply
+  - hybrid_battery_warranty_period
   - hybrid_system_type
   - item_condition
+  - odometer_unit
+  - towing_capacity
   - transmission_type
   - upholstery_color
   - upholstery_pattern
   - vehicle_features
+  - vehicle_mileage
   return_reasons:
   - performance
   - efficiency
@@ -13164,12 +14868,16 @@
   - car_type
   - drive_type
   - fuel_supply
+  - hybrid_battery_warranty_period
   - hybrid_system_type
   - item_condition
+  - odometer_unit
+  - towing_capacity
   - transmission_type
   - upholstery_color
   - upholstery_pattern
   - vehicle_features
+  - vehicle_mileage
   return_reasons:
   - size
   - performance
@@ -13188,14 +14896,18 @@
   - body_pattern
   - drive_type
   - fuel_supply
+  - hybrid_battery_warranty_period
   - hybrid_system_type
   - hybrid_truck_cab_type
   - item_condition
+  - odometer_unit
+  - towing_capacity
   - transmission_type
   - truck_type
   - upholstery_color
   - upholstery_pattern
   - vehicle_features
+  - vehicle_mileage
   return_reasons:
   - size
   - performance
@@ -13214,13 +14926,17 @@
   - body_pattern
   - drive_type
   - fuel_supply
+  - hybrid_battery_warranty_period
   - hybrid_system_type
   - item_condition
+  - odometer_unit
+  - towing_capacity
   - transmission_type
   - upholstery_color
   - upholstery_pattern
   - van_type
   - vehicle_features
+  - vehicle_mileage
   return_reasons:
   - performance
   - efficiency
@@ -13242,6 +14958,8 @@
   - body_pattern
   - fuel_supply
   - item_condition
+  - odometer_unit
+  - towing_capacity
   - transmission_type
   - upholstery_color
   - upholstery_pattern
@@ -13266,7 +14984,9 @@
   - drive_type
   - fuel_supply
   - item_condition
+  - odometer_unit
   - title_status
+  - towing_capacity
   - transmission_type
   - upholstery_color
   - upholstery_pattern
@@ -13290,6 +15010,8 @@
   - drivetrain_configuration
   - fuel_supply
   - item_condition
+  - odometer_unit
+  - towing_capacity
   - transmission_type
   - truck_bed_body_type
   - truck_type
@@ -13315,9 +15037,11 @@
   - drive_type
   - fuel_supply
   - item_condition
+  - odometer_unit
   - restoration_status
   - roof_height_class
   - steering_position
+  - towing_capacity
   - transmission_type
   - upholstery_color
   - upholstery_pattern
@@ -13338,13 +15062,20 @@
   - body_color
   - body_pattern
   - cart_type
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
   - golf_cart_intended_use
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
   - transmission_type
   - upholstery_color
   - upholstery_pattern
   - vehicle_features
+  - width
   return_reasons:
   - size
   - changed_my_mind
@@ -13364,14 +15095,21 @@
   - body_color
   - body_pattern
   - color
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
   - motorcycle_drive_type
   - pattern
   - transmission_type
   - upholstery_color
   - upholstery_pattern
   - vehicle_features
+  - width
   return_reasons:
   - size
   - performance
@@ -13386,18 +15124,26 @@
   name: Electric Motorcycles & Scooters
   children: []
   attributes:
+  - battery_range
   - battery_size
   - battery_type
   - body_color
   - body_pattern
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
   - motorcycle/scooter_type
   - motorcycle_drive_type
   - transmission_type
   - upholstery_color
   - upholstery_pattern
   - vehicle_features
+  - width
   return_reasons:
   - range
   - performance
@@ -13413,14 +15159,21 @@
   attributes:
   - body_color
   - body_pattern
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
   - motorcycle/scooter_type
   - motorcycle_drive_type
   - transmission_type
   - upholstery_color
   - upholstery_pattern
   - vehicle_features
+  - width
   return_reasons:
   - size
   - performance
@@ -13441,12 +15194,19 @@
   - body_color
   - body_pattern
   - drive_type
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
   - transmission_type
   - upholstery_color
   - upholstery_pattern
   - vehicle_features
+  - width
   return_reasons:
   - size
   - performance
@@ -13465,12 +15225,20 @@
   - body_color
   - body_pattern
   - drive_type
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - ground_clearance
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
   - transmission_type
   - upholstery_color
   - upholstery_pattern
   - vehicle_features
+  - width
   return_reasons:
   - performance
   - changed_my_mind
@@ -13488,12 +15256,19 @@
   - body_color
   - body_pattern
   - drive_type
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
   - transmission_type
   - upholstery_color
   - upholstery_pattern
   - vehicle_features
+  - width
   return_reasons:
   - size
   - performance
@@ -13534,8 +15309,14 @@
   - body_color
   - body_pattern
   - drive_type
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
   - recreational_vehicle_holding_tank_type
   - recreational_vehicle_leveling_system
   - recreational_vehicle_type
@@ -13543,6 +15324,7 @@
   - upholstery_color
   - upholstery_pattern
   - vehicle_features
+  - width
   return_reasons:
   - size
   - performance
@@ -13560,13 +15342,23 @@
   - body_color
   - body_pattern
   - drive_type
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
+  - snowmobile_track_length
+  - snowmobile_track_lug_height
   - snowmobile_type
+  - track_width
   - transmission_type
   - upholstery_color
   - upholstery_pattern
   - vehicle_features
+  - width
   return_reasons:
   - size
   - performance
@@ -13640,6 +15432,7 @@
   - upholstery_color
   - upholstery_pattern
   - vehicle_floor_configuration
+  - vehicle_length
   return_reasons:
   - performance
   - efficiency
@@ -13853,6 +15646,7 @@
   - emergency_lighting_package
   - fuel_supply
   - item_condition
+  - overall_exterior_height
   - upholstery_color
   - upholstery_pattern
   return_reasons:
@@ -14396,12 +16190,20 @@
   attributes:
   - body_color
   - body_pattern
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
   - upholstery_color
   - upholstery_pattern
+  - watercraft_beam
   - watercraft_features
   - watercraft_hull_material
+  - width
   return_reasons:
   - size
   - performance
@@ -14418,12 +16220,20 @@
   - boat_type
   - body_color
   - body_pattern
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
   - upholstery_color
   - upholstery_pattern
+  - watercraft_beam
   - watercraft_features
   - watercraft_hull_material
+  - width
   return_reasons:
   - size
   - performance
@@ -14439,13 +16249,21 @@
   attributes:
   - body_color
   - body_pattern
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
+  - length
+  - maximum_speed
   - personal_watercraft_type
   - upholstery_color
   - upholstery_pattern
+  - watercraft_beam
   - watercraft_features
   - watercraft_hull_material
+  - width
   return_reasons:
   - size
   - performance
@@ -14461,15 +16279,23 @@
   attributes:
   - body_color
   - body_pattern
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - item_condition
   - keel_type
+  - length
+  - maximum_speed
   - sailboat_type
   - upholstery_color
   - upholstery_pattern
+  - watercraft_beam
   - watercraft_features
   - watercraft_hull_material
   - watercraft_registration_status
+  - width
   return_reasons:
   - size
   - performance
@@ -14485,13 +16311,21 @@
   attributes:
   - body_color
   - body_pattern
+  - fuel_efficiency_typical
   - fuel_supply
+  - fuel_tank_capacity
+  - height
+  - horsepower
   - hull_type
   - item_condition
+  - length
+  - maximum_speed
   - upholstery_color
   - upholstery_pattern
+  - watercraft_beam
   - watercraft_features
   - watercraft_hull_material
+  - width
   - yacht_type
   return_reasons:
   - size

--- a/data/localizations/attributes/en.yml
+++ b/data/localizations/attributes/en.yml
@@ -44,9 +44,15 @@ en:
     absinthe_variety:
       name: Absinthe variety
       description: Differentiates absinthe products by their unique varieties, e.g. rouge, verte
+    absorbency_capacity:
+      name: Absorbency capacity
+      description: Absorbency capacity
     absorbency_level:
       name: Absorbency level
       description: Defines absorbency capacity, typically for personal care items; e.g. overnight, light
+    absorbent_capacity_volume:
+      name: Absorbent capacity (volume)
+      description: Absorbent capacity (volume)
     absorbent_hygiene_product_features:
       name: Absorbent hygiene product features
       description: Identifies special characteristics of hygiene products, like leakproof or hypoallergenic
@@ -56,6 +62,9 @@ en:
     ac_compressor_oil_type:
       name: AC compressor oil type
       description: Specifies the lubricant oil chemistry required/used by the AC compressor (common types include PAG and POE).
+    ac_onboard_charger_power:
+      name: AC onboard charger power
+      description: AC onboard charger power
     academic_level:
       name: Academic level
       description: Specifies the academic level of media content, such as undergraduate or doctoral
@@ -98,6 +107,9 @@ en:
     acoustic_guitar_string_core_design:
       name: Acoustic guitar string core design
       description: The core construction of the wound strings.
+    acoustic_material_thickness:
+      name: Acoustic material thickness
+      description: Defines the thickness of sound dampening materials used for acoustic insulation or noise reduction in construction and soundproofing applications.
     acoustic_piano_key_material:
       name: Acoustic piano key material
       description: Specifies the primary material used for the piano key tops/ivories.
@@ -146,6 +158,15 @@ en:
     acupuncture_model_type:
       name: Acupuncture model type
       description: 'Specifies the body part or species the acupuncture model represents, e.g. head, hand, animal '
+    adapter_case_interior_height:
+      name: Adapter case interior height
+      description: Adapter case interior height
+    adapter_case_interior_length:
+      name: Adapter case interior length
+      description: Adapter case interior length
+    adapter_case_interior_width:
+      name: Adapter case interior width
+      description: Adapter case interior width
     adapter_directionality:
       name: Adapter directionality
       description: Indicates whether the adapter supports signal flow in both directions or only in one specified direction
@@ -161,6 +182,12 @@ en:
     adc_resolution:
       name: ADC resolution
       description: Specifies the resolution (in bits) of the integrated Analog-to-Digital Converter, defining measurement precision
+    added_length:
+      name: Added length
+      description: Added length
+    added_warmth:
+      name: Added warmth
+      description: Added warmth
     additional_animation_software_features:
       name: Additional animation software features
       description: Specifies unique features in animation editing software, such as character animation or visual effects
@@ -254,6 +281,9 @@ en:
     age_restrictions:
       name: Age restrictions
       description: Indicates the minimum age requirement for a product or event, like 18 years or older
+    aging:
+      name: Aging
+      description: Indicates the duration a product has been matured to develop specific flavor profiles and characteristics, particularly relevant in spirits and aged consumables.
     ai_application:
       name: AI application
       description: Specifies the function of AI in software, like predictive analytics or speech recognition
@@ -296,6 +326,9 @@ en:
     air_mattress_valve_type:
       name: Air mattress valve type
       description: Specifies the valve style an accessory fits or contains, ensuring compatibility between pumps, valves, and repair parts.
+    air_purification_rate_cadr:
+      name: Air purification rate (CADR)
+      description: Measures the volume of filtered air delivered by an air purifier, with higher values indicating more effective air cleaning capacity in indoor spaces.
     air_purifier_filter_technology:
       name: Air purifier filter technology
       description: Identifies the primary filtration or purification method employed by the device.
@@ -332,9 +365,15 @@ en:
     aircraft_documentation_included:
       name: Aircraft documentation included
       description: Lists which documents are provided with the part (e.g., 8130-3).
+    aircraft_empty_weight:
+      name: Aircraft empty weight
+      description: Aircraft empty weight
     aircraft_engine_configuration:
       name: Aircraft engine configuration
       description: Specifies the number of engines powering the aircraft, such as single or twin
+    aircraft_engine_time_since_overhaul_tso:
+      name: Aircraft engine time since overhaul (TSO)
+      description: Aircraft engine time since overhaul (TSO)
     aircraft_engine_type:
       name: Aircraft engine type
       description: Specifies the type of engine powering the aircraft, such as jet or turboprop
@@ -356,12 +395,18 @@ en:
     aircraft_maintenance_program_enrollment:
       name: Aircraft maintenance program enrollment
       description: Indicates whether the aircraft is enrolled in an engine and/or airframe maintenance program, and if so, which coverage type applies (engine, airframe, or both).
+    aircraft_maximum_payload:
+      name: Aircraft maximum payload
+      description: Aircraft maximum payload
     aircraft_operational_certification:
       name: Aircraft operational certification
       description: Specifies the regulatory or operational certification basis under which the aircraft is operated (jurisdiction-dependent, e.g., FAA Part 91/135/121, EASA AOC).
     aircraft_protective_gear_certification:
       name: Aircraft protective gear certification
       description: Specifies the aviation/regulatory or industry standard the protective gear is certified to meet.
+    aircraft_service_ceiling:
+      name: Aircraft service ceiling
+      description: Aircraft service ceiling
     aircraft_system_application:
       name: Aircraft system application
       description: Identifies which aircraft system or area the part/accessory belongs to (used for browsing and filtering across diverse aircraft parts).
@@ -371,6 +416,15 @@ en:
     airflow_resistance_level:
       name: Airflow resistance level
       description: Indicates how restrictive the mute feels in terms of backpressure/air resistance.
+    airflow_system_diameter:
+      name: Airflow system diameter
+      description: Specifies the width or diameter of ventilation components, critical for determining compatibility with existing systems and calculating proper airflow capacity.
+    airflow_system_length:
+      name: Airflow system length
+      description: Defines the linear measurement of ventilation components, important for installation planning and ensuring proper system compatibility in HVAC applications.
+    airframe_total_time:
+      name: Airframe total time
+      description: Airframe total time
     airship_envelope_material:
       name: Airship envelope material
       description: Primary material of the airship envelope (skin).
@@ -383,6 +437,9 @@ en:
     airworthiness_approval_basis:
       name: Airworthiness approval basis
       description: Specifies the approval/certification basis for the part where applicable (e.g., PMA, TSO, STC).
+    alarm_siren_loudness:
+      name: Alarm siren loudness
+      description: Alarm siren loudness
     alarm_volume_adjustability:
       name: Alarm volume adjustability
       description: Indicates whether and how the alarm’s loudness can be adjusted by the user.
@@ -446,6 +503,9 @@ en:
     amino_acid_subtype:
       name: Amino acid subtype
       description: Specifies the primary type or profile of amino acids contained in the supplement
+    amperage:
+      name: Amperage
+      description: Measures the strength of electrical current flowing through a device, determining power consumption and compatibility with electrical systems.
     amplifier/booster_suitable_location:
       name: Amplifier/Booster suitable location
       description: Specifies best locations for amplifier or signal booster, such as vehicle or large venue
@@ -455,6 +515,9 @@ en:
     amplifier_configuration:
       name: Amplifier configuration
       description: Specifies the setup of motor vehicle amplifiers, such as two-channel or four-channel
+    amplifier_fuse_rating:
+      name: Amplifier fuse rating
+      description: Amplifier fuse rating
     amplifier_tube_function:
       name: Amplifier tube function
       description: Specifies the functional role of the tube within an instrument amplifier circuit (e.g., preamp vs power).
@@ -479,9 +542,18 @@ en:
     anchor_configuration:
       name: Anchor configuration
       description: Indicates whether the suspension system uses a single centralized anchor point or multiple independent anchor points, affecting exercise variety and setup complexity.
+    anchor_line_diameter:
+      name: Anchor line diameter
+      description: Anchor line diameter
+    anchor_shank_length:
+      name: Anchor shank length
+      description: Anchor shank length
     anchor_type:
       name: Anchor type
       description: Defines the anchor used in towed water sports equipment, such as fluke or plow
+    anchor_weight:
+      name: Anchor weight
+      description: Anchor weight
     anemometer_application:
       name: Anemometer application
       description: Identifies the intended use of an anemometer, such as industrial or meteorological
@@ -512,6 +584,9 @@ en:
     animal_type:
       name: Animal type
       description: Specifies the type of animal a product is intended for, such as ducks, deer, or dogs
+    ankle_circumference:
+      name: Ankle circumference
+      description: Specifies the measurement around the ankle area of footwear, important for proper fit and comfort especially in structured shoes and boots.
     ankle_collar_style:
       name: Ankle collar style
       description: Describes the style or construction of a shoe’s ankle collar, such as low cut, mid cut, high cut, sock collar, or laceless, which influences support, fit, and aesthetics.
@@ -590,6 +665,9 @@ en:
     antique_vehicle_era:
       name: Antique vehicle era
       description: Describes the historical period of an antique vehicle, such as Brass Era or Vintage Era
+    aperture:
+      name: Aperture
+      description: Defines the diameter of the main optical opening in telescopes and similar devices, with larger apertures generally collecting more light for better viewing.
     apple_variety:
       name: Apple variety
       description: Specifies the cultivar or variety of apple (e.g., Gala, Fuji, Granny Smith), helping customers choose based on taste, texture, and culinary use.
@@ -650,6 +728,9 @@ en:
     arbor_type:
       name: Arbor type
       description: Classifies the reel by spool arbor design, which affects line retrieval speed, backing capacity, and line memory.
+    arch_height:
+      name: Arch height
+      description: Arch height
     archery_accessory_type:
       name: Archery accessory type
       description: Specifies the type of accessory intended for archery tools so shoppers can quickly filter products.
@@ -677,6 +758,9 @@ en:
     archery_tool_type:
       name: Archery tool type
       description: Classifies the specific kind of archery tool or equipment piece.
+    arm_circumference_range:
+      name: Arm circumference range
+      description: Arm circumference range
     armband_features:
       name: Armband features
       description: Lists special functional or visual features that enhance the armband.
@@ -689,6 +773,9 @@ en:
     armrest_adjustability:
       name: Armrest adjustability
       description: Defines the dimensional adjustability and configuration of the chair’s armrests (e.g., fixed, 2D, 3D, flip-up).
+    armrest_height:
+      name: Armrest height
+      description: Measures the vertical distance from the floor or seat to the top of the armrest, important for ergonomics and user comfort in seating furniture.
     armrest_type:
       name: Armrest type
       description: Describes the presence and adjustability of armrests on the chair (e.g., no armrests, fixed, adjustable, removable).
@@ -731,6 +818,12 @@ en:
     arrow_shaft_compatibility:
       name: Arrow shaft compatibility
       description: Indicates the arrow shaft/bushing standard the lighted nock fits (e.g., X, H, S, GT).
+    arrow_spine_rating:
+      name: Arrow spine rating
+      description: Arrow spine rating
+    arrow_straightness_tolerance:
+      name: Arrow straightness tolerance
+      description: Arrow straightness tolerance
     art/crafting_tool_material:
       name: Art/Crafting tool material
       description: Identifies the main material of art or crafting tools, such as wood or metal
@@ -788,12 +881,21 @@ en:
     aspiration_type:
       name: Aspiration type
       description: Indicates how the engine is aspirated/boosted.
+    assembled_toy_kitchen_dimensions:
+      name: Assembled toy kitchen dimensions
+      description: Assembled toy kitchen dimensions
+    assembled_track_length:
+      name: Assembled track length
+      description: Assembled track length
     assembly_required:
       name: Assembly required
       description: Indicates whether the product requires assembly before use
     assembly_state:
       name: Assembly state
       description: Indicates whether the cabinet ships ready-to-assemble, pre-assembled, or in another form.
+    assembly_time:
+      name: Assembly time
+      description: Assembly time
     assistance_mechanism:
       name: Assistance mechanism
       description: Specifies any built-in assistance or resistance system the power tower provides for pull-ups, dips, or other exercises.
@@ -932,6 +1034,12 @@ en:
     autogyro_cockpit_enclosure:
       name: Autogyro cockpit enclosure
       description: Specifies whether the cockpit is open or enclosed.
+    autogyro_landing_distance:
+      name: Autogyro landing distance
+      description: Autogyro landing distance
+    autogyro_rotor_diameter:
+      name: Autogyro rotor diameter
+      description: Autogyro rotor diameter
     automation:
       name: Automation
       description: Describes the level of automation in packaging machines, such as manual or automatic
@@ -959,6 +1067,9 @@ en:
     award_plaque_plate_material:
       name: Award plaque plate material
       description: Specifies the material of the nameplate/engraving plate attached to the plaque (distinct from the backing material).
+    award_plaque_plate_size:
+      name: Award plaque plate size
+      description: Award plaque plate size
     award_ribbon_attachment_type:
       name: Award ribbon attachment type
       description: Specifies how the ribbon is intended to be attached or worn.
@@ -983,6 +1094,30 @@ en:
     axle_compatibility:
       name: Axle compatibility
       description: Indicates the axle standard that the wheel accommodates, ensuring compatibility with the bicycle frame and fork.
+    axle_diameter:
+      name: Axle diameter
+      description: Axle diameter
+    axle_shaft_diameter:
+      name: Axle shaft diameter
+      description: Axle shaft diameter
+    axle_shaft_length:
+      name: Axle shaft length
+      description: Axle shaft length
+    axle_spacing_dropout_width:
+      name: Axle spacing (dropout width)
+      description: Axle spacing (dropout width)
+    axle_to_axle_length:
+      name: Axle-to-axle length
+      description: Axle-to-axle length
+    axle_to_axle_width_cocked:
+      name: Axle-to-axle width (cocked)
+      description: Axle-to-axle width (cocked)
+    axle_to_axle_width_uncocked:
+      name: Axle-to-axle width (uncocked)
+      description: Axle-to-axle width (uncocked)
+    axle_width:
+      name: Axle width
+      description: Axle width
     baby/toddler_car_seat_features:
       name: Baby/Toddler car seat features
       description: Highlights key features of baby/toddler car seats, like 5-point harness or side-impact protection
@@ -1043,6 +1178,9 @@ en:
     back_design:
       name: Back design
       description: Specifies notable back constructions on garments that affect styling and support.
+    back_length:
+      name: Back length
+      description: Measures the vertical distance from the collar to the hem on the back of a garment, important for determining proper fit and coverage in clothing items.
     back_panel_type:
       name: Back panel type
       description: Specifies the style or material of the cabinet’s back panel, which affects display visibility and décor matching.
@@ -1055,6 +1193,9 @@ en:
     backboard_material:
       name: Backboard material
       description: Specifies the construction material of the game's backboard, affecting rebound performance, durability, and cost
+    backboard_width:
+      name: Backboard width
+      description: Backboard width
     background_design:
       name: Background design
       description: Describes the visual design or pattern on a studio background, such as printed or chroma key
@@ -1085,12 +1226,18 @@ en:
     backrest_upholstery_pattern:
       name: Backrest upholstery pattern
       description: Identifies the pattern on the sofa's backrest fabric, e.g. striped, checkered
+    backup_camera_minimum_illumination:
+      name: Backup camera minimum illumination
+      description: Backup camera minimum illumination
     backup_camera_mounting_location:
       name: Backup camera mounting location
       description: Indicates the intended install location on the vehicle for the backup camera.
     backup_camera_video_interface:
       name: Backup camera video interface
       description: Specifies the video output/interface/connector used by the backup camera to connect to a monitor, DVR, or head unit (e.g., composite RCA, LVDS OEM, IP over Ethernet).
+    backup_runtime:
+      name: Backup runtime
+      description: Indicates the duration a UPS can provide power during an outage, critical for protecting electronic equipment and preventing data loss.
     badminton_set_components_included:
       name: Badminton set components included
       description: Lists the individual items supplied in a badminton set.
@@ -1112,6 +1259,15 @@ en:
     bag_case_carrying_style:
       name: Bag/case carrying style
       description: Specifies the primary overall carrying form factor of the case/gigbag (how it is built to be carried).
+    bag_case_interior_height:
+      name: Bag/case interior height
+      description: Bag/case interior height
+    bag_case_interior_length:
+      name: Bag/case interior length
+      description: Bag/case interior length
+    bag_case_interior_width:
+      name: Bag/case interior width
+      description: Bag/case interior width
     bag_clip_style:
       name: Bag clip style
       description: Describes the mechanical style of the clip's closure mechanism.
@@ -1142,6 +1298,9 @@ en:
     bag_size_descriptor:
       name: Bag size descriptor
       description: Marketing size class for the bucket bag (e.g., mini, large) that supplements exact dimensions.
+    bag_strap_drop_length:
+      name: Bag strap drop length
+      description: Bag strap drop length
     bag_strap_type:
       name: Bag strap type
       description: Specifies the type of bag strap, for example, crossbody or shoulder
@@ -1163,6 +1322,9 @@ en:
     bait_compatibility:
       name: Bait compatibility
       description: Lists the bait types that the pellet accessory is designed to work with, helping anglers ensure their chosen tool matches their preferred bait.
+    bait_length:
+      name: Bait length
+      description: Bait length
     bait_species:
       name: Bait species
       description: Identifies the primary organism offered as bait, helping anglers ensure legality and target-species effectiveness.
@@ -1181,6 +1343,9 @@ en:
     bakeware_shape:
       name: Bakeware shape
       description: Identifies the shape of bakeware, such as bundt or rectangular
+    bakeware_size:
+      name: Bakeware size
+      description: Specifies the dimensions of baking containers, essential for recipe compatibility and determining appropriate cooking times and temperatures.
     baking_chip_form:
       name: Baking chip form
       description: Describes the physical size or shape of baking chips, which influences melting behavior and recipe appearance.
@@ -1202,6 +1367,9 @@ en:
     balance_cushion_accessories_included:
       name: Balance cushion accessories included
       description: Lists any accessories packaged with the cushion, allowing shoppers to compare bundle value.
+    balance_point:
+      name: Balance point
+      description: Balance point
     balance_type:
       name: Balance type
       description: Indicates the balancing state/grade of the drive shaft as sold (e.g., factory balanced, high speed balanced, unbalanced).
@@ -1211,6 +1379,9 @@ en:
     ball_certification:
       name: Ball certification
       description: Indicates official performance certifications or approvals the ball has earned.
+    ball_circumference:
+      name: Ball circumference
+      description: Ball circumference
     ball_construction:
       name: Ball construction
       description: Indicates the manufacturing method used to join the ball's panels, which affects durability, touch, water uptake, and price.
@@ -1223,9 +1394,15 @@ en:
     ball_cup_game_included_pieces:
       name: Ball & cup game included pieces
       description: Identifies which components are included in the product package for a ball & cup game.
+    ball_diameter:
+      name: Ball diameter
+      description: Ball diameter
     ball_drilling_state:
       name: Ball drilling state
       description: Indicates whether finger holes are drilled in the ball and, if so, to what extent.
+    ball_feed_interval:
+      name: Ball feed interval
+      description: Ball feed interval
     ball_holder_type:
       name: Ball holder type
       description: Identifies the structural style or form factor of the ball holder.
@@ -1259,6 +1436,9 @@ en:
     ball_surface_type:
       name: Ball surface type
       description: Describes the ball’s outer finish or cushioning to indicate impact feel and grip.
+    ball_weight:
+      name: Ball weight
+      description: Indicates the mass of exercise or sports balls, determining the intensity of workouts and suitability for different skill levels and training purposes.
     ballast_material:
       name: Ballast material
       description: Lists the materials that can be used to ballast (fill) the roller drum, helping shoppers choose models compatible with their preferred fill media.
@@ -1268,6 +1448,9 @@ en:
     balloon_closure_valve_type:
       name: Balloon closure/valve type
       description: Identifies how the balloon is sealed after inflation (e.g., tie, self-sealing valve).
+    balloon_kit_diameter:
+      name: Balloon kit diameter
+      description: Balloon kit diameter
     balloon_kit_finish:
       name: Balloon kit finish
       description: Describes the surface/visual finish of balloons included in the kit.
@@ -1286,6 +1469,9 @@ en:
     band_color:
       name: Band color
       description: Specifies the color of a watch band, e.g. multicolor, rose gold
+    band_length:
+      name: Band length
+      description: Specifies the total length of watchbands or straps, important for determining proper fit around different wrist sizes.
     band_material:
       name: Band material
       description: Specifies the material used in the watch band, such as leather or stainless steel
@@ -1295,6 +1481,9 @@ en:
     band_strength:
       name: Band strength
       description: Describes the durability of rubber bands, such as standard or heavy-duty
+    band_width:
+      name: Band width
+      description: Defines the measurement across the strap of a watch or wearable device, affecting both comfort and aesthetic appearance.
     bandage_shape:
       name: Bandage shape
       description: Describes the pre-cut form factor of adhesive bandages or dressings
@@ -1307,6 +1496,9 @@ en:
     banjo_pickup_configuration:
       name: Banjo pickup configuration
       description: Whether the banjo includes an onboard pickup and what general pickup technology it uses.
+    banjo_rim_diameter:
+      name: Banjo rim diameter
+      description: Banjo rim diameter
     banjo_rim_material:
       name: Banjo rim material
       description: Material of the rim/pot (the circular body), which strongly influences tone and weight.
@@ -1388,6 +1580,12 @@ en:
     barre_rail_configuration:
       name: Barre rail configuration
       description: Indicates the number of horizontal bars supplied with the ballet barre.
+    barrel_bore_diameter:
+      name: Barrel bore diameter
+      description: Barrel bore diameter
+    barrel_length:
+      name: Barrel length
+      description: Barrel length
     barrel_material:
       name: Barrel material
       description: Specifies the material used in hair product's barrel, e.g. titanium, ceramic
@@ -1400,6 +1598,9 @@ en:
     barrel_shape:
       name: Barrel shape
       description: Identifies the physical shape or profile of the barrel, which directly affects the style of curl or wave produced
+    barrel_size:
+      name: Barrel size
+      description: Indicates the diameter of a baseball bat's barrel, affecting the hitting surface area and potential power transfer when striking a ball.
     barrel_thread_standard:
       name: Barrel thread standard
       description: Identifies the barrel threading used on the marker for compatibility with aftermarket barrels.
@@ -1418,9 +1619,15 @@ en:
     base_configuration:
       name: Base configuration
       description: Indicates the structural configuration of the panel base.
+    base_curve_bc:
+      name: Base curve (BC)
+      description: Defines the curvature of contact lenses, crucial for proper fit on the eye's surface and wearer comfort.
     base_features:
       name: Base features
       description: Highlights stability or grip characteristics of the base, aiding users who need non-slip or suction functionality on work surfaces.
+    base_fill_capacity:
+      name: Base fill capacity
+      description: Base fill capacity
     base_fill_material:
       name: Base fill material
       description: Specifies the substance used to fill or weight the basketball mannequin’s base, affecting stability and setup effort.
@@ -1433,6 +1640,9 @@ en:
     base_oil_type:
       name: Base oil type
       description: Specifies the base oil formulation of the transmission fluid (e.g., full synthetic vs synthetic blend vs conventional).
+    base_plate_thickness:
+      name: Base plate thickness
+      description: Base plate thickness
     base_spirit:
       name: Base spirit
       description: Defines the primary alcohol used in a product, such as whiskey or rum
@@ -1493,9 +1703,21 @@ en:
     bass_drum_beater_shaft_material:
       name: Bass drum beater shaft material
       description: Specifies the material of the beater shaft/rod (not the beater head).
+    bass_drum_beater_weight:
+      name: Bass drum beater weight
+      description: Bass drum beater weight
+    bass_drum_depth:
+      name: Bass drum depth
+      description: Bass drum depth
+    bass_drum_diameter:
+      name: Bass drum diameter
+      description: Bass drum diameter
     bass_drum_head_built_in_muffling:
       name: Bass drum head built-in muffling
       description: Type of integrated damping/muffling included in the head design.
+    bass_drum_head_collar_depth:
+      name: Bass drum head collar depth
+      description: Bass drum head collar depth
     bass_drum_head_configuration:
       name: Bass drum head configuration
       description: Describes which heads are included/installed on the bass drum at purchase.
@@ -1523,6 +1745,9 @@ en:
     bass_harmonica_tuning_system:
       name: Bass harmonica tuning system
       description: Specifies the tuning system/temperament used for the bass harmonica.
+    bass_harmonica_weight:
+      name: Bass harmonica weight
+      description: Bass harmonica weight
     bass_recorder_bocal_type:
       name: Bass recorder bocal type
       description: Specifies the type of bocal/windway used to reach the mouthpiece on a bass recorder.
@@ -1550,6 +1775,21 @@ en:
     bassoon_bocal_system:
       name: Bassoon bocal system
       description: The bocal variant/type used for different bassoon systems and use cases.
+    bassoon_bocal_tenon_diameter:
+      name: Bassoon bocal tenon diameter
+      description: Bassoon bocal tenon diameter
+    bassoon_bocal_tip_opening_diameter:
+      name: Bassoon bocal tip opening diameter
+      description: Bassoon bocal tip opening diameter
+    bassoon_case_interior_height:
+      name: Bassoon case interior height
+      description: Bassoon case interior height
+    bassoon_case_interior_length:
+      name: Bassoon case interior length
+      description: Bassoon case interior length
+    bassoon_case_interior_width:
+      name: Bassoon case interior width
+      description: Bassoon case interior width
     bassoon_case_shell_type:
       name: Bassoon case shell type
       description: Indicates the protection structure of the case (soft, hard, or hybrid).
@@ -1562,15 +1802,27 @@ en:
     bassoon_performance_level:
       name: Bassoon performance level
       description: Indicates the intended player level for the bassoon model.
+    bassoon_reed_length:
+      name: Bassoon reed length
+      description: Bassoon reed length
     bassoon_reed_scrape_style:
       name: Bassoon reed scrape style
       description: Indicates the scrape/profile style of the bassoon reed.
+    bassoon_reed_staple_length:
+      name: Bassoon reed staple length
+      description: Bassoon reed staple length
     bassoon_reed_thread_color:
       name: Bassoon reed thread color
       description: Color of the binding thread used on the reed.
+    bassoon_reed_tip_opening:
+      name: Bassoon reed tip opening
+      description: Bassoon reed tip opening
     bassoon_reed_type:
       name: Bassoon reed type
       description: Specifies the bassoon reed subtype the product fits (where applicable).
+    bassoon_reed_width:
+      name: Bassoon reed width
+      description: Bassoon reed width
     bassoon_system:
       name: Bassoon system
       description: Identifies the bassoon key system / design tradition used by the instrument.
@@ -1583,12 +1835,18 @@ en:
     bat_handle_size_compatibility:
       name: Bat handle size compatibility
       description: Indicates the cricket bat handle size(s) the grip is designed to fit.
+    bat_length:
+      name: Bat length
+      description: Specifies the total length of a baseball bat from knob to end cap, determining reach and swing mechanics for different player sizes and styles.
     bat_material:
       name: Bat material
       description: Specifies the type of material used in a bat, for example, aluminum or carbon fiber
     bat_standard:
       name: Bat standard
       description: Defines the certification of baseball or softball bats, such as Little League or NCAA
+    batch_yield_volume:
+      name: Batch yield volume
+      description: Batch yield volume
     bath_book_interactive_features:
       name: Bath book interactive features
       description: Built-in play/learning features integrated into the bath book.
@@ -1661,15 +1919,27 @@ en:
     battery_group_size:
       name: Battery group size
       description: Standardized battery case size (e.g., BCI Group 24F, H6) used for fitment in many vehicles.
+    battery_life_active_transmission:
+      name: Battery life (active transmission)
+      description: Battery life (active transmission)
     battery_management_features:
       name: Battery management features
       description: Identifies the capabilities of a battery management system, like fault detection or remote monitoring
     battery_mounting_type:
       name: Battery mounting type
       description: Identifies the physical mounting or connection standard of the battery pack
+    battery_pack_operating_voltage_nominal:
+      name: Battery pack operating voltage (nominal)
+      description: Battery pack operating voltage (nominal)
     battery_polarity:
       name: Battery polarity
       description: Specifies the terminal polarity/orientation (positive terminal position) which is a key fitment constraint for many automotive and powersports batteries.
+    battery_range:
+      name: Battery range
+      description: Specifies the maximum distance an electric vehicle can travel on a single charge, crucial for trip planning and determining practical usability.
+    battery_service_life:
+      name: Battery service life
+      description: Battery service life
     battery_size:
       name: Battery size
       description: Indicates the battery compatibility for the product, such as AAA or 9V
@@ -1688,6 +1958,9 @@ en:
     battery_voltage_class:
       name: Battery voltage class
       description: Common voltage-system class for the EV battery pack, used for quick filtering (e.g., 400V vs 800V systems).
+    batting_and_stuffing_coverage_area:
+      name: Batting and stuffing coverage area
+      description: Batting and stuffing coverage area
     batting_cage_components_included:
       name: Batting cage components included
       description: Lists the individual parts provided with the product so buyers can confirm whether a complete system or specific replacement parts are included.
@@ -1703,6 +1976,9 @@ en:
     batting_stuffing_thermal_insulation_level:
       name: Batting & stuffing thermal insulation level
       description: Relative warmth/insulation performance of batting used in quilts, jackets, and blankets.
+    batting_stuffing_weight_per_area:
+      name: Batting & stuffing weight per area
+      description: Batting & stuffing weight per area
     batting_tee_base_design:
       name: Batting tee base design
       description: Describes the style or construction of the tee's base, which influences stability and the types of playing surfaces it suits.
@@ -1742,6 +2018,9 @@ en:
     bead_breaker_type:
       name: Bead breaker type
       description: Type/design of the bead breaker mechanism.
+    bead_diameter:
+      name: Bead diameter
+      description: Bead diameter
     bead_hole_style:
       name: Bead hole style
       description: Specifies the style or configuration of the hole/slot in the bead, which affects how it sits on the hook or line.
@@ -1790,6 +2069,9 @@ en:
     beadlock_type:
       name: Beadlock type
       description: Indicates whether the wheel is beadlock and what style (helps off-road/UTV buyers).
+    beam_distance:
+      name: Beam distance
+      description: Beam distance
     beam_material:
       name: Beam material
       description: Primary material of the beam/rod (often different from the heads/attachments).
@@ -1820,6 +2102,9 @@ en:
     bearing_construction_type:
       name: Bearing construction type
       description: Identifies the bearing design or construction style used in the hub (e.g., cartridge, loose ball).
+    bearing_diameter:
+      name: Bearing diameter
+      description: Defines the size of bearings used in mechanical components, critical for proper fit and function in moving parts.
     bearing_edge_type:
       name: Bearing edge type
       description: Type/profile of the shell bearing edge, which influences attack and sustain.
@@ -1844,6 +2129,9 @@ en:
     bearing_size_code:
       name: Bearing size code
       description: Standardized bearing designation (e.g., 608, 688) that combines inner, outer diameter, and width.
+    bearing_thickness:
+      name: Bearing thickness
+      description: Bearing thickness
     bearing_type:
       name: Bearing type
       description: Specifies the construction style of the bearings used in the headset.
@@ -1919,6 +2207,9 @@ en:
     bell_design:
       name: Bell design
       description: Describes the style of desk bells, e.g. push, call bell
+    bell_diameter:
+      name: Bell diameter
+      description: Bell diameter
     bell_guard_coverage_area:
       name: Bell guard coverage area
       description: Indicates which portion of the bell the guard is designed to protect.
@@ -1946,6 +2237,9 @@ en:
     belt_buckle_type:
       name: Belt buckle type
       description: Describes the specific buckle mechanism or design used on the belt.
+    belt_pitch:
+      name: Belt pitch
+      description: Belt pitch
     belt_profile:
       name: Belt profile
       description: Identifies the belt's cross-section or style to ensure proper fit with the pulley design.
@@ -2072,6 +2366,12 @@ en:
     binder_ring_shape:
       name: Binder ring shape
       description: Describes the binder rings in office supplies, such as round or D-shaped
+    binder_ring_size:
+      name: Binder ring size
+      description: Specifies the diameter of rings in binders, determining the paper capacity and ease of page turning in document organization systems.
+    binding_comb_size:
+      name: Binding comb size
+      description: Indicates the diameter of binding combs, determining the number of pages that can be bound together in document presentation.
     binding_compatibility_standard:
       name: Binding compatibility standard
       description: Identifies the binding interface (sole norm) the ski boot is certified for, ensuring safe and correct pairing with ski bindings.
@@ -2150,6 +2450,12 @@ en:
     bit_attachment_type:
       name: Bit attachment type
       description: Specifies how the headstall connects to the bit (e.g., tie ends, buckle ends, Chicago screw ends).
+    bit_diameter:
+      name: Bit diameter
+      description: Specifies the width of router bits or drill bits, determining the size of cuts or holes created in materials.
+    bit_length:
+      name: Bit length
+      description: Bit length
     bit_mouthpiece_design:
       name: Bit mouthpiece design
       description: Identifies the structural style or joint configuration of the mouthpiece, which governs pressure distribution, palate clearance, and overall severity.
@@ -2174,6 +2480,9 @@ en:
     blade_curve:
       name: Blade curve
       description: Specifies the blade curve on a hockey stick, e.g. open, toe
+    blade_cut_length:
+      name: Blade cut length
+      description: Blade cut length
     blade_design:
       name: Blade design
       description: Specifies the blade style on utility knives, such as razor or snap-off
@@ -2186,9 +2495,15 @@ en:
     blade_finish_coating:
       name: Blade finish/coating
       description: Surface treatment applied to the blade for aesthetics or corrosion protection.
+    blade_hollow_radius:
+      name: Blade hollow radius
+      description: Blade hollow radius
     blade_hosel_type:
       name: Blade hosel type
       description: Specifies the connection style of the blade’s hosel that fits into the shaft, affecting compatibility (e.g., Standard or Tapered).
+    blade_length:
+      name: Blade length
+      description: Measures the distance from the hilt to the tip of a blade, affecting reach, balance, and functionality in cutting implements.
     blade_length_type:
       name: Blade length type
       description: Classifies the fin’s blade length as short, medium, or long, each influencing kicking cadence and training goals.
@@ -2198,6 +2513,9 @@ en:
     blade_material:
       name: Blade material
       description: Specifies the material used in a blade's construction, such as steel or aluminum
+    blade_rocker_radius:
+      name: Blade rocker radius
+      description: Blade rocker radius
     blade_shape:
       name: Blade shape
       description: Describes the geometric shape/profile of the shovel blade.
@@ -2207,6 +2525,9 @@ en:
     blade_sidedness:
       name: Blade sidedness
       description: Indicates whether the hedge trimmer blade has cutting teeth on one side only or on both sides.
+    blade_size:
+      name: Blade size
+      description: Specifies the dimensions of equipment blades, determining the width of area covered in a single pass and overall efficiency.
     blade_size_category:
       name: Blade size category
       description: Standardized international sabre blade size code (0–5) used to distinguish youth and adult blades.
@@ -2216,9 +2537,15 @@ en:
     blade_size_number:
       name: Blade size number
       description: Standard numeric size code (0–5) defined by fencing regulations that determines blade length and age-group eligibility.
+    blade_thickness:
+      name: Blade thickness
+      description: Blade thickness
     blade_type:
       name: Blade type
       description: Defines the shape and style of a product's blade, such as straight or dagger
+    blade_width:
+      name: Blade width
+      description: Indicates the measurement across the face of a blade, affecting cutting capacity and structural strength of the implement.
     blanket_color:
       name: Blanket color
       description: Identifies the primary color of a blanket, such as navy or multicolor
@@ -2288,6 +2615,12 @@ en:
     blower_motor_mounting_position:
       name: Blower motor mounting position
       description: Where the blower motor is installed in the HVAC module/vehicle (e.g., front, rear).
+    blower_motor_rotational_speed:
+      name: Blower motor rotational speed
+      description: Blower motor rotational speed
+    blowout_extension_length:
+      name: Blowout extension length
+      description: Blowout extension length
     blowpipe_valve_type:
       name: Blowpipe valve type
       description: Specifies the blowpipe valve style included (if any).
@@ -2306,6 +2639,9 @@ en:
     board_game_mechanics:
       name: Board game mechanics
       description: Describes the gameplay structure of a board game, such as strategy or cooperative
+    board_game_set_up_time:
+      name: Board game set-up time
+      description: Board game set-up time
     board_game_theme:
       name: Board game theme
       description: Narrative/setting theme of the board game (used for discovery and browsing).
@@ -2351,9 +2687,15 @@ en:
     boat_weaving_shuttle_weft_exit_type:
       name: Boat weaving shuttle weft exit type
       description: How the weft yarn exits the shuttle during weaving.
+    bobbin_core_diameter:
+      name: Bobbin core diameter
+      description: Bobbin core diameter
     bobbin_loading_type:
       name: Bobbin loading type
       description: Specifies how the bobbin is inserted/loaded into the sewing machine.
+    bobbin_shaft_bore_diameter:
+      name: Bobbin shaft/bore diameter
+      description: Bobbin shaft/bore diameter
     bobbin_system:
       name: Bobbin system
       description: The bobbin loading system/type used by the sewing machine.
@@ -2372,6 +2714,9 @@ en:
     bodhr_n_head_material:
       name: Bodhrán head material
       description: The material of the playing head (membrane), which strongly affects tone and maintenance requirements.
+    bodhr_n_shell_depth:
+      name: Bodhrán shell depth
+      description: Bodhrán shell depth
     bodhr_n_tuning_system_type:
       name: Bodhrán tuning system type
       description: The style of built-in tuning mechanism used to adjust head tension (if tunable).
@@ -2420,6 +2765,9 @@ en:
     bodyboard_features:
       name: Bodyboard features
       description: Describes unique aspects of a bodyboard, such as hard top or inflatable
+    bodyboard_size:
+      name: Bodyboard size
+      description: Specifies the dimensions of a bodyboard, determining buoyancy, maneuverability, and suitability for riders of different sizes and skill levels.
     bodysuit_bottom_coverage:
       name: Bodysuit bottom coverage
       description: Defines the cut and coverage of the bodysuit’s bottom portion, impacting comfort and outfit compatibility.
@@ -2435,6 +2783,9 @@ en:
     bok_choy_variety:
       name: Bok choy variety
       description: Specifies the cultivar, market name or variety of the bok choy (e.g., Baby, Shanghai, Nai Bai, Tatsoi, Purple Lady), allowing shoppers to select desired flavor, size and appearance.
+    bolt_circle_diameter:
+      name: Bolt circle diameter
+      description: Bolt circle diameter
     bolt_drive_style:
       name: Bolt drive style
       description: Specifies the drive style of skateboard mounting bolts, distinguishing between common head/driver types such as Allen or Phillips.
@@ -2444,6 +2795,9 @@ en:
     bolt_material:
       name: Bolt material
       description: Identifies the composition of archery bolts, such as bamboo or fiberglass
+    bolt_roll_length:
+      name: Bolt/roll length
+      description: Bolt/roll length
     bone_anchored_interface_type:
       name: Bone-anchored interface type
       description: Defines how the processor attaches to the implant, distinguishing between percutaneous abutment and transcutaneous magnetic systems
@@ -2483,6 +2837,12 @@ en:
     booster_pump_requirement:
       name: Booster pump requirement
       description: Clarifies whether a separate booster pump is needed for the sweep to operate.
+    boot_insulation_weight:
+      name: Boot insulation weight
+      description: Boot insulation weight
+    boot_last_width:
+      name: Boot last width
+      description: Boot last width
     boot_liner_type:
       name: Boot liner type
       description: Describes the construction or customization capability of the inner liner inside the snowboard boot (e.g., heat-moldable, removable).
@@ -2516,6 +2876,12 @@ en:
     bore_cleaner_safe_for_finish:
       name: Bore cleaner safe for finish
       description: Indicates which common brass-instrument finishes the bore cleaner is safe to use with.
+    bore_cleaner_volume:
+      name: Bore cleaner volume
+      description: Bore cleaner volume
+    bore_size:
+      name: Bore size
+      description: Bore size
     bore_type:
       name: Bore type
       description: Defines the bore style or interface used to mount the pulley to the shaft.
@@ -2558,6 +2924,9 @@ en:
     bottle_style:
       name: Bottle style
       description: Common bottling bottle form factors used in homebrewing and winemaking.
+    bottle_thread_diameter:
+      name: Bottle thread diameter
+      description: Bottle thread diameter
     bottle_type:
       name: Bottle type
       description: Specifies the type of closure on a bottle, like squeeze or spray
@@ -2573,6 +2942,9 @@ en:
     bottom_bracket_standard:
       name: Bottom bracket standard
       description: Bottom bracket shell/interface supported by the frame, determining crankset compatibility.
+    bottom_depth:
+      name: Bottom depth
+      description: Bottom depth
     bottom_surface_material:
       name: Bottom surface material
       description: Identifies the material of the product's bottom surface, such as metal or glass
@@ -2582,6 +2954,9 @@ en:
     bounce_level:
       name: Bounce level
       description: Indicates how much the ball rebounds when dropped or thrown, helping users choose the correct ball for exercises such as wall throws or slams.
+    bouncy_ball_bounce_height:
+      name: Bouncy ball bounce height
+      description: Bouncy ball bounce height
     bouncy_ball_surface_finish:
       name: Bouncy ball surface finish
       description: Specifies the tactile and/or visual surface finish of a bouncy ball (e.g., smooth, spiky, glitter).
@@ -2627,6 +3002,15 @@ en:
     bow_yo_yo_embellishment_style:
       name: Bow/yo-yo embellishment style
       description: Identifies the constructed style of the embellishment (bow or fabric yo-yo construction).
+    bowl_capacity:
+      name: Bowl capacity
+      description: Indicates the volume a container can hold, determining batch size and processing capability in food preparation equipment.
+    bowl_depth:
+      name: Bowl depth
+      description: Bowl depth
+    bowl_diameter:
+      name: Bowl diameter
+      description: Bowl diameter
     bowl_type:
       name: Bowl type
       description: Classifies the primary intended use or style of the bowl.
@@ -2636,6 +3020,9 @@ en:
     bowling_ball_coverstock_type:
       name: Bowling ball coverstock type
       description: Specifies the outer coverstock material or technology of the bowling ball, which dictates traction and hook potential.
+    bowling_pin_height:
+      name: Bowling pin height
+      description: Bowling pin height
     bowling_set_style:
       name: Bowling set style
       description: Defines the general style or use case of the bowling set.
@@ -2654,6 +3041,9 @@ en:
     boxing_ring_style:
       name: Boxing ring style
       description: Classifies the overall construction style or intended use scenario of the ring (e.g., competition vs. training, elevated vs. floor).
+    bra_band_size:
+      name: Bra band size
+      description: Specifies the bra band size, such as 34 inches or 75 cm
     bra_closure_type:
       name: Bra closure type
       description: Identifies how bras are fastened or opened, e.g. front, pull-on (no closure)
@@ -2678,6 +3068,9 @@ en:
     bra_support_level:
       name: Bra support level
       description: Indicates the level of support provided by a bra, e.g. low, medium, high
+    brace_height:
+      name: Brace height
+      description: Brace height
     brace_support_level:
       name: Brace support level
       description: Indicates the manufacturer-designated overall support or protection level offered by the brace
@@ -2702,15 +3095,24 @@ en:
     brake_band_style:
       name: Brake band style
       description: Specifies the brake band tension system/style used on a spinning wheel to apply flyer/bobbin tension.
+    brake_band_thickness:
+      name: Brake band thickness
+      description: Brake band thickness
     brake_bleeding_method:
       name: Brake bleeding method
       description: Bleeding approach supported by the kit.
     brake_booster_assist_type:
       name: Brake booster assist type
       description: Indicates the assist mechanism used by the brake booster.
+    brake_booster_body_diameter:
+      name: Brake booster body diameter
+      description: Brake booster body diameter
     brake_booster_diaphragm_configuration:
       name: Brake booster diaphragm configuration
       description: Indicates the number/type of diaphragms used in the booster.
+    brake_booster_hose_port_size:
+      name: Brake booster hose port size
+      description: Brake booster hose port size
     brake_caliper_bleeder_screw_position:
       name: Brake caliper bleeder screw position
       description: Specifies the bleeder screw position on the caliper when installed (used to verify the bleeder is oriented at the highest point for proper bleeding).
@@ -2723,12 +3125,21 @@ en:
     brake_caliper_mount_type:
       name: Brake caliper mount type
       description: Mounting interface style used to attach the caliper to the knuckle/bracket.
+    brake_caliper_mounting_bolt_spacing:
+      name: Brake caliper mounting bolt spacing
+      description: Brake caliper mounting bolt spacing
     brake_caliper_paint_base_chemistry:
       name: Brake caliper paint base chemistry
       description: The paint/resin system or chemistry family used.
     brake_caliper_paint_kit_contents:
       name: Brake caliper paint kit contents
       description: Indicates what is included in the package beyond the paint itself.
+    brake_caliper_paint_maximum_temperature_resistance:
+      name: Brake caliper paint maximum temperature resistance
+      description: Brake caliper paint maximum temperature resistance
+    brake_caliper_piston_bore_diameter:
+      name: Brake caliper piston bore diameter
+      description: Brake caliper piston bore diameter
     brake_circuit_type:
       name: Brake circuit type
       description: Hydraulic circuit configuration supported by the master cylinder.
@@ -2738,12 +3149,27 @@ en:
     brake_clutch_fluid_dot_specification:
       name: Brake/Clutch fluid DOT specification
       description: DOT performance classification for hydraulic brake/clutch fluids (e.g., DOT 3, DOT 4).
+    brake_contact_diameter:
+      name: Brake contact diameter
+      description: Brake contact diameter
+    brake_drum_center_bore_diameter:
+      name: Brake drum center bore diameter
+      description: Brake drum center bore diameter
     brake_drum_finish_coating:
       name: Brake drum finish/coating
       description: Surface finish or protective coating applied to the brake drum (e.g., e-coat, painted, zinc-coated).
+    brake_drum_inside_diameter:
+      name: Brake drum inside diameter
+      description: Brake drum inside diameter
+    brake_drum_maximum_discard_diameter:
+      name: Brake drum Maximum discard diameter
+      description: Brake drum Maximum discard diameter
     brake_drum_type:
       name: Brake drum type
       description: Design type of the brake drum (with or without integrated hub/bearing).
+    brake_drum_width:
+      name: Brake drum width
+      description: Brake drum width
     brake_fluid_base:
       name: Brake fluid base
       description: Specifies the formulation of hydraulic brake fluid required or included.
@@ -2759,6 +3185,9 @@ en:
     brake_fluid_type:
       name: Brake fluid type
       description: Specifies the brake fluid required for hydraulic bicycle brake calipers.
+    brake_fluid_wet_boiling_point:
+      name: Brake fluid wet boiling point
+      description: Brake fluid wet boiling point
     brake_hose_end_fitting_type:
       name: Brake hose end fitting type
       description: Connection style at each end of the brake hose (e.g., banjo, flare, female/male threaded), used to ensure compatibility with calipers/lines.
@@ -2831,6 +3260,9 @@ en:
     brake_type:
       name: Brake type
       description: Type of warp beam brake/tensioning mechanism.
+    brake_width:
+      name: Brake width
+      description: Brake width
     brandy_age_classification:
       name: Brandy age classification
       description: Categorizes brandy using industry-standard quality/age designations (e.g., VS, VSOP, XO) that reflect minimum aging requirements.
@@ -2846,6 +3278,12 @@ en:
     brass_instrument_care_kit_purpose:
       name: Brass instrument care kit purpose
       description: Describes the intended usage scenario for the kit (routine maintenance, deep cleaning, travel/emergency, student starter kit, etc.).
+    brass_instrument_case_interior_height_depth:
+      name: Brass instrument case interior height/depth
+      description: Brass instrument case interior height/depth
+    brass_instrument_case_interior_width:
+      name: Brass instrument case interior width
+      description: Brass instrument case interior width
     brass_instrument_case_shell_material:
       name: Brass instrument case shell material
       description: Primary material of the rigid shell/frame (when applicable), separate from general bag/case material.
@@ -2873,6 +3311,9 @@ en:
     brass_mouthpiece_cup_depth:
       name: Brass mouthpiece cup depth
       description: Cup depth classification of the mouthpiece (how deep the cup is), affecting tone and response.
+    brass_mouthpiece_throat_size:
+      name: Brass mouthpiece throat size
+      description: Brass mouthpiece throat size
     brass_polishing_cloth_abrasiveness_level:
       name: Brass polishing cloth abrasiveness level
       description: Indicates how aggressive the cloth is for removing tarnish vs providing a gentle shine.
@@ -2897,6 +3338,9 @@ en:
     breath_sprays_certifications:
       name: Breath sprays certifications
       description: Specifies the standards a breath spray meets, such as fair trade or gluten-free
+    breather_port_diameter:
+      name: Breather port diameter
+      description: Breather port diameter
     brew_strength_options:
       name: Brew strength options
       description: Lists the selectable brew strength levels that adjust extraction time or flow to produce milder or bolder coffee.
@@ -2921,6 +3365,12 @@ en:
     brightness_levels:
       name: Brightness levels
       description: Specifies the range of light output for products, such as medium or high
+    brim_depth:
+      name: Brim depth
+      description: Measures the distance from the edge to the crown of a hat, affecting sun protection and overall style of headwear.
+    brim_width:
+      name: Brim width
+      description: Brim width
     briquette_ignition_type:
       name: Briquette ignition type
       description: Indicates whether the briquettes include ignition aids or are standard, helping users understand lighting convenience.
@@ -2930,6 +3380,9 @@ en:
     bristle_hardness:
       name: Bristle hardness
       description: Indicates the firmness of the toothbrush bristles
+    bristle_length:
+      name: Bristle length
+      description: Bristle length
     bristle_material:
       name: Bristle material
       description: Identifies the composition of brush bristles, such as nylon or horse hair
@@ -2987,6 +3440,9 @@ en:
     brush_head_usage:
       name: Brush head usage
       description: Specifies the intended use of brush heads, typically for cosmetics; e.g. deep cleansing, exfoliation
+    brush_head_width:
+      name: Brush head width
+      description: Brush head width
     brush_material:
       name: Brush material
       description: Specifies the type of material used in brush construction, such as silicone or plastic
@@ -3047,6 +3503,9 @@ en:
     building_board_material:
       name: Building board material
       description: Specifies the type of material used in construction boards, such as plywood or cement
+    building_board_thickness:
+      name: Building board thickness
+      description: Specifies the depth measurement of wall panels or construction boards, affecting structural integrity, insulation properties, and installation requirements.
     building_consumable_form:
       name: Building consumable form
       description: Specifies the form of wall patching compounds, such as liquid or powder
@@ -3062,6 +3521,9 @@ en:
     bulb_finish:
       name: Bulb finish
       description: Describes the external coating or finish of the bulb glass, which affects light diffusion and style.
+    bulb_power:
+      name: Bulb power
+      description: Indicates the energy consumption or light output of illumination sources, determining brightness levels and suitability for specific applications.
     bulb_shape:
       name: Bulb shape
       description: Describes the shape of lighting products, e.g. tube, spiral
@@ -3110,12 +3572,18 @@ en:
     burner_shape:
       name: Burner shape
       description: Describes the geometric design of the grill burner, which determines fit and heat distribution inside the grill.
+    burner_size:
+      name: Burner size
+      description: Specifies the diameter of heating elements in torches or cooking equipment, affecting heat distribution and maximum temperature capability.
     burr_shape:
       name: Burr shape
       description: Specifies the burr geometry for burr grinders, which influences grind consistency and heat generation.
     bus_model_type:
       name: Bus model type
       description: Identifies the real-world bus configuration/type represented by the scale model (body/usage class).
+    bust/chest_size:
+      name: Bust/Chest size
+      description: Measures the circumference around the fullest part of the chest or bust, essential for determining proper garment fit across various clothing styles.
     bust_design:
       name: Bust design
       description: Describes the bodysuit’s bust area configuration and neckline coverage (e.g., open-bust, built-in bra, plunge).
@@ -3149,12 +3617,21 @@ en:
     button_finish:
       name: Button finish
       description: Describes the surface finish/appearance of the button (e.g., matte vs glossy).
+    button_snap_diameter:
+      name: Button/Snap diameter
+      description: Button/Snap diameter
     button_surface_profile:
       name: Button surface profile
       description: Describes the physical contour of the button's plunger surface, affecting ergonomics and visual style
     buttonhole_elastic_application:
       name: Buttonhole elastic application
       description: Primary intended use/application for the fold-over embellishment elastic.
+    buttonhole_size:
+      name: Buttonhole size
+      description: Buttonhole size
+    buttonhole_spacing:
+      name: Buttonhole spacing
+      description: Buttonhole spacing
     cab_type:
       name: Cab type
       description: Specifies the truck cab configuration.
@@ -3176,6 +3653,9 @@ en:
     cabinet_type:
       name: Cabinet type
       description: Specifies the design and form factor of arcade games, such as bartop or mini arcade
+    cable_diameter:
+      name: Cable diameter
+      description: Specifies the thickness of cables or wires, determining strength, current-carrying capacity, and suitability for specific applications.
     cable_end_type:
       name: Cable end type
       description: Describes the shape or style of the cable’s end nipple or fitting that interfaces with brake or shift levers.
@@ -3194,6 +3674,9 @@ en:
     cable_jacket_rating:
       name: Cable jacket rating
       description: Specifies the environmental or safety rating of the cable's outer jacket (e.g., plenum, direct burial, UV-resistant)
+    cable_length:
+      name: Cable length
+      description: Indicates the total linear measurement of a cable from end to end, determining reach and installation flexibility in various applications.
     cable_management_type:
       name: Cable management type
       description: Specifies the type of built-in cable or power management features the conference table offers.
@@ -3227,6 +3710,9 @@ en:
     cache_level:
       name: Cache level
       description: Indicates the hierarchy position of the cache (e.g., L1, L2, L3), which affects size, latency, and proximity to the processor cores
+    cache_size:
+      name: Cache size
+      description: Specifies the amount of high-speed memory built into processors, affecting computing performance and data access speeds.
     caffeine_content:
       name: Caffeine content
       description: Indicates the amount of caffeine present in a product, e.g. decaffeinated, low caffeine
@@ -3254,6 +3740,9 @@ en:
     cajon_snare_system_type:
       name: Cajon snare system type
       description: Specifies the internal snare mechanism used to create the snare effect.
+    cajon_weight:
+      name: Cajon weight
+      description: Cajon weight
     cake_shape:
       name: Cake shape
       description: Describes the physical form in which the coffee cake is baked.
@@ -3275,6 +3764,9 @@ en:
     calendar_format:
       name: Calendar format
       description: Specifies the time frame of a calendar product, such as daily or monthly
+    calf_circumference:
+      name: Calf circumference
+      description: Measures the distance around the widest part of the calf, crucial for determining proper fit in boots and leg-covering garments.
     calibration_sensor_type:
       name: Calibration sensor type
       description: Specifies the underlying hardware technology or form factor of the calibrator
@@ -3287,6 +3779,9 @@ en:
     call_blocking_method:
       name: Call blocking method
       description: Specifies how the device identifies and blocks unwanted calls
+    call_storage_capacity:
+      name: Call storage capacity
+      description: Indicates the maximum duration of recorded messages a device can store, determining how many calls can be saved before requiring deletion.
     caller_id_compatibility:
       name: Caller ID compatibility
       description: States whether the phone supports Caller ID services provided by the telephone network
@@ -3329,6 +3824,9 @@ en:
     camera_mounting_type:
       name: Camera mounting type
       description: Specifies the method of camera attachment, e.g. tripod, clip-on
+    camera_probe_length:
+      name: Camera probe length
+      description: Specifies the reach of inspection camera probes, determining accessibility to confined or distant spaces for visual examination.
     camera_sensor_type:
       name: Camera sensor type
       description: Identifies the type of sensor in cameras or optics, e.g. CMOS, CCD
@@ -3341,9 +3839,18 @@ en:
     camping_oil_application:
       name: Camping oil application
       description: Specifies the primary intended use of the oil in camping contexts (e.g., lantern fuel versus stove fuel).
+    camshaft_base_circle_diameter:
+      name: Camshaft base circle diameter
+      description: Camshaft base circle diameter
     camshaft_construction:
       name: Camshaft construction
       description: Manufacturing/blank style of the camshaft.
+    camshaft_journal_diameter:
+      name: Camshaft journal diameter
+      description: Camshaft journal diameter
+    camshaft_lobe_lift:
+      name: Camshaft lobe lift
+      description: Camshaft lobe lift
     camshaft_material:
       name: Camshaft material
       description: Primary material of the camshaft core/shaft (base material).
@@ -3440,6 +3947,9 @@ en:
     canvas_mounting_format:
       name: Canvas mounting/format
       description: Physical format/mounting style of the painting canvas product.
+    canvas_roll_core_diameter:
+      name: Canvas roll core diameter
+      description: Canvas roll core diameter
     canvas_stretcher_assembly_type:
       name: Canvas stretcher assembly type
       description: Whether the stretcher is sold assembled as a frame or as bars/kits requiring assembly.
@@ -3479,12 +3989,21 @@ en:
     capacitance_tolerance:
       name: Capacitance tolerance
       description: Indicates the permissible deviation of the actual capacitance from the nominal value, expressed as a percentage
+    capacitance_value:
+      name: Capacitance value
+      description: Indicates the electrical charge storage capability of capacitors, determining their function and suitability in specific electronic circuits.
     capacitor_application:
       name: Capacitor application
       description: Denotes the primary intended use or application class of the capacitor (e.g., motor run, audio, snubber)
     capacitor_polarity:
       name: Capacitor polarity
       description: States whether the capacitor is polarized, non-polarized, or bipolar, affecting installation orientation and suitable circuit positions
+    capacity:
+      name: Capacity
+      description: Specifies the maximum volume or quantity a container can hold, determining storage capability and usage duration before refilling.
+    caper_size:
+      name: Caper size
+      description: Caper size
     caper_size_grade:
       name: Caper size grade
       description: Classifies capers by industry-standard grade names that correspond to bud diameter.
@@ -3536,12 +4055,18 @@ en:
     car_wash_solution_scent:
       name: Car wash solution scent
       description: Specifies the fragrance/scent of the car wash solution (if scented).
+    carabiner_gate_opening_clearance:
+      name: Carabiner gate opening clearance
+      description: Carabiner gate opening clearance
     carabiner_gate_type:
       name: Carabiner gate type
       description: Defines the type of gate on climbing carabiners, such as screw gate or snap gate
     carabiner_shape:
       name: Carabiner shape
       description: Identifies the form of carabiners used in climbing, like HMS or pear
+    carbohydrates_per_100_g:
+      name: Carbohydrates per 100 g
+      description: Carbohydrates per 100 g
     carbonated_water_variety:
       name: Carbonated water variety
       description: Classifies carbonated water based on common market varieties and formulation (e.g., tonic, seltzer, functional sparkling water).
@@ -3551,6 +4076,9 @@ en:
     carbonation_level_adjustment:
       name: Carbonation level adjustment
       description: Indicates whether the soda maker provides a fixed or adjustable carbonation level.
+    carburetor_airflow_rating:
+      name: Carburetor airflow rating
+      description: Carburetor airflow rating
     carburetor_barrel_count:
       name: Carburetor barrel count
       description: Indicates the number of throttle bores/barrels in the carburetor.
@@ -3605,6 +4133,12 @@ en:
     carding_surface_pin_material:
       name: Carding surface pin material
       description: Material of the pins/teeth used to tease and open fiber.
+    carding_surface_width:
+      name: Carding surface width
+      description: Carding surface width
+    carding_width:
+      name: Carding width
+      description: Carding width
     care_durability:
       name: Care durability
       description: Indicates laundering/heat durability expectations for the label after application.
@@ -3641,6 +4175,12 @@ en:
     carpet_cleaner_application_method:
       name: Carpet cleaner application method
       description: Specifies the intended way the product is applied and worked into the carpet (beyond general form).
+    carpet_kit_thickness:
+      name: Carpet kit thickness
+      description: Carpet kit thickness
+    carpet_pile_height:
+      name: Carpet pile height
+      description: Carpet pile height
     carrier_style:
       name: Carrier style
       description: The carrying mechanism/style used to support the boat on the vehicle.
@@ -3689,12 +4229,18 @@ en:
     case_color:
       name: Case color
       description: Specifies the color of a product's case, such as clear or white
+    case_depth:
+      name: Case depth
+      description: Measures the thickness of a watch case from front to back, affecting how the timepiece sits on the wrist and overall comfort.
     case_features:
       name: Case features
       description: Highlights functional features of the cymbal/drum set case related to protection and transport.
     case_humidifier_refill_type:
       name: Case humidifier refill type
       description: Indicates whether the humidifier uses reusable (rewettable/regenerable) media or disposable replaceable refills.
+    case_interior_length:
+      name: Case interior length
+      description: Case interior length
     case_lining_material:
       name: Case lining material
       description: Identifies the primary material lining the inside of a case or gigbag that contacts and protects the instrument or contents.
@@ -3704,6 +4250,9 @@ en:
     case_mounting_method:
       name: Case mounting method
       description: How the humidifier is intended to be positioned or attached inside the instrument case.
+    case_padding_thickness:
+      name: Case padding thickness
+      description: Case padding thickness
     case_pattern:
       name: Case pattern
       description: Describes the design or motif on a product's case, such as floral or geometric
@@ -3719,6 +4268,9 @@ en:
     case_type:
       name: Case type
       description: Specifies the kind of case for electronics and accessories, such as wallet or book style
+    case_width:
+      name: Case width
+      description: Specifies the diameter or width measurement of a watch case, determining the visual presence and style classification of timepieces.
     casing_material:
       name: Casing material
       description: Identifies the primary fabric used in the tire casing, impacting weight, ride feel, and puncture protection.
@@ -3806,6 +4358,9 @@ en:
     center_hole_shape:
       name: Center hole shape
       description: Describes the geometric shape of the blade’s mounting/center hole, which determines compatibility with specific mower spindles.
+    center_stick_diameter:
+      name: Center stick diameter
+      description: Center stick diameter
     cereal_bar_texture:
       name: Cereal bar texture
       description: Describes the mouthfeel and consistency of the cereal bar (e.g., chewy, crunchy).
@@ -3833,6 +4388,12 @@ en:
     chain_connection_type:
       name: Chain connection type
       description: Specifies the closure method provided or required to join the ends of the chain.
+    chain_diameter:
+      name: Chain diameter
+      description: Indicates the thickness of chain links, determining strength, weight capacity, and suitability for specific lifting or securing applications.
+    chain_length:
+      name: Chain length
+      description: Specifies the total linear measurement of a chain from end to end, determining reach and application suitability in various contexts.
     chain_link_type:
       name: Chain link type
       description: Defines the style of chain link for jewelry, such as rope or flat
@@ -3845,6 +4406,9 @@ en:
     chain_type:
       name: Chain type
       description: Identifies the type of chain used in watercraft parts, like BBB or High test (HT)
+    chainline_offset:
+      name: Chainline offset
+      description: Chainline offset
     chainring_shape:
       name: Chainring shape
       description: Indicates the shape of the chainring, such as round or oval/elliptical.
@@ -3860,6 +4424,12 @@ en:
     chainsaw_cutter_type:
       name: Chainsaw cutter type
       description: Identifies the cutter profile/design of the chain, affecting cutting speed, durability, and kickback characteristics.
+    chainsaw_gauge:
+      name: Chainsaw gauge
+      description: Indicates the thickness of the drive links on chainsaw chains, crucial for matching with the corresponding bar groove for proper operation.
+    chainsaw_pitch:
+      name: Chainsaw pitch
+      description: Defines the distance between drive links on a chainsaw chain, crucial for matching with the corresponding sprocket and bar for proper operation.
     chair/sofa_features:
       name: Chair/Sofa features
       description: Identifies unique characteristics of seating furniture, such as stain resistant or power reclining
@@ -3941,6 +4511,9 @@ en:
     charging_port_location:
       name: Charging port location
       description: Physical location of the vehicle’s primary external charging inlet (charging port).
+    charging_time:
+      name: Charging time
+      description: Charging time
     chassis_construction_type:
       name: Chassis construction type
       description: Describes the primary chassis construction method used for the vehicle.
@@ -4016,6 +4589,12 @@ en:
     chime_sound_character:
       name: Chime sound character
       description: Describes the intended sound character/timbre of the chimes.
+    chime_tube_bar_length:
+      name: Chime tube/bar length
+      description: Chime tube/bar length
+    chime_tube_diameter:
+      name: Chime tube diameter
+      description: Chime tube diameter
     chin_cup_type:
       name: Chin cup type
       description: Specifies the style or construction of the chin cup, which affects comfort and impact protection.
@@ -4064,6 +4643,9 @@ en:
     choy_sum_variety:
       name: Choy sum variety
       description: Identifies the specific market or botanical variety of choy sum being sold.
+    chuck_size:
+      name: Chuck size
+      description: Specifies the maximum diameter of drill bits or tools that can be secured in a power tool, determining versatility and application range.
     chuck_type:
       name: Chuck type
       description: Specifies the kind of chuck in hardware tools, such as SDS or SDS max
@@ -4109,30 +4691,51 @@ en:
     circular_knitting_needles_tip_material:
       name: Circular knitting needles tip material
       description: Material of the two needle tips (as distinct from the cable material).
+    circumference:
+      name: Circumference
+      description: Measures the distance around the head, essential for proper fit and comfort in hats and headwear.
     circumference_adjustment_mechanism:
       name: Circumference adjustment mechanism
       description: Mechanism used to adjust or lock the skein circumference.
     clamp_design:
       name: Clamp design
       description: Describes the structural style or mechanism of the clamp.
+    clamp_opening:
+      name: Clamp opening
+      description: Clamp opening
+    clamp_rod_diameter:
+      name: Clamp rod diameter
+      description: Clamp rod diameter
     clamp_sheet_music_clip_features:
       name: Clamp sheet music clip features
       description: Functional and protection features of clamp sheet music clips (e.g., padding, non-slip, swivel).
     clamping_closure_type:
       name: Clamping/closure type
       description: Specifies the mechanism used to tighten or secure the embroidery hoop around fabric.
+    clarinet_barrel_length:
+      name: Clarinet barrel length
+      description: Clarinet barrel length
     clarinet_bell_acoustic_design:
       name: Clarinet bell acoustic design
       description: Describes the bell’s sound/venting design intended to influence response and intonation.
     clarinet_bell_adjustment_mechanism:
       name: Clarinet bell adjustment mechanism
       description: Describes how the bell length/geometry is adjusted.
+    clarinet_bell_opening_diameter:
+      name: Clarinet bell opening diameter
+      description: Clarinet bell opening diameter
     clarinet_bell_ring_material:
       name: Clarinet bell ring material
       description: Specifies the material of the protective ring/band on the clarinet bell rim, if present.
+    clarinet_bell_throat_tenon_diameter:
+      name: Clarinet bell throat/tenon diameter
+      description: Clarinet bell throat/tenon diameter
     clarinet_bell_tuning_effect:
       name: Clarinet bell tuning effect
       description: Indicates how the bell is designed to affect tuning/intonation (especially throat tones and low register) compared to a standard bell.
+    clarinet_bell_weight:
+      name: Clarinet bell weight
+      description: Clarinet bell weight
     clarinet_body_type:
       name: Clarinet body type
       description: Indicates the primary body construction type for the A clarinet.
@@ -4145,6 +4748,15 @@ en:
     clarinet_care_kit_intended_use:
       name: Clarinet care kit intended use
       description: Primary usage context the kit is designed for (e.g., quick daily drying vs deep cleaning/maintenance).
+    clarinet_case_interior_height:
+      name: Clarinet case interior height
+      description: Clarinet case interior height
+    clarinet_case_interior_length:
+      name: Clarinet case interior length
+      description: Clarinet case interior length
+    clarinet_case_interior_width:
+      name: Clarinet case interior width
+      description: Clarinet case interior width
     clarinet_included_accessories:
       name: Clarinet included accessories
       description: Identifies what comes in the box with the Bb clarinet.
@@ -4250,6 +4862,9 @@ en:
     cleaning_purpose:
       name: Cleaning purpose
       description: Specifies the intended use of cleaning or laundry products, e.g. refreshing, stain
+    cleaning_rod_length:
+      name: Cleaning rod length
+      description: Cleaning rod length
     cleaning_solution_concentration:
       name: Cleaning solution concentration
       description: Indicates whether the product is sold ready-to-use, concentrated, or in other dilution formats.
@@ -4271,6 +4886,9 @@ en:
     cleanup_method:
       name: Cleanup method
       description: Specifies how the glue is intended to be cleaned up (while wet) from hands/tools/surfaces.
+    clear_aperture:
+      name: Clear aperture
+      description: Defines the unobstructed diameter of an optical lens, determining light-gathering ability and resolution in microscopy applications.
     clear_glue_application_method:
       name: Clear glue application method
       description: Specifies the dispensing/applicator style included with the clear glue packaging.
@@ -4313,6 +4931,12 @@ en:
     climbing_protection_device_type:
       name: Climbing protection device type
       description: Specifies the style of protection device (e.g., cam, nut, piton), helping climbers quickly narrow to the correct gear for a given rock feature or climbing style.
+    climbing_rope_diameter:
+      name: Climbing rope diameter
+      description: Specifies the thickness of climbing ropes, directly affecting strength, handling characteristics, and suitability for different climbing styles.
+    climbing_rope_length:
+      name: Climbing rope length
+      description: Indicates the total measurement of a climbing rope, determining maximum climbing height and safety margin for various routes.
     climbing_rope_middle_marking:
       name: Climbing rope middle marking
       description: Describes how the rope’s midpoint (and/or ends) are identified to assist with safe rappelling and lowering.
@@ -4394,6 +5018,9 @@ en:
     clothing_features:
       name: Clothing features
       description: Describes unique properties of apparel, such as water resistant or wrinkle resistant
+    clothing_weight:
+      name: Clothing weight
+      description: Specifies the mass of weighted garments used for resistance training, determining exercise intensity and muscle development potential.
     club_head_material:
       name: Club head material
       description: Specifies the main material used in the construction of the club head.
@@ -4409,9 +5036,18 @@ en:
     clutch_line_connection_type:
       name: Clutch line connection type
       description: Specifies the end-connection/fitting interface used by the clutch line (important for compatibility with master/slave cylinders and hard lines).
+    clutch_master_cylinder_bore_diameter:
+      name: Clutch master cylinder bore diameter
+      description: Clutch master cylinder bore diameter
     clutch_pressure_plate_actuation_type:
       name: Clutch pressure plate actuation type
       description: Indicates whether the clutch is released by a push-type or pull-type release mechanism (diaphragm spring actuation).
+    clutch_pressure_plate_bolt_circle_diameter_bcd:
+      name: Clutch pressure plate bolt circle diameter (BCD)
+      description: Clutch pressure plate bolt circle diameter (BCD)
+    clutch_pressure_plate_diameter:
+      name: Clutch pressure plate diameter
+      description: Clutch pressure plate diameter
     clutch_pressure_plate_release_mechanism_type:
       name: Clutch pressure plate release mechanism type
       description: The style of release/actuation interface used by the pressure plate.
@@ -4424,6 +5060,9 @@ en:
     clutch_slave_cylinder_mounting_type:
       name: Clutch slave cylinder mounting type
       description: How the slave cylinder mounts to the transmission/bellhousing (e.g., bolt-on, clip-in, integrated concentric).
+    co2_cartridge_capacity:
+      name: CO2 cartridge capacity
+      description: CO2 cartridge capacity
     co2_cylinder_compatibility:
       name: CO2 cylinder compatibility
       description: Defines the type or size of CO2 cylinder the soda maker accepts, ensuring shoppers can find compatible refill cartridges.
@@ -4445,6 +5084,9 @@ en:
     cocking_mechanism:
       name: Cocking mechanism
       description: Specifies the primary method or device used to cock or de-cock the crossbow string.
+    cockpit_dimensions:
+      name: Cockpit dimensions
+      description: Cockpit dimensions
     cockpit_type:
       name: Cockpit type
       description: Specifies the design and technology used in an aircraft's cockpit, such as analog or hybrid
@@ -4463,6 +5105,12 @@ en:
     cocktail_napkin_features:
       name: Cocktail napkin features
       description: Highlights functional, convenience, and eco-friendly features of cocktail napkins.
+    cocktail_napkin_unfolded_size:
+      name: Cocktail napkin unfolded size
+      description: Cocktail napkin unfolded size
+    cocktail_pick_length:
+      name: Cocktail pick length
+      description: Cocktail pick length
     cocktail_pick_tip_style:
       name: Cocktail pick tip style
       description: Describes the tip shape/feature used to pierce or hold garnishes.
@@ -4475,6 +5123,9 @@ en:
     cocktail_type:
       name: Cocktail type
       description: States the specific cocktail recipe or style represented by the premixed product (e.g., Margarita, Negroni, Piña Colada).
+    cocktail_umbrella_canopy_diameter:
+      name: Cocktail umbrella canopy diameter
+      description: Cocktail umbrella canopy diameter
     cocktail_umbrella_handle_pick_material:
       name: Cocktail umbrella handle/pick material
       description: Material of the stick/pick portion (excluding canopy) of the cocktail umbrella.
@@ -4505,6 +5156,9 @@ en:
     coffee_bean_species:
       name: Coffee bean species
       description: Specifies the species of coffee beans used in the product.
+    coffee_beans_capacity:
+      name: Coffee beans capacity
+      description: Indicates the maximum amount of coffee beans a grinder can process at once, determining batch size and preparation efficiency.
     coffee_beverage_variety:
       name: Coffee beverage variety
       description: Classifies ready-to-consume or mix coffee beverages by style.
@@ -4526,6 +5180,9 @@ en:
     coffee_grinder_accessory_type:
       name: Coffee grinder accessory type
       description: Classifies the specific kind of accessory to aid in filtering and search.
+    coffee_growing_altitude:
+      name: Coffee growing altitude
+      description: Coffee growing altitude
     coffee_input_type:
       name: Coffee input type
       description: Identifies the coffee format, e.g. pods, beans
@@ -4550,15 +5207,27 @@ en:
     coil_spring_finish_coating:
       name: Coil spring finish/coating
       description: Surface finish or coating applied for corrosion protection.
+    coil_spring_free_length:
+      name: Coil spring free length
+      description: Coil spring free length
+    coil_spring_lift_height:
+      name: Coil spring lift height
+      description: Coil spring lift height
     coil_spring_material:
       name: Coil spring material
       description: Primary material/composition of the coil spring.
+    coil_spring_wire_diameter:
+      name: Coil spring wire diameter
+      description: Coil spring wire diameter
     coil_system_type:
       name: Coil system type
       description: Details the specific coil or spring system used in applicable mattresses, such as pocket coils or Bonnell coils.
     coil_type:
       name: Coil type
       description: Describes the coil construction or technology used, impacting vapor production and flavor.
+    coin_diameter:
+      name: Coin diameter
+      description: Coin diameter
     coin_grade_numismatic:
       name: Coin grade (numismatic)
       description: Standardized grade of the coin (e.g., Sheldon scale or adjectival grade).
@@ -4571,6 +5240,12 @@ en:
     coin_strike_type:
       name: Coin strike type
       description: Describes the strike/finish type of the coin (e.g., proof, business strike).
+    coin_thickness:
+      name: Coin thickness
+      description: Coin thickness
+    coin_weight:
+      name: Coin weight
+      description: Coin weight
     colander_style:
       name: Colander style
       description: Classifies the structural design of the colander, such as footed bowl or over-the-sink.
@@ -4589,6 +5264,9 @@ en:
     collar_lock_type:
       name: Collar lock type
       description: Specifies the type of collar lock on weight lifting equipment, like spinlock or spring clamp
+    collar_size:
+      name: Collar size
+      description: Measures the circumference of a garment's neck opening, crucial for comfort and proper fit in shirts and uniforms.
     collar_style:
       name: Collar style
       description: Defines the design of the collar or neckline on the garment.
@@ -4601,6 +5279,9 @@ en:
     collectible_knife_blade_finish:
       name: Collectible knife blade finish
       description: Describes the blade’s surface finish/treatment for appearance (and sometimes corrosion resistance).
+    collet_size:
+      name: Collet size
+      description: Specifies the diameter of tool shanks that can be secured in a machine, determining compatibility with cutting tools and accessories.
     color:
       name: Color
       description: Defines the primary color or pattern, such as blue or striped
@@ -4727,9 +5408,15 @@ en:
     compatible_archery_tool:
       name: Compatible archery tool
       description: Indicates the primary archery tool or piece of equipment that the accessory is designed to work with.
+    compatible_arrow_shaft_diameter:
+      name: Compatible arrow shaft diameter
+      description: Compatible arrow shaft diameter
     compatible_awning_rail_type:
       name: Compatible awning rail type
       description: Specifies the awning rail or piping system the hanger clip is designed to fit.
+    compatible_axle_diameter:
+      name: Compatible axle diameter
+      description: Compatible axle diameter
     compatible_axle_size:
       name: Compatible axle size
       description: Specifies the hub/axle diameter or thread standard the foot peg is designed to fit (e.g., 10 mm/3⁄8 in, 14 mm, 3/8 in 26 TPI).
@@ -4751,12 +5438,24 @@ en:
     compatible_baby_transport_type:
       name: Compatible baby transport type
       description: Identifies compatible baby transport items, like stroller or car seat
+    compatible_backboard_width:
+      name: Compatible backboard width
+      description: Compatible backboard width
     compatible_bait_type:
       name: Compatible bait type
       description: Identifies the types of fishing bait the bait drill is compatible with so anglers can choose a tool that matches their preferred bait.
+    compatible_ball_diameter:
+      name: Compatible ball diameter
+      description: Compatible ball diameter
     compatible_ball_type:
       name: Compatible ball type
       description: Identifies the ball types suitable for use with the product, e.g. tennis, wiffle
+    compatible_bar_diameter:
+      name: Compatible bar diameter
+      description: Indicates the thickness of weight bars that can be accommodated by collars or clamps, ensuring secure attachment during exercise.
+    compatible_bar_size:
+      name: Compatible bar size
+      description: Specifies the length and gauge of chainsaw bars that work with specific chains, ensuring proper fit and operation.
     compatible_bass_scale_length:
       name: Compatible bass scale length
       description: Indicates the bass scale length(s) the string set is intended for (important for proper winding length and fit).
@@ -4772,6 +5471,12 @@ en:
     compatible_bb_size:
       name: Compatible BB size
       description: Indicates the diameter of airsoft pellets the product supports.
+    compatible_bead_hole_size:
+      name: Compatible bead hole size
+      description: Compatible bead hole size
+    compatible_beam_width:
+      name: Compatible beam width
+      description: Compatible beam width
     compatible_bed_frame_style:
       name: Compatible bed frame style
       description: Specifies the bed or frame style the accessory is designed to fit.
@@ -4805,15 +5510,27 @@ en:
     compatible_blade_system:
       name: Compatible blade system
       description: 'Indicates the replacement blade system/format the knife accepts (e.g., standard hobby #11, snap-off segment blades).'
+    compatible_board_length:
+      name: Compatible board length
+      description: Compatible board length
     compatible_boat_weaving_shuttle_loom:
       name: Compatible boat weaving shuttle loom
       description: What loom types the boat shuttle is intended to be used with.
+    compatible_bobbin_diameter:
+      name: Compatible bobbin diameter
+      description: Compatible bobbin diameter
     compatible_bobbin_type:
       name: Compatible bobbin type
       description: Indicates what style of bobbin/spool the boat shuttle is designed to use.
+    compatible_boilie_diameter:
+      name: Compatible boilie diameter
+      description: Compatible boilie diameter
     compatible_bottle_mouth:
       name: Compatible bottle mouth
       description: Bottle mouth type or diameter that the straw or cap is designed to fit.
+    compatible_bottle_volume:
+      name: Compatible bottle volume
+      description: Compatible bottle volume
     compatible_bow_attachment_system:
       name: Compatible bow attachment system
       description: Indicates the limb or accessory interface the part is designed for (e.g., ILF, screw fit, quick detach).
@@ -4829,6 +5546,9 @@ en:
     compatible_brake_service_system:
       name: Compatible brake service system
       description: Specifies whether the part is intended for disc brakes, drum brakes, or both.
+    compatible_brake_shoe_width:
+      name: Compatible brake shoe width
+      description: Compatible brake shoe width
     compatible_brake_system:
       name: Compatible brake system
       description: Specifies key system compatibility notes for brake fluid usage.
@@ -4859,6 +5579,9 @@ en:
     compatible_cardio_machine_type:
       name: Compatible cardio machine type
       description: Identifies the type of cardio machine the accessory or part is designed to work with.
+    compatible_case_width:
+      name: Compatible case width
+      description: Indicates watch case sizes that can be paired with specific watch bands, ensuring proper fit and aesthetic balance.
     compatible_chain_link_type:
       name: Compatible chain link type
       description: Identifies the chain link style the tool supports (standard, half-link, quick link, etc.).
@@ -4895,6 +5618,9 @@ en:
     compatible_clipless_pedal_system:
       name: Compatible clipless pedal system
       description: Identifies the specific clipless pedal/cleat standard the product is designed to interface with.
+    compatible_clutch_disc_diameter:
+      name: Compatible clutch disc diameter
+      description: Compatible clutch disc diameter
     compatible_clutch_type:
       name: Compatible clutch type
       description: Clutch interface compatibility for the flywheel (where applicable).
@@ -4916,6 +5642,9 @@ en:
     compatible_contact_lenses:
       name: Compatible contact lenses
       description: Indicates the types or materials of contact lenses the solution can be safely used with
+    compatible_container_capacity:
+      name: Compatible container capacity
+      description: Compatible container capacity
     compatible_contra_bass_clarinet_peg_stand:
       name: Compatible contra-bass clarinet peg/stand
       description: Indicates the stand/peg interface or support style required.
@@ -4928,6 +5657,9 @@ en:
     compatible_cooling_system_material:
       name: Compatible cooling system material
       description: Specifies which cooling systems/materials the radiator flush is safe for (e.g., aluminum radiators, mixed-metal systems).
+    compatible_cord_diameter:
+      name: Compatible cord diameter
+      description: Compatible cord diameter
     compatible_cosmetic_tools:
       name: Compatible cosmetic tools
       description: Specifies which beauty tools the product can be used with, e.g. sponges, tweezers
@@ -4979,6 +5711,9 @@ en:
     compatible_drum_configuration:
       name: Compatible drum configuration
       description: Identifies the drum set-up the product is designed for, like double bass or hi-hat
+    compatible_drum_inside_diameter:
+      name: Compatible drum inside diameter
+      description: Compatible drum inside diameter
     compatible_electric/acoustic_instrument:
       name: Compatible electric/acoustic instrument
       description: Identifies the electric or acoustic instrument the product is designed for, such as electric guitar or synthesizer
@@ -5042,12 +5777,18 @@ en:
     compatible_flywheel_type:
       name: Compatible flywheel type
       description: Specifies the flywheel type the clutch pressure plate is intended to be used with.
+    compatible_foam_roller_diameter:
+      name: Compatible foam roller diameter
+      description: Compatible foam roller diameter
     compatible_football_kick_type:
       name: Compatible football kick type
       description: Identifies the kicking situations the product is designed to support (e.g., kickoff, field goal), helping athletes quickly locate appropriate gear.
     compatible_footwear_material:
       name: Compatible footwear material
       description: Lists the types of shoe materials the polish or wax is suitable for.
+    compatible_fuel_cap_neck_outer_diameter:
+      name: Compatible fuel cap neck outer diameter
+      description: Compatible fuel cap neck outer diameter
     compatible_fuel_system_type:
       name: Compatible fuel system type
       description: Specifies the fuel delivery system the cleaner is designed for.
@@ -5066,12 +5807,21 @@ en:
     compatible_gas_type:
       name: Compatible gas type
       description: Identifies the type of compressed gas the paintball air tank is designed to store.
+    compatible_gel_ball_size:
+      name: Compatible gel ball size
+      description: Compatible gel ball size
     compatible_gel_wax_additives:
       name: Compatible gel wax additives
       description: Specifies which additive types are compatible with this gel wax (e.g., dye type, embeds).
     compatible_glaze_layering:
       name: Compatible glaze layering
       description: Whether the glaze is intended to be layered with other glazes for effects.
+    compatible_glue_stick_diameter:
+      name: Compatible glue stick diameter
+      description: Compatible glue stick diameter
+    compatible_goal_frame_size:
+      name: Compatible goal frame size
+      description: Compatible goal frame size
     compatible_golf_bag_type:
       name: Compatible golf bag type
       description: Indicates which golf bag formats the cover or case fits.
@@ -5102,6 +5852,9 @@ en:
     compatible_hammock_design:
       name: Compatible hammock design
       description: Specifies the type of a hammock a product is compatible with, e.g. hanging, frame
+    compatible_handlebar_size:
+      name: Compatible handlebar size
+      description: Specifies the diameter of bicycle handlebars that can be fitted with specific stems, ensuring secure attachment and proper steering.
     compatible_harmonica_type:
       name: Compatible harmonica type
       description: Identifies the type of harmonica a product is designed for, like diatonic or chromatic
@@ -5114,6 +5867,9 @@ en:
     compatible_head_and_neck_restraint_system:
       name: Compatible head and neck restraint system
       description: Indicates whether the helmet includes anchor points and/or is compatible with head and neck restraint systems (e.g., HANS), including anchor post inclusion/installation status.
+    compatible_headstock_thickness:
+      name: Compatible headstock thickness
+      description: Compatible headstock thickness
     compatible_helmet_certification_standard:
       name: Compatible helmet certification standard
       description: Indicates any helmet safety standard or certification context the accessory is designed to support (e.g., race-use tear-offs often reference specific sanctioning rules).
@@ -5171,6 +5927,9 @@ en:
     compatible_leaf_blower_style:
       name: Compatible leaf blower style
       description: Specifies the leaf blower form factor with which the accessory is compatible.
+    compatible_lens_diameter:
+      name: Compatible lens diameter
+      description: Indicates the size of camera lenses that can be fitted with specific accessories, ensuring proper coverage and attachment.
     compatible_license_plate_hole_pattern:
       name: Compatible license plate hole pattern
       description: Specifies the mounting hole configuration supported by the mount/holder (vehicle side and/or plate side).
@@ -5201,18 +5960,36 @@ en:
     compatible_mast_type:
       name: Compatible mast type
       description: 'Specifies which mast diameters the sail is designed for: reduced diameter (RDM), standard diameter (SDM), or both.'
+    compatible_mat_length:
+      name: Compatible mat length
+      description: Compatible mat length
+    compatible_mat_thickness:
+      name: Compatible mat thickness
+      description: Compatible mat thickness
+    compatible_mat_width:
+      name: Compatible mat width
+      description: Compatible mat width
+    compatible_mattress_dimensions:
+      name: Compatible mattress dimensions
+      description: Compatible mattress dimensions
     compatible_mattress_size:
       name: Compatible mattress size
       description: Specifies the mattress size that fits the product; i.e. king, twin
     compatible_memory_cards:
       name: Compatible memory cards
       description: Identifies the types of memory cards a product can use, typically for cameras; e.g. SD, microSDHC
+    compatible_microphone_size:
+      name: Compatible microphone size
+      description: Specifies the diameter of microphones that can be secured in specific mounts, ensuring stable positioning during use.
     compatible_microphone_thread:
       name: Compatible microphone thread
       description: Specifies the compatible thread size for microphone products, e.g. 5/8"-27
     compatible_model_system_train_scale:
       name: Compatible model system (train scale)
       description: Specifies the model train scale/system the accessory fits when applicable (e.g., HO, N, O).
+    compatible_monitor_size:
+      name: Compatible monitor size
+      description: Indicates the dimensions of displays that can be safely supported by mounting systems, ensuring secure installation and viewing.
     compatible_motherboard_form_factor:
       name: Compatible motherboard form factor
       description: Specifies the motherboard sizes the product can support, such as ATX
@@ -5273,6 +6050,9 @@ en:
     compatible_pinball_machine_edition:
       name: Compatible pinball machine edition
       description: Specifies which edition or trim level of the pinball machine the accessory fits (e.g., Pro, Premium, LE)
+    compatible_pipe_diameter:
+      name: Compatible pipe diameter
+      description: Specifies the size of pipes that can be worked with specific threading tools, ensuring proper grip and thread formation.
     compatible_pipe_filter_size:
       name: Compatible pipe filter size
       description: Indicates the filter size or style the pipe is designed to accept (or that no filter is required).
@@ -5291,6 +6071,9 @@ en:
     compatible_playing_surface:
       name: Compatible playing surface
       description: Indicates the type of playing field or surface the American football shoes are designed for.
+    compatible_poker_chip_diameter:
+      name: Compatible poker chip diameter
+      description: Compatible poker chip diameter
     compatible_pole_dimensions:
       name: Compatible pole dimensions
       description: Specifies the pole cross-section size the accessory fits.
@@ -5315,6 +6098,9 @@ en:
     compatible_printer:
       name: Compatible printer
       description: Identifies the type of printer a product is compatible with, such as laser or inkjet
+    compatible_printer_filament_size:
+      name: Compatible printer filament size
+      description: Indicates the diameter of 3D printing material that can be used with specific extruders, ensuring proper feeding and extrusion.
     compatible_processor_series:
       name: Compatible processor series
       description: Specifies the processor series that the product is compatible with, such as AMD Ryzen or Intel core solo
@@ -5372,6 +6158,15 @@ en:
     compatible_ride_equipment:
       name: Compatible ride equipment
       description: Types of wheeled sports equipment the ramp is intended for.
+    compatible_rim_diameter:
+      name: Compatible rim diameter
+      description: Compatible rim diameter
+    compatible_rivet_size:
+      name: Compatible rivet size
+      description: Specifies the dimensions of rivets that can be installed using specific tools, ensuring proper fastening and joint integrity.
+    compatible_rod_length:
+      name: Compatible rod length
+      description: Compatible rod length
     compatible_roof_height:
       name: Compatible roof height
       description: Indicates which roof profile the cover is designed for (standard vs extended/high roof).
@@ -5402,12 +6197,18 @@ en:
     compatible_seat_airbag:
       name: Compatible seat airbag
       description: Indicates whether the seat supports/contains side airbags or is compatible with vehicles equipped with seat-mounted airbags.
+    compatible_seat_belt_tongue_width:
+      name: Compatible seat belt tongue width
+      description: Compatible seat belt tongue width
     compatible_seat_type:
       name: Compatible seat type
       description: Specifies the type of child car seat the product fits, such as booster or infant car seat
     compatible_seating_capacity:
       name: Compatible seating capacity
       description: Specifies the number of seats or configuration the accessory is designed to fit.
+    compatible_seatpost_diameter:
+      name: Compatible seatpost diameter
+      description: Compatible seatpost diameter
     compatible_sensor_port_type:
       name: Compatible sensor port type
       description: Specifies whether the oil pan supports oil level and/or oil temperature sensors and the port style if applicable.
@@ -5423,6 +6224,9 @@ en:
     compatible_skating_discipline:
       name: Compatible skating discipline
       description: Indicates the skating discipline(s) the part or accessory is designed to fit.
+    compatible_ski_width:
+      name: Compatible ski width
+      description: Compatible ski width
     compatible_snowshoe_deck_type:
       name: Compatible snowshoe deck type
       description: Specifies the snowshoe frame or deck style with which the binding is compatible.
@@ -5483,6 +6287,18 @@ en:
     compatible_surface_material:
       name: Compatible surface material
       description: Vehicle surface materials the product is designed to be used on.
+    compatible_table_length:
+      name: Compatible table length
+      description: Compatible table length
+    compatible_table_size:
+      name: Compatible table size
+      description: Compatible table size
+    compatible_table_width:
+      name: Compatible table width
+      description: Compatible table width
+    compatible_tape_size:
+      name: Compatible tape size
+      description: Indicates the width of recording media that can be used with specific players, ensuring proper alignment and playback.
     compatible_tear_off_system:
       name: Compatible tear-off system
       description: Indicates whether the goggles support tear-offs and/or roll-offs, including whether they have mounting posts for tear-offs.
@@ -5522,9 +6338,15 @@ en:
     compatible_treadmill_design:
       name: Compatible treadmill design
       description: Specifies the treadmill design the accessory is compatible with, such as folding or non-folding models.
+    compatible_truck_bed_length:
+      name: Compatible truck bed length
+      description: Compatible truck bed length
     compatible_tube:
       name: Compatible tube
       description: Indicates the inner tube or tire construction the patch is designed for, such as butyl, latex, TPU, or tubeless.
+    compatible_tube_diameter:
+      name: Compatible tube diameter
+      description: Compatible tube diameter
     compatible_umbrella_type:
       name: Compatible umbrella type
       description: Specifies the style of outdoor umbrella the cover is designed to fit.
@@ -5582,6 +6404,9 @@ en:
     compatible_wax_form:
       name: Compatible wax form
       description: Specifies the forms of depilatory wax the warmer is designed to melt
+    compatible_weaving_shuttle_bobbin_length:
+      name: Compatible weaving shuttle bobbin length
+      description: Compatible weaving shuttle bobbin length
     compatible_weight_lifting_accessory:
       name: Compatible weight lifting accessory
       description: Specifies the weight lifting equipment the product is compatible with, such as barbell or dumbbell
@@ -5591,6 +6416,9 @@ en:
     compatible_wheel_finish:
       name: Compatible wheel finish
       description: Specifies the wheel finishes/materials the cleaner is safe to use on (as claimed by the manufacturer).
+    compatible_wheel_size:
+      name: Compatible wheel size
+      description: Specifies the diameter of bicycle wheels that can be used with specific forks, ensuring proper clearance and handling characteristics.
     compatible_whorl_drive_band_type:
       name: Compatible whorl drive band type
       description: Specifies which drive band style the whorl is intended to work with.
@@ -5693,6 +6521,12 @@ en:
     concertina_button_configuration:
       name: Concertina button configuration
       description: Specifies the number and layout of buttons on a concertina, such as 20-button anglo concertina
+    condenser_inlet_port_diameter:
+      name: Condenser inlet port diameter
+      description: Condenser inlet port diameter
+    condenser_outlet_port_diameter:
+      name: Condenser outlet port diameter
+      description: Condenser outlet port diameter
     condiment_form:
       name: Condiment form
       description: Indicates the physical form or consistency of the horseradish product (e.g. paste, powder, cream).
@@ -5720,9 +6554,15 @@ en:
     conductor_core_type:
       name: Conductor core type
       description: Indicates whether the internal conductor is stranded or solid core
+    cone_height:
+      name: Cone height
+      description: Cone height
     confetti_format:
       name: Confetti format
       description: Specifies the confetti product format based on how the confetti is packaged or launched (e.g., loose scatter vs poppers/cannons).
+    confetti_piece_size:
+      name: Confetti piece size
+      description: Confetti piece size
     conga_head_tensioning_system:
       name: Conga head tensioning system
       description: Type of hardware used to tension/tune the conga head (e.g., traditional lug tuning vs modern quick-tune mechanisms).
@@ -5750,6 +6590,9 @@ en:
     connector_2_type:
       name: Connector 2 type
       description: Specifies the connector or interface present on the second end of the adapter or coupler
+    connector_case_internal_dimensions:
+      name: Connector case internal dimensions
+      description: Connector case internal dimensions
     connector_case_style:
       name: Connector case style
       description: Classifies the overall construction style of the connector case (e.g., hard shell vs soft pouch) to reflect protection level and portability.
@@ -5981,6 +6824,9 @@ en:
     cookware_lid_style:
       name: Cookware lid style
       description: Describes the overall style or functional construction of the lid.
+    cookware_size:
+      name: Cookware size
+      description: Indicates the diameter or dimensions of cooking vessels, determining cooking capacity and compatibility with heat sources.
     coolant_additive_purpose:
       name: Coolant additive purpose
       description: Primary intended function of the coolant additive (not radiator flush or dedicated sealer products).
@@ -5996,6 +6842,9 @@ en:
     coolant_technology:
       name: Coolant technology
       description: Specifies the coolant chemistry/technology family used by the antifreeze/coolant (as commonly labeled on packaging).
+    coolant_temperature_sensor_hex_size:
+      name: Coolant temperature sensor hex size
+      description: Coolant temperature sensor hex size
     coolant_temperature_sensor_port:
       name: Coolant temperature sensor port
       description: Whether the water neck includes a port for a coolant temperature sensor or switch and what interface it uses.
@@ -6017,9 +6866,15 @@ en:
     cooling_technology:
       name: Cooling technology
       description: Specifies the method used to cool electronics, such as air or heat sink
+    cord_diameter:
+      name: Cord diameter
+      description: Specifies the thickness of elastic or utility cords, determining strength, elasticity, and load-bearing capacity.
     cord_fastening_system:
       name: Cord fastening system
       description: Specifies the type of fastening system for bungee cords, e.g. toggle ball, hook
+    cord_length:
+      name: Cord length
+      description: Indicates the distance from a device to the power outlet, determining placement flexibility and operational range.
     cord_material:
       name: Cord material
       description: Specifies the material of the cord/string used to pull the swab through the saxophone.
@@ -6161,12 +7016,18 @@ en:
     coverage_area:
       name: Coverage area
       description: Indicates the geographical coverage countries or territories for GPS software, such as United States or Canada
+    coverage_area_per_container:
+      name: Coverage area per container
+      description: Coverage area per container
     coverage_country:
       name: Coverage country
       description: Specifies the primary country in which the prepaid credit can be used.
     coverage_level:
       name: Coverage level
       description: Indicates the opacity or intensity of coverage the product provides once applied (e.g., sheer, medium, full)
+    coverage_radius:
+      name: Coverage radius
+      description: Indicates the maximum distance from a base station where reliable signal can be maintained, determining effective usage area.
     coverage_region:
       name: Coverage region
       description: Indicates the broad geographical coverage region for GPS software, such as North America or Oceania
@@ -6176,6 +7037,12 @@ en:
     cowbell_mounting_method:
       name: Cowbell mounting method
       description: How the cowbell is intended to be mounted/used (handheld vs mounted to hardware).
+    cowbell_mouth_opening_width:
+      name: Cowbell mouth opening width
+      description: Cowbell mouth opening width
+    cowbell_opening_size:
+      name: Cowbell opening size
+      description: Cowbell opening size
     cowbell_sound_character:
       name: Cowbell sound character
       description: General tonal character used in listings (supports discovery beyond size).
@@ -6251,9 +7118,15 @@ en:
     crafting_stretcher_features:
       name: Crafting stretcher features
       description: Describes the key features of a crafting stretcher, like adjustable tension or lightweight
+    crafting_wire_diameter:
+      name: Crafting wire diameter
+      description: Crafting wire diameter
     crampon_attachment_type:
       name: Crampon attachment type
       description: Identifies how crampons attach to footwear, such as hybrid or step-in
+    crank_arm_length:
+      name: Crank arm length
+      description: Crank arm length
     crank_spindle_interface:
       name: Crank spindle interface
       description: Specifies the crank spindle system the bottom bracket supports (e.g., SRAM DUB, Square Taper), ensuring compatibility between crankset and bottom bracket.
@@ -6263,6 +7136,9 @@ en:
     crankshaft_bolt_pattern:
       name: Crankshaft bolt pattern
       description: Bolt pattern on the rear flange for flywheel/flexplate attachment.
+    crankshaft_main_bearing_journal_diameter:
+      name: Crankshaft main bearing journal diameter
+      description: Crankshaft main bearing journal diameter
     crankshaft_sensor_reluctor_type:
       name: Crankshaft sensor reluctor type
       description: Crankshaft position sensor trigger/reluctor wheel configuration used (where applicable).
@@ -6383,6 +7259,9 @@ en:
     cross_stitch_pattern_technique:
       name: Cross stitch pattern technique
       description: The cross-stitch technique/style required by the chart.
+    crossbar_height:
+      name: Crossbar height
+      description: Crossbar height
     crossbar_shape_profile:
       name: Crossbar shape/profile
       description: Specifies the crossbar aerodynamic/profile shape.
@@ -6401,12 +7280,18 @@ en:
     crossover_type:
       name: Crossover type
       description: Type of crossover network included with the component set.
+    crown_height:
+      name: Crown height
+      description: Crown height
     crown_profile:
       name: Crown profile
       description: Specifies the height/profile of the cap crown above the brim.
     crown_style:
       name: Crown style
       description: Defines the overall silhouette or profile of the crown on a bowler hat.
+    crusher_output_size:
+      name: Crusher output size
+      description: Specifies the dimensions of processed materials after crushing, determining suitability for subsequent processing or application.
     crushing_method:
       name: Crushing method
       description: Describes the mechanism used to compress the can.
@@ -6446,6 +7331,9 @@ en:
     cue_head_material:
       name: Cue head material
       description: Identifies the material of the cue head (the portion that contacts the puck), which affects durability and surface protection.
+    cue_size:
+      name: Cue size
+      description: Indicates the length of billiard cues, affecting leverage, control, and suitability for players of different heights and playing styles.
     cue_sport_compatibility:
       name: Cue sport compatibility
       description: Identifies which cue sport the accessory is designed for.
@@ -6455,6 +7343,9 @@ en:
     cue_thread_size:
       name: Cue thread size
       description: Specifies the thread specification used on extensions, joint protectors, weight bolts, and other cue accessories to ensure proper fit.
+    cue_tip_diameter:
+      name: Cue tip diameter
+      description: Cue tip diameter
     cue_tip_hardness:
       name: Cue tip hardness
       description: Rates the firmness of the cue’s tip which influences cue ball control and feedback.
@@ -6494,6 +7385,9 @@ en:
     cultivator_type:
       name: Cultivator type
       description: Classifies the structural design of the cultivator, such as front-tine or rear-tine.
+    cup_mute_depth:
+      name: Cup mute depth
+      description: Cup mute depth
     cup_size:
       name: Cup size
       description: Specifies bust size of bras, such as AA or L
@@ -6512,6 +7406,9 @@ en:
     cure_method:
       name: Cure method
       description: Describes the process required for the adhesive to set or cure (e.g., UV light, air humidity, heat).
+    cure_time:
+      name: Cure time
+      description: Cure time
     curing_method:
       name: Curing method
       description: Indicates how the glue sets or cures (e.g., air dry, UV/LED lamp, heat)
@@ -6551,6 +7448,9 @@ en:
     curry_variety:
       name: Curry variety
       description: Classifies curry sauce products by the specific curry style or recipe they are intended to create, such as Tikka Masala, Massaman, or Thai green, to enable precise flavour/style filtering.
+    curtain_drop:
+      name: Curtain drop
+      description: Specifies the vertical measurement of curtains from top to bottom, determining coverage area and visual impact.
     curtain_heading_style:
       name: Curtain heading style
       description: Specifies the style of the upper edge/heading used to hang the curtain or drape, which determines the required hardware and overall look.
@@ -6560,12 +7460,18 @@ en:
     curtain_rod_type:
       name: Curtain rod type
       description: Classifies the structural style of the rod, helping shoppers quickly locate rods suited to their installation needs.
+    curtain_width:
+      name: Curtain width
+      description: Indicates the horizontal measurement of curtains, determining coverage area and gathering fullness when installed.
     cushion_design:
       name: Cushion design
       description: Describes the overall form factor or style of the metatarsal cushion (e.g., pad, sleeve, dome)
     cushion_rubber_profile:
       name: Cushion rubber profile
       description: Shape or profile code of rail cushion rubber pieces.
+    cushion_thickness:
+      name: Cushion thickness
+      description: Cushion thickness
     cushioning_level:
       name: Cushioning level
       description: Indicates the amount of under-foot padding provided by the sock for impact protection and comfort.
@@ -6596,6 +7502,12 @@ en:
     cutting_application:
       name: Cutting application
       description: Primary intended cutting use-case for the scissors.
+    cutting_depth:
+      name: Cutting depth
+      description: Specifies the maximum thickness of material that can be cut through in a single pass, determining tool capability and application range.
+    cutting_diameter:
+      name: Cutting diameter
+      description: Indicates the width of cut that can be made with a specific tool, determining material removal rate and finish quality.
     cutting_disc_function:
       name: Cutting disc function
       description: Defines the specific food-processing action the disc performs.
@@ -6620,18 +7532,30 @@ en:
     cv_boot_kit_contents:
       name: CV boot kit contents
       description: Lists what is included with the CV boot (e.g., clamps, grease packet, retaining bands).
+    cv_boot_large_end_inner_diameter:
+      name: CV boot large end inner diameter
+      description: CV boot large end inner diameter
+    cv_boot_length:
+      name: CV boot length
+      description: CV boot length
     cv_boot_material:
       name: CV boot material
       description: Specifies the primary material construction of the CV boot.
     cv_boot_position:
       name: CV boot position
       description: Specifies whether the CV boot fits the inner (inboard) or outer (outboard) CV joint position on the axle.
+    cv_boot_small_end_inner_diameter:
+      name: CV boot small end inner diameter
+      description: CV boot small end inner diameter
     cycling_apparel_fit:
       name: Cycling apparel fit
       description: Describes the cut of the garment, indicating intended tightness and aerodynamics (e.g., Race, Relaxed).
     cycling_style:
       name: Cycling style
       description: Defines the intended use or riding style of cycling products, like road racing or BMX racing
+    cylinder_bore:
+      name: Cylinder bore
+      description: Specifies the internal diameter of engine cylinders, directly affecting displacement, power output, and efficiency.
     cylinder_connector_type:
       name: Cylinder connector type
       description: Specifies the connection or thread interface of the cylinder, determining compatibility with specific soda maker models.
@@ -6647,12 +7571,18 @@ en:
     cylinder_size_designation:
       name: Cylinder size designation
       description: Identifies the standard letter or number code used to identify an oxygen cylinder's dimensions and capacity (e.g., M6, D, E)
+    cylinder_thread_size:
+      name: Cylinder thread size
+      description: Cylinder thread size
     cymbal_alloy:
       name: Cymbal alloy
       description: Alloy/composition of the cymbal(s) in the kit.
     cymbal_application:
       name: Cymbal application
       description: Primary playing application the cymbal is designed/marketed for.
+    cymbal_arm_length:
+      name: Cymbal arm length
+      description: Cymbal arm length
     cymbal_arm_mounting_interface:
       name: Cymbal arm mounting interface
       description: Specifies how the cymbal arm attaches to the rest of the drum hardware (e.g., clamp, rack, stand receiver).
@@ -6662,6 +7592,9 @@ en:
     cymbal_arm_style:
       name: Cymbal arm style
       description: Specifies whether a cymbal arm is straight or boom, for reach and positioning preferences.
+    cymbal_bell_size:
+      name: Cymbal bell size
+      description: Cymbal bell size
     cymbal_drum_case_wheel_configuration:
       name: Cymbal & drum case wheel configuration
       description: Indicates whether the case has wheels and (if applicable) the wheel configuration for rolling transport.
@@ -6689,6 +7622,9 @@ en:
     cymbal_sustain:
       name: Cymbal sustain
       description: How long the cymbal rings after being struck.
+    cymbal_thickness:
+      name: Cymbal thickness
+      description: Cymbal thickness
     cymbal_type:
       name: Cymbal type
       description: Specifies the functional cymbal role the electronic cymbal pad is intended to emulate.
@@ -6800,6 +7736,9 @@ en:
     decal_visibility_property:
       name: Decal visibility property
       description: Optical/visibility properties of a decal intended to improve visibility or light response (e.g., reflective, fluorescent, glow-in-the-dark, or transparency characteristics).
+    decibel_accuracy:
+      name: Decibel accuracy
+      description: Indicates the precision of sound level measurements, determining reliability for acoustic analysis and compliance verification.
     deck_concave_level:
       name: Deck concave level
       description: Indicates the depth or intensity of the deck’s concave (e.g., mellow, medium, deep).
@@ -6938,6 +7877,9 @@ en:
     deployment_type:
       name: Deployment type
       description: Describes how AI software is implemented, such as hybrid or cloud-based
+    depth:
+      name: Depth
+      description: Measures the distance from front to back of an item, affecting capacity and how it fits in pockets or storage spaces.
     derailleur_cage_length:
       name: Derailleur cage length
       description: Indicates the derailleur cage length that determines chain capacity (primarily for rear derailleurs).
@@ -6953,6 +7895,9 @@ en:
     desiccant_material:
       name: Desiccant material
       description: Specifies the moisture-absorbing substance used, important for performance, reusability, and safety considerations.
+    desk_lip_depth:
+      name: Desk lip depth
+      description: Desk lip depth
     desk_organizer_features:
       name: Desk organizer features
       description: Describes the specific features of a desk organizer, such as adjustable dividers or built-in compartments
@@ -6965,6 +7910,9 @@ en:
     detectable_drugs:
       name: Detectable drugs
       description: Specifies the types of drugs a test can identify, e.g. marijuana, opiates
+    detection_range:
+      name: Detection range
+      description: Specifies the maximum distance at which a device can sense movement or presence, determining effective monitoring area.
     detection_technology:
       name: Detection technology
       description: Specifies the scientific principle or biological marker the HIV test detects (e.g., antibody, antigen/antibody combo, RNA PCR)
@@ -6989,12 +7937,18 @@ en:
     device_technology:
       name: Device technology
       description: Describes the type of technology in hardware tools, such as digital or analog
+    devil_stick_weight:
+      name: Devil stick weight
+      description: Devil stick weight
     dexterity_skills:
       name: Dexterity skills
       description: Identifies the specific dexterity skills required for a game, like balancing or precision
     diabolo_axle_system:
       name: Diabolo axle system
       description: Specifies the diabolo axle system/configuration that affects grinds, stability, and string wear.
+    diabolo_cup_width:
+      name: Diabolo cup width
+      description: Diabolo cup width
     diagnostic_functions_supported:
       name: Diagnostic functions supported
       description: Specifies the diagnostic/maintenance functions the scanner can perform.
@@ -7013,6 +7967,9 @@ en:
     dialing_method:
       name: Dialing method
       description: Defines the mechanism the phone uses to enter numbers.
+    diameter:
+      name: Diameter
+      description: Indicates the measurement across the widest part of a circular object, determining size, capacity, and compatibility with other items.
     diamond_color_grade:
       name: Diamond color grade
       description: Indicates the color grade of diamonds, from D (colorless) to Z (light color), or denotes fancy color diamonds.
@@ -7058,9 +8015,15 @@ en:
     didgeridoo_construction_type:
       name: Didgeridoo construction type
       description: How the didgeridoo is constructed or formed (traditional or modern construction approach).
+    didgeridoo_length:
+      name: Didgeridoo length
+      description: Didgeridoo length
     dielectric_type:
       name: Dielectric type
       description: Specifies the dielectric or insulating material used in capacitors, such as ceramic or electrolytic
+    dietary_fiber_per_serving:
+      name: Dietary fiber per serving
+      description: Dietary fiber per serving
     dietary_formulation_claim:
       name: Dietary formulation claim
       description: Highlights key formulation attributes or exclusions relevant to equine nutrition (e.g., Grain-free, Low starch, Organic).
@@ -7082,6 +8045,9 @@ en:
     digestive_supplement_type:
       name: Digestive supplement type
       description: Classifies the specific kind of digestive supplement (e.g., probiotic, enzyme, fiber)
+    digit_height:
+      name: Digit height
+      description: Digit height
     digital_sound_processing:
       name: Digital sound processing
       description: Specifies the sound modification techniques in audio components, such as delay or reverb
@@ -7208,6 +8174,15 @@ en:
     disposable_tableware_material:
       name: Disposable tableware material
       description: Identifies the material used in disposable tableware, such as plastic or paper
+    distance_measurement_accuracy:
+      name: Distance measurement accuracy
+      description: Specifies the precision of length measurements, determining reliability for dimensional control and quality assurance.
+    distance_per_charge:
+      name: Distance per charge
+      description: Indicates how far an electric vehicle can travel on a single battery charge, determining practical range and usability.
+    distance_range:
+      name: Distance range
+      description: Specifies the maximum effective measurement distance of surveying equipment, determining suitability for various project scales.
     distillation_method:
       name: Distillation method
       description: Identifies the distillation method or still type used to produce the spirit.
@@ -7226,6 +8201,9 @@ en:
     distributor_advance_mechanism:
       name: Distributor advance mechanism
       description: Specifies the type of ignition timing advance mechanism used by the distributor.
+    distributor_cap_diameter:
+      name: Distributor cap diameter
+      description: Distributor cap diameter
     distributor_cap_terminal_type:
       name: Distributor cap terminal type
       description: Specifies the style of distributor cap terminals.
@@ -7334,6 +8312,9 @@ en:
     doll_making_kit_components_included:
       name: Doll making kit components included
       description: Lists the key materials and tools included in the doll-making kit so shoppers can compare bundles and know what they need to supply themselves.
+    doll_size:
+      name: Doll size
+      description: Indicates the height or dimensions of dolls, determining compatibility with accessories and appropriateness for different age groups.
     doll_type:
       name: Doll type
       description: Identifies the category of a doll, such as baby or collectible
@@ -7355,6 +8336,9 @@ en:
     dollhouse_style_theme:
       name: Dollhouse style/theme
       description: Overall style or theme of the dollhouse for browsing and gifting (e.g., modern vs Victorian).
+    domestic_hot_water_flow:
+      name: Domestic hot water flow
+      description: Specifies the volume of hot water a system can deliver per unit time, determining shower, bath, and appliance supply capability.
     donnos_playing_technique:
       name: Donnos playing technique
       description: How the Donnos is played/actuated (hand-only vs with stick/striker), to match buyer expectations and included accessories.
@@ -7547,6 +8531,15 @@ en:
     drainage_method:
       name: Drainage method
       description: Describes how the collected water is expelled, indicating whether manual emptying is required.
+    drained_weight:
+      name: Drained weight
+      description: Drained weight
+    draw_length:
+      name: Draw length
+      description: Indicates the distance a bowstring can be pulled back, customized to archer's arm length for optimal shooting form and power.
+    draw_weight:
+      name: Draw weight
+      description: Specifies the force required to pull a bow to full draw, determining arrow speed, trajectory, and suitability for different users.
     drawer_features:
       name: Drawer features
       description: Details special drawer construction elements or functionalities (e.g., soft-close, felt-lined).
@@ -7571,6 +8564,9 @@ en:
     dress_form_features:
       name: Dress form features
       description: Highlights key features of a dress form, such as a pinnable surface or rotating base
+    dress_length:
+      name: Dress length
+      description: Measures the distance from shoulder or waist to hem, determining style classification and appropriate usage occasions.
     dress_occasion:
       name: Dress occasion
       description: Specifies the intended occasion for a dress, e.g. holiday, everyday
@@ -7583,6 +8579,9 @@ en:
     dried_surface_finish:
       name: Dried surface finish
       description: Describes the typical surface appearance after drying (sheen/texture).
+    drill_bit_size:
+      name: Drill bit size
+      description: Specifies the diameter of holes a bit will create, determining application suitability and compatibility with fasteners.
     drill_features:
       name: Drill features
       description: Identifies special characteristics of a drill, like adjustable speed or built-in lighting
@@ -7625,6 +8624,9 @@ en:
     drive_band_material_type:
       name: Drive band material type
       description: Specifies the material/type of the drive band used on spinning wheels.
+    drive_diameter:
+      name: Drive diameter
+      description: Indicates the size of the square drive on sockets and wrenches, determining compatibility with ratchets and other drive tools.
     drive_form_factor:
       name: Drive form factor
       description: Specifies the height or size class of the drive mechanism (e.g., full-height, half-height, slimline)
@@ -7634,6 +8636,9 @@ en:
     drive_mechanism:
       name: Drive mechanism
       description: Identifies the type of drivetrain used to transfer power from the pedals to the flywheel.
+    drive_shaft_length:
+      name: Drive shaft length
+      description: Drive shaft length
     drive_shaft_material:
       name: Drive shaft material
       description: Specifies the primary construction material of the drive shaft tube or complete assembly.
@@ -7646,6 +8651,9 @@ en:
     drive_type:
       name: Drive type
       description: Identifies the type of drive system in vehicles or heavy machinery, like 2WD or 4WD
+    drive_wheel_hub_bore_diameter:
+      name: Drive wheel hub bore diameter
+      description: Drive wheel hub bore diameter
     driver_configuration:
       name: Driver configuration
       description: Specifies the number of discrete driver ways in the speaker system (e.g., 2-way, 3-way)
@@ -7670,9 +8678,15 @@ en:
     drone_transmission_type:
       name: Drone transmission type
       description: Primary method used for the control and/or video link between the drone and controller/device.
+    drop:
+      name: Drop
+      description: Measures the vertical length of hanging jewelry pieces, determining visual impact and how they move with the wearer.
     drop_spindle_whorl_position:
       name: Drop spindle whorl position
       description: Location of the whorl on the shaft.
+    drum_brush_bristle_wire_length:
+      name: Drum brush bristle/wire length
+      description: Drum brush bristle/wire length
     drum_carder_accessories_included:
       name: Drum carder accessories included
       description: Common included items with a drum carder kit.
@@ -7700,6 +8714,9 @@ en:
     drum_head_application_batter_resonant:
       name: Drum head application (batter/resonant)
       description: Specifies which side/role the head is designed for on a drum (top playing surface vs bottom resonant/snare-side).
+    drum_head_collar_depth:
+      name: Drum head collar depth
+      description: Drum head collar depth
     drum_head_collar_type:
       name: Drum head collar type
       description: Specifies whether the head has a standard collar, low collar, or specialty collar profile to match certain bearing edges/shells.
@@ -7733,6 +8750,9 @@ en:
     drum_head_reinforcement_type:
       name: Drum head reinforcement type
       description: Specifies whether the snare head includes reinforcement features such as a center dot or control ring to increase durability and focus tone.
+    drum_head_size:
+      name: Drum head size
+      description: Specifies the diameter of percussion membranes, determining tone quality, volume, and compatibility with specific drum shells.
     drum_head_surface_finish:
       name: Drum head surface finish
       description: Surface texture/finish of the head that influences attack and brush response.
@@ -7748,6 +8768,9 @@ en:
     drum_key_handle_style:
       name: Drum key handle style
       description: Describes the handle/ergonomic style of the drum key, affecting comfort and leverage during tuning.
+    drum_kit_bass_drum_diameter:
+      name: Drum kit bass drum diameter
+      description: Drum kit bass drum diameter
     drum_kit_included_items:
       name: Drum kit included items
       description: Lists what major items are included in the drum kit bundle beyond the shells/pads (e.g., hardware, cymbals, throne).
@@ -7778,6 +8801,9 @@ en:
     drum_pedal_bearing_type:
       name: Drum pedal bearing type
       description: Specifies the bearing mechanism used at primary pivot points (e.g., rocker, heel, cam).
+    drum_pedal_beater_shaft_length:
+      name: Drum pedal beater shaft length
+      description: Drum pedal beater shaft length
     drum_pedal_cam_type:
       name: Drum pedal cam type
       description: Specifies the cam shape/geometry of a drum pedal that influences the feel and response (e.g., linear vs accelerator).
@@ -7790,6 +8816,9 @@ en:
     drum_pedal_clamp_type:
       name: Drum pedal clamp type
       description: Specifies how the pedal attaches to the bass drum hoop.
+    drum_pedal_footboard_length:
+      name: Drum pedal footboard length
+      description: Drum pedal footboard length
     drum_pedal_intended_use:
       name: Drum pedal intended use
       description: Indicates the primary playing context the belt-drive pedal is designed/marketed for.
@@ -7799,6 +8828,9 @@ en:
     drum_pedal_spring_type:
       name: Drum pedal spring type
       description: Specifies the spring mechanism used for pedal return action.
+    drum_rack_tube_diameter:
+      name: Drum rack tube diameter
+      description: Drum rack tube diameter
     drum_shell_material:
       name: Drum shell material
       description: Specifies the primary shell construction material for acoustic drums (e.g., maple, birch, acrylic).
@@ -7820,6 +8852,12 @@ en:
     dry_bean_variety:
       name: Dry bean variety
       description: Identifies the variety of dry beans used, e.g. chickpeas, black beans
+    dry_boiling_point:
+      name: Dry boiling point
+      description: Dry boiling point
+    dry_weight:
+      name: Dry weight
+      description: Indicates the mass of an engine without fluids, determining ease of handling and installation requirements.
     dryer_drum_material:
       name: Dryer drum material
       description: Indicates the interior drum construction material, which affects durability, static build-up, and noise.
@@ -7844,21 +8882,36 @@ en:
     drying_system:
       name: Drying system
       description: Indicates the technology the dishwasher uses to dry dishes at the end of the cycle.
+    drying_time:
+      name: Drying time
+      description: Drying time
     drysuit_footwear_style:
       name: Drysuit footwear style
       description: Describes the integrated lower-leg finish of the drysuit (e.g., built-in boots, neoprene socks, stockingfoot, or bare ankle seals).
+    drywall_thickness:
+      name: Drywall thickness
+      description: Specifies the depth measurement of wallboard panels, affecting sound insulation, fire resistance, and structural properties.
     dsl_standard_compatibility:
       name: DSL standard compatibility
       description: Identifies which DSL standards a filter or accessory supports to ensure proper noise suppression and connection quality.
     duct_design:
       name: Duct design
       description: Identifies the form of air ducts in HVAC systems, e.g solid, flexible
+    duct_diameter:
+      name: Duct diameter
+      description: Indicates the width of air passages in ventilation systems, determining airflow capacity and system efficiency.
+    duct_length:
+      name: Duct length
+      description: Specifies the linear measurement of ventilation passages, determining installation requirements and system layout options.
     duct_shape:
       name: Duct shape
       description: Describes the form of air ducts in HVAC systems, such as round or flat
     dumbbell_style:
       name: Dumbbell style
       description: Identifies the fundamental design of the dumbbell—whether it is a fixed unit, an adjustable system or a loadable handle style—which strongly influences buying decisions and workout use-cases.
+    dumbbell_weight:
+      name: Dumbbell weight
+      description: Indicates the mass of free weights used for strength training, determining exercise intensity and muscle development potential.
     dundun_playing_position:
       name: Dundun playing position
       description: Intended playing/carry position for the drum.
@@ -7877,6 +8930,12 @@ en:
     durability_features:
       name: Durability features
       description: Highlights a product's ability to withstand various conditions, e.g. rustproof, shockproof
+    duration:
+      name: Duration
+      description: Specifies the total playback time of audio content, determining listening time and content length.
+    durometer_hardness_shore_a:
+      name: Durometer hardness (Shore A)
+      description: Durometer hardness (Shore A)
     dust_container_type:
       name: Dust container type
       description: Specifies the type of dust collection system in vacuums and appliances, e.g. bagless, dust bag
@@ -7931,6 +8990,9 @@ en:
     e_cigarette/vaporizer_style:
       name: E-cigarette/Vaporizer style
       description: Classifies e-cigarettes and vaporizers by their form factor, e.g. disposable, pen
+    e_liquid_capacity:
+      name: E-liquid capacity
+      description: E-liquid capacity
     e_liquid_flavor:
       name: E-liquid flavor
       description: Specifies the taste of e-liquids for vaporizers and electronic cigarettes, e.g. coffee, strawberry
@@ -8009,6 +9071,9 @@ en:
     easel_art_desk_surface_type:
       name: Easel & art desk surface type
       description: Identifies the usable drawing/writing surface(s) provided (e.g., chalkboard, whiteboard, paper roll, magnetic board).
+    easel_art_desk_working_surface_dimensions:
+      name: Easel & art desk working surface dimensions
+      description: Easel & art desk working surface dimensions
     eb_clarinet_body_type:
       name: Eb clarinet body type
       description: Specifies whether the Eb clarinet is a soprano or alto variant.
@@ -8042,6 +9107,15 @@ en:
     educational_topic:
       name: Educational topic
       description: Primary learning topic supported by the ant farm’s educational content.
+    effect_duration:
+      name: Effect duration
+      description: Indicates how long a product remains effective after application, determining reapplication frequency and overall protection period.
+    effective_edge_length:
+      name: Effective edge length
+      description: Effective edge length
+    effective_focal_length_efl:
+      name: Effective focal length (EFL)
+      description: Specifies the optical magnification power of lenses, determining viewing capabilities and image characteristics.
     effects_processor_form_factor:
       name: Effects processor form factor
       description: Describes the physical or delivery format of the processor
@@ -8096,6 +9170,9 @@ en:
     eggshell_color:
       name: Eggshell color
       description: Specifies the predominant shell color of the eggs.
+    elastic_band_width:
+      name: Elastic band width
+      description: Elastic band width
     elastic_edge_finish_type:
       name: Elastic edge finish/type
       description: Specifies edge construction of the woven elastic that impacts comfort and application.
@@ -8213,6 +9290,9 @@ en:
     embellishment/trim_material:
       name: Embellishment/Trim material
       description: Identifies the material used for decorative details or finishes, like sequins or pearls
+    embellishment_height:
+      name: Embellishment height
+      description: Indicates how far decorative elements extend from the base of jewelry, affecting visual impact and practical wearability.
     embellishment_technique:
       name: Embellishment technique
       description: Details the primary decorative or surface work applied to the garment, such as embroidery, print, or beadwork.
@@ -8231,6 +9311,9 @@ en:
     embossing_stylus_tip_shape:
       name: Embossing stylus tip shape
       description: Describes the geometry of the embossing tip used to create different effects (e.g., ball vs pointed).
+    embossing_tip_size:
+      name: Embossing tip size
+      description: Embossing tip size
     embouchure_hole_shape:
       name: Embouchure hole shape
       description: Describes the shape of the hole on a flute headjoint, such as round or oval
@@ -8246,6 +9329,9 @@ en:
     embroidery_machine_bobbin_type:
       name: Embroidery machine bobbin type
       description: Type/loading style of bobbin system.
+    embroidery_machine_maximum_embroidery_area:
+      name: Embroidery machine maximum embroidery area
+      description: Embroidery machine maximum embroidery area
     emergency/safety_sign_design:
       name: Emergency/Safety sign design
       description: Identifies the type of safety or emergency message on a sign, like fire exit or guard dog
@@ -8309,6 +9395,21 @@ en:
     energy_efficiency_class_sdr:
       name: Energy efficiency class (SDR)
       description: Specifies the energy efficiency of SDR-enabled devices, typically televisions; e.g. A+++
+    energy_per_100_g:
+      name: Energy per 100 g
+      description: Specifies the caloric or nutritional energy content by weight, important for dietary planning and nutritional assessment.
+    energy_per_100_ml:
+      name: Energy per 100 ml
+      description: Indicates the caloric or nutritional energy content by volume, crucial for comparing liquid nutritional products.
+    energy_per_serving:
+      name: Energy per serving
+      description: Specifies the caloric or nutritional energy provided in a standard portion, essential for meal planning and dietary tracking.
+    energy_selection_adult_mode:
+      name: Energy selection (adult mode)
+      description: Indicates the power level settings for defibrillation of adult patients, crucial for emergency medical response protocols.
+    energy_selection_child_mode:
+      name: Energy selection (child mode)
+      description: Specifies the reduced power level settings for defibrillation of pediatric patients, essential for safe emergency medical response.
     engine_bay_mounting_location:
       name: Engine bay mounting location
       description: Where the overflow tank is intended to mount in the engine bay (relative position).
@@ -8363,6 +9464,9 @@ en:
     engine_valve_coating:
       name: Engine valve coating
       description: Identifies any surface treatment or coating applied to the valve for wear/heat resistance.
+    engine_valve_length:
+      name: Engine valve length
+      description: Engine valve length
     engine_valve_position:
       name: Engine valve position
       description: Specifies whether the engine valve is intended for the intake side or exhaust side of the engine.
@@ -8375,6 +9479,9 @@ en:
     engraving:
       name: Engraving
       description: Details the type of engraving on a product, such as custom text or logo engraving
+    engraving_plate_size:
+      name: Engraving plate size
+      description: Engraving plate size
     enhancement_level:
       name: Enhancement level
       description: 'Approximate volume increase provided by the insert, expressed in cup sizes: Subtle (up to 1 cup), Moderate (1–2 cups), Significant (2+ cups).'
@@ -8426,6 +9533,9 @@ en:
     esrb_rating:
       name: ESRB rating
       description: Identifies the age appropriateness of video games, such as E (Everyone) or T (Teen)
+    estimated_max_altitude:
+      name: Estimated max altitude
+      description: Estimated max altitude
     ethernet_cable_category:
       name: Ethernet cable category
       description: Indicates the TIA/EIA category rating of twisted-pair Ethernet cables, defining bandwidth and performance
@@ -8498,6 +9608,12 @@ en:
     evenweave_fabric_package_format:
       name: Evenweave fabric package format
       description: How the fabric is sold (cut piece vs continuous by-the-yard/meter).
+    exercise_ball_maximum_user_weight:
+      name: Exercise ball maximum user weight
+      description: Exercise ball maximum user weight
+    exercise_ball_size:
+      name: Exercise ball size
+      description: Indicates the diameter of fitness balls, determining stability challenge, exercise options, and user compatibility.
     exercise_bike_accessory_part_type:
       name: Exercise bike accessory/part type
       description: Describes the primary function or component type of the item (e.g., Pedal, Drive belt, Bottle holder, Screen cover, Crank arm).
@@ -8543,6 +9659,9 @@ en:
     exhaust_outlet_configuration:
       name: Exhaust outlet configuration
       description: Specifies the exhaust exit layout at the rear of the vehicle.
+    exhaust_runner_volume:
+      name: Exhaust runner volume
+      description: Exhaust runner volume
     expansion_slots:
       name: Expansion slots
       description: Specifies slots for adding hardware in computers or servers, e.g. PCIe, M.2
@@ -8570,6 +9689,9 @@ en:
     extension_mechanism:
       name: Extension mechanism
       description: Describes the method a table uses to expand its length or surface area, if applicable.
+    extension_rise:
+      name: Extension rise
+      description: Extension rise
     extension_table_features:
       name: Extension table features
       description: Highlights functional features specific to sewing machine extension tables.
@@ -8585,6 +9707,9 @@ en:
     extinguishing_agent_type:
       name: Extinguishing agent type
       description: Specifies the type of extinguishing substance in fire safety products, such as water or foam
+    extinguishing_agent_volume:
+      name: Extinguishing agent volume
+      description: Specifies the amount of fire suppression material contained in safety equipment, determining firefighting capacity and duration.
     extraction_method:
       name: Extraction method
       description: Identifies the technique used to extract cannabinoids from the hemp plant material
@@ -8600,6 +9725,9 @@ en:
     extractor_tip_style:
       name: Extractor tip style
       description: Defines the design of the tip on extraction tools, e.g. scoop, needle
+    extruder_shaft_size:
+      name: Extruder shaft size
+      description: Indicates the diameter of the component that pushes filament in 3D printers, determining compatibility and material flow characteristics.
     eye_care_applicator_type:
       name: Eye care applicator type
       description: Defines the style of built-in applicator or dispenser tip provided with the eye treatment product
@@ -8720,6 +9848,9 @@ en:
     fabric_patch_shape:
       name: Fabric patch shape
       description: Describes the shape of patches included in the kit.
+    fabric_piece_size:
+      name: Fabric piece size
+      description: Fabric piece size
     fabric_repair_kit_application_method:
       name: Fabric repair kit application method
       description: Specifies how the repair is applied to the fabric (e.g., iron-on, sew-on, adhesive).
@@ -8759,6 +9890,9 @@ en:
     fabric_weight_class:
       name: Fabric weight class
       description: Categorizes flannel by typical use-weight bands to help shoppers filter without knowing exact GSM/oz.
+    fabric_width_selvage_to_selvage:
+      name: Fabric width (selvage-to-selvage)
+      description: Fabric width (selvage-to-selvage)
     face_area:
       name: Face area
       description: Specifies the area of the face a skincare product targets, such as eyes or neck
@@ -8810,6 +9944,9 @@ en:
     false_nail_application_method:
       name: False nail application method
       description: Identifies how false nails are applied, such as glue-on or press-on
+    fan_diameter:
+      name: Fan diameter
+      description: Specifies the width of the blade assembly in air circulation devices, determining air movement capacity and coverage area.
     fan_shroud_type:
       name: Fan shroud type
       description: Specifies the coverage/geometry style of the fan shroud (e.g., full vs half vs ring).
@@ -8822,12 +9959,21 @@ en:
     fascinator_style:
       name: Fascinator style
       description: Describes the structural design or shape of the fascinator so shoppers can quickly filter by popular millinery styles.
+    fastener_diameter:
+      name: Fastener diameter
+      description: Indicates the thickness of screws, bolts or other securing devices, determining strength and compatibility with materials.
     fastener_finish:
       name: Fastener finish
       description: Describes the surface coating of a hardware accessory, like brass or chrome
     fastener_grade:
       name: Fastener grade
       description: Indicates the strength grade/class of the bolt, such as Grade 8 or Class 10.9, which determines load capacity.
+    fastener_hole_spacing:
+      name: Fastener hole spacing
+      description: Fastener hole spacing
+    fastener_length:
+      name: Fastener length
+      description: Specifies the measurement from head to tip of securing devices, determining penetration depth and material compatibility.
     fastener_material:
       name: Fastener material
       description: Specifies the type of material used in fasteners, e.g. brass, stainless steel
@@ -8837,6 +9983,12 @@ en:
     fat_content:
       name: Fat content
       description: Specifies the amount of fat in food and beverage products, e.g. full fat, low fat
+    fat_per_100_g:
+      name: Fat per 100 g
+      description: Fat per 100 g
+    fat_per_serving:
+      name: Fat per serving
+      description: Fat per serving
     fat_rendering_state:
       name: Fat rendering state
       description: Specifies whether the fat is rendered, unrendered (raw), or partially rendered, affecting shelf life and culinary applications.
@@ -8891,6 +10043,9 @@ en:
     feather_stiffness:
       name: Feather stiffness
       description: Relative stiffness/rigidity of the feather barbs/structure.
+    feather_width:
+      name: Feather width
+      description: Feather width
     features:
       name: Features
       description: Describes additional qualities or characteristics of a product, such as lightweight or foldable
@@ -8900,6 +10055,9 @@ en:
     feed_purpose:
       name: Feed purpose
       description: Describes the primary nutritional or functional goal of the feed or supplement.
+    feed_size:
+      name: Feed size
+      description: Indicates the maximum dimensions of materials that can be processed by crushing equipment, determining operational capabilities.
     feed_system:
       name: Feed system
       description: Describes how paper is fed into a device, such as automatic or manual
@@ -8921,6 +10079,9 @@ en:
     felt_tip_design:
       name: Felt tip design
       description: Describes the thickness of the pen's felt tip, such as medium or fine
+    felting_mold_cavity_depth:
+      name: Felting mold cavity depth
+      description: Felting mold cavity depth
     felting_mold_intended_use:
       name: Felting mold intended use
       description: What the mold is intended to create or be used for in felting projects.
@@ -8987,6 +10148,9 @@ en:
     fiber_art_project_type:
       name: Fiber art project type
       description: Categorizes the fiber art craft, such as embroidery or macrame
+    fiber_length:
+      name: Fiber length
+      description: Specifies the measurement of individual fibers used in crafting, affecting texture, strength, and spinning characteristics.
     fiber_luster_level:
       name: Fiber luster level
       description: Visual sheen of the fiber, ranging from matte to high luster.
@@ -9092,6 +10256,9 @@ en:
     filter_installation_type:
       name: Filter installation type
       description: Specifies the physical style and installation method of the DSL filter
+    filter_lifetime_capacity:
+      name: Filter lifetime capacity
+      description: Filter lifetime capacity
     filter_material:
       name: Filter material
       description: Specifies the type of material used in filters, typically for coffee; e.g. paper, hemp
@@ -9122,6 +10289,9 @@ en:
     filtration_technology:
       name: Filtration technology
       description: Identifies the technology or stage used by the filter to remove airborne contaminants produced during printing
+    fin_base_length:
+      name: Fin base length
+      description: Fin base length
     fin_box_system:
       name: Fin box system
       description: Specifies the fin box or mounting interface the board uses, determining aftermarket fin compatibility.
@@ -9191,6 +10361,12 @@ en:
     fingerboard_color:
       name: Fingerboard color
       description: Specifies the fingerboard color on string instruments, e.g. silver, white
+    fingerboard_deck_length:
+      name: Fingerboard deck length
+      description: Fingerboard deck length
+    fingerboard_deck_width:
+      name: Fingerboard deck width
+      description: Fingerboard deck width
     fingerboard_grip_type:
       name: Fingerboard grip type
       description: Specifies the grip surface material/type used on the fingerboard deck.
@@ -9200,6 +10376,9 @@ en:
     fingerboard_pattern:
       name: Fingerboard pattern
       description: Describes the design or motif on a guitar's fingerboard, like floral or geometric
+    fingerboard_truck_width:
+      name: Fingerboard truck width
+      description: Fingerboard truck width
     fingerprint_capture_method:
       name: Fingerprint capture method
       description: Defines the type of fingerprint detection method used, such as capacitive or optical
@@ -9224,9 +10403,24 @@ en:
     finish_type:
       name: Finish type
       description: Surface finish applied to the ukulele body.
+    finished_item_size:
+      name: Finished item size
+      description: Finished item size
     finished_product_format:
       name: Finished product format
       description: Specifies the type of fragrance product the kit is intended to make.
+    finished_project_width:
+      name: Finished project width
+      description: Finished project width
+    finished_puzzle_height:
+      name: Finished puzzle height
+      description: Finished puzzle height
+    finished_puzzle_length:
+      name: Finished puzzle length
+      description: Finished puzzle length
+    finished_puzzle_width:
+      name: Finished puzzle width
+      description: Finished puzzle width
     fire_alarm_panel_type:
       name: Fire alarm panel type
       description: Identifies the system architecture of the panel.
@@ -9248,6 +10442,9 @@ en:
     fireplace_tool_items_included:
       name: Fireplace tool items included
       description: Lists the specific fireplace tools or accessories provided with the product so shoppers know exactly what they are getting and can compare bundles easily.
+    firewall_throughput:
+      name: Firewall throughput
+      description: Specifies the data processing speed of network security devices, determining capacity to handle traffic without creating bottlenecks.
     firewire_standard:
       name: FireWire standard
       description: Identifies the IEEE 1394 specification the cable supports, which determines maximum speed and device compatibility
@@ -9260,9 +10457,15 @@ en:
     firework_assortment_types_included:
       name: Firework assortment types included
       description: Identifies the primary firework types included in the assortment to help shoppers compare bundle contents (e.g., fountains, roman candles, firecrackers).
+    firework_burn_duration:
+      name: Firework burn duration
+      description: Firework burn duration
     firework_effect_types:
       name: Firework effect types
       description: Primary visual and/or sensory effect families produced by the assortment (select all that apply).
+    firework_fountain_height:
+      name: Firework fountain height
+      description: Firework fountain height
     firework_ignition_method:
       name: Firework ignition method
       description: Specifies how the firework is ignited or initiated (e.g., fuse or electric e-match).
@@ -9347,6 +10550,9 @@ en:
     fitting_angle:
       name: Fitting angle
       description: Specifies the bend angle of the fitting body (e.g., straight, 45°, 90°). Use “Adjustable / swivel” for fittings with variable angle and “Other” for uncommon angles.
+    fitting_size:
+      name: Fitting size
+      description: Specifies the dimensions of plumbing connections, determining compatibility between pipes, fixtures, and sealing components.
     fixation_type:
       name: Fixation type
       description: Defines the attachment mechanism, typically for Christmas tree stands; e.g. fixing spike, fixing screw
@@ -9359,6 +10565,9 @@ en:
     flag_design_theme:
       name: Flag design theme
       description: Describes the primary design theme represented on the flag (e.g., country/national, sports team, holiday), supporting discovery and filtering for intent-based shopping.
+    flag_dimensions:
+      name: Flag dimensions
+      description: Flag dimensions
     flag_mounting_method:
       name: Flag mounting method
       description: Specifies how the flag attaches to the vehicle (e.g., antenna mount, hitch mount, magnetic).
@@ -9410,6 +10619,9 @@ en:
     flash_modes:
       name: Flash modes
       description: Identifies the different settings for a camera's flash, such as auto or manual
+    flash_point:
+      name: Flash point
+      description: Flash point
     flash_type:
       name: Flash type
       description: Identifies the type of flash used in cameras, such as ring or macro
@@ -9461,6 +10673,9 @@ en:
     fletching_profile:
       name: Fletching profile
       description: Defines the geometric shape or cut of the fletching, which affects drag, clearance, noise, and overall arrow flight characteristics.
+    flex_strength:
+      name: Flex strength
+      description: Flex strength
     flexibility_rating:
       name: Flexibility rating
       description: Indicates the flexibility level of snowboard or snowshoe bindings, e.g. 4
@@ -9479,6 +10694,9 @@ en:
     floatation:
       name: Floatation
       description: Whether the beacon is designed to float in water.
+    floor_area:
+      name: Floor area
+      description: Floor area
     floor_configuration:
       name: Floor configuration
       description: Indicates whether the tent includes a floor and, if so, the type of floor provided
@@ -9536,6 +10754,12 @@ en:
     flow_control_type:
       name: Flow control type
       description: Describes whether the spike includes an adjustable mechanism to vary water output.
+    flow_rate:
+      name: Flow rate
+      description: Indicates the volume of fluid moving through a system per unit time, determining processing capacity and effectiveness.
+    flow_rate_accuracy:
+      name: Flow rate accuracy
+      description: Specifies the precision of flow measurement devices, determining reliability for critical fluid monitoring applications.
     flow_rate_type:
       name: Flow rate type
       description: Defines the speed at which liquid is dispensed, typically for baby bottles; e.g. medium, slow
@@ -9593,6 +10817,9 @@ en:
     flute_case_capacity:
       name: Flute case capacity
       description: Indicates what the case is designed to hold, beyond the main flute body (e.g., flute + piccolo, extra headjoint).
+    flute_case_interior_length:
+      name: Flute case interior length
+      description: Flute case interior length
     flute_cleaning_rod_tip_type:
       name: Flute cleaning rod tip type
       description: Describes the design of the rod end that holds the cloth/swab or contacts the instrument (e.g., slotted, threaded, eyelet).
@@ -9617,6 +10844,9 @@ en:
     flute_wall_thickness:
       name: Flute wall thickness
       description: Wall thickness category of the flute tubing (thinwall, standard, heavywall).
+    flutophone_tuning_pitch_reference:
+      name: Flutophone tuning pitch reference
+      description: Flutophone tuning pitch reference
     fly_pattern_type:
       name: Fly pattern type
       description: Classifies the artificial fly by its angling style or insect/forage imitation to help anglers quickly filter for the correct fly style.
@@ -9659,6 +10889,15 @@ en:
     flywheel_balance_type:
       name: Flywheel balance type
       description: Indicates whether the flywheel is neutrally balanced or uses an external imbalance weight.
+    flywheel_outer_diameter:
+      name: Flywheel outer diameter
+      description: Flywheel outer diameter
+    flywheel_thickness:
+      name: Flywheel thickness
+      description: Flywheel thickness
+    flywheel_weight:
+      name: Flywheel weight
+      description: Flywheel weight
     fm_transmitter_playback_source:
       name: FM Transmitter playback source
       description: Identifies the media input options the device can play from, beyond Bluetooth (e.g., USB stick, microSD card)
@@ -9668,12 +10907,21 @@ en:
     foam_blocks_surface_texture:
       name: Foam blocks surface texture
       description: Describes the exterior surface feel/finish of the foam blocks.
+    foam_cube_size:
+      name: Foam cube size
+      description: Foam cube size
     foam_form:
       name: Foam form
       description: Identifies the shape or type of craft foam product, like balls or sheets
     foam_surface_effect:
       name: Foam surface effect
       description: Describes common decorative surface effects applied to craft foam or styrofoam, such as glitter, metallic, or holographic finishes.
+    focal_length_telephoto:
+      name: Focal length (telephoto)
+      description: Indicates the magnification power at the longest zoom setting of a lens, determining maximum reach for distant subjects.
+    focal_length_wide:
+      name: Focal length (wide)
+      description: Specifies the field of view at the shortest zoom setting of a lens, determining how much of a scene can be captured.
     focus_adjustment:
       name: Focus adjustment
       description: Specifies how a camera adjusts its focus, e.g. auto, manual
@@ -9710,6 +10958,12 @@ en:
     foil_mounting_type:
       name: Foil mounting type
       description: Identifies the interface system used to attach the foil to the board, ensuring compatibility between components.
+    foil_stabilizer_span:
+      name: Foil stabilizer span
+      description: Foil stabilizer span
+    foil_wingspan:
+      name: Foil wingspan
+      description: Foil wingspan
     fold_over_elastic_application:
       name: Fold-over elastic application
       description: Primary intended use/application for buttonhole elastic.
@@ -9722,6 +10976,9 @@ en:
     foldability_stow:
       name: Foldability (stow)
       description: Whether the rack folds/stows when not in use (e.g., folds up against the vehicle).
+    folded_length:
+      name: Folded length
+      description: Indicates the size of collapsed equipment when packed for transport, determining portability and storage requirements.
     folder/report_cover_material:
       name: Folder/Report cover material
       description: Identifies the material used in making folders or report covers, such as paper or leather
@@ -9884,12 +11141,18 @@ en:
     footwear_type_compatibility:
       name: Footwear type compatibility
       description: Identifies the type of footwear the shaper is intended for.
+    footwear_weight:
+      name: Footwear weight
+      description: Footwear weight
     force_feedback_type:
       name: Force feedback type
       description: Describes the drive mechanism used to generate force feedback and steering resistance
     fork_material:
       name: Fork material
       description: Specifies the material used for a bicycle's front fork, influencing stiffness, weight and ride quality.
+    fork_offset:
+      name: Fork offset
+      description: Specifies the distance between the steering axis and wheel hub center, affecting bicycle handling characteristics and stability.
     form_factor:
       name: Form factor
       description: Primary hardware form factor of the DMX controller.
@@ -9914,6 +11177,9 @@ en:
     formulation_type:
       name: Formulation type
       description: The formulation style of the disinfectant spray.
+    forward_offset:
+      name: Forward offset
+      description: Forward offset
     fossil_preparation_level:
       name: Fossil preparation level
       description: Degree of preparation/cleaning performed on the specimen (e.g., unprepared in matrix vs fully prepared).
@@ -9986,6 +11252,9 @@ en:
     frame_pattern:
       name: Frame pattern
       description: Describes the visual design or style of a product's frame, such as geometric or striped
+    frame_size:
+      name: Frame size
+      description: Indicates the dimensions of a bicycle's main structure, determining proper fit for riders of different heights.
     frame_steel_gauge:
       name: Frame steel gauge
       description: Identifies the thickness (gauge) of the steel tubing used in the rack’s uprights, a critical indicator of strength and stability.
@@ -10010,9 +11279,15 @@ en:
     freewheel_thread_standard:
       name: Freewheel thread standard
       description: Specifies the hub thread standard or size that the freewheel is compatible with.
+    freeze_protection_temperature_minimum:
+      name: Freeze protection temperature (minimum)
+      description: Freeze protection temperature (minimum)
     freezer_configuration:
       name: Freezer configuration
       description: Identifies the physical orientation/design style of the freezer unit.
+    freezing_capacity:
+      name: Freezing capacity
+      description: Specifies how much unfrozen food can be frozen within a 24-hour period, determining suitability for bulk food preservation.
     freezing_method:
       name: Freezing method
       description: Specifies the technology used to freeze the mixture in an ice cream maker, helping shoppers distinguish between compressor models, pre-freeze bowl units, hand crank salt & ice types, and other designs.
@@ -10061,6 +11336,9 @@ en:
     fringe_curtain_use_location:
       name: Fringe curtain use location
       description: Indicates whether the fringe curtain is intended for indoor use, outdoor use, or both.
+    fringe_drop_length:
+      name: Fringe drop length
+      description: Fringe drop length
     fringe_trim_style:
       name: Fringe trim style
       description: Specifies the construction/style of fringe trim (how the strands or loops are formed and presented).
@@ -10088,6 +11366,9 @@ en:
     front_style:
       name: Front style
       description: Describes the front construction of the chinos, indicating whether the pant is flat-front, pleated or otherwise detailed.
+    front_suspension_travel:
+      name: Front suspension travel
+      description: Front suspension travel
     frosting_or_icing_type:
       name: Frosting or icing type
       description: Specifies the type of frosting or icing applied to the cake or dessert bar.
@@ -10136,6 +11417,9 @@ en:
     fuel_container_features:
       name: Fuel container features
       description: Describes specific features of fuel tanks, such as spill-proof spout or fuel gauge
+    fuel_efficiency_typical:
+      name: Fuel efficiency (typical)
+      description: Indicates the rate of fuel consumption during operation, determining running costs and refueling frequency.
     fuel_filter_features:
       name: Fuel filter features
       description: Lists notable functional features of the fuel filter (water separation, drain valve, sensor port, etc.).
@@ -10154,6 +11438,9 @@ en:
     fuel_injector_electrical_connector_type:
       name: Fuel injector electrical connector type
       description: Specifies the injector electrical connector standard/shape.
+    fuel_injector_o_ring_size:
+      name: Fuel injector O-ring size
+      description: Fuel injector O-ring size
     fuel_injector_seat_type:
       name: Fuel injector seat type
       description: Specifies the injector tip/seat interface style used for sealing at the intake/fuel rail.
@@ -10187,6 +11474,9 @@ en:
     fuel_pump_outlet_connection_type:
       name: Fuel pump outlet connection type
       description: Specifies the physical connection style at the fuel pump outlet for fitment/installation compatibility.
+    fuel_pump_outlet_diameter:
+      name: Fuel pump outlet diameter
+      description: Fuel pump outlet diameter
     fuel_purity:
       name: Fuel purity
       description: Specifies the purity level of propane fuel, e.g. HD-5, commercial
@@ -10205,6 +11495,9 @@ en:
     fuel_system_type:
       name: Fuel system type
       description: Specifies the engine’s fuel delivery system (e.g., carburetor or fuel injection architecture).
+    fuel_tank_capacity:
+      name: Fuel tank capacity
+      description: Specifies the volume of fuel that can be stored in equipment, determining operational duration before refueling.
     fuel_tank_installation_position:
       name: Fuel tank installation position
       description: Specifies the typical installation position of the fuel tank on the vehicle.
@@ -10214,6 +11507,9 @@ en:
     fuel_tank_shape:
       name: Fuel tank shape
       description: Describes the overall form factor/shape of the fuel tank to support physical fitment and replacement matching.
+    fuel_volume_treated:
+      name: Fuel volume treated
+      description: Fuel volume treated
     funnel_type:
       name: Funnel type
       description: Classifies the funnel based on its design or intended use.
@@ -10241,6 +11537,9 @@ en:
     furniture_finish:
       name: Furniture finish
       description: Describes the surface treatment or finish applied to the furniture item, affecting its appearance and maintenance requirements.
+    fuse_delay_time:
+      name: Fuse delay time
+      description: Fuse delay time
     fuse_form_factor:
       name: Fuse form factor
       description: Specifies the physical fuse style/footprint to ensure it fits the intended fuse holder or fuse block (e.g., blade vs cartridge).
@@ -10292,6 +11591,9 @@ en:
     game_name:
       name: Game name
       description: Identifies the specific name of a drinking game, such as Beer pong or Kings cup
+    game_setup_time:
+      name: Game setup time
+      description: Game setup time
     game_variation:
       name: Game variation
       description: Specifies the style of gameplay the set is designed for (e.g., classic tetherball, tether tennis, speedball).
@@ -10304,6 +11606,9 @@ en:
     gaming_enhancement_features:
       name: Gaming enhancement features
       description: Indicates HDMI 2.1 gaming-oriented technologies supported by the receiver
+    gap_size:
+      name: Gap size
+      description: Indicates the width of spaces that can be effectively sealed by weatherproofing materials, determining application suitability.
     garage_door_material:
       name: Garage door material
       description: Identifies the construction material of garage doors, such as steel or wood
@@ -10340,6 +11645,9 @@ en:
     garment_back_style:
       name: Garment back style
       description: Identifies the design or construction of the back of the garment (e.g., open back, racerback, crisscross back).
+    garment_length:
+      name: Garment length
+      description: Measures the vertical dimension of clothing items from top to bottom, determining coverage and style classification.
     garment_pattern_type:
       name: Garment pattern type
       description: Specifies the type of clothing item the sewing pattern is intended to make.
@@ -10355,6 +11663,9 @@ en:
     gas_propellant_type:
       name: Gas propellant type
       description: Specifies the type of gas propellant recommended or compatible when the blaster is gas-powered.
+    gas_strut_compressed_length:
+      name: Gas strut compressed length
+      description: Gas strut compressed length
     gas_type:
       name: Gas type
       description: Identifies the type of compressed gas contained in the charger cylinder.
@@ -10367,9 +11678,15 @@ en:
     gate_mounting_type:
       name: Gate mounting type
       description: Specifies where a baby or pet gate is installed, such as wall or doorway
+    gate_opening_clearance:
+      name: Gate opening clearance
+      description: Gate opening clearance
     gatta_tabla_tuning_block_material:
       name: Gatta (tabla tuning block) material
       description: Material of the tuning blocks (gatta) used between the tuning strap and the shell.
+    gauge_cutout_diameter:
+      name: Gauge cutout diameter
+      description: Gauge cutout diameter
     gauge_mounting_type:
       name: Gauge mounting type
       description: How the fuel meter is mounted/installed on the watercraft.
@@ -10400,6 +11717,9 @@ en:
     gel_wax_density_grade:
       name: Gel wax density grade
       description: Indicates the density grade of gel wax, which affects clarity, fragrance load, and suitability for embeds.
+    gel_wax_melt_temperature:
+      name: Gel wax melt temperature
+      description: Gel wax melt temperature
     gel_wax_transparency_level:
       name: Gel wax transparency level
       description: Describes the clarity/opacity of the gel wax when used as intended.
@@ -10439,6 +11759,9 @@ en:
     geological_period:
       name: Geological period
       description: Geological period (and optionally epoch) of the fossil when known (e.g., Jurassic, Cretaceous, Eocene).
+    gift_bag_gusset_depth:
+      name: Gift bag gusset depth
+      description: Gift bag gusset depth
     gift_bag_handle_design:
       name: Gift bag handle design
       description: Describes the style of handles on gift bags, such as rope or ribbon
@@ -10484,6 +11807,9 @@ en:
     glass_stone_application_method:
       name: Glass stone application method
       description: Specifies how the glass stones are intended to be attached/applied in projects (e.g., glue-on, hotfix, sew-on).
+    glass_thickness:
+      name: Glass thickness
+      description: Specifies the depth measurement of glass panels, determining strength, insulation properties, and sound dampening capabilities.
     glass_tint:
       name: Glass tint
       description: The glass/plastic tint used for the bottle to manage light exposure (common in brewing/winemaking).
@@ -10568,6 +11894,9 @@ en:
     glove_insulation:
       name: Glove insulation
       description: Specifies the glove’s insulation/thermal construction or heating (e.g., insulation level, lining/insulation technology, or heated type).
+    glove_length:
+      name: Glove length
+      description: Glove length
     glove_palm_material:
       name: Glove palm material
       description: Specifies the primary material used on the glove palm (the main contact/grip surface), which may differ from the backhand.
@@ -10586,6 +11915,12 @@ en:
     glow_plug_heating_element_type:
       name: Glow plug heating element type
       description: Type/technology of the heating element used by the glow plug.
+    glow_plug_reach_length:
+      name: Glow plug reach length
+      description: Glow plug reach length
+    glow_plug_voltage:
+      name: Glow plug voltage
+      description: Glow plug voltage
     glucose_measurement_units:
       name: Glucose measurement units
       description: Indicates which measurement units (mg/dL or mmol/L) the meter can display results in
@@ -10739,6 +12074,9 @@ en:
     gong_profile_type:
       name: Gong profile type
       description: Describes the physical profile of the opera gong (e.g., flat vs raised center), which strongly affects tone and playing style.
+    gooseneck_length:
+      name: Gooseneck length
+      description: Gooseneck length
     gps_compatible_device:
       name: GPS compatible device
       description: Specifies devices that can use GPS software, such as laptops or aviation devices
@@ -10853,6 +12191,9 @@ en:
     grille_mounting_method:
       name: Grille mounting method
       description: Specifies how the grille installs onto the vehicle (e.g., direct replacement vs insert/overlay; bolt-on vs clip/snap; drilling required vs no drilling required).
+    grille_opening_dimensions:
+      name: Grille opening dimensions
+      description: Grille opening dimensions
     grille_style:
       name: Grille style
       description: Specifies the visual/design style of the vehicle grille.
@@ -10868,6 +12209,9 @@ en:
     grip_chalk_form:
       name: Grip chalk form
       description: Identifies the physical form of the chalk supplied or used with the bag.
+    grip_circumference:
+      name: Grip circumference
+      description: Grip circumference
     grip_coverage:
       name: Grip coverage
       description: Identifies the presence and location of silicone or rubberized grip elements on the sock.
@@ -10940,9 +12284,15 @@ en:
     groove_sampler_storage_expansion_type:
       name: Groove sampler storage expansion type
       description: Specifies removable/expandable storage options supported by the groove sampler.
+    groove_sampler_weight:
+      name: Groove sampler weight
+      description: Groove sampler weight
     ground_attachment_method:
       name: Ground attachment method
       description: Describes how the passing arc is secured to the playing surface, affecting stability and surface compatibility.
+    ground_clearance:
+      name: Ground clearance
+      description: Ground clearance
     groupset_components_included:
       name: Groupset components included
       description: Lists the specific drivetrain components included in the groupset so customers understand the bundle contents.
@@ -10997,12 +12347,24 @@ en:
     guitar_bridge_system_type:
       name: Guitar bridge system type
       description: Bridge/tailpiece system design family for compatibility and browsing.
+    guitar_case_internal_depth:
+      name: Guitar case internal depth
+      description: Guitar case internal depth
+    guitar_case_internal_length:
+      name: Guitar case internal length
+      description: Guitar case internal length
+    guitar_case_internal_width:
+      name: Guitar case internal width
+      description: Guitar case internal width
     guitar_case_style:
       name: Guitar case style
       description: Specifies the overall protection/structure style of the guitar case or gig bag.
     guitar_fitting/part_type:
       name: Guitar fitting/part type
       description: Specifies the type of guitar part or fitting, like a pickguard or tuning peg
+    guitar_fitting_part_mounting_hole_spacing:
+      name: Guitar fitting/part mounting hole spacing
+      description: Guitar fitting/part mounting hole spacing
     guitar_humidifier_placement:
       name: Guitar humidifier placement
       description: Specifies where the humidifier is intended to be used/placed relative to the instrument or environment.
@@ -11045,6 +12407,9 @@ en:
     guitar_string_winding_type:
       name: Guitar string winding type
       description: Specifies the outer wrap style of wound strings in the set.
+    guitar_tuning_peg_bushing_outer_diameter:
+      name: Guitar tuning peg bushing outer diameter
+      description: Guitar tuning peg bushing outer diameter
     guitar_tuning_peg_button_shape:
       name: Guitar tuning peg button shape
       description: The shape/style of the tuning key/button.
@@ -11054,12 +12419,18 @@ en:
     guitar_tuning_peg_mounting_style:
       name: Guitar tuning peg mounting style
       description: How a tuning machine mounts to the headstock (bushing type and anti-rotation method).
+    guitar_tuning_peg_post_height:
+      name: Guitar tuning peg post height
+      description: Guitar tuning peg post height
     guitar_tuning_peg_shaft_type:
       name: Guitar tuning peg shaft type
       description: Whether the string post is solid or split, and how the string is secured.
     guitar_tuning_peg_style:
       name: Guitar tuning peg style
       description: The physical tuning machine/peg style and mounting format used on an instrument headstock (e.g., sealed gear vs open gear, locking, split-post).
+    gullet_width:
+      name: Gullet width
+      description: Gullet width
     gum_condition:
       name: Gum condition
       description: Condition/status of the stamp gum on the reverse (e.g., never hinged, hinged, no gum).
@@ -11117,6 +12488,9 @@ en:
     hair_extension_texture:
       name: Hair extension texture
       description: Describes the curl, wave, or texture pattern of the extension strands.
+    hair_length:
+      name: Hair length
+      description: Hair length
     hair_loss_type:
       name: Hair loss type
       description: Organizes products based on type of hair loss, e.g. alopecia areata, male pattern baldness
@@ -11222,6 +12596,9 @@ en:
     hand_soap_features:
       name: Hand soap features
       description: Highlights special characteristics or benefits of the powdered hand soap
+    hand_spindle_weight:
+      name: Hand spindle weight
+      description: Hand spindle weight
     hand_support_level:
       name: Hand support level
       description: Specifies the degree of support or compression provided by the glove, wrap, or strap.
@@ -11267,6 +12644,9 @@ en:
     handle_ergonomics:
       name: Handle ergonomics
       description: Describes ergonomic features of the handle intended to improve comfort and control.
+    handle_grip_diameter:
+      name: Handle grip diameter
+      description: Handle grip diameter
     handle_grip_material:
       name: Handle grip material
       description: Specifies the material used on the handle’s grip surface, which affects comfort and traction, particularly when wet.
@@ -11279,6 +12659,9 @@ en:
     handle_grip_type:
       name: Handle grip type
       description: Specifies the handle grip covering/material or surface style intended to improve comfort and control.
+    handle_length:
+      name: Handle length
+      description: Indicates the measurement of carrying straps or grips, determining how a bag can be carried and comfort during use.
     handle_length_adjustability:
       name: Handle length adjustability
       description: Describes whether and how the handle length can be adjusted, enabling shoppers to filter between fixed and telescopic options.
@@ -11303,6 +12686,12 @@ en:
     handlebar_design:
       name: Handlebar design
       description: Specifies the type of handlebars on the stair stepper, such as none, fixed, adjustable height, foldable, or resistance band handles.
+    handlebar_drop:
+      name: Handlebar drop
+      description: Handlebar drop
+    handlebar_rise:
+      name: Handlebar rise
+      description: Handlebar rise
     handlebar_type:
       name: Handlebar type
       description: Identifies the style of handlebars fitted to the bike, influencing riding posture, control and comfort.
@@ -11345,6 +12734,9 @@ en:
     hanging_chair_design:
       name: Hanging chair design
       description: Specifies if a hanging chair comes with a stand or not
+    hanging_drop_length:
+      name: Hanging drop length
+      description: Hanging drop length
     hanging_suspension_method:
       name: Hanging suspension method
       description: Defines the primary hardware or system used to suspend the swing (e.g., rope, chain, stand frame).
@@ -11477,6 +12869,9 @@ en:
     head_configuration:
       name: Head configuration
       description: Specifies whether the axe head features an adze, hammer, both, or none, directly affecting functionality on ice and mixed terrain.
+    head_diameter:
+      name: Head diameter
+      description: Specifies the width of the cutting or working end of tools, determining the area covered in a single pass.
     head_material:
       name: Head material
       description: Material of the playing head supplied with the quinto.
@@ -11507,6 +12902,12 @@ en:
     headjoint_pitch_standard:
       name: Headjoint pitch standard
       description: Indicates the design tuning standard of the headjoint (e.g., A=440 vs A=442).
+    headjoint_wall_thickness:
+      name: Headjoint wall thickness
+      description: Headjoint wall thickness
+    headliner_backing_thickness:
+      name: Headliner backing thickness
+      description: Headliner backing thickness
     headliner_product_form:
       name: Headliner product form
       description: Specifies whether the product is a complete molded headliner assembly, a replacement fabric, or a repair/trim component.
@@ -11612,6 +13013,9 @@ en:
     heating_pad_features:
       name: Heating pad features
       description: Highlights special functional or convenience features built into the heating pad
+    heating_power:
+      name: Heating power
+      description: Specifies the energy output of heating devices, determining temperature rise capability and suitable application area size.
     heating_speed:
       name: Heating speed
       description: Indicates the rate at which a product heats up, e.g. fast, slow
@@ -11621,6 +13025,12 @@ en:
     heating_technology:
       name: Heating technology
       description: Identifies the primary heating mechanism the vaporizer uses to convert material into vapor.
+    heating_time:
+      name: Heating time
+      description: Indicates how quickly a device reaches operating temperature, determining preparation time and operational efficiency.
+    heel_height:
+      name: Heel height
+      description: Measures the vertical distance from the ground to the bottom of the heel seat, determining posture impact and style classification.
     heel_height_type:
       name: Heel height type
       description: Defines the height of a shoe's heel, such as flat or high
@@ -11630,12 +13040,24 @@ en:
     heel_shoe_type:
       name: Heel shoe type
       description: Identifies the style of heel on a shoe, such as platform heels or wedge heels
+    heel_to_toe_drop:
+      name: Heel-to-toe drop
+      description: Heel-to-toe drop
     height:
       name: Height
       description: Specifies the vertical measurement from bottom to top, determining space requirements and compatibility with other items.
     height_adjustment:
       name: Height adjustment
       description: Specifies if a product's height can be altered, e.g. fixed height, adjustable height
+    height_folded:
+      name: Height (folded)
+      description: Indicates the vertical dimension when collapsed for storage, determining space efficiency and transport requirements.
+    height_packed:
+      name: Height (packed)
+      description: Specifies the vertical measurement when prepared for transport, determining storage and shipping space requirements.
+    height_pitched:
+      name: Height (pitched)
+      description: Specifies the vertical measurement of a tent when fully assembled, determining interior headroom and weather resistance profile.
     helicobacter_pylori_detection_method:
       name: Helicobacter pylori detection method
       description: Identifies the biological principle or approach the kit uses to detect Helicobacter pylori infection
@@ -11705,6 +13127,9 @@ en:
     helmet_visor_shield_type:
       name: Helmet visor/shield type
       description: Primary face shield/visor configuration included with the helmet.
+    helmet_weight:
+      name: Helmet weight
+      description: Helmet weight
     hem_style:
       name: Hem style
       description: Identifies the finishing style of the leg opening—such as clean, rolled or raw—that strongly influences the garment’s look.
@@ -11735,15 +13160,36 @@ en:
     highback_style:
       name: Highback style
       description: Describes the structural style/design of the highback that influences ride characteristics.
+    hip_size:
+      name: Hip size
+      description: Measures the circumference at the fullest part of the hips, essential for determining proper fit in pants, skirts, and dresses.
     hitch_ball_diameter:
       name: Hitch ball diameter
       description: Diameter of the hitch ball head (sphere) that mates with a trailer coupler (e.g., 1 7/8 in, 2 in, 2 5/16 in, 50 mm).
     hitch_ball_mounting_style:
       name: Hitch ball mounting style
       description: Whether the hitch ball is a standard nut-mounted ball, a fixed/pressed style for specific hitch heads, or includes integrated hardware.
+    hitch_ball_threaded_shank_diameter:
+      name: Hitch ball threaded shank diameter
+      description: Hitch ball threaded shank diameter
+    hitch_ball_threaded_shank_length:
+      name: Hitch ball threaded shank length
+      description: Hitch ball threaded shank length
+    hitch_ball_tongue_weight_rating:
+      name: Hitch ball tongue weight rating
+      description: Hitch ball tongue weight rating
+    hitch_ball_weight_rating_gtw:
+      name: Hitch ball weight rating (GTW)
+      description: Hitch ball weight rating (GTW)
     hitch_class:
       name: Hitch class
       description: Identifies the towing capacity of a vehicle's hitch, such as Class I or Class II
+    hitch_mount_drop:
+      name: Hitch mount drop
+      description: Hitch mount drop
+    hitch_mount_rise:
+      name: Hitch mount rise
+      description: Hitch mount rise
     hitch_type:
       name: Hitch type
       description: Specifies the mounting method for bicycle trailers, such as axle-mounted or seat post
@@ -11774,9 +13220,18 @@ en:
     hold_surface_texture:
       name: Hold surface texture
       description: Describes the coarseness or tactile finish of the hold’s gripping surface.
+    hole_diameter:
+      name: Hole diameter
+      description: Hole diameter
     hole_plating_type:
       name: Hole plating type
       description: Indicates whether the board's holes are non-plated, plated-through, or feature via barrels, which impacts soldering and inter-layer connectivity
+    hole_punch_size:
+      name: Hole punch size
+      description: Indicates the diameter of holes created by paper perforating tools, determining compatibility with binding systems and standards.
+    hole_spacing:
+      name: Hole spacing
+      description: Hole spacing
     home_alarm_features:
       name: Home alarm features
       description: Identifies special functions of a home alarm system, such as battery backup or professional monitoring.
@@ -11834,6 +13289,9 @@ en:
     hook_eye_type:
       name: Hook eye type
       description: Specifies the design of the hook eye, affecting knot choice and rigging.
+    hook_gap_size:
+      name: Hook gap size
+      description: Hook gap size
     hook_grip_design:
       name: Hook grip design
       description: Describes the grip style of crochet hooks, such as non-slip or ergonomic
@@ -11861,15 +13319,24 @@ en:
     hook_size:
       name: Hook size
       description: Identifies the size of crochet hooks, such as B, G, or I
+    hook_strength_rating:
+      name: Hook strength rating
+      description: Hook strength rating
     hook_style:
       name: Hook style
       description: Classifies the design/function of the hook for easier visual and functional matching.
     hook_type:
       name: Hook type
       description: Identifies the style of boat hooks, such as fixed or telescoping
+    hook_wire_diameter:
+      name: Hook wire diameter
+      description: Hook wire diameter
     hooks_eyes_attachment_method:
       name: Hooks & eyes attachment method
       description: How the hooks & eyes are affixed to the garment or project.
+    hooks_eyes_strip_length:
+      name: Hooks & eyes strip length
+      description: Hooks & eyes strip length
     hoop_shape:
       name: Hoop shape
       description: Describes the shape of a hoop-based item, typically fishing nets; e.g. D-shaped
@@ -11903,6 +13370,21 @@ en:
     horse_model_breed:
       name: Horse model breed
       description: Specifies the horse breed depicted by the scale model (if applicable).
+    horsepower:
+      name: Horsepower
+      description: Specifies the power output of engines or motors, determining work capacity and performance capabilities.
+    horsepower_rpm:
+      name: Horsepower RPM
+      description: Horsepower RPM
+    horseshoe_weight:
+      name: Horseshoe weight
+      description: Horseshoe weight
+    hose_diameter:
+      name: Hose diameter
+      description: Indicates the internal width of fluid-carrying tubes, determining flow capacity and connection compatibility.
+    hose_length:
+      name: Hose length
+      description: Specifies the total linear measurement of flexible tubing, determining reach and installation flexibility.
     hose_material:
       name: Hose material
       description: Specifies the type of material used in hoses, such as PVC or aluminum
@@ -11942,6 +13424,12 @@ en:
     hub_motor_type:
       name: Hub motor type
       description: Describes the construction style of the hub motor (geared, direct drive, brushed, brushless) to inform shoppers about torque, weight, and efficiency characteristics.
+    hub_size:
+      name: Hub size
+      description: Indicates the dimensions of the central component of bicycle wheels, determining compatibility with frames and axle systems.
+    hub_spacing:
+      name: Hub spacing
+      description: Hub spacing
     hula_hoop_construction_type:
       name: Hula hoop construction type
       description: Describes how the hoop is constructed/assembled.
@@ -11951,6 +13439,9 @@ en:
     hull_design:
       name: Hull design
       description: Describes the hull shape that influences performance and handling characteristics.
+    hull_rocker_length:
+      name: Hull rocker length
+      description: Hull rocker length
     hull_type:
       name: Hull type
       description: Describes the hull form that impacts performance and stability.
@@ -12005,6 +13496,9 @@ en:
     hvac_control_type:
       name: HVAC control type
       description: Identifies the kind of HVAC control, such as digital or manual
+    hybrid_battery_warranty_period:
+      name: Hybrid battery warranty period
+      description: Hybrid battery warranty period
     hybrid_drivetrain_configuration:
       name: Hybrid drivetrain configuration
       description: Indicates the PHEV system architecture describing how the electric motor(s) and combustion engine provide propulsion.
@@ -12029,6 +13523,9 @@ en:
     hydration_pack_style:
       name: Hydration pack style
       description: Specifies the structural style of the hydration pack, such as backpack or vest, to aid fit and use-case filtering.
+    hydration_reservoir_capacity:
+      name: Hydration reservoir capacity
+      description: Hydration reservoir capacity
     hydration_system_insulation:
       name: Hydration system insulation
       description: Indicates whether the reservoir and/or drinking tube are insulated to help maintain liquid temperature in hot or cold conditions.
@@ -12038,6 +13535,9 @@ en:
     hydraulic_fluid_type:
       name: Hydraulic fluid type
       description: Specifies the type of brake fluid that a hydraulic bicycle brake lever is designed to use. This information is critical for maintenance and safety.
+    hydrofoil_mast_length:
+      name: Hydrofoil mast length
+      description: Hydrofoil mast length
     hydrogenation_level:
       name: Hydrogenation level
       description: Indicates whether the fat is unhydrogenated, partially hydrogenated, or fully hydrogenated, which impacts trans-fat content and baking performance.
@@ -12065,6 +13565,9 @@ en:
     ice_pack_type:
       name: Ice pack type
       description: Specifies the material or technology used in an ice pack, e.g. gel pack, foam pack
+    ice_production_rate:
+      name: Ice production rate
+      description: Specifies the quantity of ice that can be generated per unit time, determining suitability for various cooling applications.
     ice_shape:
       name: Ice shape
       description: Describes the form of ice the machine produces, helping users select machines that create their preferred ice style.
@@ -12083,6 +13586,9 @@ en:
     identity_verification_requirement:
       name: Identity verification requirement
       description: Specifies if real-name registration or eKYC identity verification is required before the SIM or eSIM can be used
+    idle_speed:
+      name: Idle speed
+      description: Indicates the rotational velocity of a motor or engine when not under load, affecting noise levels and fuel consumption.
     ignition_coil_configuration:
       name: Ignition coil configuration
       description: Specifies the ignition coil form factor (single coil/coil-on-plug, multi-tower coil pack by cylinder count, coil rail/cassette, or distributor-style).
@@ -12101,6 +13607,9 @@ en:
     ignition_system:
       name: Ignition system
       description: Identifies the type of ignition system in generators, such as manual or electronic
+    illuminance:
+      name: Illuminance
+      description: Specifies the amount of light falling on a surface, determining visibility and suitability for specific observation tasks.
     illumination_technique:
       name: Illumination technique
       description: Identifies the lighting method used in microscopes, such as brightfield or darkfield
@@ -12134,6 +13643,18 @@ en:
     impact_surface_material:
       name: Impact surface material
       description: Describes the primary impact/striking surface material for safety and feel (e.g., foam, plastic).
+    impedance:
+      name: Impedance
+      description: Indicates the resistance to electrical current in audio components, determining compatibility with amplifiers and sound quality.
+    impeller_height:
+      name: Impeller height
+      description: Impeller height
+    impression_height:
+      name: Impression height
+      description: Impression height
+    impression_width:
+      name: Impression width
+      description: Impression width
     incense_base_material:
       name: Incense base material
       description: Primary base/binder material used to make the incense (powder base) in the kit.
@@ -12227,6 +13748,9 @@ en:
     inflation_method_included:
       name: Inflation method included
       description: Specifies the type of tire inflation solution included with the repair kit, if any.
+    inflation_time:
+      name: Inflation time
+      description: Specifies how quickly a safety device can deploy to full size, critical for emergency protection in avalanche situations.
     infused_scent:
       name: Infused scent
       description: Identifies scent or flavor additives impregnated in the bait material.
@@ -12266,6 +13790,9 @@ en:
     ink_colors_included:
       name: Ink colors included
       description: Specifies the ink colors included in the stamp pad(s) in the set.
+    ink_dry_time:
+      name: Ink dry time
+      description: Ink dry time
     ink_form:
       name: Ink form
       description: Describes the packaging or delivery method of art ink, like pen or bottle
@@ -12293,12 +13820,21 @@ en:
     ink_type:
       name: Ink type
       description: Identifies the kind of ink used in a product, such as solvent-based or dye
+    inlet_port_diameter:
+      name: Inlet port diameter
+      description: Inlet port diameter
+    inlet_port_inner_diameter:
+      name: Inlet port inner diameter
+      description: Inlet port inner diameter
     inline_skate_brake_type:
       name: Inline skate brake type
       description: Specifies the brake configuration included with inline skates, such as a removable heel brake or no brake.
     inline_skating_style:
       name: Inline skating style
       description: Defines the specific style of inline skating the product is designed for, such as recreational or speed inline skating
+    inner_diameter:
+      name: Inner diameter
+      description: Indicates the measurement across the inside of circular objects, determining capacity and compatibility with inserted items.
     inner_pot_coating:
       name: Inner pot coating
       description: Identifies the type of surface coating on the inner pot, indicating non-stick properties and ease of cleaning.
@@ -12320,6 +13856,9 @@ en:
     input_connector_type:
       name: Input connector type
       description: Specifies the audio input connector type used by the pedal (typically 1/4-inch TS).
+    input_shaft_diameter:
+      name: Input shaft diameter
+      description: Input shaft diameter
     input_signal_interface:
       name: Input signal interface
       description: Specifies the type(s) of input connection(s) the audio converter accepts
@@ -12329,6 +13868,12 @@ en:
     input_video_interface:
       name: Input video interface
       description: Specifies the type(s) of video connector accepted as input by the scan converter
+    input_voltage:
+      name: Input voltage
+      description: Specifies the electrical potential required for proper operation, determining compatibility with power sources and safety requirements.
+    inseam_length:
+      name: Inseam length
+      description: Measures the distance from the crotch seam to the bottom hem of pants, determining leg coverage and proper fit.
     insecticide_treatment:
       name: Insecticide treatment
       description: Indicates whether the netting has been factory-treated with insecticide and, if so, the treatment type used for additional protection.
@@ -12422,6 +13967,9 @@ en:
     instrument_pattern:
       name: Instrument pattern
       description: Describes the visual design or motif on a musical instrument, such as solid or texture
+    instrument_playing_surface_thickness:
+      name: Instrument playing surface thickness
+      description: Instrument playing surface thickness
     instrument_playing_technique:
       name: Instrument playing technique
       description: How the instrument is typically played/actuated (e.g., shaken, struck, clacked).
@@ -12440,6 +13988,9 @@ en:
     instrument_support_type:
       name: Instrument support type
       description: Identifies the type of support used for a musical instrument, like a neck strap or music stand
+    instrument_weight:
+      name: Instrument weight
+      description: Instrument weight
     insulation_capability:
       name: Insulation capability
       description: Indicates whether and how the sleeve insulates beverages, distinguishing purely decorative sleeves from temperature-controlling ones.
@@ -12458,6 +14009,12 @@ en:
     insulation_type:
       name: Insulation type
       description: Specifies whether and how the beverage tub or chiller is insulated, affecting ice-retention performance and condensation control.
+    insulation_weight:
+      name: Insulation weight
+      description: Insulation weight
+    intake_valve_diameter:
+      name: Intake valve diameter
+      description: Intake valve diameter
     integrated_bottom_type:
       name: Integrated bottom type
       description: Indicates whether the garment includes built-in briefs, shorts, leotard or similar underlayers for coverage during movement.
@@ -12575,6 +14132,9 @@ en:
     interfacing_stiffness_level:
       name: Interfacing stiffness level
       description: Describes the degree of stiffness/firmness provided by the interfacing.
+    interior_length:
+      name: Interior length
+      description: Interior length
     interior_lining_material:
       name: Interior lining material
       description: Identifies the primary material that lines the inside of the jewelry box, protecting jewelry from scratches and wear
@@ -12587,15 +14147,36 @@ en:
     interior_texture:
       name: Interior texture
       description: Defines the internal surface pattern that helps create lather inside the bowl or mug
+    interior_width:
+      name: Interior width
+      description: Interior width
     internal_drive_form_factor_supported:
       name: Internal drive form factor supported
       description: Indicates the compatible hard drive sizes for a device, e.g. 2.5-inch
+    internal_fit_dimensions:
+      name: Internal fit dimensions
+      description: Internal fit dimensions
+    internal_height:
+      name: Internal height
+      description: Internal height
     internal_membrane_type:
       name: Internal membrane type
       description: Identifies the internal separation design that keeps water and air apart inside the tank.
+    internal_memory:
+      name: Internal memory
+      description: Indicates the built-in data storage capacity of electronic devices, determining how much information can be saved without external media.
+    internal_rim_width:
+      name: Internal rim width
+      description: Internal rim width
+    internal_storage_capacity:
+      name: Internal storage capacity
+      description: Specifies the amount of data that can be stored within a device, determining how many photos or videos can be saved.
     internet_radio_form_factor:
       name: Internet radio form factor
       description: Defines the physical style or mounting orientation of the internet radio
+    interrupt_rating:
+      name: Interrupt rating
+      description: Indicates the maximum current a circuit breaker can safely interrupt, determining protection capability for electrical systems.
     intimate_apparel_features:
       name: Intimate apparel features
       description: Describes special characteristics of intimate apparel, like breathable design or comfort fit
@@ -12623,12 +14204,24 @@ en:
     iron_on_applique_application_method:
       name: Iron-on applique application method
       description: Specifies how the iron-on applique is intended to be applied to the substrate.
+    iron_on_applique_application_temperature:
+      name: Iron-on applique application temperature
+      description: Iron-on applique application temperature
+    iron_on_applique_press_time:
+      name: Iron-on applique press time
+      description: Iron-on applique press time
     ironing_board_form_factor:
       name: Ironing board form factor
       description: Classifies the overall style/installation of the board to aid shoppers in finding the correct type.
+    ironing_board_length:
+      name: Ironing board length
+      description: Ironing board length
     ironing_board_pad_shape:
       name: Ironing board pad shape
       description: Indicates the overall shape/profile of the pad to ensure it matches different ironing board designs.
+    ironing_board_width:
+      name: Ironing board width
+      description: Ironing board width
     ironing_center_features:
       name: Ironing center features
       description: Lists specialized features of ironing centers that enhance usability and convenience.
@@ -12665,9 +14258,15 @@ en:
     jaw_material:
       name: Jaw material
       description: Identifies the material used in the jaw of a tool, like steel or titanium
+    jaw_opening:
+      name: Jaw opening
+      description: Specifies the maximum width between gripping surfaces, determining the size of objects that can be securely held.
     jaw_shape:
       name: Jaw shape
       description: Geometry of the jaws or tip (e.g., straight, bent, long-nose) affecting precision and reach.
+    jaw_width:
+      name: Jaw width
+      description: Jaw width
     jerky_form:
       name: Jerky form
       description: Describes the physical form or cut of the jerky pieces (e.g., strips, sticks, bites).
@@ -12722,9 +14321,15 @@ en:
     joint_face_type:
       name: Joint face type
       description: Specifies the type of joint face on billiard shafts, such as full or piloted
+    joint_size:
+      name: Joint size
+      description: Joint size
     joint_style:
       name: Joint style
       description: Defines the type of joint used in billiard cues, such as uni-loc or radial
+    joule_rating:
+      name: Joule rating
+      description: Indicates the energy absorption capability of surge protectors, determining the level of protection against power spikes.
     journey_type:
       name: Journey type
       description: Specifies the type of journey covered by the ticket based on trip count and travel direction.
@@ -12758,6 +14363,9 @@ en:
     jump_rope_design:
       name: Jump rope design
       description: Describes the type of jump rope, such as regular or smart
+    jump_rope_size:
+      name: Jump rope size
+      description: Specifies the length of exercise ropes, determining suitability for users of different heights and jumping styles.
     jump_rope_style:
       name: Jump rope style
       description: Classifies the construction style of the rope/cable (e.g., beaded, cloth, speed cable), which strongly affects intended use and performance.
@@ -12803,6 +14411,9 @@ en:
     kettlebell_style:
       name: Kettlebell style
       description: Identifies the construction or style variant of the kettlebell (e.g., competition, adjustable, soft), helping shoppers choose the right bell for their training needs.
+    kettlebell_weight:
+      name: Kettlebell weight
+      description: Indicates the mass of weighted training implements, determining exercise intensity and muscle development potential.
     key_attachment_mechanism:
       name: Key attachment mechanism
       description: Specifies the hardware used to secure keys inside the case, such as rings, clips, or screw posts.
@@ -12830,9 +14441,18 @@ en:
     keyboard_backlight_type:
       name: Keyboard backlight type
       description: Details the illumination technology or style used for the keyboard keys or case
+    keyboard_case_empty_weight:
+      name: Keyboard case empty weight
+      description: Keyboard case empty weight
     keyboard_case_handle_type:
       name: Keyboard case handle type
       description: Primary handle system used to move/carry the keyboard case (in addition to straps).
+    keyboard_case_interior_height:
+      name: Keyboard case interior height
+      description: Keyboard case interior height
+    keyboard_case_interior_length:
+      name: Keyboard case interior length
+      description: Keyboard case interior length
     keyboard_case_interior_padding_type:
       name: Keyboard case interior padding type
       description: Primary interior cushioning/lining approach used inside the hard case.
@@ -12869,6 +14489,9 @@ en:
     keyboard_specialized_features:
       name: Keyboard specialized features
       description: Identifies unique characteristics of a keyboard, like adjustable angle or backlighting
+    keyboard_stand_crossbar_depth:
+      name: Keyboard stand crossbar depth
+      description: Keyboard stand crossbar depth
     keyboard_stand_tier_type:
       name: Keyboard stand tier type
       description: Indicates whether the stand is sold as a base stand only or includes/adds a second-tier attachment.
@@ -12881,6 +14504,9 @@ en:
     keyboard_type:
       name: Keyboard type
       description: Specifies the design and functionality of a keyboard, e.g. standard, backlit
+    keyboard_weight:
+      name: Keyboard weight
+      description: Keyboard weight
     keycap_legend_printing_method:
       name: Keycap legend printing method
       description: Describes how legends are applied to the keycaps, impacting longevity and appearance
@@ -12896,6 +14522,9 @@ en:
     keychain_style:
       name: Keychain style
       description: Describes the overall form factor of the keychain item (what it is physically).
+    keyhole_cylinder_size:
+      name: Keyhole cylinder size
+      description: Specifies the dimensions of lock mechanisms, determining compatibility with door preparations and security hardware.
     keypad_style:
       name: Keypad style
       description: Defines input method for keypads, such as digital or alphanumeric
@@ -12923,6 +14552,12 @@ en:
     kickstand_type:
       name: Kickstand type
       description: Describes the structural style or mechanism of the kickstand (e.g., single-leg side stand, double-leg center stand, telescoping).
+    kicktail_height:
+      name: Kicktail height
+      description: Kicktail height
+    kidney_belt_panel_height:
+      name: Kidney belt panel height
+      description: Kidney belt panel height
     kidney_belt_support_level:
       name: Kidney belt support level
       description: Manufacturer-designated overall support level provided by a kidney belt for lower back and abdominal stabilization.
@@ -12974,18 +14609,30 @@ en:
     kitchen_utensil_items_included:
       name: Kitchen utensil items included
       description: Identifies the tools included in a kitchen utensil set, such as whisk or tongs
+    kite_area:
+      name: Kite area
+      description: Kite area
     kite_inflation_system:
       name: Kite inflation system
       description: Indicates how the kite's leading edge and struts are inflated.
     kite_line_configuration:
       name: Kite line configuration
       description: Indicates the number of flying/control lines the kite sail is designed to use, a common specification for pairing bars and lines correctly.
+    kite_line_length:
+      name: Kite line length
+      description: Kite line length
+    kite_line_strength_rating:
+      name: Kite line strength rating
+      description: Kite line strength rating
     kite_type:
       name: Kite type
       description: Defines the structural design category of the kite (shape and bridle style).
     kiteboard_bag_style:
       name: Kiteboard bag style
       description: Specific style or subtype of kiteboard case (e.g., Boardbag, Golf bag, Travel bag, Foil bag).
+    kiteboard_size:
+      name: Kiteboard size
+      description: Indicates the dimensions of water sports equipment, determining buoyancy, maneuverability, and rider weight compatibility.
     kitesurfing_style:
       name: Kitesurfing style
       description: Defines the specific style of kitesurfing the product is designed for, such as wave riding
@@ -13202,12 +14849,21 @@ en:
     laser_light_source:
       name: Laser light source
       description: Specifies the light technology used in laser pointers, such as LED
+    laser_output_power:
+      name: Laser output power
+      description: Laser output power
     laser_pattern:
       name: Laser pattern
       description: Identifies the design or motif produced by a laser, such as stars or animal
     laser_safety_class:
       name: Laser safety class
       description: Laser safety classification of the product (e.g., Class 2, 3R, 3B, 4) as indicated on the device documentation/labeling.
+    last_width:
+      name: Last width
+      description: Last width
+    latency:
+      name: Latency
+      description: Indicates the time delay between input and response in electronic systems, determining perceived speed and responsiveness.
     latex_processing_method:
       name: Latex processing method
       description: Specifies the manufacturing process used to produce the latex foam—typically Dunlop or Talalay—which affects feel, responsiveness, and price.
@@ -13253,6 +14909,12 @@ en:
     layer_design:
       name: Layer design
       description: Describes the hair net’s construction in terms of layers or reversibility.
+    lazy_kate_rod_dowel_diameter:
+      name: Lazy kate rod/dowel diameter
+      description: Lazy kate rod/dowel diameter
+    lazy_kate_rod_usable_length:
+      name: Lazy kate rod usable length
+      description: Lazy kate rod usable length
     lazy_kate_tension_control_type:
       name: Lazy kate tension control type
       description: How the lazy kate applies drag/tension to bobbins during plying or winding.
@@ -13262,15 +14924,33 @@ en:
     lead_hardware_type:
       name: Lead hardware type
       description: Defines the attachment or fastener style at the end of the lead (snap, clip, loop, chain, etc.), impacting ease of use, safety, and discipline suitability.
+    lead_size:
+      name: Lead size
+      description: Indicates the diameter of pencil refills, determining compatibility with mechanical pencils and line thickness.
     leaf_gelatin_grade:
       name: Leaf gelatin grade
       description: Specifies the standardized strength grade used for gelatin sheets.
     leaf_preparation:
       name: Leaf preparation
       description: Describes how the leaves are prepared before packaging, such as chopped, shredded, or julienned.
+    leaf_spring_bushing_inside_diameter:
+      name: Leaf spring bushing inside diameter
+      description: Leaf spring bushing inside diameter
+    leaf_spring_center_bolt_diameter:
+      name: Leaf spring center bolt diameter
+      description: Leaf spring center bolt diameter
+    leaf_spring_eye_to_eye_length:
+      name: Leaf spring eye-to-eye length
+      description: Leaf spring eye-to-eye length
+    leaf_spring_free_arch_height:
+      name: Leaf spring free arch height
+      description: Leaf spring free arch height
     leaf_spring_material:
       name: Leaf spring material
       description: Primary construction material of the leaf spring pack.
+    leaf_spring_width:
+      name: Leaf spring width
+      description: Leaf spring width
     leak_protection_layer:
       name: Leak protection layer
       description: Indicates whether the swim jammer’s built-in nappy (diaper) system uses a single- or double-layer design for leak protection.
@@ -13331,6 +15011,9 @@ en:
     leg_cut_style:
       name: Leg cut style
       description: Describes the shape of the leg opening, which affects appearance, comfort, and tan lines.
+    leg_guard_length:
+      name: Leg guard length
+      description: Leg guard length
     leg_length:
       name: Leg length
       description: Categorizes trunks by relative leg length (short, mid, long) to let shoppers choose their preferred coverage without splitting the category.
@@ -13343,6 +15026,9 @@ en:
     leg_material:
       name: Leg material
       description: Specifies the material used for the legs of a product, such as cherry wood or bamboo
+    leg_opening:
+      name: Leg opening
+      description: Measures the circumference at the bottom of pant legs, determining fit style and ease of putting on or removing.
     leg_opening_style:
       name: Leg opening style
       description: Specifies how the leg openings are finished on the joggers, such as elastic cuffs, zip hems, or open hems.
@@ -13370,12 +15056,24 @@ en:
     lemon_variety:
       name: Lemon variety
       description: Identifies the specific cultivar or variety of the lemons (e.g., Eureka, Meyer, Amalfi).
+    length:
+      name: Length
+      description: Specifies the measurement from end to end, determining size, reach, or coverage area depending on the item.
     length_adjustability:
       name: Length adjustability
       description: Indicates whether the strap or chain length can be altered by the user or is fixed
     length_adjustment_method:
       name: Length adjustment method
       description: Indicates whether and how the jump rope length can be adjusted to fit the user.
+    length_folded:
+      name: Length (folded)
+      description: Indicates the horizontal dimension when collapsed for storage, determining space efficiency and transport requirements.
+    length_packed:
+      name: Length (packed)
+      description: Specifies the longest dimension when prepared for transport, determining storage and shipping space requirements.
+    length_pitched:
+      name: Length (pitched)
+      description: Indicates the horizontal measurement of a tent when fully assembled, determining floor space and sleeping capacity.
     lens/slide_material:
       name: Lens/Slide material
       description: Specifies the material used in the making of lenses or slides, like plastic or glass
@@ -13406,6 +15104,9 @@ en:
     lens_construction:
       name: Lens construction
       description: Specifies the structural build of the lens (e.g., single pane, dual-pane thermal) to indicate fog-resistance and optical performance.
+    lens_diameter:
+      name: Lens diameter
+      description: Specifies the width of optical components, determining light-gathering ability and visual field in optical devices.
     lens_filter_category:
       name: Lens filter category
       description: Specifies the European standard filter category (0–4) that classifies lenses by their tint density and the lighting conditions they are suited for
@@ -13484,6 +15185,9 @@ en:
     lid_material:
       name: Lid material
       description: Identifies the type of material used in the product's lid, such as glass or stainless steel
+    lid_size:
+      name: Lid size
+      description: Indicates the dimensions of container covers, determining compatibility with specific cups, containers, or vessels.
     lid_support_positions:
       name: Lid support positions
       description: Specifies the supported lid stick positions for the grand piano (how far the lid can be opened).
@@ -13508,6 +15212,12 @@ en:
     life_raft_container_type:
       name: Life raft container type
       description: How the life raft is packed for storage and deployment.
+    life_raft_packed_dimensions:
+      name: Life raft packed dimensions
+      description: Life raft packed dimensions
+    life_raft_packed_weight:
+      name: Life raft packed weight
+      description: Life raft packed weight
     life_vest_approval_standard:
       name: Life vest approval standard
       description: Specifies the certification/approval standard the life vest complies with.
@@ -13520,6 +15230,9 @@ en:
     lifebuoy_features:
       name: Lifebuoy features
       description: Functional safety, mounting/handling, and included accessory features for lifebuoys.
+    lifebuoy_weight:
+      name: Lifebuoy weight
+      description: Lifebuoy weight
     lift_mechanism:
       name: Lift mechanism
       description: Indicates the operating mechanism used to raise, lower, or tilt the blind or shade.
@@ -13646,6 +15359,9 @@ en:
     lime_variety:
       name: Lime variety
       description: Identifies the specific botanical or commercial variety of lime being sold.
+    limit_temperature_rating:
+      name: Limit temperature rating
+      description: Limit temperature rating
     line/rope_type:
       name: Line/Rope type
       description: Identifies the construction style of anchor lines or ropes, like three-strand or double braid
@@ -13748,6 +15464,9 @@ en:
     load_mechanism:
       name: Load mechanism
       description: Specifies the primary method by which resistance is generated or added to the machine (e.g., selectorized weight stack, plate-loaded, band-loaded).
+    loadable_sleeve_length:
+      name: Loadable sleeve length
+      description: Specifies the portion of a barbell where weight plates can be loaded, determining maximum weight capacity and balance.
     loading_ramp_type:
       name: Loading ramp type
       description: Identifies the style of loading ramp for vehicles, like single or tri-fold
@@ -13775,6 +15494,9 @@ en:
     locker_bench_configuration:
       name: Locker bench configuration
       description: Describes the orientation or structural configuration of the locker bench (e.g., single-sided, double-sided island, wall-mounted).
+    locking_bolt_diameter:
+      name: Locking bolt diameter
+      description: Locking bolt diameter
     locking_mechanism:
       name: Locking mechanism
       description: Specifies the type of lock used, typically for safety products; e.g. auto-close, slide
@@ -13787,6 +15509,9 @@ en:
     loft_bed_height_classification:
       name: Loft bed height classification
       description: Indicates the overall height style of the loft bed (low, mid, high, extra-high), helping shoppers match ceiling height and under-bed space requirements.
+    loft_uncompressed_thickness:
+      name: Loft (uncompressed thickness)
+      description: Loft (uncompressed thickness)
     logic_family:
       name: Logic family
       description: Identifies the semiconductor logic family or technology of the IC
@@ -13862,6 +15587,9 @@ en:
     lubrication_type:
       name: Lubrication type
       description: Specifies the bushing’s lubrication/greaseability and whether it is designed to be serviced with grease (e.g., grooves or a zerk fitting).
+    luff_length:
+      name: Luff length
+      description: Luff length
     lug_nut_seat_profile:
       name: Lug nut seat profile
       description: Specifies the lug nut seat profile required by the wheel to ensure correct lug nut compatibility and safe installation.
@@ -13871,9 +15599,15 @@ en:
     lumbar_support_type:
       name: Lumbar support type
       description: Describes the style of lumbar support provided with the chair (e.g., detachable pillow, adjustable mechanism, massage).
+    lumber/wood_thickness:
+      name: Lumber/Wood thickness
+      description: Indicates the depth measurement of building materials, determining structural properties and construction applications.
     lumber/wood_type:
       name: Lumber/Wood type
       description: Identifies the specific type of wood or lumber used in a product, like oak or pine
+    luminous_flux:
+      name: Luminous flux
+      description: Specifies the total amount of visible light emitted by a source, determining brightness and area illumination capability.
     lunch_set_items_included:
       name: Lunch set items included
       description: Lists the individual components that come in the lunch box set.
@@ -13907,6 +15641,9 @@ en:
     magazine_compatibility:
       name: Magazine compatibility
       description: Identifies the primary magazine calibers or magazine types that the vest’s built-in pouches are designed to hold.
+    magnet_pull_force:
+      name: Magnet pull force
+      description: Magnet pull force
     magnet_requirement:
       name: Magnet requirement
       description: Indicates whether the sensor needs an external magnet to operate.
@@ -14015,12 +15752,21 @@ en:
     marabou_feather_form:
       name: Marabou feather form
       description: The form factor of the marabou feather product as sold.
+    marabou_feather_length:
+      name: Marabou feather length
+      description: Marabou feather length
     marabou_feather_treatment:
       name: Marabou feather treatment
       description: How the marabou feather was processed or finished for crafting use.
+    marble_size:
+      name: Marble size
+      description: Indicates the diameter of spherical game pieces, determining playability and compatibility with specific games and tracks.
     marble_track_set_feature_modules:
       name: Marble track set feature modules
       description: Highlights special functional modules included with the set (e.g., lift, launcher, switches).
+    marching_bass_drum_weight:
+      name: Marching bass drum weight
+      description: Marching bass drum weight
     marine_flare_certification_standard:
       name: Marine flare certification/standard
       description: Indicates which marine safety certification(s) or standards the flare claims to meet.
@@ -14141,6 +15887,9 @@ en:
     mast_diameter_type:
       name: Mast diameter type
       description: Standardized diameter classification of the windsurfing mast (e.g., RDM, SDM, MDM) used for compatibility checks.
+    mast_length:
+      name: Mast length
+      description: Mast length
     mat/rug_shape:
       name: Mat/Rug shape
       description: Describes the form of mats or rugs, such as round or square
@@ -14198,24 +15947,333 @@ en:
     maturation_vessel_material:
       name: Maturation vessel material
       description: Specifies the primary material of the vessel or barrel used for aging the shochu.
+    mature_height:
+      name: Mature height
+      description: Specifies the expected vertical growth of plants at full development, determining placement planning and spatial requirements.
+    maximum_airflow:
+      name: Maximum airflow
+      description: Indicates the highest volume of air movement a device can generate, determining cooling, drying, or ventilation capability.
+    maximum_aperture_telephoto:
+      name: Maximum aperture (telephoto)
+      description: Specifies the largest lens opening at maximum zoom, determining light-gathering ability and depth of field control for distant subjects.
+    maximum_aperture_wide:
+      name: Maximum aperture (wide)
+      description: Indicates the largest lens opening at minimum zoom, determining light-gathering ability and depth of field control for wide scenes.
+    maximum_arm_reach:
+      name: Maximum arm reach
+      description: Maximum arm reach
+    maximum_assisted_speed:
+      name: Maximum assisted speed
+      description: Maximum assisted speed
+    maximum_ball_speed:
+      name: Maximum ball speed
+      description: Indicates the highest velocity at which projectiles can be propelled, determining training intensity and skill development potential.
+    maximum_battery_life:
+      name: Maximum battery life
+      description: Specifies the longest duration a device can operate on a single charge, determining usage time between recharging.
     maximum_bit_depth:
       name: Maximum bit depth
       description: Defines the highest digital word length (in bits) that the converter supports, affecting dynamic range and resolution
+    maximum_board_length:
+      name: Maximum board length
+      description: Maximum board length
+    maximum_boiling_protection_temperature:
+      name: Maximum boiling protection temperature
+      description: Maximum boiling protection temperature
+    maximum_boost_and_cut_per_band:
+      name: Maximum boost and cut per band
+      description: Maximum boost and cut per band
+    maximum_bread_weight:
+      name: Maximum bread weight
+      description: Indicates the heaviest dough mass that can be properly processed, determining batch size capability for baking equipment.
+    maximum_cable_length_supported:
+      name: Maximum cable length supported
+      description: Maximum cable length supported
+    maximum_chuck_capacity:
+      name: Maximum chuck capacity
+      description: Specifies the largest diameter tool shank that can be securely held, determining versatility and application range.
+    maximum_compatible_neck_width:
+      name: Maximum compatible neck width
+      description: Maximum compatible neck width
+    maximum_compatible_rope_or_band_diameter:
+      name: Maximum compatible rope or band diameter
+      description: Maximum compatible rope or band diameter
+    maximum_compatible_strap_width:
+      name: Maximum compatible strap width
+      description: Maximum compatible strap width
+    maximum_cord_length:
+      name: Maximum cord length
+      description: Indicates the greatest stretched length of elastic cords, determining maximum securing distance and flexibility in load restraint.
+    maximum_current_rating:
+      name: Maximum current rating
+      description: Specifies the highest electrical flow a component can safely handle, determining power handling capability and safety margins.
+    maximum_cut_off_frequency:
+      name: Maximum cut-off frequency
+      description: Indicates the highest frequency point where signals are blocked by filters, determining audio or signal processing characteristics.
+    maximum_cutting_diameter:
+      name: Maximum cutting diameter
+      description: Specifies the largest material thickness that can be processed, determining operational capability for wood processing equipment.
+    maximum_cutting_height:
+      name: Maximum cutting height
+      description: Indicates the tallest grass or vegetation that can be effectively mowed, determining capability for overgrown area maintenance.
+    maximum_data_transfer_rate:
+      name: Maximum data transfer rate
+      description: Specifies the highest speed at which information can be transmitted, determining performance for file transfers and streaming.
+    maximum_delivery_height:
+      name: Maximum delivery height
+      description: Indicates the greatest vertical distance to which a pump can raise fluid, determining installation options and application suitability.
+    maximum_detection_depth:
+      name: Maximum detection depth
+      description: Specifies the deepest water level at which objects can be located, determining effectiveness for various fishing environments.
+    maximum_distance:
+      name: Maximum distance
+      description: Specifies the furthest range at which measurements can be accurately taken, determining suitability for various surveying applications.
+    maximum_dive_depth:
+      name: Maximum dive depth
+      description: Maximum dive depth
+    maximum_door_leaf_thickness:
+      name: Maximum door leaf thickness
+      description: Indicates the thickest door panel that can accommodate specific hardware, determining installation compatibility.
+    maximum_door_weight:
+      name: Maximum door weight
+      description: Specifies the heaviest door that can be properly controlled by closing mechanisms, determining hardware selection for installations.
+    maximum_door_width:
+      name: Maximum door width
+      description: Indicates the widest door that can be properly controlled by specific hardware, determining installation compatibility.
+    maximum_drag:
+      name: Maximum drag
+      description: Specifies the highest resistance force that can be applied to fishing line, determining control capability for large or powerful fish.
+    maximum_drilling_diameter:
+      name: Maximum drilling diameter
+      description: Indicates the largest hole size that can be created, determining capability for various construction and fabrication tasks.
+    maximum_effective_range:
+      name: Maximum effective range
+      description: Maximum effective range
+    maximum_ethernet_port_speed:
+      name: Maximum Ethernet port speed
+      description: Indicates the fastest data transmission rate supported by network connections, determining throughput for connected devices.
+    maximum_extended_length:
+      name: Maximum extended length
+      description: Maximum extended length
+    maximum_flow_rate:
+      name: Maximum flow rate
+      description: Indicates the greatest volume of fluid that can be delivered per unit time, determining cleaning power and efficiency.
+    maximum_frequency:
+      name: Maximum frequency
+      description: Specifies the highest sound vibration rate that can be reproduced, determining audio quality and range in sound systems.
+    maximum_fretboard_width_supported:
+      name: Maximum fretboard width supported
+      description: Maximum fretboard width supported
+    maximum_gain_level:
+      name: Maximum gain level
+      description: Indicates the greatest signal amplification provided by antennas, determining reception strength and transmission range.
+    maximum_heat_output:
+      name: Maximum heat output
+      description: Maximum heat output
+    maximum_heater_power:
+      name: Maximum heater power
+      description: Specifies the highest energy output of heating elements, determining temperature rise capability and heating area coverage.
+    maximum_height:
+      name: Maximum height
+      description: Indicates the tallest extension position, determining reach and positioning flexibility for equipment support.
+    maximum_idle_speed:
+      name: Maximum idle speed
+      description: Specifies the highest rotational velocity when not under load, determining operational characteristics and control requirements.
+    maximum_inductance:
+      name: Maximum inductance
+      description: Indicates the greatest electrical energy storage in magnetic fields, determining filtering and signal processing capabilities.
+    maximum_kayak_width:
+      name: Maximum kayak width
+      description: Maximum kayak width
+    maximum_launch_height:
+      name: Maximum launch height
+      description: Maximum launch height
+    maximum_length:
+      name: Maximum length
+      description: Indicates the greatest extended dimension, determining reach and stability when fully deployed.
+    maximum_load_capacity:
+      name: Maximum load capacity
+      description: Indicates the heaviest weight that can be safely supported, determining user or cargo limitations for equipment.
+    maximum_load_capacity_per_shelf:
+      name: Maximum load capacity per shelf
+      description: Maximum load capacity per shelf
+    maximum_log_diameter:
+      name: Maximum log diameter
+      description: Specifies the largest wood diameter that can be processed, determining capability for various forestry and firewood applications.
+    maximum_log_length:
+      name: Maximum log length
+      description: Indicates the longest wood pieces that can be accommodated, determining processing capability for various timber sizes.
     maximum_magnification:
       name: Maximum magnification
       description: Indicates the highest enlargement factor a microscope can achieve, such as 10x or 100x
+    maximum_mattress_thickness:
+      name: Maximum mattress thickness
+      description: Maximum mattress thickness
+    maximum_operating_depth:
+      name: Maximum operating depth
+      description: Maximum operating depth
+    maximum_operating_distance:
+      name: Maximum operating distance
+      description: Specifies the greatest separation between tool and workpiece for effective operation, determining reach and application flexibility.
+    maximum_operating_pressure:
+      name: Maximum operating pressure
+      description: Indicates the highest safe fluid pressure for system components, determining application suitability and safety margins.
+    maximum_operating_temperature:
+      name: Maximum operating temperature
+      description: Specifies the highest heat level at which components function reliably, determining environmental suitability and safety margins.
+    maximum_operating_voltage:
+      name: Maximum operating voltage
+      description: Indicates the highest electrical potential that can be safely applied, determining circuit compatibility and insulation requirements.
+    maximum_pool_capacity:
+      name: Maximum pool capacity
+      description: Specifies the largest water volume that can be effectively treated, determining suitability for various swimming pool sizes.
+    maximum_power_output:
+      name: Maximum power output
+      description: Maximum power output
+    maximum_preamp_output_voltage:
+      name: Maximum preamp output voltage
+      description: Maximum preamp output voltage
+    maximum_pressure:
+      name: Maximum pressure
+      description: Indicates the highest force per unit area that can be safely contained, determining operational limits and safety parameters.
+    maximum_projectile_speed_rating:
+      name: Maximum projectile speed rating
+      description: Maximum projectile speed rating
+    maximum_projection_distance:
+      name: Maximum projection distance
+      description: Indicates the greatest separation between projector and screen for effective display, determining installation flexibility.
+    maximum_puncture_diameter_sealed:
+      name: Maximum puncture diameter sealed
+      description: Maximum puncture diameter sealed
+    maximum_puncture_size_supported:
+      name: Maximum puncture size supported
+      description: Maximum puncture size supported
     maximum_quilt_size_supported:
       name: Maximum quilt size supported
       description: The maximum quilt/project size the frame can accommodate (commonly described by bed sizes or maximum width).
+    maximum_range:
+      name: Maximum range
+      description: Maximum range
     maximum_reel_diameter_supported:
       name: Maximum reel diameter supported
       description: Specifies the largest reel diameter the deck can accommodate
+    maximum_refresh_rate:
+      name: Maximum refresh rate
+      description: Specifies the highest frequency at which display content is updated, determining motion smoothness and visual performance.
+    maximum_resistance_power:
+      name: Maximum resistance power
+      description: Maximum resistance power
+    maximum_resistance_weight:
+      name: Maximum resistance weight
+      description: Indicates the greatest force that can be applied against movement, determining training intensity and development potential.
+    maximum_room_area:
+      name: Maximum room area
+      description: Indicates the largest space that can be effectively conditioned, determining coverage capability for climate control equipment.
+    maximum_rope_length:
+      name: Maximum rope length
+      description: Maximum rope length
+    maximum_rotational_speed:
+      name: Maximum rotational speed
+      description: Indicates the highest turning rate that can be safely achieved, determining operational capability and power characteristics.
+    maximum_screen_height:
+      name: Maximum screen height
+      description: Specifies the tallest display dimension that can be accommodated, determining device compatibility for protective accessories.
+    maximum_screen_size:
+      name: Maximum screen size
+      description: Indicates the largest display diagonal measurement that can be fitted, determining device compatibility for accessories.
+    maximum_screen_width:
+      name: Maximum screen width
+      description: Specifies the widest display dimension that can be accommodated, determining device compatibility for protective accessories.
+    maximum_sound_detection_level:
+      name: Maximum sound detection level
+      description: Indicates the loudest noise that can be accurately measured, determining suitability for various acoustic monitoring applications.
+    maximum_sound_output_level:
+      name: Maximum sound output level
+      description: Maximum sound output level
+    maximum_sound_pressure_level_spl:
+      name: Maximum sound pressure level (SPL)
+      description: Indicates the loudest sound a microphone can handle without distortion, determining suitability for high-volume recording environments.
+    maximum_speed:
+      name: Maximum speed
+      description: Specifies the fastest rate of movement possible, determining exercise intensity and training capability for canine fitness.
+    maximum_spin_speed:
+      name: Maximum spin speed
+      description: Indicates the highest rotational velocity achievable, determining separation force and processing efficiency in laboratory equipment.
+    maximum_spool_bobbin_diameter_supported:
+      name: Maximum spool/bobbin diameter supported
+      description: Maximum spool/bobbin diameter supported
+    maximum_spool_bobbin_width_supported:
+      name: Maximum spool/bobbin width supported
+      description: Maximum spool/bobbin width supported
+    maximum_stencil_width:
+      name: Maximum stencil width
+      description: Maximum stencil width
+    maximum_stick_length:
+      name: Maximum stick length
+      description: Maximum stick length
+    maximum_stitch_length:
+      name: Maximum stitch length
+      description: Maximum stitch length
+    maximum_stitch_width:
+      name: Maximum stitch width
+      description: Maximum stitch width
+    maximum_stitch_yarn_thickness_supported:
+      name: Maximum stitch/yarn thickness supported
+      description: Maximum stitch/yarn thickness supported
+    maximum_string_tension:
+      name: Maximum string tension
+      description: Maximum string tension
+    maximum_suitable_water_depth:
+      name: Maximum suitable water depth
+      description: Maximum suitable water depth
+    maximum_supported_kayak_length:
+      name: Maximum supported kayak length
+      description: Maximum supported kayak length
+    maximum_table_thickness:
+      name: Maximum table thickness
+      description: Maximum table thickness
+    maximum_takeoff_weight_mtow:
+      name: Maximum takeoff weight (MTOW)
+      description: Maximum takeoff weight (MTOW)
+    maximum_tank_rim_size:
+      name: Maximum tank rim size
+      description: Specifies the thickest aquarium edge that can accommodate mounting hardware, determining compatibility with specific tanks.
+    maximum_temperature:
+      name: Maximum temperature
+      description: Indicates the highest heat level that can be produced, determining suitability for various material processing applications.
+    maximum_thickness:
+      name: Maximum thickness
+      description: Specifies the largest material dimension that can be effectively processed, determining cutting capability for various foods.
+    maximum_tire_clearance:
+      name: Maximum tire clearance
+      description: Maximum tire clearance
+    maximum_tire_diameter_supported:
+      name: Maximum tire diameter supported
+      description: Maximum tire diameter supported
+    maximum_tire_width_supported:
+      name: Maximum tire width supported
+      description: Maximum tire width supported
+    maximum_transmission_distance:
+      name: Maximum transmission distance
+      description: Indicates the greatest separation between sender and receiver for reliable signal, determining effective operational range.
+    maximum_tube_diameter:
+      name: Maximum tube diameter
+      description: Specifies the largest pipe size that can be effectively cut, determining application range for plumbing and construction tools.
+    maximum_user_height:
+      name: Maximum user height
+      description: Indicates the tallest person who can safely use equipment, determining accommodation range for various body sizes.
+    maximum_wheelbase_supported:
+      name: Maximum wheelbase supported
+      description: Maximum wheelbase supported
     meal_course:
       name: Meal course
       description: Identifies the typical meal occasion for the product.
     meal_preparation_state:
       name: Meal preparation state
       description: Indicates how much preparation is required before consumption (e.g., Ready to eat, Meal kit).
+    measurable_speed_range:
+      name: Measurable speed range
+      description: Measurable speed range
     measured_parameters:
       name: Measured parameters
       description: Lists the electrical or battery metrics the device can measure or display
@@ -14357,9 +16415,18 @@ en:
     melon_variety:
       name: Melon variety
       description: Specifies the specific type of melon in the product to help shoppers quickly identify their preferred variety.
+    memory_capacity:
+      name: Memory capacity
+      description: Indicates the amount of data that can be stored, determining how many sounds or samples can be saved for playback.
+    memory_card_size:
+      name: Memory card size
+      description: Specifies the data storage volume of removable media, determining how many images or videos can be recorded.
     memory_channels:
       name: Memory channels
       description: Defines the data transmission capacity of computer processors, such as dual or quad
+    memory_clock_speed:
+      name: Memory clock speed
+      description: Indicates the operational frequency of data storage components, determining access speed and processing performance.
     memory_foam_infusion_material:
       name: Memory foam infusion material
       description: Identifies special substances infused into the memory foam for cooling, odor control, or antimicrobial purposes.
@@ -14381,6 +16448,9 @@ en:
     memory_wire_project_size:
       name: Memory wire project size
       description: Specifies the intended jewelry form/coil size that the memory wire is shaped for (e.g., bracelet, necklace, ring).
+    memory_wire_wire_diameter:
+      name: Memory wire wire diameter
+      description: Memory wire wire diameter
     menstrual_cup_shape:
       name: Menstrual cup shape
       description: Describes the form of menstrual cups, e.g. bell, V-shaped
@@ -14396,6 +16466,9 @@ en:
     mesh_networking_technology:
       name: Mesh networking technology
       description: Specifies whether the access point supports mesh capability and the standard or protocol used
+    mesh_opening_size:
+      name: Mesh opening size
+      description: Mesh opening size
     mesh_type:
       name: Mesh type
       description: Specifies the style or construction of mesh fabric, indicating its intended use or characteristics, e.g. athletic, brushed
@@ -14450,6 +16523,9 @@ en:
     microscope_slide_material:
       name: Microscope slide material
       description: Specifies the type of material used in microscope slides, such as glass or plastic
+    microscope_slide_thickness:
+      name: Microscope slide thickness
+      description: Indicates the depth measurement of specimen holders, determining compatibility with microscope focus range and clarity.
     microwave_compatibility:
       name: Microwave compatibility
       description: Specifies if the item can safely be used in a microwave oven.
@@ -14504,9 +16580,72 @@ en:
     mineral_compound_form:
       name: Mineral compound form
       description: Specifies the chemical form or chelate of the mineral (e.g., citrate, glycinate) which affects absorption
+    minimum_ball_speed:
+      name: Minimum ball speed
+      description: Specifies the slowest projectile velocity possible, determining training options for beginning players and skill development.
+    minimum_ceiling_height:
+      name: Minimum ceiling height
+      description: Minimum ceiling height
+    minimum_chuck_capacity:
+      name: Minimum chuck capacity
+      description: Indicates the smallest tool shank diameter that can be securely held, determining compatibility with precision bits.
+    minimum_curve_radius:
+      name: Minimum curve radius
+      description: Minimum curve radius
+    minimum_cut_off_frequency:
+      name: Minimum cut-off frequency
+      description: Specifies the lowest frequency point where signals are blocked by filters, determining audio or signal processing characteristics.
+    minimum_cutting_height:
+      name: Minimum cutting height
+      description: Indicates the shortest grass or vegetation setting possible, determining capability for maintaining manicured lawns.
+    minimum_door_leaf_thickness_supported:
+      name: Minimum door leaf thickness supported
+      description: Specifies the thinnest door panel that can properly accommodate specific hardware, determining installation compatibility.
+    minimum_drilling_diameter:
+      name: Minimum drilling diameter
+      description: Indicates the smallest hole size that can be effectively created, determining precision capability for detailed work.
+    minimum_frequency:
+      name: Minimum frequency
+      description: Specifies the lowest sound vibration rate that can be reproduced, determining bass response in audio systems.
+    minimum_height:
+      name: Minimum height
+      description: Indicates the shortest collapsed position possible, determining storage requirements and low-position usage options.
+    minimum_inductance:
+      name: Minimum inductance
+      description: Specifies the lowest electrical energy storage in magnetic fields, determining filtering and signal processing capabilities.
+    minimum_length:
+      name: Minimum length
+      description: Specifies the shortest adjustment position possible, determining compact storage and usage in confined spaces.
     minimum_magnification:
       name: Minimum magnification
       description: Indicates the lowest magnification level of a microscope lens, such as 1x or 0.5x
+    minimum_operating_temperature:
+      name: Minimum operating temperature
+      description: Indicates the coldest environment in which equipment functions reliably, determining climate suitability and operational range.
+    minimum_pool_capacity:
+      name: Minimum pool capacity
+      description: Specifies the smallest water volume that can be effectively heated, determining suitability for various swimming pool sizes.
+    minimum_resistance_weight:
+      name: Minimum resistance weight
+      description: Minimum resistance weight
+    minimum_skein_circumference:
+      name: Minimum skein circumference
+      description: Minimum skein circumference
+    minimum_sound_detection_level:
+      name: Minimum sound detection level
+      description: Indicates the quietest noise that can be accurately measured, determining sensitivity for acoustic monitoring applications.
+    minimum_speed:
+      name: Minimum speed
+      description: Specifies the slowest controlled movement rate possible, determining exercise options for rehabilitation or beginning fitness levels.
+    minimum_temperature:
+      name: Minimum temperature
+      description: Indicates the lowest heat setting available, determining suitability for heat-sensitive materials and precision applications.
+    minimum_thickness:
+      name: Minimum thickness
+      description: Specifies the thinnest material slice that can be effectively cut, determining precision capability for delicate foods.
+    minimum_user_height:
+      name: Minimum user height
+      description: Minimum user height
     mint_mark:
       name: Mint mark
       description: Mint mark as shown on the coin (if applicable).
@@ -14534,6 +16673,9 @@ en:
     mirror_sides:
       name: Mirror sides
       description: Indicates the number or configuration of reflective surfaces a mirror has (e.g., single-sided, double-sided, tri-fold)
+    mirror_size:
+      name: Mirror size
+      description: Specifies the viewing area dimensions of reflective surfaces, determining visibility range for inspection applications.
     mirror_type:
       name: Mirror type
       description: Classifies the general style or functional category of the mirror.
@@ -14609,6 +16751,9 @@ en:
     model_making_product_type:
       name: Model making product type
       description: Identifies what the item fundamentally is within model making (kit, accessory, tool, or supply) to improve browse and filtering across mixed product types within Model Making.
+    model_rocket_body_tube_diameter:
+      name: Model rocket body tube diameter
+      description: Model rocket body tube diameter
     model_rocket_kit_contents:
       name: Model rocket kit contents
       description: Indicates whether the product is a complete multi-stage model rocket kit or an add-on/module/parts kit (e.g., booster or sustainer stage components).
@@ -14624,6 +16769,9 @@ en:
     model_rocket_power_source_required:
       name: Model rocket power source required
       description: Indicates whether the product requires batteries/external power, and what kind.
+    model_rocket_predicted_maximum_altitude:
+      name: Model rocket predicted maximum altitude
+      description: Model rocket predicted maximum altitude
     model_rocket_propellant_type:
       name: Model rocket propellant type
       description: Identifies the propellant/engine system used for propulsion in model rocketry products.
@@ -14771,6 +16919,12 @@ en:
     motor_configuration:
       name: Motor configuration
       description: Indicates how many independent drive motors the scooter uses.
+    motor_frequency:
+      name: Motor frequency
+      description: Indicates the operational rate of electrical power, determining compatibility with power sources and performance characteristics.
+    motor_mount_diameter:
+      name: Motor mount diameter
+      description: Motor mount diameter
     motor_mounting_configuration:
       name: Motor mounting configuration
       description: Describes how the motor is mounted/implemented in the conversion kit for a scooter.
@@ -14813,15 +16967,24 @@ en:
     motor_vehicle_paint_application_method:
       name: Motor vehicle paint application method
       description: How the paint is intended to be applied to the vehicle surface.
+    motor_vehicle_paint_coverage_area:
+      name: Motor vehicle paint coverage area
+      description: Motor vehicle paint coverage area
     motor_vehicle_paint_system_step:
       name: Motor vehicle paint system step
       description: Indicates which step or component of an automotive refinishing paint system the product is intended for (e.g., primer, basecoat, clearcoat).
     motor_vehicle_placement:
       name: Motor vehicle placement
       description: Identifies where on a vehicle a part is designed to fit, like front or rear
+    motor_vehicle_speaker_mounting_depth:
+      name: Motor vehicle speaker mounting depth
+      description: Motor vehicle speaker mounting depth
     motor_vehicle_speaker_mounting_type:
       name: Motor vehicle speaker mounting type
       description: How the speaker is intended to be installed in the vehicle (mounting form factor).
+    motor_vehicle_subwoofer_sensitivity:
+      name: Motor vehicle subwoofer sensitivity
+      description: Motor vehicle subwoofer sensitivity
     motor_vehicle_subwoofer_size:
       name: Motor vehicle subwoofer size
       description: Nominal subwoofer driver diameter (e.g., 8 in, 10 in, 12 in), used to match vehicle space and enclosure compatibility.
@@ -14885,6 +17048,9 @@ en:
     motorcycle_riding_discipline:
       name: Motorcycle riding discipline
       description: Identifies the primary riding/use discipline the neck brace is designed for.
+    motorcycle_tire_overall_diameter:
+      name: Motorcycle tire overall diameter
+      description: Motorcycle tire overall diameter
     motorcycle_tire_speed_rating:
       name: Motorcycle tire speed rating
       description: Identifies the maximum sustained speed the tire is rated for, using the standard letter code (e.g., H, V, W).
@@ -14930,6 +17096,12 @@ en:
     mounting_hardware_included_for_installation:
       name: Mounting hardware included (for installation)
       description: Indicates whether the mounting hardware required to install the rear seat (e.g., brackets, bolts, rails) is included with the product.
+    mounting_hole_diameter:
+      name: Mounting hole diameter
+      description: Mounting hole diameter
+    mounting_hole_spacing:
+      name: Mounting hole spacing
+      description: Mounting hole spacing
     mounting_interface_pattern:
       name: Mounting interface pattern
       description: Identifies the mechanical interface or hole pattern used to connect the mount to a radio cradle, bracket, or ball system
@@ -14954,6 +17126,9 @@ en:
     mounting_receiver_size:
       name: Mounting receiver size
       description: Receiver hitch size required for hitch-mounted cargo racks.
+    mounting_screw_hole_spacing:
+      name: Mounting screw hole spacing
+      description: Mounting screw hole spacing
     mounting_storage_type:
       name: Mounting/Storage type
       description: How the device is intended to be mounted or stowed on the vessel/person.
@@ -14996,6 +17171,9 @@ en:
     mouthpiece_facing_length:
       name: Mouthpiece facing length
       description: Indicates the mouthpiece facing (lay) curve length category (not the overall mouthpiece length), which affects response, resistance, and reed compatibility.
+    mouthpiece_length:
+      name: Mouthpiece length
+      description: Mouthpiece length
     mouthpiece_material:
       name: Mouthpiece material
       description: Specifies the material of the mouth-contact mouthpiece/tip portion of a blowout (party blower), which may differ from the main body material.
@@ -15014,6 +17192,12 @@ en:
     mouthpiece_style:
       name: Mouthpiece style
       description: Classifies the design/shape of the mouthpiece portion of the curb bit, which influences pressure points, severity, and horse preference.
+    mouthpiece_thickness:
+      name: Mouthpiece thickness
+      description: Mouthpiece thickness
+    mouthpiece_tip_opening:
+      name: Mouthpiece tip opening
+      description: Mouthpiece tip opening
     mouthpiece_type:
       name: Mouthpiece type
       description: Type of mouthpiece at the blowing end (built-in, removable, or add-on styles).
@@ -15056,9 +17240,15 @@ en:
     music_stand_design:
       name: Music stand design
       description: Describes the type of a music stand, such as floor or wall
+    music_stand_desk_height:
+      name: Music stand desk height
+      description: Music stand desk height
     music_stand_desk_tilt_adjustment:
       name: Music stand desk tilt adjustment
       description: Indicates whether and how the desk angle can be adjusted.
+    music_stand_desk_width:
+      name: Music stand desk width
+      description: Music stand desk width
     music_stand_intended_use:
       name: Music stand intended use
       description: Indicates the primary intended setting/use-case for the stand.
@@ -15074,6 +17264,9 @@ en:
     musical_keyboard_case_fit_type:
       name: Musical keyboard case fit type
       description: Describes how the case is sized to the instrument (e.g., universal/generic size range vs model-specific/custom fit).
+    musical_ratchet_handle_length:
+      name: Musical ratchet handle length
+      description: Musical ratchet handle length
     musical_ratchet_sound_character:
       name: Musical ratchet sound character
       description: General description of the ratchet’s timbre/loudness character.
@@ -15098,6 +17291,15 @@ en:
     mute_finish:
       name: Mute finish
       description: Surface finish of the mute that may affect durability and aesthetic (e.g., polished vs satin).
+    mute_thickness:
+      name: Mute thickness
+      description: Mute thickness
+    mute_weight:
+      name: Mute weight
+      description: Mute weight
+    nacre_thickness:
+      name: Nacre thickness
+      description: Nacre thickness
     nail_art_items_included:
       name: Nail art items included
       description: Identifies the specific nail art accessories in a kit, such as decals or dotting tool
@@ -15110,6 +17312,12 @@ en:
     nail_design:
       name: Nail design
       description: Defines the aesthetic pattern or finish of nail items, e.g. french tip, ombre
+    nail_gauge:
+      name: Nail gauge
+      description: Indicates the diameter or thickness of fasteners, determining strength and appropriate applications for various materials.
+    nail_length:
+      name: Nail length
+      description: Specifies the measurement from head to point of fasteners, determining penetration depth and holding power in materials.
     nail_polish_drying_form:
       name: Nail polish drying form
       description: Identifies the application method of nail polish drying aids, such as drops or spray
@@ -15161,6 +17369,9 @@ en:
     neck_pattern:
       name: Neck pattern
       description: Identifies the design or print on a guitar's neck, like floral or striped
+    neck_support_circumference:
+      name: Neck support circumference
+      description: Neck support circumference
     neck_support_size_system:
       name: Neck support size system
       description: Indicates the sizing system used for the racing neck support/brace (e.g., adult, youth, or one size).
@@ -15185,6 +17396,9 @@ en:
     needle_damping_type:
       name: Needle damping type
       description: Describes how the compass needle is stabilized (e.g., liquid-filled, dry, or electronically stabilized), affecting settling time and durability.
+    needle_diameter:
+      name: Needle diameter
+      description: Indicates the thickness of knitting implements, determining yarn compatibility and finished fabric characteristics.
     needle_eye_type:
       name: Needle eye type
       description: Describes the size and style of the needle's eye, such as large or split
@@ -15263,6 +17477,9 @@ en:
     needlepoint_frame_contents:
       name: Needlepoint frame contents
       description: Specifies which components and accessories are included with the needlepoint frame (e.g., frame, extra bars/rods, tacks/pins, grip strips, carrying bag).
+    needlepoint_frame_roller_length:
+      name: Needlepoint frame roller length
+      description: Needlepoint frame roller length
     needlepoint_frame_tension_adjustment_type:
       name: Needlepoint frame tension adjustment type
       description: Indicates how (or if) the frame’s tension can be adjusted during use.
@@ -15287,12 +17504,24 @@ en:
     net_mesh_pattern:
       name: Net mesh pattern
       description: Specifies the geometric shape of the net openings, which can influence visibility and strength.
+    net_mesh_size:
+      name: Net mesh size
+      description: Net mesh size
     net_mounting_type:
       name: Net mounting type
       description: Identifies how a tennis net is mounted, such as clip-on or tripod stand
+    net_rosin_weight:
+      name: Net rosin weight
+      description: Net rosin weight
     net_twine_gauge:
       name: Net twine gauge
       description: Indicates the twine thickness or strength of the net, traditionally expressed as a gauge number (e.g., 18, 36).
+    net_volume:
+      name: Net volume
+      description: Net volume
+    net_weight:
+      name: Net weight
+      description: Specifies the mass of a product excluding packaging, determining actual food content and nutritional calculations.
     network_cable_interface:
       name: Network cable interface
       description: Specifies the type of connector on a network cable, e.g. BNC, MPO/MTP
@@ -15308,9 +17537,15 @@ en:
     neutral_density_rating:
       name: Neutral density rating
       description: Defines the optical density or strength of an ND filter, expressed by common ND factors or stop reductions
+    nicotine_content:
+      name: Nicotine content
+      description: Indicates the concentration of addictive substances in tobacco products, determining strength and potential health impact.
     nicotine_source:
       name: Nicotine source
       description: Indicates whether the nicotine in the product is tobacco derived, synthetic, or if the product contains no nicotine.
+    nicotine_strength:
+      name: Nicotine strength
+      description: Specifies the concentration of addictive substances in vaping liquids, determining intensity and potential health impact.
     nightgown_style:
       name: Nightgown style
       description: Specifies nightgown style, e.g babydoll, chemise
@@ -15350,6 +17585,9 @@ en:
     noise_intensity:
       name: Noise intensity
       description: Describes the level of sound produced by a product, typically fireworks; e.g. low, high
+    noise_level:
+      name: Noise level
+      description: Specifies the sound intensity produced during operation, determining suitability for various environments and user comfort.
     noise_reduction_system:
       name: Noise reduction system
       description: Specifies the built-in analog noise-reduction standard(s) supported by the deck
@@ -15359,6 +17597,9 @@ en:
     noise_suppression_technology:
       name: Noise suppression technology
       description: Specifies whether the product uses passive damping or active electronic circuitry that compresses loud sounds and/or amplifies ambient sound.
+    nominal_thermal_power:
+      name: Nominal thermal power
+      description: Indicates the rated heat output of heating devices, determining room heating capability and energy consumption.
     non_slip_base_features:
       name: Non-slip base features
       description: Indicates the anti-slip features included to keep the pedal from moving during performance.
@@ -15377,6 +17618,9 @@ en:
     nose_coverage_style:
       name: Nose coverage style
       description: Indicates the presence and type of nose or muzzle protection panel on the fly mask.
+    nose_size:
+      name: Nose size
+      description: Specifies the width of the front portion of skateboards, determining trick capability and riding style suitability.
     noseband_type:
       name: Noseband type
       description: Specifies the design of the noseband (if any) supplied with the bridle.
@@ -15395,6 +17639,9 @@ en:
     nozzle_material:
       name: Nozzle material
       description: Specifies the material of the misting nozzles for durability and clog-resistance considerations.
+    nozzle_size:
+      name: Nozzle size
+      description: Indicates the diameter of material extrusion openings, determining print resolution and material flow characteristics.
     nozzle_style:
       name: Nozzle style
       description: Specifies the functional shape or style of the tube’s nozzle end.
@@ -15407,6 +17654,9 @@ en:
     nozzle_types_included:
       name: Nozzle types included
       description: Lists the shapes/styles of nozzles supplied with the jerky gun, helping buyers know what product forms they can create.
+    nrr_rating:
+      name: NRR rating
+      description: Specifies the Noise Reduction Rating of hearing protection, determining effectiveness in reducing harmful sound exposure.
     number_of_canvas_meshes:
       name: Number of canvas meshes
       description: The mesh size of the plastic canvas sheet, expressed as holes per inch (HPI) or count, which determines stitch size and project detail.
@@ -15494,6 +17744,9 @@ en:
     nut_processing_method:
       name: Nut processing method
       description: Defines how nuts or seeds are prepared, e.g. candied, raw
+    nut_width:
+      name: Nut width
+      description: Nut width
     nutrient_content:
       name: Nutrient content
       description: Specifies the nutritional elements present, typically for fertilizers; e.g. nitrogen, phosphorus
@@ -15506,6 +17759,9 @@ en:
     oak_toast_level:
       name: Oak toast level
       description: Specifies the toast level of oak products.
+    objective_diameter:
+      name: Objective diameter
+      description: Specifies the width of the front lens in optical instruments, determining light-gathering ability and image brightness.
     oboe_case_capacity:
       name: Oboe case capacity
       description: Indicates what instrument(s) and major components the case is designed to carry.
@@ -15515,6 +17771,15 @@ en:
     oboe_case_design:
       name: Oboe case design
       description: Classifies the construction/rigidity of an oboe case or gig bag (e.g., hard, semi-rigid, soft) to indicate protection level.
+    oboe_case_interior_height:
+      name: Oboe case interior height
+      description: Oboe case interior height
+    oboe_case_interior_length:
+      name: Oboe case interior length
+      description: Oboe case interior length
+    oboe_case_interior_width:
+      name: Oboe case interior width
+      description: Oboe case interior width
     oboe_case_internal_fit_type:
       name: Oboe case internal fit type
       description: Indicates whether the interior is molded for a specific instrument configuration or uses adjustable compartments.
@@ -15548,6 +17813,9 @@ en:
     ocarina_style:
       name: Ocarina style
       description: Describes the style of ocarinas, e.g. transverse or pendant
+    ocarina_tuning_reference:
+      name: Ocarina tuning reference
+      description: Ocarina tuning reference
     occasion:
       name: Occasion
       description: Specifies the suitable event or setting for a product, e.g. casual, formal
@@ -15566,6 +17834,12 @@ en:
     octoban_mounting_system_type:
       name: Octoban mounting system type
       description: How the octoban is mounted/positioned during play (mount/bracket/stand setup).
+    octoban_shell_depth:
+      name: Octoban shell depth
+      description: Octoban shell depth
+    odometer_unit:
+      name: Odometer unit
+      description: Odometer unit
     odor_control_features:
       name: Odor control features
       description: Indicates whether the product provides odor neutralization/deodorizing functionality and by what approach.
@@ -15596,6 +17870,9 @@ en:
     oil_dipstick_measurement_markings:
       name: Oil dipstick measurement markings
       description: Specifies what markings/scale are present on the dipstick for reading oil level.
+    oil_dipstick_tube_inner_diameter:
+      name: Oil dipstick tube inner diameter
+      description: Oil dipstick tube inner diameter
     oil_dipstick_tube_mounting_type:
       name: Oil dipstick tube mounting type
       description: Specifies how the oil dipstick tube is retained or mounted to the engine or engine block.
@@ -15617,6 +17894,9 @@ en:
     oil_filler_cap_attachment_type:
       name: Oil filler cap attachment type
       description: Specifies how the oil filler cap is retained on the engine/oil fill neck (e.g., threaded, bayonet/quarter-turn, press-fit).
+    oil_filler_cap_diameter:
+      name: Oil filler cap diameter
+      description: Oil filler cap diameter
     oil_filler_cap_installation_position:
       name: Oil filler cap installation position
       description: Specifies where the cap is used when multiple oil fill points exist (e.g., valve cover, remote fill tube).
@@ -15629,12 +17909,18 @@ en:
     oil_filler_cap_venting_type:
       name: Oil filler cap venting type
       description: Specifies whether the cap is vented and the venting mechanism (if applicable).
+    oil_filter_gasket_outer_diameter:
+      name: Oil filter gasket outer diameter
+      description: Oil filter gasket outer diameter
     oil_filter_style:
       name: Oil filter style
       description: Specifies the oil filter form factor and mounting/installation style for compatibility with the engine’s filter mount.
     oil_pan_baffle_windage_features:
       name: Oil pan baffle/windage features
       description: Indicates internal oil control features included in the pan.
+    oil_pan_capacity:
+      name: Oil pan capacity
+      description: Oil pan capacity
     oil_pan_finish_coating:
       name: Oil pan finish/coating
       description: Describes the surface finish or coating of the oil pan (painted, powder-coated, plated, raw, etc.).
@@ -15650,6 +17936,9 @@ en:
     oil_pump_drive_method:
       name: Oil pump drive method
       description: Indicates what drives the oil pump within the engine.
+    oil_pump_inlet_port_diameter:
+      name: Oil pump inlet port diameter
+      description: Oil pump inlet port diameter
     oil_pump_mounting_style:
       name: Oil pump mounting style
       description: Specifies where and how the oil pump mounts in the engine (e.g., internal vs external/remote, cover mount, oil pan mount).
@@ -15701,12 +17990,18 @@ en:
     operating_modes:
       name: Operating modes
       description: Primary built-in effect/motion modes supported by the laser light.
+    operating_pressure:
+      name: Operating pressure
+      description: Operating pressure
     operating_system:
       name: Operating system
       description: Defines the system software a device uses, such as iOS or ChromeOS
     operating_system_compatibility:
       name: Operating system compatibility
       description: Identifies the operating systems the remote shutter supports out of the box.
+    operating_time:
+      name: Operating time
+      description: Specifies the duration a device remains functional after activation, determining usage period before replacement or recharging.
     operating_voltage:
       name: Operating voltage
       description: Specifies the nominal system voltage the injector is designed for.
@@ -15764,6 +18059,9 @@ en:
     orchestral_string_winding_material:
       name: Orchestral string winding material
       description: Specifies the outer winding/wrap material used on the string.
+    orchid_flower_size:
+      name: Orchid flower size
+      description: Orchid flower size
     organic_certification:
       name: Organic certification
       description: Identifies which organic or sustainability certification the product holds
@@ -15806,6 +18104,9 @@ en:
     ostrich_feather_part:
       name: Ostrich feather part
       description: Identifies the ostrich feather style/part used (e.g., plume vs drab) which impacts softness, density, and typical craft applications.
+    outboard_motor_alternator_output:
+      name: Outboard motor alternator output
+      description: Outboard motor alternator output
     outboard_motor_shaft_type:
       name: Outboard motor shaft type
       description: Standard shaft length class used by outboards (label form used in the marine industry).
@@ -15833,6 +18134,9 @@ en:
     outerwear_clothing_features:
       name: Outerwear clothing features
       description: Identifies special characteristics of outerwear, like insulated or waterproof
+    outerwear_length:
+      name: Outerwear length
+      description: Measures the vertical distance from shoulder to bottom hem, determining coverage and style classification of jackets and coats.
     outerwear_length_type:
       name: Outerwear length type
       description: Classifies an outerwear garment’s overall length into standard descriptive ranges.
@@ -15845,6 +18149,9 @@ en:
     outfit_items_included:
       name: Outfit items included
       description: Lists the specific garment items included in the set (e.g., bodysuit, shorts, headband).
+    outlet_port_diameter:
+      name: Outlet port diameter
+      description: Outlet port diameter
     outlet_thread_type:
       name: Outlet thread type
       description: Thread standard used at the master cylinder brake line outlet ports (e.g., metric bubble flare vs SAE inverted flare).
@@ -15857,6 +18164,9 @@ en:
     output_connection_type:
       name: Output connection type
       description: Specifies the connector or interface standard provided by the converter on its output side
+    output_frequency:
+      name: Output frequency
+      description: Indicates the electrical cycle rate produced by power conversion equipment, determining compatibility with connected devices.
     output_jack_type_instrument:
       name: Output jack type (instrument)
       description: Specifies the type of audio output jack on the electric mandolin.
@@ -15872,9 +18182,18 @@ en:
     output_video_interface:
       name: Output video interface
       description: Specifies the type(s) of video connector provided as output by the scan converter
+    output_voltage:
+      name: Output voltage
+      description: Specifies the electrical potential produced by power supplies, determining compatibility with devices and safety considerations.
     output_waveform:
       name: Output waveform
       description: Specifies the type of signal an electronic oscillator generates, such as sawtooth or sine
+    outseam_length:
+      name: Outseam length
+      description: Measures the distance from waistband to hem along the outside of the leg, determining overall length and fit of pants.
+    outside_diameter:
+      name: Outside diameter
+      description: Indicates the measurement across the widest part of circular objects, determining space requirements and fitting compatibility.
     outsole_marking_type:
       name: Outsole marking type
       description: Indicates whether the shoe’s outsole leaves marks on court surfaces, a critical consideration for indoor racquet sports.
@@ -15893,21 +18212,48 @@ en:
     oven_housing_configuration:
       name: Oven housing configuration
       description: Defines the intended appliance layout accommodated by the cabinet (e.g., single oven, double oven, or oven and microwave combo).
+    oven_opening_depth:
+      name: Oven opening depth
+      description: Oven opening depth
+    oven_opening_height:
+      name: Oven opening height
+      description: Oven opening height
+    oven_opening_width:
+      name: Oven opening width
+      description: Oven opening width
+    overall_dimensions:
+      name: Overall dimensions
+      description: Overall dimensions
+    overall_exterior_height:
+      name: Overall exterior height
+      description: Overall exterior height
+    overall_length:
+      name: Overall length
+      description: Overall length
     overclock_profile_support:
       name: Overclock profile support
       description: Identifies standardized overclocking profiles stored in the module (e.g., Intel XMP, AMD EXPO)
+    overhang_length:
+      name: Overhang length
+      description: Overhang length
     overhead_mount_installation_method:
       name: Overhead mount installation method
       description: How the overhead mount is secured to the vehicle (hardware/attachment style).
     oversize_or_undersize_grade:
       name: Oversize or undersize grade
       description: Specifies the kit’s size grade (oversize pistons/rings and/or undersize bearings) relative to OEM standard size.
+    oxygen_capacity:
+      name: Oxygen capacity
+      description: Specifies the volume of compressed gas that can be stored, determining usage duration for respiratory support applications.
     oxygen_cylinder_outlet_standard:
       name: Oxygen cylinder outlet standard
       description: Specifies the CGA outlet connection standard of the cylinder valve
     oxygen_indicator_type:
       name: Oxygen indicator type
       description: Specifies whether a visual indicator is included to show if the absorber packet is still active, and what form it takes.
+    oxygen_sensor_hex_size:
+      name: Oxygen sensor hex size
+      description: Oxygen sensor hex size
     oxygen_tank_valve_type:
       name: Oxygen tank valve type
       description: Specifies the valve used in oxygen tanks, e.g. toggle, post valve
@@ -15926,12 +18272,21 @@ en:
     packability:
       name: Packability
       description: Indicates whether and how the vest can be packed or stowed when not in use.
+    package_length:
+      name: Package length
+      description: Package length
+    package_size:
+      name: Package size
+      description: Indicates the quantity of product contained in retail packaging, determining value comparison and usage duration.
     package_type:
       name: Package type
       description: Defines the type of packaging for a product, e.g. jar, pump
     packaging_format:
       name: Packaging format
       description: How the strings are packaged/sold (individual envelopes, bulk, etc.).
+    packaging_length:
+      name: Packaging length
+      description: Packaging length
     packaging_material:
       name: Packaging material
       description: Specifies the primary material of the bottle or container that holds the water.
@@ -15968,6 +18323,9 @@ en:
     pad_mounting_or_holding_style:
       name: Pad mounting or holding style
       description: Indicates how the pad is held, worn or installed during use.
+    pad_saver_diameter:
+      name: Pad saver diameter
+      description: Pad saver diameter
     pad_saver_style:
       name: Pad saver style
       description: Indicates the physical style/design of the pad saver used to dry the pads and bore.
@@ -15998,6 +18356,9 @@ en:
     padding_material:
       name: Padding material
       description: Specifies the internal stuffing or padding substance that absorbs impact inside bags, shields, mitts, and dummies.
+    padding_thickness:
+      name: Padding thickness
+      description: Padding thickness
     paddle/oar_material:
       name: Paddle/Oar material
       description: Identifies the material used in the construction of paddles or oars, like aluminum or wood
@@ -16007,6 +18368,9 @@ en:
     paddle_equipment_included:
       name: Paddle equipment included
       description: Specifies the supplementary equipment in paddle sets, such as posts or paddle balls
+    paddle_grip_circumference:
+      name: Paddle grip circumference
+      description: Paddle grip circumference
     paddle_leash_style:
       name: Paddle leash style
       description: Identifies the style or design of the paddle leash cord.
@@ -16019,6 +18383,12 @@ en:
     paddleboard_intended_use:
       name: Paddleboard intended use
       description: Classifies the primary design purpose or activity for which the board is built (e.g., Touring, Yoga, Racing).
+    paddleboard_size:
+      name: Paddleboard size
+      description: Specifies the dimensions of water sports equipment, determining stability, maneuverability, and rider weight compatibility.
+    paddler_weight_range:
+      name: Paddler weight range
+      description: Paddler weight range
     page_layout:
       name: Page layout
       description: Defines the layout of pages, typically in address books; e.g. blank, tabbed
@@ -16040,9 +18410,15 @@ en:
     paint_brush_design:
       name: Paint brush design
       description: Describes the shape or style of a paint brush, like round or flat
+    paint_brush_size:
+      name: Paint brush size
+      description: Indicates the width of the bristle area, determining coverage area and detail capability for various painting applications.
     paint_by_number_surface_type:
       name: Paint-by-number surface type
       description: The surface the numbered design is printed on (e.g., canvas, paper, wood panel).
+    paint_dry_to_touch_time:
+      name: Paint dry-to-touch time
+      description: Paint dry-to-touch time
     paint_finish:
       name: Paint finish
       description: Indicates the type of finish on paint, typically for vehicles; e.g. metallic, gloss
@@ -16058,6 +18434,9 @@ en:
     paint_medium_type:
       name: Paint medium type
       description: Specifies the kind of paint medium in craft items, such as varnish or watercolor
+    paint_roller_size:
+      name: Paint roller size
+      description: Specifies the width of the painting surface, determining coverage area and efficiency for large surface applications.
     paint_safe_bristles:
       name: Paint-safe bristles
       description: Indicates whether the brush bristles are marketed as safe for use on automotive paint/clear coat (scratch-free).
@@ -16121,6 +18500,12 @@ en:
     palette_surface_finish:
       name: Palette surface finish
       description: Describes the mixing surface finish/coating that affects stain resistance and ease of cleaning.
+    palette_thickness:
+      name: Palette thickness
+      description: Palette thickness
+    palm_circumference:
+      name: Palm circumference
+      description: Palm circumference
     palm_padding_level:
       name: Palm padding level
       description: Describes the amount of cushioning in the palm area of the glove or grip pad.
@@ -16142,6 +18527,9 @@ en:
     pan_perforation_type:
       name: Pan perforation type
       description: Indicates whether the pan bottom/sides are solid or perforated to allow liquid drainage.
+    panel_cutout_diameter:
+      name: Panel cutout diameter
+      description: Panel cutout diameter
     panel_specification:
       name: Panel specification
       description: Defines the type of patch panel for cable management, such as fiber optic or Cat6
@@ -16244,6 +18632,9 @@ en:
     parking_sensor_finish:
       name: Parking sensor finish
       description: Indicates the surface finish of the parking sensor face/cap (e.g., paintable/primed, matte, glossy) to help match bumper aesthetics.
+    parking_sensor_hole_diameter:
+      name: Parking sensor hole diameter
+      description: Parking sensor hole diameter
     parking_sensor_type:
       name: Parking sensor type
       description: Specifies the sensing technology used by the parking sensor (e.g., ultrasonic, electromagnetic, radar, optical).
@@ -16283,6 +18674,9 @@ en:
     party_horn_style:
       name: Party horn style
       description: Describes the construction/behavior style of the party horn (how it extends or produces sound).
+    party_streamer_curtain_coverage_area:
+      name: Party streamer/curtain coverage area
+      description: Party streamer/curtain coverage area
     pass_duration:
       name: Pass duration
       description: Specifies the validity period or lifespan of the travel pass or ticket.
@@ -16358,6 +18752,9 @@ en:
     pattern_sizing_system:
       name: Pattern sizing system
       description: Specifies the regional sizing system or standard used for the pattern’s size chart (e.g., US, UK, EU).
+    payload_capacity:
+      name: Payload capacity
+      description: Payload capacity
     payment_mechanism_type:
       name: Payment mechanism type
       description: Identifies how players activate the machine (e.g., coin-operated, card swipe)
@@ -16373,12 +18770,21 @@ en:
     pcie_lane_configuration:
       name: PCIe lane configuration
       description: Specifies the physical lane width the riser supports (e.g., x1, x4, x8, x16), indicating slot size and electrical bandwidth
+    peak_power_handling:
+      name: Peak power handling
+      description: Peak power handling
+    peak_power_per_channel:
+      name: Peak power per channel
+      description: Indicates the maximum audio amplification capability, determining volume potential and speaker compatibility.
     peak_style:
       name: Peak style
       description: Specifies the style of the visor or peak on the helmet, affecting coverage, aesthetics, and discipline rules.
     pear_variety:
       name: Pear variety
       description: Identifies the cultivar or variety of pears (e.g., Bartlett, Bosc, Conference), allowing shoppers to choose their preferred taste, texture and culinary use.
+    pearl_hole_size:
+      name: Pearl hole size
+      description: Pearl hole size
     pearl_luster_grade:
       name: Pearl luster grade
       description: Qualitative luster/shine grade of the pearl surface.
@@ -16433,6 +18839,9 @@ en:
     pellet_grade:
       name: Pellet grade
       description: Indicates the manufacturing precision or performance grade of the airsoft pellets.
+    pellet_weight:
+      name: Pellet weight
+      description: Pellet weight
     pen/felt_tip_design:
       name: Pen/Felt tip design
       description: Describes the thickness and style of a pen's tip, like bold or fine
@@ -16451,9 +18860,15 @@ en:
     pen_pattern:
       name: Pen pattern
       description: Identifies the visual theme on pens, such as camouflage or checkered
+    pen_size:
+      name: Pen size
+      description: Specifies the dimensions of writing or input devices, determining handling comfort and precision capability.
     pen_tip_design:
       name: Pen tip design
       description: Describes the style of a pen's tip, such as medium or fine
+    pen_tip_size:
+      name: Pen tip size
+      description: Pen tip size
     pen_type:
       name: Pen type
       description: Identifies the type of pen or writing instrument, such as gel or fountain
@@ -16517,6 +18932,9 @@ en:
     perfumery_base_carrier_type:
       name: Perfumery base carrier type
       description: Specifies the carrier/solvent system of a perfumery base (what the base is primarily made of for dilution and performance).
+    perfumery_base_flash_point:
+      name: Perfumery base flash point
+      description: Perfumery base flash point
     perfumery_base_intended_application:
       name: Perfumery base intended application
       description: Indicates the end-use format the base is designed for (e.g., fine fragrance spray vs roll-on).
@@ -16634,6 +19052,9 @@ en:
     pet_treat_type:
       name: Pet treat type
       description: Identifies the kind of pet treat, such as chewy or crunchy
+    petri_dish_size:
+      name: Petri dish size
+      description: Indicates the diameter of laboratory culture containers, determining growth area and specimen capacity for experiments.
     ph_adjustment_direction:
       name: pH adjustment direction
       description: Indicates whether the product is formulated to raise (pH Up) or lower (pH Down) the solution’s pH level.
@@ -16643,6 +19064,9 @@ en:
     phase_type:
       name: Phase type
       description: Identifies the phase type of motor controllers, such as single-phase or two-phase
+    phev_charging_time:
+      name: PHEV charging time
+      description: PHEV charging time
     phone_camera_position:
       name: Phone camera position
       description: Indicates the physical position or function of the camera module within the phone
@@ -16748,6 +19172,9 @@ en:
     pig_feed_stage:
       name: Pig feed stage
       description: Identifies the life stage of pigs the feed is intended for, like grower or starter
+    pile_depth:
+      name: Pile depth
+      description: Specifies the length of fibers on paint applicators, determining paint holding capacity and surface texture creation.
     pile_type:
       name: Pile type
       description: Defines the texture and style of carpets, rugs, and mats; e.g. plush, berber
@@ -16766,6 +19193,12 @@ en:
     pilot_helmet_visor_configuration:
       name: Pilot helmet visor configuration
       description: Specifies the visor/face shield configuration included with the pilot helmet.
+    pin/rod_diameter:
+      name: Pin/Rod diameter
+      description: Specifies the thickness of cylindrical fasteners or supports, determining strength and appropriate applications.
+    pin/rod_length:
+      name: Pin/Rod length
+      description: Indicates the measurement from end to end of cylindrical components, determining reach and application suitability.
     pin_attachment_type:
       name: Pin attachment type
       description: Specifies the pin back/backing mechanism used to attach the pin to clothing or a surface (e.g., butterfly clutch, magnetic back).
@@ -16781,6 +19214,12 @@ en:
     pin_face_customization_method:
       name: Pin face customization method
       description: Specifies how the front design is produced (e.g., hard enamel, soft enamel, printed).
+    pin_gauge:
+      name: Pin gauge
+      description: Pin gauge
+    pin_length:
+      name: Pin length
+      description: Indicates the measurement from head to point of fastening implements, determining penetration depth and holding capability.
     pin_shape:
       name: Pin shape
       description: Describes the overall form of the pin that anchors the fabric.
@@ -16826,18 +19265,36 @@ en:
     ping_pong_rubber_type:
       name: Ping pong rubber type
       description: Specifies the surface construction style of a ping pong rubber sheet, which influences playing characteristics.
+    ping_pong_sponge_thickness:
+      name: Ping pong sponge thickness
+      description: Ping pong sponge thickness
     ping_pong_table_type:
       name: Ping pong table type
       description: Classifies the overall style or format of the table for easier comparison (e.g., competition, conversion top, mini).
+    pipe_brush_size:
+      name: Pipe brush size
+      description: Specifies the diameter of cleaning tools, determining compatibility with specific pipe sizes for maintenance operations.
     pipe_clamp_design:
       name: Pipe clamp design
       description: Describes the design of a pipe clamp, such as snap or C-clamp
     pipe_connection_method:
       name: Pipe connection method
       description: Specifies the style of connections on the pipe bend’s ends (e.g., male, female, push fit, threaded) to ensure installation compatibility.
+    pipe_diameter:
+      name: Pipe diameter
+      description: Indicates the width of fluid-carrying conduits, determining flow capacity and connection compatibility with fixtures.
+    pipe_diameter_supported:
+      name: Pipe diameter supported
+      description: Specifies the range of tube sizes that can be processed by specific tools, determining application versatility.
+    pipe_inner_diameter_musical_instrument_pipe:
+      name: Pipe inner diameter (musical instrument pipe)
+      description: Pipe inner diameter (musical instrument pipe)
     pipe_instrument_voicing_sound_production_method:
       name: Pipe instrument voicing / sound production method
       description: Specifies how the instrument produces sound (airflow mechanism), helping distinguish pan flutes, reed pipes, and organ pipe families in filters.
+    pipe_length:
+      name: Pipe length
+      description: Indicates the linear measurement of fluid-carrying conduits, determining reach and installation configuration options.
     pipe_shape:
       name: Pipe shape
       description: Defines the form of smoking pipes, e.g. gourd, billiard
@@ -16850,9 +19307,18 @@ en:
     piston_crown_dish_style:
       name: Piston crown/dish style
       description: Shape of the piston crown that influences combustion chamber volume and compression (e.g., flat top, dome, dish).
+    piston_oversize:
+      name: Piston oversize
+      description: Piston oversize
     piston_pin_retention_type:
       name: Piston pin retention type
       description: Specifies how the wrist (piston) pin is retained in the piston/connecting rod assembly.
+    piston_ring_thickness:
+      name: Piston ring thickness
+      description: Piston ring thickness
+    pit_ball_size:
+      name: Pit ball size
+      description: Specifies the diameter of play equipment spheres, determining safety for different age groups and play experience.
     pit_configuration:
       name: Pit configuration
       description: Defines the structural format of the landing area (one piece vs. multi-module) and, by extension, the number of sections or modules supplied.
@@ -16931,6 +19397,9 @@ en:
     plant_class:
       name: Plant class
       description: Classifies plants into specific taxonomic groups, e.g. liliopsida, brassicales
+    plant_container_size:
+      name: Plant container size
+      description: Indicates the dimensions of gardening vessels, determining soil capacity and suitability for various plant types.
     plant_container_type:
       name: Plant container type
       description: Identifies the type of container included with the artificial shrub, if any.
@@ -16967,6 +19436,9 @@ en:
     plastic_canvas_finish:
       name: Plastic canvas finish
       description: Surface/finish treatment of the plastic canvas roll.
+    plastic_canvas_hole_size:
+      name: Plastic canvas hole size
+      description: Plastic canvas hole size
     plastic_canvas_sheet_finish:
       name: Plastic canvas sheet finish
       description: Surface/edge treatment of the plastic canvas sheet.
@@ -16997,6 +19469,12 @@ en:
     plate_type:
       name: Plate type
       description: Identifies the type of plate in hair styling tools, e.g. titanium, ceramic
+    plate_weight:
+      name: Plate weight
+      description: Specifies the mass of weightlifting discs, determining exercise intensity and muscle development potential.
+    platform_height:
+      name: Platform height
+      description: Measures the vertical distance from ground to shoe sole, determining elevation and style impact of footwear.
     play_dough_putty_kit_contents:
       name: Play dough & putty kit contents
       description: Identifies the main included components beyond the compound itself (e.g., tools, molds, extruder, storage).
@@ -17030,6 +19508,9 @@ en:
     play_sprinkler_mounting_type:
       name: Play sprinkler mounting type
       description: How the play sprinkler is positioned/secured during use.
+    play_sprinkler_spray_coverage_diameter:
+      name: Play sprinkler spray coverage diameter
+      description: Play sprinkler spray coverage diameter
     play_vehicle_lights_and_sounds:
       name: Play vehicle lights and sounds
       description: Indicates whether the toy vehicle includes electronic play effects such as lights and/or sounds.
@@ -17066,6 +19547,12 @@ en:
     player_specialized_features:
       name: Player specialized features
       description: Identifies unique capabilities of video players, like 4K support or HDR support
+    playfield_thickness:
+      name: Playfield thickness
+      description: Playfield thickness
+    playfield_width:
+      name: Playfield width
+      description: Playfield width
     playhouse_design:
       name: Playhouse design
       description: Specifies the type of playhouse, such as tree house or floorstanding playhouse
@@ -17078,12 +19565,21 @@ en:
     playing_surface_material:
       name: Playing surface material
       description: Identifies the material of the cajon’s front playing surface (tapa), which strongly affects tone and feel.
+    playing_surface_size:
+      name: Playing surface size
+      description: Playing surface size
     playing_surface_type:
       name: Playing surface type
       description: Describes the playing surface construction/feel of the practice pad.
+    playing_time:
+      name: Playing time
+      description: Indicates the duration of gameplay or activity, determining entertainment value and session planning requirements.
     playset_activities_included:
       name: Playset activities included
       description: Identifies the main play activities/components built into the swing set/playset to help shoppers filter by what kids can do on the structure.
+    playset_deck_height:
+      name: Playset deck height
+      description: Playset deck height
     playset_features:
       name: Playset features
       description: Highlights special aspects of a playset, e.g. limited edition, waterproof
@@ -17135,6 +19631,9 @@ en:
     pocket_knife_opening_mechanism:
       name: Pocket knife opening mechanism
       description: How the blade is deployed/opened (manual nail nick, thumb stud, flipper, assisted, automatic, etc.).
+    pocket_opening_size:
+      name: Pocket opening size
+      description: Pocket opening size
     pocket_style:
       name: Pocket style
       description: Specifies the main pocket construction featured on the pants.
@@ -17213,6 +19712,12 @@ en:
     pole_construction_type:
       name: Pole construction type
       description: Defines the structural style of the pole, affecting setup and portability.
+    pole_diameter:
+      name: Pole diameter
+      description: Pole diameter
+    pole_length:
+      name: Pole length
+      description: Specifies the measurement of tool handles or extensions, determining reach and operational capability in various environments.
     pole_material:
       name: Pole material
       description: Specifies the material used in pole construction, e.g. steel, wood
@@ -17327,6 +19832,12 @@ en:
     pork_rind_form:
       name: Pork rind form
       description: Categorizes the physical form or style of pork rind snacks (e.g., rind, crackling, puff, pellet, etc.).
+    port_diameter:
+      name: Port diameter
+      description: Port diameter
+    port_height:
+      name: Port height
+      description: Port height
     portability:
       name: Portability
       description: Specifies the ease of moving or carrying a product, typically for breast pumps; e.g. portable, compact size
@@ -17411,18 +19922,33 @@ en:
     powdered_beverage_variety:
       name: Powdered beverage variety
       description: Classifies the product by the type of beverage it prepares (e.g., lemonade, sports drink, protein shake).
+    power:
+      name: Power
+      description: Indicates the energy consumption or output rating of equipment, determining operational capability and electrical requirements.
     power_connector_type:
       name: Power connector type
       description: Specifies the auxiliary power connector(s) required or provided by the riser or adapter
+    power_consumption_typical:
+      name: Power consumption (typical)
+      description: Specifies the energy used during normal operation, determining operating costs and electrical supply requirements.
     power_conversion_semiconductor_type:
       name: Power conversion semiconductor type
       description: Identifies the primary semiconductor material used in the charger's power stage, which influences size, efficiency, and heat generation
+    power_dissipation:
+      name: Power dissipation
+      description: Indicates the heat energy released by electronic components, determining cooling requirements and thermal management needs.
     power_equipment_hitch_type:
       name: Power equipment hitch type
       description: Identifies the connection interface the attachment uses to mount on tractors or power units.
+    power_output_typical:
+      name: Power output (typical)
+      description: Specifies the energy delivered during normal operation, determining performance capability and application suitability.
     power_rack_style:
       name: Power rack style
       description: Specifies the overall rack design/configuration, helping shoppers distinguish between full cages, half racks and space-saving variants.
+    power_rating:
+      name: Power rating
+      description: Indicates the energy handling capability of equipment, determining performance potential and electrical supply requirements.
     power_source:
       name: Power source
       description: Specifies the power source a product uses to operate, such as solar or batteries
@@ -17477,6 +20003,9 @@ en:
     preparation_style:
       name: Preparation style
       description: Defines the cut or processing state of the water chestnuts when sold (e.g., whole, sliced, roasted, frozen).
+    preparation_time:
+      name: Preparation time
+      description: Specifies the duration required to make food ready for consumption, determining convenience and meal planning requirements.
     preparation_type:
       name: Preparation type
       description: Describes the method required to make the food ready to eat.
@@ -17498,6 +20027,9 @@ en:
     presser_foot_attachment_method:
       name: Presser foot attachment method
       description: Indicates how the sewing machine presser foot attaches to the presser foot holder/shank (e.g., snap-on vs screw-on), which affects compatibility.
+    presser_foot_lift_height:
+      name: Presser foot lift height
+      description: Presser foot lift height
     pressure_cooker_handle_type:
       name: Pressure cooker handle type
       description: Indicates the style or location of the pressure cooker handle being replaced.
@@ -17621,6 +20153,9 @@ en:
     printer_connection_interface:
       name: Printer connection interface
       description: Defines the type of port the print server uses to connect to the printer itself
+    printer_filament_size:
+      name: Printer filament size
+      description: Indicates the diameter of 3D printing material, determining compatibility with specific printer models and extrusion systems.
     printer_form_factor:
       name: Printer form factor
       description: Classifies the physical style or portability of the device
@@ -17648,6 +20183,12 @@ en:
     privacy_or_acoustic_feature:
       name: Privacy or acoustic feature
       description: Specifies built-in privacy or acoustic elements such as divider panels, acoustic screens or full enclosures.
+    probe_diameter:
+      name: Probe diameter
+      description: Specifies the thickness of inspection tools, determining access capability to confined spaces and minimal opening requirements.
+    probe_length:
+      name: Probe length
+      description: Indicates the reach of search implements, determining depth capability for locating buried objects or victims.
     procedure:
       name: Procedure
       description: Specifies the medical procedure or training type the equipment is designed for
@@ -17660,6 +20201,9 @@ en:
     processor_family:
       name: Processor family
       description: Identifies the series or brand of the electronic device's CPU, e.g. Intel Core i7
+    processor_frequency:
+      name: Processor frequency
+      description: Specifies the operational speed of computing chips, determining performance capability for various applications.
     processor_socket:
       name: Processor socket
       description: Specifies compatible processor socket type in electronics, such as LGA 1151 (socket H4) or Socket AM4
@@ -17711,12 +20255,18 @@ en:
     projectile_ammunition_type:
       name: Projectile/ammunition type
       description: Specifies the type of projectiles or consumables used by the toy weapon, if applicable.
+    projectile_caliber:
+      name: Projectile caliber
+      description: Projectile caliber
     projectile_finish:
       name: Projectile finish
       description: Specifies any surface coating applied to the BB, aiding corrosion resistance or visibility (e.g., copper-coated, zinc-plated, painted).
     projectile_type:
       name: Projectile type
       description: Identifies the kind of projectile the product uses or is intended for.
+    projection_coverage_area:
+      name: Projection coverage area
+      description: Projection coverage area
     projection_design:
       name: Projection design
       description: Describes the pattern or image projected by a lighting filter or gobo, such as text or logo
@@ -17768,6 +20318,9 @@ en:
     protection_level:
       name: Protection level
       description: Indicates the case’s intended level of protection for transporting and storing the instrument.
+    protection_time:
+      name: Protection time
+      description: Specifies the duration of effectiveness against pests, determining reapplication frequency and overall coverage period.
     protection_type:
       name: Protection type
       description: Identifies the level of protection offered by safety gear, like Type I or Type II
@@ -17825,6 +20378,12 @@ en:
     protector_coverage_area:
       name: Protector coverage area
       description: Specifies which torso area(s) the protector is designed to cover (e.g., chest, back, sides).
+    protein_per_100_g:
+      name: Protein per 100 g
+      description: Protein per 100 g
+    protein_per_serving:
+      name: Protein per serving
+      description: Protein per serving
     protein_processing_type:
       name: Protein processing type
       description: Specifies how the protein is refined or processed (e.g., isolate vs. concentrate), affecting purity, digestion rate, and consumer preference
@@ -17900,15 +20459,24 @@ en:
     puppet_puppet_theater_accessory_type:
       name: Puppet & puppet theater accessory type
       description: Specifies what kind of accessory the product is (e.g., stage prop, puppet costume, control bar, replacement string).
+    puppet_size:
+      name: Puppet size
+      description: Indicates the dimensions of performance toys, determining handling characteristics and visibility for audiences.
     puppet_theme:
       name: Puppet theme
       description: Categorizes puppets based on their design theme, like human or fantastic
     puppet_type:
       name: Puppet type
       description: Identifies the style of puppet, such as hand puppet or marionette
+    purification_contact_time:
+      name: Purification contact time
+      description: Purification contact time
     purity_unit:
       name: Purity unit
       description: How purity is expressed for the coin (fineness vs karat).
+    push_button_size:
+      name: Push button size
+      description: Specifies the diameter of control interfaces, determining ease of operation and installation requirements.
     push_button_terminal_type:
       name: Push button terminal type
       description: Specifies the electrical connection style on the button, ensuring compatibility with wiring harnesses and quick-connect tabs during installation
@@ -17942,6 +20510,9 @@ en:
     pyrometric_cone_range:
       name: Pyrometric cone range
       description: The recommended pyrometric cone(s) the glaze is formulated to fire to (e.g., Cone 06–04, Cone 5–6).
+    q_factor:
+      name: Q factor
+      description: Q factor
     quarter_panel_coverage_type:
       name: Quarter panel coverage type
       description: Specifies how much of the quarter panel area the product replaces/repairs.
@@ -17966,6 +20537,9 @@ en:
     quilting_thread_weight_system:
       name: Quilting thread weight system
       description: Specifies the thread size/weight rating system used to express thread thickness (e.g., wt, Tex, Denier), so the numeric size can be interpreted correctly.
+    quilting_width_capacity:
+      name: Quilting width capacity
+      description: Quilting width capacity
     quince_variety:
       name: Quince variety
       description: Identifies the specific cultivar or variety of quince, as flavor, aroma, and culinary suitability can differ by variety.
@@ -18047,6 +20621,9 @@ en:
     rack_system_configuration:
       name: Rack system configuration
       description: Describes the overall rack layout/shape of the drum rack system.
+    rack_tom_diameters:
+      name: Rack tom diameters
+      description: Rack tom diameters
     rack_type:
       name: Rack type
       description: Identifies the style of a vehicle's storage rack, like trunk or roof
@@ -18056,6 +20633,9 @@ en:
     racket_balance:
       name: Racket balance
       description: Indicates the weight distribution of a racket, e.g. head-heavy, even balance
+    racket_balance_point:
+      name: Racket balance point
+      description: Racket balance point
     racket_dampener_type:
       name: Racket dampener type
       description: Specifies the installation mechanism or functional style of the racket vibration dampener.
@@ -18068,6 +20648,12 @@ en:
     racket_head_shape:
       name: Racket head shape
       description: Defines the shape of the racket head, e.g. oval, isometric
+    racket_head_size:
+      name: Racket head size
+      description: Indicates the striking surface area of sports equipment, determining power potential and forgiveness on off-center hits.
+    racket_length:
+      name: Racket length
+      description: Specifies the total measurement from handle to head, determining reach and leverage for various playing styles.
     racket_material:
       name: Racket material
       description: Specifies the type of material from which a sport racket is made, such as wood or carbon fiber
@@ -18077,6 +20663,9 @@ en:
     racket_string_design:
       name: Racket string design
       description: Identifies the string construction in tennis rackets, such as mono-filament and multi-filament
+    racket_string_gauge:
+      name: Racket string gauge
+      description: Indicates the thickness of tensioned cords in sports equipment, determining durability, power, and control characteristics.
     racket_string_material:
       name: Racket string material
       description: Specifies the composition of tennis racket strings, such as Kevlar or Polyurethane (PU)
@@ -18092,6 +20681,9 @@ en:
     racquet_toy_set_equipment_included:
       name: Racquet toy set equipment included
       description: Lists what items are included in the toy or set (e.g., net, balls, paddles/rackets).
+    racquetball_grip_size:
+      name: Racquetball grip size
+      description: Racquetball grip size
     racquetball_squash_training_aid_type:
       name: Racquetball & squash training aid type
       description: Classifies the specific kind of training aid or accessory so shoppers can quickly locate the item they need.
@@ -18104,6 +20696,9 @@ en:
     radiator_cap_gasket_material:
       name: Radiator cap gasket material
       description: Material of the sealing gasket(s) used on the radiator cap.
+    radiator_cap_neck_depth:
+      name: Radiator cap neck depth
+      description: Radiator cap neck depth
     radiator_cap_pressure_relief_style:
       name: Radiator cap pressure-relief style
       description: Specifies the radiator cap’s pressure-relief/venting/actuation style, which can affect handling, safety, and intended application.
@@ -18131,6 +20726,9 @@ en:
     radiator_hose_shape:
       name: Radiator hose shape
       description: Overall hose geometry/form factor used for installation routing and fitment.
+    radiator_overflow_tank_hose_port_diameter:
+      name: Radiator overflow tank hose port diameter
+      description: Radiator overflow tank hose port diameter
     radiator_overflow_tank_level_sensor_provision:
       name: Radiator overflow tank level sensor provision
       description: Indicates whether the tank includes or supports a coolant level sensor.
@@ -18155,6 +20753,9 @@ en:
     radish_variety:
       name: Radish variety
       description: Specifies the cultivar or type of radish so shoppers can choose specific flavor, color or size characteristics (e.g., Daikon, Watermelon, French Breakfast).
+    radius_of_gyration:
+      name: Radius of gyration
+      description: Radius of gyration
     radius_of_hollow:
       name: Radius of hollow
       description: Specifies the blade hollow profile produced by the sharpener, expressed as common discrete sizes or flat.
@@ -18203,12 +20804,18 @@ en:
     raising_method:
       name: Raising method
       description: Describes how the animals were raised and finished prior to processing (e.g., grass-fed, pasture-raised, grain-finished).
+    rake_head_width:
+      name: Rake head width
+      description: Rake head width
     rally_competition_class:
       name: Rally competition class
       description: Sanctioning-body or ruleset class the rally car is built to (where known).
     rally_surface_setup:
       name: Rally surface setup
       description: Primary surface/terrain the rally car setup or build targets.
+    ram_memory:
+      name: RAM memory
+      description: Specifies the amount of temporary data storage in electronic devices, determining multitasking capability and application performance.
     ramp_surface_texture:
       name: Ramp surface texture
       description: Describes the finish or grip level of the ramp’s riding surface.
@@ -18230,6 +20837,9 @@ en:
     ratchet_mounting_style:
       name: Ratchet mounting style
       description: How the musical ratchet is held or mounted during play or setup.
+    rated_capacity_weight:
+      name: Rated capacity (weight)
+      description: Indicates the maximum mass of laundry that can be properly processed, determining batch size capability for heavy fabrics.
     rattle_element_material:
       name: Rattle element material
       description: Material of the rattling elements (e.g., teeth/jingles/beads) that create the characteristic buzz/rattle.
@@ -18269,9 +20879,15 @@ en:
     rc_vehicle_terrain_type:
       name: RC vehicle terrain type
       description: Indicates the primary terrain the remote control car/truck is designed for.
+    reach:
+      name: Reach
+      description: Reach
     reach_adjustment_type:
       name: Reach adjustment type
       description: Indicates whether the distance between the lever blade and handlebar can be adjusted and, if adjustable, whether the adjustment is tool-free or requires a tool.
+    reaction_time:
+      name: Reaction time
+      description: Specifies how quickly protective equipment responds to hazardous conditions, determining safety level for users.
     read/write_speed:
       name: Read/Write speed
       description: Indicates data transfer rate or speed, typically for disk duplicators; e.g. 4x, 52x
@@ -18296,6 +20912,9 @@ en:
     rear_seat_configuration:
       name: Rear seat configuration
       description: Specifies the configuration of the rear seat assembly to support fitment and interior layout selection.
+    rear_suspension_travel:
+      name: Rear suspension travel
+      description: Rear suspension travel
     rear_view_mirror_ornament_attachment_type:
       name: Rear view mirror ornament attachment type
       description: Specifies how the ornament attaches to the rear-view mirror stem or housing (e.g., string loop, clip, hook).
@@ -18311,6 +20930,9 @@ en:
     rebound_surface_configuration:
       name: Rebound surface configuration
       description: Specifies the layout of rebound surfaces and the predictability of rebounds (single-, dual-, or multi-sided; predictable vs. unpredictable).
+    rebound_surface_dimensions:
+      name: Rebound surface dimensions
+      description: Rebound surface dimensions
     rebounder_design:
       name: Rebounder design
       description: Defines the structural style or rebounding surface configuration of the product.
@@ -18347,6 +20969,9 @@ en:
     recommended_candle_format:
       name: Recommended candle format
       description: Indicates the recommended candle format(s) these self-adhesive wick tabs are intended for.
+    recommended_child_weight_range:
+      name: Recommended child weight range
+      description: Recommended child weight range
     recommended_container_type:
       name: Recommended container type
       description: Container materials that are recommended/safe for gel wax candles.
@@ -18359,6 +20984,9 @@ en:
     recommended_food_pairing:
       name: Recommended food pairing
       description: Identifies the primary proteins or dishes the sauce is intended for (e.g., chicken, pork, beef, fish, vegetables).
+    recommended_hoop_size:
+      name: Recommended hoop size
+      description: Recommended hoop size
     recommended_lane_condition:
       name: Recommended lane condition
       description: Indicates the oil pattern or lane condition for which the ball is designed.
@@ -18374,6 +21002,9 @@ en:
     recommended_sleep_position:
       name: Recommended sleep position
       description: Identifies which sleep positions the mattress is designed to support comfortably (e.g., side or back sleepers).
+    recommended_speed_range:
+      name: Recommended speed range
+      description: Recommended speed range
     recommended_storage:
       name: Recommended storage
       description: Indicates how the product should be stored to maintain freshness.
@@ -18392,6 +21023,9 @@ en:
     recommended_vehicle_surfaces:
       name: Recommended vehicle surfaces
       description: Specifies the vehicle surfaces/finishes the brush is intended to be safe for (e.g., clear coat paint, matte/satin paint, vinyl wrap/PPF, glass, wheels).
+    recommended_water_temperature:
+      name: Recommended water temperature
+      description: Recommended water temperature
     record_cleaning_components_included:
       name: Record cleaning components included
       description: Lists the specific items supplied in the kit so customers can compare bundles at a glance (e.g., brush, fluid, cloth)
@@ -18437,6 +21071,9 @@ en:
     recorder_thumb_hole_type:
       name: Recorder thumb hole type
       description: Specifies whether the recorder has a single thumb hole or a double thumb hole design.
+    recorder_total_weight:
+      name: Recorder total weight
+      description: Recorder total weight
     recorder_type:
       name: Recorder type
       description: Identifies the recording technology used (e.g., DVR, NVR) to help compare analog and IP solutions.
@@ -18467,6 +21104,9 @@ en:
     recreational_vehicle_type:
       name: Recreational vehicle type
       description: Identifies the category of a recreational vehicle, such as Class A or travel trailer
+    recycle_time:
+      name: Recycle time
+      description: Recycle time
     recycled_material_content:
       name: Recycled material content
       description: Indicates the proportion of the garment made from recycled fibers or yarns.
@@ -18488,6 +21128,9 @@ en:
     reel_capacity:
       name: Reel capacity
       description: Specifies the capacity of a reel in a developing tank, such as single or quad
+    reel_knob_diameter:
+      name: Reel knob diameter
+      description: Reel knob diameter
     reel_profile:
       name: Reel profile
       description: Classifies the structural style/profile of the baitcasting reel body.
@@ -18536,6 +21179,9 @@ en:
     regulator_diaphragm_material:
       name: Regulator diaphragm material
       description: Specifies the diaphragm material, which affects fuel/ethanol compatibility (e.g., E85) and durability.
+    regulator_output_pressure:
+      name: Regulator output pressure
+      description: Regulator output pressure
     regulator_port_thread_standard:
       name: Regulator port thread standard
       description: Specifies the port thread/connection standard used on the regulator body for inlet/outlet/return ports.
@@ -18632,6 +21278,9 @@ en:
     repair_method:
       name: Repair method
       description: Specifies the primary repair approach the kit uses, such as peel-and-stick adhesive patches or valve replacement.
+    repair_patch_size:
+      name: Repair patch size
+      description: Repair patch size
     repellent_mechanism:
       name: Repellent mechanism
       description: Specifies the primary deterrent mechanism employed by the product, such as chemical scent, ultrasonic sound, or flashing light.
@@ -18665,12 +21314,21 @@ en:
     reptile/amphibian_habitat_supply_type:
       name: Reptile/Amphibian habitat supply type
       description: Identifies the type of heating or lighting supply for reptile/amphibian habitats, like a heat lamp or UVB lamp
+    required_safety_clearance:
+      name: Required safety clearance
+      description: Required safety clearance
+    required_yardage:
+      name: Required yardage
+      description: Required yardage
     research_focus:
       name: Research focus
       description: Identifies the main area of study in academic papers, like biology or economics
     research_methodology:
       name: Research methodology
       description: Identifies the type of research methods used in academic papers, like survey or qualitative
+    reserve_capacity_rc:
+      name: Reserve capacity (RC)
+      description: Reserve capacity (RC)
     reservoir_orientation:
       name: Reservoir orientation
       description: Specifies the intended orientation or profile of the bladder inside the pack.
@@ -18698,9 +21356,15 @@ en:
     resistance_tolerance:
       name: Resistance tolerance
       description: Defines the permissible deviation of the actual resistance from its nominal value, expressed as a percentage (e.g., ±1%)
+    resistance_value:
+      name: Resistance value
+      description: Indicates the opposition to electrical current flow, determining circuit behavior and power dissipation characteristics.
     response_fields_included:
       name: Response fields included
       description: Specifies which standard response fields/options are present on the response card (e.g., accept/decline, meal choice).
+    response_time:
+      name: Response time
+      description: Specifies how quickly protective devices react to power anomalies, determining effectiveness against damaging electrical events.
     restoration_status:
       name: Restoration status
       description: Indicates whether the van is original, restored, restomod, or project condition.
@@ -18749,6 +21413,9 @@ en:
     ribbon_construction:
       name: Ribbon construction
       description: Describes key construction features of grosgrain ribbon such as being wired or elastic, which changes its use (e.g., bows vs sewing).
+    ribbon_length:
+      name: Ribbon length
+      description: Indicates the total linear measurement of decorative strips, determining project coverage and design possibilities.
     ribbon_packaging_type:
       name: Ribbon packaging type
       description: Indicates how the ribbon is supplied/sold.
@@ -18794,6 +21461,9 @@ en:
     rifle_action_type:
       name: Rifle action type
       description: The operating mechanism of the rifle (how it loads/fires/ejects), important for identification and collector interest.
+    rifle_barrel_length:
+      name: Rifle barrel length
+      description: Rifle barrel length
     rifle_finish:
       name: Rifle finish
       description: Primary external finish/coating of the metalwork.
@@ -18809,6 +21479,15 @@ en:
     rim_clamping_method:
       name: Rim clamping method
       description: How the machine secures the wheel/rim during mounting and demounting.
+    rim_depth:
+      name: Rim depth
+      description: Rim depth
+    rim_diameter:
+      name: Rim diameter
+      description: Rim diameter
+    rim_internal_width:
+      name: Rim internal width
+      description: Rim internal width
     rim_strip_type:
       name: Rim strip type
       description: Classifies the strip/tape by its style, construction, or specific application (e.g., tubeless rim tape vs. protective rubber strip).
@@ -18818,6 +21497,9 @@ en:
     ring_design:
       name: Ring design
       description: Describes the style of a ring, such as band or solitaire
+    ring_lock_wheel_clearance_width:
+      name: Ring lock wheel clearance width
+      description: Ring lock wheel clearance width
     ring_size:
       name: Ring size
       description: Specifies the size of a ring, such as L or 6.5
@@ -18827,6 +21509,9 @@ en:
     ripeness_stage:
       name: Ripeness stage
       description: Indicates the maturity level of the fruit at the time of sale (e.g., unripe, ripe, ready to eat).
+    rise:
+      name: Rise
+      description: Measures the vertical distance from crotch seam to top of waistband, determining fit style and coverage level.
     rise_height_class:
       name: Rise height class
       description: Categorizes how much additional height the thumb grip adds relative to the stock stick (e.g., low-rise, mid-rise, high-rise)
@@ -18845,6 +21530,9 @@ en:
     rivet_form:
       name: Rivet form
       description: Describes the form of hardware rivets, e.g. solid, split
+    rms_rated_power:
+      name: RMS rated power
+      description: Specifies the continuous power handling capability of audio equipment, determining long-term performance with various speakers.
     road_sign_design:
       name: Road sign design
       description: Identifies the type of information displayed on a road sign, e.g. stop, speed limit
@@ -18881,6 +21569,9 @@ en:
     rock_formation:
       name: Rock formation
       description: Specifies the geological classification of rocks, such as igneous or sedimentary
+    rocker_height:
+      name: Rocker height
+      description: Rocker height
     rocker_type:
       name: Rocker type
       description: Specifies the curvature style of snowboards or skis, e.g. flat, rocker
@@ -18905,6 +21596,9 @@ en:
     rod_handle_type:
       name: Rod handle type
       description: Specifies the grip configuration of a fishing rod, aiding comfort and technique selection.
+    rod_journal_diameter:
+      name: Rod journal diameter
+      description: Rod journal diameter
     rod_material:
       name: Rod material
       description: Identifies the material used in rod-based sporting goods, such as graphite or fiberglass
@@ -18914,9 +21608,27 @@ en:
     rod_shape:
       name: Rod shape
       description: Defines the form or configuration of shower rods, e.g. straight, U-shaped
+    rod_size:
+      name: Rod size
+      description: Indicates the length of fishing equipment, determining casting distance and appropriate fishing environments.
     roll_cage_tubing_material:
       name: Roll cage tubing material
       description: Specifies the tubing material/alloy used for the roll cage/roll bar (e.g., DOM steel vs 4130 chromoly).
+    roll_cage_tubing_wall_thickness:
+      name: Roll cage tubing wall thickness
+      description: Roll cage tubing wall thickness
+    roll_diameter:
+      name: Roll diameter
+      description: Specifies the width of cylindrical lawn tools, determining ground pressure and effectiveness for soil compaction.
+    roll_length_per_unit:
+      name: Roll length per unit
+      description: Roll length per unit
+    roll_size:
+      name: Roll size
+      description: Indicates the length of material on a spool, determining coverage area and project capability without replacement.
+    roll_width:
+      name: Roll width
+      description: Specifies the lateral dimension of cylindrical lawn tools, determining area covered in a single pass.
     roller_head:
       name: Roller head
       description: Defines the number of heads on rollers, typically for skincare tools; e.g. single, dual
@@ -18980,6 +21692,12 @@ en:
     rope_construction:
       name: Rope construction
       description: Specifies fiber construction details beyond braid style, such as twisted vs braided core/sheath and whether the rope is kernmantle-style.
+    rope_diameter:
+      name: Rope diameter
+      description: Rope diameter
+    rope_length:
+      name: Rope length
+      description: Indicates the total linear measurement of cordage, determining coverage area and boundary marking capability.
     rope_material:
       name: Rope material
       description: Identifies the material of the tuning rope/cord.
@@ -18998,6 +21716,9 @@ en:
     rose_grade:
       name: Rose grade
       description: Commercial quality grade of cut roses.
+    rose_head_diameter:
+      name: Rose head diameter
+      description: Rose head diameter
     rosette_center_type:
       name: Rosette center type
       description: Specifies the type of center detail or insert on the front of the rosette.
@@ -19028,6 +21749,9 @@ en:
     rotation_motion_features:
       name: Rotation/motion features
       description: Indicates whether planets/orbits rotate or move and how.
+    rotational_speed:
+      name: Rotational speed
+      description: Specifies how quickly storage media spins, determining data access speed and overall system performance.
     rotator_control_technology:
       name: Rotator control technology
       description: Defines the control mechanism of antenna rotators, such as manual or motorized
@@ -19037,12 +21761,18 @@ en:
     rotor_construction_type:
       name: Rotor construction type
       description: Specifies the rotor build style, which influences weight, stiffness, and heat management.
+    rotor_diameter:
+      name: Rotor diameter
+      description: Indicates the width of braking surfaces, determining heat dissipation capability and stopping power.
     rotor_mounting_interface:
       name: Rotor mounting interface
       description: Defines the hub interface standard used to attach the rotor to the wheel.
     rotor_mounting_standard:
       name: Rotor mounting standard
       description: Specifies the interface standard used to attach the rotor to the hub (e.g., 6-bolt or Center Lock).
+    rotor_weight:
+      name: Rotor weight
+      description: Specifies the mass of braking components, determining heat capacity and performance characteristics under heavy use.
     roulette_set_components_included:
       name: Roulette set components included
       description: Key roulette-related components included with the wheel/set.
@@ -19055,6 +21785,9 @@ en:
     rounders_equipment_included:
       name: Rounders equipment included
       description: Lists the specific rounders items or accessories supplied with the training aid set or pack so buyers know exactly what is in the box.
+    rounders_glove_size:
+      name: Rounders glove size
+      description: Rounders glove size
     rounders_governing_body_approval:
       name: Rounders governing body approval
       description: Indicates certification or approval by an official rounders or other sports governing body.
@@ -19076,6 +21809,9 @@ en:
     rowing_machine_part_type:
       name: Rowing machine part type
       description: Identifies the specific component the product is intended to replace on a rowing machine so shoppers can quickly find the exact part they need without creating an explosion of micro-categories.
+    rubber_band_size:
+      name: Rubber band size
+      description: Indicates the dimensions of elastic loops when relaxed, determining stretch capacity and appropriate applications.
     rubber_ducky_character_theme:
       name: Rubber ducky character/theme
       description: Theme or character styling of the rubber ducky (useful for novelty/collectible duckies).
@@ -19124,12 +21860,24 @@ en:
     rum_grade:
       name: Rum grade
       description: Classifies rum based on characteristics or grade, e.g. premium, spiced
+    rung_spacing:
+      name: Rung spacing
+      description: Rung spacing
     runner_configuration:
       name: Runner configuration
       description: Describes the number and arrangement of runners on the sledge.
     runner_material:
       name: Runner material
       description: Specifies the material used for the sled’s runners or glide strips.
+    running_surface_length:
+      name: Running surface length
+      description: Running surface length
+    running_surface_width:
+      name: Running surface width
+      description: Running surface width
+    running_time:
+      name: Running time
+      description: Specifies the total duration of video content, determining viewing time and content length.
     saddle_base_color:
       name: Saddle base color
       description: Identifies the primary color of a bicycle saddle base, like black or blue
@@ -19166,6 +21914,9 @@ en:
     saddle_rail_material:
       name: Saddle rail material
       description: Specifies the material used for the rails beneath a bicycle saddle, which affects strength, comfort, weight, and price.
+    saddle_rail_size:
+      name: Saddle rail size
+      description: Saddle rail size
     saddle_seat_color:
       name: Saddle seat color
       description: Specifies the color of a bicycle saddle seat, like silver or red
@@ -19175,6 +21926,9 @@ en:
     saddle_seat_pattern:
       name: Saddle seat pattern
       description: Describes the design or print on a bicycle saddle seat, such as floral or geometric
+    saddle_seat_size:
+      name: Saddle seat size
+      description: Saddle seat size
     saddle_tree_material:
       name: Saddle tree material
       description: Specifies the material used for the saddle tree, the internal frame of the saddle.
@@ -19235,6 +21989,9 @@ en:
     salt_level:
       name: Salt level
       description: Indicates the amount of salt or sodium added to the nuts or seeds.
+    sampling_rate:
+      name: Sampling rate
+      description: Indicates how frequently sound is digitally captured, determining audio quality and frequency reproduction capability.
     sand_color:
       name: Sand color
       description: Indicates the color of the sand or granular fill inside the hourglass, independent of the external frame color.
@@ -19259,6 +22016,9 @@ en:
     sandbag_style:
       name: Sandbag style
       description: Identifies the specific design and intended training use of the sandbag (e.g., Bulgarian, Strongman, Power), helping shoppers choose between different workout modalities.
+    sandbag_weight:
+      name: Sandbag weight
+      description: Specifies the mass of weighted training implements, determining exercise intensity and muscle development potential.
     sandblaster_application:
       name: Sandblaster application
       description: Defines the intended function of sandblasting tools, like polishing or sanding
@@ -19283,6 +22043,9 @@ en:
     sapote_variety:
       name: Sapote variety
       description: Specifies the particular species/type of sapote offered (e.g., black, white, mamey), allowing shoppers to distinguish between different kinds.
+    saree_length:
+      name: Saree length
+      description: Saree length
     satellite_coverage_area:
       name: Satellite coverage area
       description: Defines the geographical regions a satellite phone can access, such as Australia or Africa
@@ -19298,6 +22061,9 @@ en:
     satin_ribbon_face_type:
       name: Satin ribbon face type
       description: Specifies whether the ribbon has a satin finish on one side or both sides.
+    saturation_current:
+      name: Saturation current
+      description: Indicates the maximum electrical flow before magnetic components lose effectiveness, determining power handling limits.
     sauce_consistency:
       name: Sauce consistency
       description: Describes the texture or thickness of the pizza sauce.
@@ -19319,6 +22085,9 @@ en:
     sauna_heater_type:
       name: Sauna heater type
       description: Indicates the type of heater included or supported by the sauna kit.
+    saw_size:
+      name: Saw size
+      description: Specifies the diameter of circular cutting tools, determining hole size capability in various materials.
     saxophone_body_finish:
       name: Saxophone body finish
       description: Describes the primary finish/plating on the saxophone body (separate from keywork).
@@ -19340,6 +22109,9 @@ en:
     saxophone_mouthpiece_baffle_type:
       name: Saxophone mouthpiece baffle type
       description: Describes the baffle design that shapes airflow and brightness.
+    saxophone_neck_bore_diameter:
+      name: Saxophone neck bore diameter
+      description: Saxophone neck bore diameter
     saxophone_neck_type:
       name: Saxophone neck type
       description: Specifies the neck configuration supplied with the bass saxophone.
@@ -19361,12 +22133,18 @@ en:
     saxophone_swab_application_area:
       name: Saxophone swab application area
       description: Indicates what part of the saxophone the swab is intended to clean/dry.
+    saxophone_swab_length:
+      name: Saxophone swab length
+      description: Saxophone swab length
     scabbard_material:
       name: Scabbard material
       description: Specifies the primary material of the included scabbard/sheath (if present).
     scaffolding_mounting_type:
       name: Scaffolding mounting type
       description: Specifies the setup style of scaffolding, e.g. frame, mobile
+    scale_length:
+      name: Scale length
+      description: Scale length
     scale_material:
       name: Scale material
       description: Identifies the material used in a scale, typically tree calipers; e.g. stainless steel, plastic
@@ -19445,6 +22223,9 @@ en:
     scarf/shawl_style:
       name: Scarf/Shawl style
       description: Identifies the style of scarves and shawls, e.g. blanket, wrap
+    scarf_length_end_to_end:
+      name: Scarf length (end-to-end)
+      description: Scarf length (end-to-end)
     scene_modes:
       name: Scene modes
       description: Defines the camera's mode for capturing different scenarios, such as night or underwater
@@ -19502,6 +22283,9 @@ en:
     scoreboard_features:
       name: Scoreboard features
       description: Describes special characteristics of a scoreboard, such as portable or weather resistant
+    scoring_groove_spacing:
+      name: Scoring groove spacing
+      description: Scoring groove spacing
     scoring_method:
       name: Scoring method
       description: Specifies how scores are tracked on the foosball table, such as manual bead counters or electronic scoreboards.
@@ -19556,15 +22340,27 @@ en:
     screen_protector_finish:
       name: Screen protector finish
       description: Identifies the optical surface finish of the protector (e.g., glossy, matte, privacy, anti-glare)
+    screen_size:
+      name: Screen size
+      description: Indicates the diagonal measurement of display surfaces, determining visibility and impact for presentation applications.
     screen_specialized_features:
       name: Screen specialized features
       description: Identifies unique capabilities of a computer screen, like anti-glare or touchscreen
     screen_surface_finish:
       name: Screen surface finish
       description: Describes the surface treatment of the screen glass, influencing glare and feel
+    screen_width:
+      name: Screen width
+      description: Specifies the horizontal dimension of enclosures, determining space requirements and user accommodation.
+    screw_diameter:
+      name: Screw diameter
+      description: Indicates the thickness of threaded fasteners, determining strength and appropriate applications for various materials.
     screw_drive_type:
       name: Screw drive type
       description: Specifies the drive recess style on the screw or bolt head, indicating the tool required to tighten or remove it (e.g., hex/Allen, Torx).
+    screw_length:
+      name: Screw length
+      description: Specifies the measurement from head to tip of threaded fasteners, determining penetration depth and material compatibility.
     screw_thread_size:
       name: Screw thread size
       description: Specifies the thread size standard of the included or compatible screws (e.g., M4, M5, M6).
@@ -19574,6 +22370,9 @@ en:
     scrubbing_strength:
       name: Scrubbing strength
       description: Indicates the relative scrubbing/abrasiveness level provided by the product.
+    sculpting_clay_bake_cure_temperature:
+      name: Sculpting clay bake/cure temperature
+      description: Sculpting clay bake/cure temperature
     sculpting_clay_base_type:
       name: Sculpting clay base type
       description: Describes the underlying formulation/base of the sculpting clay.
@@ -19604,6 +22403,9 @@ en:
     sealant_formulation:
       name: Sealant formulation
       description: Indicates the primary chemical formulation or additive technology of the bicycle tire sealant (e.g., latex-based, fiber-reinforced, acrylic).
+    sealant_volume:
+      name: Sealant volume
+      description: Sealant volume
     sealing_modes:
       name: Sealing modes
       description: Lists the operational sealing programs available on the appliance.
@@ -19670,6 +22472,12 @@ en:
     seat_belt_strap_installation_location:
       name: Seat belt strap installation location
       description: Indicates where the strap is installed within the belt system.
+    seat_belt_strap_thickness:
+      name: Seat belt strap thickness
+      description: Seat belt strap thickness
+    seat_belt_strap_width:
+      name: Seat belt strap width
+      description: Seat belt strap width
     seat_color:
       name: Seat color
       description: Specifies the color of a product's seating area, like black or green
@@ -19685,9 +22493,15 @@ en:
     seat_cushioning:
       name: Seat cushioning
       description: Describes the type of cushioning in seating products, such as padded or non-padded
+    seat_depth:
+      name: Seat depth
+      description: Indicates the front-to-back dimension of sitting surfaces, determining comfort and proper support for users.
     seat_fabric:
       name: Seat fabric
       description: Primary fabric used for the seat and backrest sling of the chair.
+    seat_height:
+      name: Seat height
+      description: Specifies the vertical distance from floor to sitting surface, determining accessibility and ergonomic positioning.
     seat_height_category:
       name: Seat height category
       description: Classifies the stool by typical seat height range (e.g., counter or bar height) to simplify selection.
@@ -19727,12 +22541,18 @@ en:
     seat_upholstery_pattern:
       name: Seat upholstery pattern
       description: Identifies the design or motif on a sofa's fabric, such as paisley or swirl
+    seat_width:
+      name: Seat width
+      description: Seat width
     seating_surface_material:
       name: Seating surface material
       description: Specifies the material of the area a person reclines on (e.g., Textilene mesh, sling fabric, wicker, cushioned upholstery).
     seatpost_clamp_mechanism:
       name: Seatpost clamp mechanism
       description: Type of clamping/closing system that secures the seatpost.
+    seatpost_diameter:
+      name: Seatpost diameter
+      description: Seatpost diameter
     section_orientation_compatibility:
       name: Section orientation compatibility
       description: Indicates whether the accessory fits a left-arm facing, right-arm facing, or universal orientation section.
@@ -19754,6 +22574,9 @@ en:
     security_sensor_subtype:
       name: Security sensor subtype
       description: Defines the specific function/type of the security sensor.
+    see_saw_weight_capacity_per_seat:
+      name: See saw weight capacity per seat
+      description: See saw weight capacity per seat
     seed_content:
       name: Seed content
       description: Indicates whether the citrus fruit is seedless, has few seeds, or is fully seeded.
@@ -19826,6 +22649,9 @@ en:
     sensory_toy_light_features:
       name: Sensory toy light features
       description: Lighting behaviors/effects provided by the toy.
+    sensory_toy_size:
+      name: Sensory toy size
+      description: Sensory toy size
     sensory_toy_texture_type:
       name: Sensory toy texture type
       description: Dominant surface feel/texture elements used for tactile stimulation.
@@ -19841,6 +22667,9 @@ en:
     sequin_shape:
       name: Sequin shape
       description: Defines the shape of sequin, like round or flower
+    sequin_size:
+      name: Sequin size
+      description: Sequin size
     serger_stitch_functions:
       name: Serger stitch functions
       description: The stitch functions the serger supports (overlock/overedge variations and specialty serger stitches).
@@ -19880,6 +22709,9 @@ en:
     set_items_included:
       name: Set items included
       description: Specifies the garments or accessories included in the set, such as saree fabric, dupatta, or belt.
+    set_time:
+      name: Set time
+      description: Specifies the duration required for materials to harden or cure, determining workflow planning and project timing.
     setup_mechanism:
       name: Setup mechanism
       description: Describes the primary deployment method of the tent (e.g., pop-up, inflatable/airbeam, rooftop clamshell).
@@ -19946,18 +22778,27 @@ en:
     sfx_control_technology:
       name: SFX control technology
       description: Identifies how special effects devices are operated, such as DMX or sound-activated
+    shackle_diameter:
+      name: Shackle diameter
+      description: Shackle diameter
     shaft_color:
       name: Shaft color
       description: Specifies the hue of the shaft on items like plungers, e.g. silver or red
     shaft_curvature:
       name: Shaft curvature
       description: Describes the overall shape of the shaft, which influences clearance, swing, and ergonomics.
+    shaft_diameter:
+      name: Shaft diameter
+      description: Indicates the thickness of weight-bearing bars, determining strength and compatibility with accessories.
     shaft_flex:
       name: Shaft flex
       description: Indicates the flexibility level of golf club shafts, e.g. stiff, ladies
     shaft_kick_point:
       name: Shaft kick point
       description: Identifies the position along the shaft where it bends most during a swing, influencing ball flight trajectory.
+    shaft_length:
+      name: Shaft length
+      description: Specifies the linear measurement of tool handles, determining reach and leverage for various applications.
     shaft_length_type:
       name: Shaft length type
       description: Industry-standard categorical size designation for dart shafts (e.g., Short, Medium) used when exact millimeter measurements are not provided.
@@ -19973,6 +22814,12 @@ en:
     shaft_shape:
       name: Shaft shape
       description: Defines the cross-sectional profile of the tonfa shaft (e.g., round, square, octagonal).
+    shaft_size:
+      name: Shaft size
+      description: Indicates the dimensions of replaceable billiard components, determining compatibility with cue bodies and playing characteristics.
+    shaft_tip_diameter:
+      name: Shaft tip diameter
+      description: Shaft tip diameter
     shaker_fill_material:
       name: Shaker fill material
       description: Specifies the primary internal fill used to create the shaker sound (when applicable), such as beads, seeds, or shot.
@@ -19994,6 +22841,12 @@ en:
     shampoo_type:
       name: Shampoo type
       description: Classifies shampoos based on their formulation, such as powder or 2-in-1
+    shank_length:
+      name: Shank length
+      description: Shank length
+    shank_size:
+      name: Shank size
+      description: Specifies the diameter of the portion that fits into tool holders, determining compatibility with various machines.
     shank_style:
       name: Shank style
       description: Describes the overall shape/configuration of the curb bit’s shanks (e.g., straight, curved, grazing).
@@ -20039,9 +22892,15 @@ en:
     sheet_pattern:
       name: Sheet pattern
       description: 'Describes the design or print on a paper products, such as plaid or rainbow '
+    sheet_thickness:
+      name: Sheet thickness
+      description: Sheet thickness
     shelf_color:
       name: Shelf color
       description: Describes the color of a product's shelf, such as beige or black
+    shelf_life:
+      name: Shelf life
+      description: Indicates the duration products remain usable in storage, determining stockpiling capability and rotation requirements.
     shelf_location_in_appliance:
       name: Shelf location in appliance
       description: Indicates where inside the appliance the shelf is intended to be installed.
@@ -20063,15 +22922,24 @@ en:
     shell_construction:
       name: Shell construction
       description: Specifies how the bass drum shell is constructed, which strongly affects tone and weight.
+    shell_diameter:
+      name: Shell diameter
+      description: Specifies the width of bicycle components, determining compatibility with frame designs and cranksets.
     shell_finish:
       name: Shell finish
       description: Exterior finish treatment of the doumbek shell.
     shell_hull_status:
       name: Shell/hull status
       description: Specifies whether the nuts or seeds are sold with shells or hulls intact or removed.
+    shell_width:
+      name: Shell width
+      description: Indicates the lateral measurement of bicycle components, determining compatibility with frame designs and cranksets.
     shift_boot_attachment_method:
       name: Shift boot attachment method
       description: Specifies how the shift boot attaches to the vehicle console/shifter trim (e.g., clip-in trim bezel, retainer ring, adhesive).
+    shift_boot_inner_opening_diameter:
+      name: Shift boot inner opening diameter
+      description: Shift boot inner opening diameter
     shift_boot_installation_hardware_included:
       name: Shift boot installation hardware included
       description: Lists the installation hardware and components included with the shift boot.
@@ -20105,6 +22973,9 @@ en:
     shin_guard_attachment_method:
       name: Shin guard attachment method
       description: Classifies the overall design format of the shin guard, including ankle-guard integration or sock construction.
+    shin_guard_length:
+      name: Shin guard length
+      description: Shin guard length
     shingle/tile_material:
       name: Shingle/Tile material
       description: Identifies the composition of roofing shingles or tiles, such as cement or rubber
@@ -20123,6 +22994,9 @@ en:
     shock_absorber_charge_type:
       name: Shock absorber charge type
       description: Specifies the shock absorber charging/damping technology (e.g., hydraulic/oil, gas-charged, air) and/or related tube design where applicable.
+    shock_absorber_compressed_length:
+      name: Shock absorber compressed length
+      description: Shock absorber compressed length
     shock_absorber_mount_type_lower:
       name: Shock absorber mount type (lower)
       description: Bottom mounting interface style of the shock absorber for fitment matching.
@@ -20156,6 +23030,12 @@ en:
     shoe_fit:
       name: Shoe fit
       description: Defines the width of footwear, such as narrow or wide
+    shoe_height:
+      name: Shoe height
+      description: Indicates the vertical measurement from sole to top edge, determining coverage and style classification.
+    shoe_length:
+      name: Shoe length
+      description: Specifies the measurement from heel to toe, determining proper fit and comfort for various foot sizes.
     shoe_organizer_design:
       name: Shoe organizer design
       description: Identifies the overall style or format of the shoe organizer to help shoppers filter items.
@@ -20174,6 +23054,12 @@ en:
     shoe_tree_design:
       name: Shoe tree design
       description: Identifies the structural style or mechanism of the shoe tree, impacting adjustability, intended footwear type, and usability.
+    shoe_weight:
+      name: Shoe weight
+      description: Shoe weight
+    shoe_width:
+      name: Shoe width
+      description: Indicates the measurement across the widest part of footwear, determining proper fit for various foot shapes.
     shoelace_aglet_material:
       name: Shoelace aglet material
       description: Identifies the material used for the tips (aglets) at the ends of the shoelaces, which influences durability and style.
@@ -20222,6 +23108,9 @@ en:
     shotgun_stock_material:
       name: Shotgun stock material
       description: Specifies the primary material of the stock/forend (furniture).
+    shoulder_width:
+      name: Shoulder width
+      description: Specifies the measurement from shoulder seam to shoulder seam, determining proper fit across the upper body.
     shovel_handle_grip_type:
       name: Shovel handle grip type
       description: Specifies the grip style at the end of the handle.
@@ -20285,18 +23174,30 @@ en:
     side_wall_mechanism:
       name: Side wall mechanism
       description: Describes how the bassinet’s bedside wall opens or lowers to access the baby.
+    sidecut_radius:
+      name: Sidecut radius
+      description: Sidecut radius
     siding_material:
       name: Siding material
       description: Identifies the type of material used in siding products, such as wood or vinyl
+    sieve_opening_size:
+      name: Sieve opening size
+      description: Sieve opening size
     signal_path_technology:
       name: Signal path technology
       description: Identifies the core circuit topology (e.g., tube, solid-state, hybrid) that shapes the channel strip's sound character
+    signal_range:
+      name: Signal range
+      description: Indicates the maximum distance for reliable communication between devices, determining effective monitoring area.
     signal_source:
       name: Signal source
       description: Indicates how the odometer receives/derives distance or time information.
     signal_technology:
       name: Signal technology
       description: Identifies the primary wireless or data technology the product is designed to amplify or extend
+    signal_to_noise_ratio_snr:
+      name: Signal-to-noise ratio (SNR)
+      description: Specifies the relationship between desired audio and unwanted background noise, determining sound clarity and quality.
     signal_types_blocked:
       name: Signal types blocked
       description: Lists the specific wireless or electromagnetic signals the product is engineered to block or shield
@@ -20312,6 +23213,9 @@ en:
     silk_fiber_type:
       name: Silk fiber type
       description: Type/source of silk fiber used to make the fabric (e.g., mulberry or tussah), impacting texture, uniformity, and price.
+    silk_weight_momme:
+      name: Silk weight (momme)
+      description: Silk weight (momme)
     sim_card_capability:
       name: SIM card capability
       description: Indicates the type of SIM card configuration in mobile devices, e.g. dual, embedded
@@ -20381,6 +23285,9 @@ en:
     skate_blade_discipline:
       name: Skate blade discipline
       description: Identifies the skating discipline or application the blade is designed for, such as hockey or figure skating, allowing shoppers to filter to relevant blades.
+    skate_blade_hollow_radius:
+      name: Skate blade hollow radius
+      description: Skate blade hollow radius
     skate_brake_type:
       name: Skate brake type
       description: Identifies the style of stopping mechanism included with the skates.
@@ -20399,6 +23306,9 @@ en:
     skein_winder_drive_type:
       name: Skein winder drive type
       description: How the skein winder is powered/turned during use.
+    skein_winder_maximum_skein_circumference:
+      name: Skein winder maximum skein circumference
+      description: Skein winder maximum skein circumference
     skewer_tip_type:
       name: Skewer tip type
       description: Defines the type of tip on a skewer, affecting ease of piercing food and overall presentation.
@@ -20414,6 +23324,12 @@ en:
     ski_construction:
       name: Ski construction
       description: Identifies the type of ski construction, such as hybrid cap or partial cap
+    ski_size:
+      name: Ski size
+      description: Indicates the length of winter sports equipment, determining performance characteristics and rider compatibility.
+    ski_waist_width:
+      name: Ski waist width
+      description: Ski waist width
     skiing_style:
       name: Skiing style
       description: Classifies products based on skiing technique and style, such as downhill or Nordic
@@ -20426,6 +23342,9 @@ en:
     skimboard_construction:
       name: Skimboard construction
       description: Describes the primary build of the board, focusing on core and lay-up technique (e.g., foam core, wood core).
+    skimboard_size:
+      name: Skimboard size
+      description: Specifies the dimensions of water sports equipment, determining buoyancy, maneuverability, and rider weight compatibility.
     skin_care_effect:
       name: Skin care effect
       description: Defines the intended benefits of skin care products, e.g. anti-aging, plumping
@@ -20450,6 +23369,9 @@ en:
     skirt/dress_length_type:
       name: Skirt/Dress length type
       description: Defines the length of skirts or dresses, such as mini or maxi
+    skirt_length:
+      name: Skirt length
+      description: Measures the vertical distance from waist to hem, determining style classification and appropriate usage occasions.
     skirt_style:
       name: Skirt style
       description: Describes the design or cut of a skirt, such as pencil or pleated
@@ -20468,6 +23390,9 @@ en:
     slat_pattern:
       name: Slat pattern
       description: Identifies the visual pattern of slats on items like mattress foundations, e.g. striped, floral
+    slate_thickness:
+      name: Slate thickness
+      description: Slate thickness
     sled_brake_type:
       name: Sled brake type
       description: Specifies the braking mechanism included on the sled, if any.
@@ -20492,9 +23417,15 @@ en:
     sleeve_bearing_type:
       name: Sleeve bearing type
       description: Identifies the technology that allows sleeve rotation, affecting spin quality for Olympic lifts.
+    sleeve_diameter:
+      name: Sleeve diameter
+      description: Indicates the internal width of barbell components, determining compatibility with standard weight plates.
     sleeve_insulation:
       name: Sleeve insulation
       description: Indicates whether the sleeve provides thermal insulation to keep beverages cold or hot.
+    sleeve_length:
+      name: Sleeve length
+      description: Measures the distance from shoulder seam to cuff, determining arm coverage and overall garment proportions.
     sleeve_length_type:
       name: Sleeve length type
       description: Specifies the style of sleeves on clothing items, such as short or sleeveless
@@ -20510,12 +23441,18 @@ en:
     slide_board_accessories_included:
       name: Slide board accessories included
       description: Lists supplementary items packaged with the slide board so shoppers know exactly what’s included and can compare bundles.
+    slide_chute_length:
+      name: Slide chute length
+      description: Slide chute length
     slide_installation_type:
       name: Slide installation type
       description: How the slide is intended to be installed or mounted (standalone, attached to a playset, etc.).
     slide_intended_finger:
       name: Slide intended finger
       description: Indicates which finger the slide is intended to be worn on, or whether it is not applicable (e.g., a tone bar).
+    slide_platform_height_compatibility:
+      name: Slide platform height compatibility
+      description: Slide platform height compatibility
     slide_safety_features:
       name: Slide safety features
       description: Safety-related design elements included on the slide.
@@ -20525,12 +23462,18 @@ en:
     slide_water_use_capability:
       name: Slide water use capability
       description: Whether the slide is designed to be used with water (e.g., hose connection) and how.
+    slider_thickness:
+      name: Slider thickness
+      description: Slider thickness
     slime_putty_kit_components_included:
       name: Slime & putty kit components included
       description: Lists the tools and add-ins included with the slime/putty product (especially for kits/bundles).
     sling_material:
       name: Sling material
       description: Specifies the fiber/textile used in the quickdraw’s sling (dog-bone).
+    sling_width:
+      name: Sling width
+      description: Sling width
     slip_texture:
       name: Slip texture
       description: Describes the feel of pottery slips, such as medium or smooth
@@ -20540,9 +23483,15 @@ en:
     slipper_style:
       name: Slipper style
       description: Identifies the style of slippers, such as ballerina or flip-flop
+    slot_length:
+      name: Slot length
+      description: Slot length
     slot_machine_type:
       name: Slot machine type
       description: Identifies the style of the slot machine, such as novelty or traditional
+    slot_width:
+      name: Slot width
+      description: Slot width
     small_animal_dietary_requirements:
       name: Small animal dietary requirements
       description: Indicates special diet for small animals, like hairball control or kidney care
@@ -20570,6 +23519,9 @@ en:
     smoke_color:
       name: Smoke color
       description: Color of smoke produced by the flare/smoke signal (distinct from the product body color).
+    smoke_point:
+      name: Smoke point
+      description: Smoke point
     smoked_malt_smoking_material:
       name: Smoked malt smoking material
       description: For smoked malts, identifies the material used during smoking (e.g., specific wood species or peat).
@@ -20594,6 +23546,12 @@ en:
     snare_drum_bearing_edge_profile:
       name: Snare drum bearing edge profile
       description: Bearing edge cut/profile of the snare shell.
+    snare_drum_depth:
+      name: Snare drum depth
+      description: Snare drum depth
+    snare_drum_diameter:
+      name: Snare drum diameter
+      description: Snare drum diameter
     snare_drum_finish_type:
       name: Snare drum finish type
       description: High-level finish construction/type used on the snare shell.
@@ -20651,12 +23609,21 @@ en:
     snowboard_design:
       name: Snowboard design
       description: Defines the shape and style of a snowboard, such as twin tip or directional twin
+    snowboard_size:
+      name: Snowboard size
+      description: Specifies the length of winter sports equipment, determining performance characteristics and rider weight compatibility.
     snowboard_width_class:
       name: Snowboard width class
       description: Categorizes overall board width relative to boot size (e.g., Regular, Wide).
     snowboarding_style:
       name: Snowboarding style
       description: Defines the type of snowboarding the product is designed for, such as backcountry or freeriding
+    snowmobile_track_length:
+      name: Snowmobile track length
+      description: Snowmobile track length
+    snowmobile_track_lug_height:
+      name: Snowmobile track lug height
+      description: Snowmobile track lug height
     snowmobile_type:
       name: Snowmobile type
       description: Specifies the intended use or design of a snowmobile, like utility or touring
@@ -20696,6 +23663,9 @@ en:
     sock_toe_style:
       name: Sock toe style
       description: Describes the construction style of the sock’s toe area.
+    socket_diameter:
+      name: Socket diameter
+      description: Indicates the size of fastener heads that can be engaged, determining compatibility with specific bolts and nuts.
     socket_driver_tip:
       name: Socket driver tip
       description: Identifies the type of tip on a socket driver, such as square or hex
@@ -20729,6 +23699,9 @@ en:
     softball_certification:
       name: Softball certification
       description: Lists the governing-body stamps or approvals printed on the ball that determine league/game eligibility.
+    softball_circumference:
+      name: Softball circumference
+      description: Softball circumference
     softball_discipline:
       name: Softball discipline
       description: 'Defines the specific type of softball, such as fastpitch or slowpitch '
@@ -20819,6 +23792,9 @@ en:
     soprano_saxophone_mouthpiece_included_accessories:
       name: Soprano saxophone mouthpiece included accessories
       description: Identifies which accessories are included with the mouthpiece.
+    soprano_saxophone_mouthpiece_table_length:
+      name: Soprano saxophone mouthpiece table length
+      description: Soprano saxophone mouthpiece table length
     soprano_saxophone_mouthpiece_tonal_character:
       name: Soprano saxophone mouthpiece tonal character
       description: High-level tonal profile commonly associated with the mouthpiece design.
@@ -20828,6 +23804,9 @@ en:
     sound_controls:
       name: Sound controls
       description: Identifies the sound control features on musical instruments or amplifiers, e.g. reverb, equalizer
+    sound_detection_resolution:
+      name: Sound detection resolution
+      description: Specifies the smallest change in noise level that can be measured, determining precision for acoustic analysis.
     sound_effects:
       name: Sound effects
       description: Identifies the types of sound effects, typically for musical instruments and accessories; e.g. compression, delay
@@ -20864,6 +23843,9 @@ en:
     sour_cream_variety:
       name: Sour cream variety
       description: Classifies sour cream products by their specific variety or cultural style, such as crème fraîche or Mexican crema.
+    sousaphone_weight:
+      name: Sousaphone weight
+      description: Sousaphone weight
     soy_sauce_variety:
       name: Soy sauce variety
       description: Identifies the specific style or formulation of soy sauce (e.g., light, dark, tamari, ponzu), enabling shoppers to quickly filter by flavor profile and culinary use.
@@ -20894,12 +23876,18 @@ en:
     speaker_design:
       name: Speaker design
       description: Defines the physical and functional design of speakers, such as subwoofer or tower
+    speaker_driver_diameter:
+      name: Speaker driver diameter
+      description: Speaker driver diameter
     speaker_enclosure_type:
       name: Speaker enclosure type
       description: Describes the acoustic enclosure principle used by the speaker cabinet
     speaker_features:
       name: Speaker features
       description: Identifies special capabilities of audio speakers, like noise cancellation or voice control
+    speaker_mounting_cutout_diameter:
+      name: Speaker mounting cutout diameter
+      description: Speaker mounting cutout diameter
     speaker_position_in_laptop:
       name: Speaker position in laptop
       description: Indicates where the speaker assembly installs within the laptop
@@ -20912,6 +23900,9 @@ en:
     speakerphone_type:
       name: Speakerphone type
       description: Specifies the functionality of speakerphones in vehicles, like wireless or hands-free
+    spear_size:
+      name: Spear size
+      description: Indicates the dimensions of fishing implements, determining target species capability and penetration effectiveness.
     special_effects_output_interface:
       name: Special effects output interface
       description: Specifies the output connector/interface used to control special effects devices.
@@ -20924,9 +23915,18 @@ en:
     specimen_presentation:
       name: Specimen presentation
       description: Indicates how the collectible specimen is prepared or presented (e.g., raw/unprepared, polished, cut, or mounted).
+    speed:
+      name: Speed
+      description: Specifies how quickly projectiles are propelled, determining hunting effectiveness and target penetration capability.
     speed_bag_accessories_included:
       name: Speed bag accessories included
       description: Lists additional items supplied with the speed bag, such as gloves, air pumps, swivels, chains, or stands.
+    speed_measurement_accuracy:
+      name: Speed measurement accuracy
+      description: Speed measurement accuracy
+    speed_range:
+      name: Speed range
+      description: Speed range
     speed_rating:
       name: Speed rating
       description: Indicates the playing surface speed provided by the billiard table cloth (e.g., slow, medium, or fast).
@@ -20951,6 +23951,12 @@ en:
     spike_design:
       name: Spike design
       description: Identifies the style of spikes, such as tent or landscape fabric
+    spike_diameter:
+      name: Spike diameter
+      description: Indicates the thickness of ground anchoring devices, determining stability and holding power in various soil types.
+    spike_length:
+      name: Spike length
+      description: Specifies the penetration depth of ground anchoring devices, determining stability and holding power in various soil types.
     spike_replaceability:
       name: Spike replaceability
       description: Indicates whether the spikes on the shoe are replaceable, fixed, or if the shoe is spikeless.
@@ -20966,6 +23972,9 @@ en:
     spin_profile:
       name: Spin profile
       description: Specifies the relative spin characteristics that the shaft promotes.
+    spin_time:
+      name: Spin time
+      description: Spin time
     spin_types_supported:
       name: Spin types supported
       description: Lists the kinds of spin the machine can impart to balls so players can practice against different shot styles.
@@ -20996,6 +24005,9 @@ en:
     spindle_whorl_position:
       name: Spindle whorl position
       description: Where the whorl sits on the spindle shaft.
+    spindle_whorl_weight:
+      name: Spindle whorl weight
+      description: Spindle whorl weight
     spinner_blade_shape:
       name: Spinner blade shape
       description: Identifies the primary blade shape used on the spinner, influencing vibration, flash, and running depth.
@@ -21023,15 +24035,24 @@ en:
     spinning_top_launch_mechanism:
       name: Spinning top launch mechanism
       description: How the spinning top is started/propelled for spinning.
+    spinning_wheel_bobbin_weight:
+      name: Spinning wheel bobbin weight
+      description: Spinning wheel bobbin weight
     spinning_wheel_brake_tension_system_type:
       name: Spinning wheel brake/tension system type
       description: Specifies the braking/take-up tension system used to control yarn uptake.
     spinning_wheel_drive_system:
       name: Spinning wheel drive system
       description: Indicates the drive system the bobbin is intended for.
+    spinning_wheel_drive_wheel_diameter:
+      name: Spinning wheel drive wheel diameter
+      description: Spinning wheel drive wheel diameter
     spinning_wheel_hook_system:
       name: Spinning wheel hook system
       description: Specifies how yarn is guided along the flyer arms.
+    spinning_wheel_orifice_height:
+      name: Spinning wheel orifice height
+      description: Spinning wheel orifice height
     spinning_wheel_part_application:
       name: Spinning wheel part application
       description: Specifies which spinning wheel components the oil is intended for.
@@ -21068,6 +24089,9 @@ en:
     spoiler_adjustability:
       name: Spoiler adjustability
       description: Indicates whether the spoiler angle/height is adjustable.
+    spoiler_width:
+      name: Spoiler width
+      description: Spoiler width
     spoke_accessory_function:
       name: Spoke accessory function
       description: Classifies the accessory’s primary function on the wheel, such as decorative, reflective, or illuminated.
@@ -21197,6 +24221,9 @@ en:
     sprout_presentation:
       name: Sprout presentation
       description: Identifies the physical presentation of the product (e.g., fresh sprouts, microgreens, live grow pot, powder).
+    spur_shank_length:
+      name: Spur shank length
+      description: Spur shank length
     squash_and_gourd_variety:
       name: Squash and gourd variety
       description: Identifies the specific cultivar or market variety of the squash or gourd, helping shoppers quickly locate their desired type.
@@ -21221,6 +24248,9 @@ en:
     stack_configuration:
       name: Stack configuration
       description: Specifies the layout of fuel cells in power devices, e.g. serial, parallel
+    stack_height:
+      name: Stack height
+      description: Stack height
     stackability:
       name: Stackability
       description: Indicates whether multiple units can be securely stacked for space-efficient storage.
@@ -21251,9 +24281,15 @@ en:
     staircase_type:
       name: Staircase type
       description: Defines the design of staircases, e.g. curved, outdoor
+    stake_length:
+      name: Stake length
+      description: Stake length
     stake_shape:
       name: Stake shape
       description: Defines the cross-section or design style of a tent stake, which affects holding power in different ground types.
+    stalk_length:
+      name: Stalk length
+      description: Stalk length
     stamp_block_features:
       name: Stamp block features
       description: Highlights functional features of stamp blocks such as measurement grids, handles, or non-slip surfaces.
@@ -21269,12 +24305,18 @@ en:
     stamp_type:
       name: Stamp type
       description: Identifies the kind of office stamp, such as traditional or self-inking
+    stanchion_diameter:
+      name: Stanchion diameter
+      description: Stanchion diameter
     stand/display_type:
       name: Stand/Display type
       description: Describes the style of stand or display for collectibles, like wall-mounted or tabletop
     stand_padding_material:
       name: Stand padding material
       description: Material used on contact points to protect the instrument finish (e.g., foam, rubber, silicone).
+    stand_weight:
+      name: Stand weight
+      description: Stand weight
     staple/pin_shape:
       name: Staple/pin shape
       description: Defines the overall form of the fastener, helping customers choose between U-shaped staples, round-top pins, etc.
@@ -21293,6 +24335,12 @@ en:
     staple_fiber_source_type:
       name: Staple fiber source type
       description: Broad origin category for the fiber content.
+    staple_fiber_weight:
+      name: Staple fiber weight
+      description: Staple fiber weight
+    staple_length:
+      name: Staple length
+      description: Staple length
     staple_wire_gauge:
       name: Staple wire gauge
       description: Identifies the thickness of the wire used in staples, like medium or heavy
@@ -21326,6 +24374,9 @@ en:
     starter_terminal_type:
       name: Starter terminal type
       description: Specifies the terminal/connector style used for electrical connections on the starter or starter solenoid (e.g., stud, spade, plug connector).
+    starting_bar_weight:
+      name: Starting bar weight
+      description: Starting bar weight
     starting_block_anchoring_method:
       name: Starting block anchoring method
       description: Describes how the blocks secure to the track surface (e.g., spikes, suction cups, rubber pads).
@@ -21341,6 +24392,9 @@ en:
     steam_nozzle_type:
       name: Steam nozzle type
       description: Identifies the functional style of the steam cleaner nozzle attachment.
+    steam_pressure:
+      name: Steam pressure
+      description: Specifies the force of vapor in sterilization equipment, determining effectiveness for killing microorganisms.
     steam_table_pan_cover_features:
       name: Steam table pan cover features
       description: Highlights special functional characteristics of steam table pan covers that aid food-service operations.
@@ -21353,9 +24407,15 @@ en:
     steam_table_pan_type:
       name: Steam table pan type
       description: Specifies the construction style of the pan, affecting drainage and heating performance.
+    steeping_temperature:
+      name: Steeping temperature
+      description: Steeping temperature
     steerer_tube_design:
       name: Steerer tube design
       description: Describes the structural design of the steerer tube—straight, tapered, threaded, etc.—which determines headset and frame compatibility.
+    steerer_tube_diameter:
+      name: Steerer tube diameter
+      description: Indicates the thickness of bicycle fork components, determining compatibility with frames and stems.
     steering_cable_end_fitting_type:
       name: Steering cable end fitting type
       description: Identifies the termination/attachment style at the ends of a watercraft steering cable (helm end and engine/tiller end) to ensure compatibility with the steering helm and engine connection points. Use the standard or manufacturer designation where applicable.
@@ -21365,6 +24425,15 @@ en:
     steering_column_ignition_provision:
       name: Steering column ignition provision
       description: Indicates whether the steering column is designed to accept an ignition lock cylinder/switch and/or steering lock.
+    steering_column_mounting_pattern_bolt_spacing:
+      name: Steering column mounting pattern / bolt spacing
+      description: Steering column mounting pattern / bolt spacing
+    steering_column_overall_length:
+      name: Steering column overall length
+      description: Steering column overall length
+    steering_column_shaft_diameter:
+      name: Steering column shaft diameter
+      description: Steering column shaft diameter
     steering_column_shaft_end_interface_type:
       name: Steering column shaft end interface type
       description: Identifies the steering column shaft-end interface style (e.g., splined, double D, keyed).
@@ -21389,6 +24458,9 @@ en:
     steering_wheel_cover_installation_type:
       name: Steering wheel cover installation type
       description: How the steering wheel cover is installed/secured on the wheel.
+    steering_wheel_dish_depth:
+      name: Steering wheel dish depth
+      description: Steering wheel dish depth
     steering_wheel_grip_material:
       name: Steering wheel grip material
       description: Specifies the material on the wheel rim/grip (where hands contact), which can differ from the wheel’s core/spokes.
@@ -21398,12 +24470,18 @@ en:
     steering_wheel_rim_material_grip_surface:
       name: Steering wheel rim material (grip surface)
       description: Specifies the primary grip/rim covering material (distinct from overall construction material).
+    steering_wheel_size:
+      name: Steering wheel size
+      description: Specifies the diameter of vehicle control interfaces, determining leverage, comfort, and driving precision.
     stem_length:
       name: Stem length
       description: Indicates the length of a flower's stem, such as short, medium, or long
     stem_material:
       name: Stem material
       description: Specifies the material used specifically for the pipe stem or mouthpiece (e.g., acrylic, ebonite, lucite).
+    stem_rise:
+      name: Stem rise
+      description: Stem rise
     stemware_design:
       name: Stemware design
       description: Specifies whether the drinkware has a traditional stem or is stemless.
@@ -21413,12 +24491,18 @@ en:
     stencil_machine_consumable_type:
       name: Stencil machine consumable type
       description: Specifies the consumables required to operate (if any).
+    step_height:
+      name: Step height
+      description: Step height
     step_surface_texture:
       name: Step surface texture
       description: Specifies the step tread or surface design/material intended to improve grip and comfort when wet.
     step_type:
       name: Step type
       description: Identifies the number of steps in docking and anchoring equipment, like double or single
+    step_width:
+      name: Step width
+      description: Step width
     stepper_motion_type:
       name: Stepper motion type
       description: Defines the primary stepping motion offered by the machine.
@@ -21437,6 +24521,15 @@ en:
     stethoscope_technology:
       name: Stethoscope technology
       description: Identifies the type of technology used in stethoscopes, such as electronic or acoustic
+    stick_balance_point:
+      name: Stick balance point
+      description: Stick balance point
+    stick_bow_height:
+      name: Stick bow height
+      description: Stick bow height
+    stick_bow_placement:
+      name: Stick bow placement
+      description: Stick bow placement
     stick_bow_profile:
       name: Stick bow profile
       description: Specifies the curvature profile (or “bow type”) of the field-hockey stick shaft, a critical factor that influences ball control, drag-flick performance, and playing style.
@@ -21452,6 +24545,9 @@ en:
     stick_material:
       name: Stick material
       description: Identifies the composition of sports sticks, such as wood or carbon fiber
+    stick_size:
+      name: Stick size
+      description: Indicates the length of sports implements, determining reach, control, and playing style compatibility.
     stick_size_compatibility:
       name: Stick size compatibility
       description: Identifies the hockey stick size group the product is compatible with (e.g., Youth, Junior, Intermediate, Senior, Goalie, Universal).
@@ -21602,6 +24698,9 @@ en:
     straight_pin_head_shape:
       name: Straight pin head shape
       description: Describes the shape/style of the pin head for usability and visibility.
+    straightness_tolerance:
+      name: Straightness tolerance
+      description: Straightness tolerance
     strainer_style:
       name: Strainer style
       description: Classifies the design of the strainer or colander.
@@ -21623,12 +24722,18 @@ en:
     strap_design:
       name: Strap design
       description: Describes the visual appearance of a product's strap, such as printed or patterned
+    strap_drop_length:
+      name: Strap drop length
+      description: Strap drop length
     strap_end_fitting_type:
       name: Strap end fitting type
       description: Specifies the hardware or fitting located at the end of the pull strap that facilitates connection, anchoring, or adjustment.
     strap_functionality:
       name: Strap functionality
       description: Specifies the primary intended use or design of the yoga mat strap.
+    strap_maximum_length:
+      name: Strap maximum length
+      description: Strap maximum length
     strap_padding:
       name: Strap padding
       description: Indicates the level of padded construction in the strap intended to improve comfort and distribute weight.
@@ -21647,6 +24752,9 @@ en:
     straw_dispensing_mechanism:
       name: Straw dispensing mechanism
       description: Describes the method by which straws are dispensed, assisting shoppers seeking specific hygiene or convenience features.
+    straw_length:
+      name: Straw length
+      description: Straw length
     strength_classification:
       name: Strength classification
       description: Marketing strength label commonly used by brands (e.g., Light, Strong, Extra Strong).
@@ -21665,6 +24773,9 @@ en:
     stretcher_bar_material:
       name: Stretcher bar material
       description: Material used for the stretcher bars/frame (e.g., pine, fir, poplar, birch, MDF/engineered wood).
+    stride_length:
+      name: Stride length
+      description: Stride length
     strike_shield_shape:
       name: Strike shield shape
       description: Specifies the overall form factor of a strike shield’s hitting surface.
@@ -21683,6 +24794,9 @@ en:
     string_instrument_size:
       name: String instrument size
       description: Indicates the size of a string instrument, such as 3/4 or full size
+    string_length:
+      name: String length
+      description: Specifies the total measurement of tensioning material, determining compatibility with specific racket models.
     string_material:
       name: String material
       description: Identifies the material used in archery string, such as dacron or fastflight
@@ -21698,6 +24812,12 @@ en:
     stripper_application:
       name: Stripper application
       description: Specifies the coating or adhesive material that a product is designed to remove or dissolve, e.g. epoxy. paint
+    stroke:
+      name: Stroke
+      description: Indicates the linear distance traveled by a piston in an engine cycle, determining displacement and power characteristics.
+    stroke_length:
+      name: Stroke length
+      description: Specifies the vertical travel distance of cutting blades, determining cutting capability and material thickness capacity.
     stroller_features:
       name: Stroller features
       description: Identifies specific characteristics of a stroller, such as a foldable design or lockable wheels
@@ -21707,21 +24827,33 @@ en:
     strung_status:
       name: Strung status
       description: Indicates whether the lacrosse head comes pre-strung with a pocket or is sold unstrung.
+    strut_extended_length:
+      name: Strut extended length
+      description: Strut extended length
     strut_placement:
       name: Strut placement
       description: Specifies the intended installation position on the vehicle (front/rear and left/right) for the strut.
+    strut_travel:
+      name: Strut travel
+      description: Strut travel
     stud_attachment_type:
       name: Stud attachment type
       description: Specifies how the studs/cleats are affixed or configured on the outsole, impacting traction, maintenance, and compliance with league regulations.
     stud_configuration:
       name: Stud configuration
       description: Defines the shape and arrangement of studs/cleats on the outsole, affecting traction and performance on various surfaces.
+    stud_length:
+      name: Stud length
+      description: Stud length
     stud_material:
       name: Stud material
       description: Identifies the primary material of the studs/cleats, informing durability, weight, and compliance with safety regulations.
     stuffed_animal_features:
       name: Stuffed animal features
       description: Highlights built-in play and comfort features of the stuffed animal.
+    stuffed_animal_size:
+      name: Stuffed animal size
+      description: Indicates the dimensions of plush toys, determining age appropriateness and display or storage requirements.
     stump_base_type:
       name: Stump base type
       description: Defines the style of base or mounting system the cricket stump uses (spike, spring-return, weighted rubber, etc.).
@@ -21767,6 +24899,9 @@ en:
     subwoofer_installation_type:
       name: Subwoofer installation type
       description: How the subwoofer is intended to be installed in a vehicle audio system.
+    subwoofer_mounting_depth:
+      name: Subwoofer mounting depth
+      description: Subwoofer mounting depth
     suction_cup_color:
       name: Suction cup color
       description: Identifies the color of the suction cup, such as black or blue
@@ -21776,6 +24911,9 @@ en:
     suction_cup_pattern:
       name: Suction cup pattern
       description: Describes the design or motif on the suction cup of tools like plungers, e.g. floral, geometric
+    suction_cup_size:
+      name: Suction cup size
+      description: Specifies the diameter of vacuum-creating surfaces, determining grip strength and effectiveness on various surfaces.
     suction_levels:
       name: Suction levels
       description: Indicates suction strength in breast pumps, such as adjustable or fixed
@@ -21788,12 +24926,18 @@ en:
     sugar_dispenser_mechanism:
       name: Sugar dispenser mechanism
       description: Details how the sugar is dispensed from the container, aiding shoppers in selecting their preferred pouring style.
+    sugar_per_serving:
+      name: Sugar per serving
+      description: Sugar per serving
     sugar_refinement_level:
       name: Sugar refinement level
       description: Indicates the degree or style of refining (color, molasses content, or processing level).
     sugar_source:
       name: Sugar source
       description: Identifies the botanical or material origin from which the sugar is derived.
+    sugars_per_100_g:
+      name: Sugars per 100 g
+      description: Sugars per 100 g
     suit_fit:
       name: Suit fit
       description: Overall cut of the suit, indicating how closely it sits to the body.
@@ -22115,9 +25259,18 @@ en:
     surfboard_features:
       name: Surfboard features
       description: Specifies unique characteristics of a surfboard, like inflatable or hard top
+    surfboard_size:
+      name: Surfboard size
+      description: Indicates the dimensions of water sports equipment, determining buoyancy, maneuverability, and rider weight compatibility.
     surfboard_tail_shape:
       name: Surfboard tail shape
       description: Defines the outline of the board’s tail, which influences maneuverability and hold.
+    surfboard_volume:
+      name: Surfboard volume
+      description: Surfboard volume
+    surge_energy_rating:
+      name: Surge energy rating
+      description: Specifies the electrical spike absorption capability, determining protection level for connected equipment.
     surveillance_camera_design:
       name: Surveillance camera design
       description: Identifies the design type of security cameras, for example, thermal or panoramic
@@ -22136,6 +25289,9 @@ en:
     suspension_configuration:
       name: Suspension configuration
       description: Describes whether the tricycle has suspension and where it is located.
+    suspension_lift_amount:
+      name: Suspension lift amount
+      description: Suspension lift amount
     suspension_material:
       name: Suspension material
       description: Specifies the material of the chains, ropes, or cables used to hang the swing.
@@ -22160,12 +25316,21 @@ en:
     sustainability_certification:
       name: Sustainability certification
       description: Environmental or sourcing certification for the wood material.
+    swab_cord_length:
+      name: Swab cord length
+      description: Swab cord length
     swab_end_configuration:
       name: Swab end configuration
       description: Indicates whether the swab has one usable end or two, and if the ends differ
+    swab_head_diameter:
+      name: Swab head diameter
+      description: Swab head diameter
     swab_intended_bassoon_section:
       name: Swab intended bassoon section
       description: Identifies which part of a bassoon the swab is designed to clean (different bores/parts require different swab shapes and sizes).
+    swab_length:
+      name: Swab length
+      description: Swab length
     swab_material:
       name: Swab material
       description: Specifies the fabric of a musical instrument cleaning swab, e.g. silk, felt
@@ -22184,6 +25349,9 @@ en:
     sway_bar_coating:
       name: Sway bar coating
       description: Surface treatment or coating on the sway bar for corrosion resistance and appearance.
+    sway_bar_diameter:
+      name: Sway bar diameter
+      description: Sway bar diameter
     sway_bar_fitment_front_rear_kit:
       name: Sway bar fitment (front/rear/kit)
       description: Indicates whether the sway bar is intended for the front axle, rear axle, or sold as a front-and-rear kit.
@@ -22214,6 +25382,9 @@ en:
     swim_board_features:
       name: Swim board features
       description: Highlights special characteristics or enhancements of the swim board that improve usability or safety.
+    swim_board_size:
+      name: Swim board size
+      description: Indicates the dimensions of flotation devices, determining buoyancy and stability for swimming assistance.
     swim_bottom_length:
       name: Swim bottom length
       description: Classifies the overall leg coverage of the swim boxers (e.g., short trunks vs knee-length).
@@ -22307,6 +25478,9 @@ en:
     synthetic_formulation_type:
       name: Synthetic formulation type
       description: Specifies the synthetic base stock/formulation type (e.g., PAO, ester, hydrocracked Group III).
+    syringe_size:
+      name: Syringe size
+      description: Specifies the fluid capacity of medical dispensing devices, determining dosage capability and application suitability.
     syrup_base_ingredient:
       name: Syrup base ingredient
       description: Identifies the primary plant or sugar source from which the syrup or nectar is derived (e.g., maple, agave, cane sugar).
@@ -22334,6 +25508,9 @@ en:
     t_shirt_fit:
       name: T-shirt fit
       description: Describes the intended overall fit/cut of the t-shirt.
+    tab_neck_height:
+      name: Tab neck height
+      description: Tab neck height
     tab_style:
       name: Tab style
       description: Specifies the style of tabs on binder accessories, e.g. pre-printed, numbered
@@ -22409,6 +25586,9 @@ en:
     tag_fastening:
       name: Tag fastening
       description: Describes the method used to secure a tag to luggage, such as buckles or loops
+    tail_size:
+      name: Tail size
+      description: Indicates the width of the rear portion of skateboards, determining stability and trick capability.
     talc_content:
       name: Talc content
       description: States whether the formulation contains talc, is talc-free, or uses reduced talc levels
@@ -22427,6 +25607,12 @@ en:
     tam_tam_items_included:
       name: Tam-tam items included
       description: Accessories included with the tam-tam (e.g., mallet, stand, cover).
+    tam_tam_playing_area_diameter:
+      name: Tam-tam playing area diameter
+      description: Tam-tam playing area diameter
+    tam_tam_thickness:
+      name: Tam-tam thickness
+      description: Tam-tam thickness
     tamarillo_variety:
       name: Tamarillo variety
       description: Identifies the specific cultivar or color variant of the tamarillo fruit.
@@ -22505,6 +25691,9 @@ en:
     tape_type:
       name: Tape type
       description: Classifies the functional style or construction of the hockey tape, such as cloth, clear polyethylene, grip, stretch cohesive, shin pad, or chamois.
+    tape_width:
+      name: Tape width
+      description: Tape width
     tapenade_main_ingredients:
       name: Tapenade main ingredients
       description: Specifies the primary base ingredient that defines the tapenade (olive, tomato, eggplant, pepper, etc.), useful for shoppers with ingredient-based preferences or restrictions.
@@ -22523,12 +25712,21 @@ en:
     tar_playing_style:
       name: Tar playing style
       description: Specifies the primary playing position/technique the tar is designed for.
+    tar_rim_depth:
+      name: Tar rim depth
+      description: Tar rim depth
     tar_tuning_system:
       name: Tar tuning system
       description: Specifies how the tar is tuned (how head tension is adjusted).
+    tar_yield:
+      name: Tar yield
+      description: Specifies the amount of residue produced during consumption, relevant to health impact assessment of tobacco products.
     target_audience:
       name: Target audience
       description: Specifies who a product is suitable for, such as kids or all ages
+    target_batch_volume:
+      name: Target batch volume
+      description: Target batch volume
     target_components:
       name: Target components
       description: Specifies which fuel/air-intake components the product is intended to clean.
@@ -22565,6 +25763,12 @@ en:
     taro_variety:
       name: Taro variety
       description: Specifies the cultivar, species, or market name of the taro root offered (e.g., Purple Taro, Eddoe, Dasheen).
+    tassel_drop_length:
+      name: Tassel drop length
+      description: Tassel drop length
+    tassel_spacing:
+      name: Tassel spacing
+      description: Tassel spacing
     tassel_trim_header_type:
       name: Tassel trim header type
       description: Specifies the construction of the top header/mounting portion used to attach tassel trim to a surface (e.g., tape, braid, cord).
@@ -22592,6 +25796,9 @@ en:
     tee_base_style:
       name: Tee base style
       description: Identifies the structural design of a rugby kicking tee's base that supports the ball.
+    teeth_length:
+      name: Teeth length
+      description: Indicates the penetration depth of garden tool tines, determining effectiveness in various soil conditions.
     teeth_material:
       name: Teeth material
       description: Identifies the material used in teeth, usually for gardening tools; e.g. plastic, metal
@@ -22631,6 +25838,9 @@ en:
     temperature:
       name: Temperature
       description: Specifies the heat settings for devices like glue guns, e.g. dual, high
+    temperature_accuracy:
+      name: Temperature accuracy
+      description: Specifies the precision of heat measurement devices, determining reliability for critical temperature monitoring.
     temperature_control:
       name: Temperature control
       description: 'Defines the ability to adjust the product''s temperature, usually for bottle warmers; e.g. adjustable, preset '
@@ -22664,9 +25874,18 @@ en:
     tennis_racket_grip_size:
       name: Tennis racket grip size
       description: Specifies the standardized circumference of the racket handle (L0–L5 or inch equivalents) to ensure proper hand fit and comfort.
+    tenon_diameter:
+      name: Tenon diameter
+      description: Tenon diameter
+    tenor_flutophone_body_length:
+      name: Tenor flutophone body length
+      description: Tenor flutophone body length
     tenor_flutophone_fingering_system:
       name: Tenor flutophone fingering system
       description: Specifies the fingering system used by the tenor flutophone (curriculum/notation convention).
+    tenor_flutophone_weight:
+      name: Tenor flutophone weight
+      description: Tenor flutophone weight
     tenor_recorder_joint_type:
       name: Tenor recorder joint type
       description: Specifies the joint/connection type between sections of the tenor recorder.
@@ -22676,6 +25895,9 @@ en:
     tenor_saxophone_pad_material:
       name: Tenor saxophone pad material
       description: Specifies the primary material used for the instrument pads.
+    tenor_saxophone_weight:
+      name: Tenor saxophone weight
+      description: Tenor saxophone weight
     tenor_trombone_slide_type:
       name: Tenor trombone slide type
       description: Type of slide used on the tenor trombone (e.g., standard/straight vs trigger/axial flow).
@@ -22739,6 +25961,9 @@ en:
     test_sample:
       name: Test sample
       description: Specifies the type of sample required for health and medical tests, e.g. swab, saliva
+    test_time:
+      name: Test time
+      description: Indicates the duration required to obtain results, determining convenience and emergency response capability.
     tether_strap_system:
       name: Tether/strap system
       description: Type of tether or strap system used to connect the neck support to the helmet/harness (if applicable).
@@ -22793,6 +26018,12 @@ en:
     therapy_temperature_type:
       name: Therapy temperature type
       description: Indicates whether the product provides heat therapy, cold therapy, or both
+    thermal_accuracy:
+      name: Thermal accuracy
+      description: Specifies the precision of heat pattern detection, determining reliability for identifying temperature variations.
+    thermal_design_power:
+      name: Thermal design power
+      description: Indicates the heat generation of computing components, determining cooling requirements and power consumption.
     thermal_detector_type:
       name: Thermal detector type
       description: Specifies the technology used for thermal detection in devices, such as Amorphous silicon (a Si) detector
@@ -22817,12 +26048,21 @@ en:
     thermos_handle_type:
       name: Thermos handle type
       description: Describes the style of handle or carrying aid integrated into the thermos.
+    thermostat_flange_diameter:
+      name: Thermostat flange diameter
+      description: Thermostat flange diameter
     thermostat_type:
       name: Thermostat type
       description: The functional design or control style of a motor vehicle cooling system thermostat.
+    thickness:
+      name: Thickness
+      description: Specifies the depth measurement from front to back, determining structural properties and installation requirements.
     thickness_type:
       name: Thickness type
       description: Indicates the level of thickness for items, such as thin, medium, or thick
+    thigh_circumference:
+      name: Thigh circumference
+      description: Thigh circumference
     thimble_guide_size:
       name: Thimble guide size
       description: Size designation of the thimble guide (fit/coverage size), typically sold as small/medium/large rather than measured dimensions.
@@ -22856,6 +26096,9 @@ en:
     thread_finish_treatment:
       name: Thread finish / treatment
       description: Surface finish or treatment applied to the thread affecting handling and performance (e.g., waxed, bonded, mercerized).
+    thread_length:
+      name: Thread length
+      description: Indicates the total linear measurement of fine cordage, determining project capability and usage duration.
     thread_material:
       name: Thread material
       description: Primary fiber/material content of the thread/floss (not fabric).
@@ -22865,15 +26108,24 @@ en:
     thread_package_format:
       name: Thread package format
       description: Packaging form factor of the sewing thread (e.g., spool, cone, bobbin).
+    thread_pitch:
+      name: Thread pitch
+      description: Specifies the distance between adjacent screw threads, determining compatibility and functional characteristics.
     thread_rack_compatible_spool_type:
       name: Thread rack compatible spool type
       description: Type of thread package the rack is designed to accommodate (spools vs cones, etc.).
+    thread_rack_peg_length:
+      name: Thread rack peg length
+      description: Thread rack peg length
     thread_standard:
       name: Thread standard
       description: Identifies the thread specification used on the accessory's connections to ensure cross-compatibility with plumbing components.
     thread_standard_size:
       name: Thread standard size
       description: Identifies the thread size/weight standard used on the product label (e.g., wt, Tex, denier).
+    thread_thickness:
+      name: Thread thickness
+      description: Thread thickness
     thread_type:
       name: Thread type
       description: Specifies the construction/type of cross-stitch thread/floss.
@@ -22901,6 +26153,9 @@ en:
     threading_type:
       name: Threading type
       description: Indicates whether the jewelry uses internal threads, external threads, is threadless, or not applicable.
+    throat_space:
+      name: Throat space
+      description: Throat space
     throttle_type_scooter_conversion:
       name: Throttle type (scooter conversion)
       description: Specifies the throttle form factor/interface included or required by the conversion kit.
@@ -22991,6 +26246,9 @@ en:
     timer_display_type:
       name: Timer display type
       description: Indicates how the game timer presents the remaining time (e.g., digital screen, analog dial, sand hourglass, or no visual display).
+    timer_duration:
+      name: Timer duration
+      description: Indicates the maximum countable period, determining suitability for various cooking and timing applications.
     timer_features:
       name: Timer features
       description: Describes the special functions of a timer, like adjustable duration or built-in display
@@ -23003,6 +26261,9 @@ en:
     timer_type:
       name: Timer type
       description: Specifies the frequency setting for timers, e.g. daily, weekly
+    timing_accuracy:
+      name: Timing accuracy
+      description: Timing accuracy
     timing_belt_construction_material_rubber_compound:
       name: Timing belt construction material (rubber compound)
       description: Primary belt rubber compound used (e.g., HNBR), which impacts heat/oil resistance and longevity.
@@ -23015,6 +26276,9 @@ en:
     timing_component_material:
       name: Timing component material
       description: Primary material of the timing component (belt compound, chain/gear metal, cover material).
+    timing_precision:
+      name: Timing precision
+      description: Timing precision
     tin_whistle_body_material:
       name: Tin whistle body material
       description: Captures common tin whistle body materials more specifically than the broad Instrument material list when needed.
@@ -23036,6 +26300,9 @@ en:
     tip_finish_coating:
       name: Tip finish/coating
       description: Specifies the surface treatment on the working end (e.g., chrome-plated, powder-coated) that affects corrosion resistance and rim marring.
+    tip_length:
+      name: Tip length
+      description: Tip length
     tip_material:
       name: Tip material
       description: Specifies the material used in the product's tip, e.g. cotton, silicone
@@ -23075,15 +26342,30 @@ en:
     tire_load_range:
       name: Tire load range
       description: Indicates the tire ply rating/load range designation (commonly for LT tires) reflecting load carrying capacity.
+    tire_outside_diameter:
+      name: Tire outside diameter
+      description: Tire outside diameter
     tire_position:
       name: Tire position
       description: Recommended mounting position on the vehicle.
+    tire_profile:
+      name: Tire profile
+      description: Specifies the height of tire sidewalls as a percentage of width, determining handling characteristics and ride comfort.
     tire_repair_kit_components:
       name: Tire repair kit components
       description: Specifies the items included in the kit, allowing customers to compare bundle completeness.
+    tire_rim:
+      name: Tire rim
+      description: Indicates the diameter of the wheel that a tire fits onto, determining compatibility with vehicles and performance characteristics.
+    tire_section_width:
+      name: Tire section width
+      description: Tire section width
     tire_sidewall_type:
       name: Tire sidewall type
       description: Specifies the sidewall styling or construction features.
+    tire_size:
+      name: Tire size
+      description: Specifies the dimensions of wheels, determining load capacity and performance characteristics for various applications.
     tire_speed_rating:
       name: Tire speed rating
       description: Tire speed rating letter (e.g., H, V, W) indicating maximum sustained speed capability.
@@ -23099,6 +26381,9 @@ en:
     tire_traction_rating_utqg:
       name: Tire traction rating (UTQG)
       description: UTQG traction grade for wet braking performance.
+    tire_tread_depth:
+      name: Tire tread depth
+      description: Tire tread depth
     tire_tread_pattern:
       name: Tire tread pattern
       description: Describes the style of tread on the tire, indicating suitability for different turf conditions and traction needs.
@@ -23108,6 +26393,9 @@ en:
     tire_tube_type:
       name: Tire tube type
       description: Whether the tire is designed for tubeless or tube-type use.
+    tire_width:
+      name: Tire width
+      description: Indicates the measurement across the tread, determining contact patch size and performance on various surfaces.
     tissue_lotion_content:
       name: Tissue lotion content
       description: Indicates whether the tissues are infused with lotion or other soothing additives.
@@ -23150,6 +26438,9 @@ en:
     toe_spacer_design:
       name: Toe spacer design
       description: Describes the design of toe separators used in foot care, e.g. contoured, loop design
+    toe_stop_stem_length:
+      name: Toe stop stem length
+      description: Toe stop stem length
     toe_stop_stem_thread_size:
       name: Toe stop stem thread size
       description: Specifies the thread size of toe stop stems to ensure plate compatibility.
@@ -23186,6 +26477,9 @@ en:
     tom_mount_mounting_position:
       name: Tom mount mounting position
       description: Specifies where the tom mount is intended to attach (e.g., bass drum, cymbal stand, rack).
+    tom_tom_depth:
+      name: Tom-tom depth
+      description: Tom-tom depth
     tom_tom_design:
       name: Tom-tom design
       description: Describes the type of tom-tom drum, such as floor or rack
@@ -23240,12 +26534,18 @@ en:
     top_color:
       name: Top color
       description: Defines the primary color of a product's top surface, e.g. clear, bronze
+    top_depth:
+      name: Top depth
+      description: Top depth
     top_fit:
       name: Top fit
       description: Specifies the overall silhouette or fit of the top on the body (e.g., slim or oversized).
     top_hat_style:
       name: Top hat style
       description: Identifies the specific style variation of a top hat.
+    top_length:
+      name: Top length
+      description: Measures the vertical distance from shoulder to bottom hem, determining coverage and style classification of upper garments.
     top_length_type:
       name: Top length type
       description: Defines the length of tops or shirts, like crop top or long
@@ -23261,6 +26561,9 @@ en:
     top_surface_material:
       name: Top surface material
       description: Specifies the material used on the product's top surface, such as stainless steel or ceramic glass
+    top_tube_length:
+      name: Top tube length
+      description: Top tube length
     top_up_method:
       name: Top-up method
       description: Specifies the ways customers can add additional credit or renew the plan on the prepaid card or SIM.
@@ -23273,6 +26576,15 @@ en:
     topping_type:
       name: Topping type
       description: Indicates the primary exterior topping or coating applied to the donut.
+    torso_length:
+      name: Torso length
+      description: Torso length
+    total_sugars_per_100_g:
+      name: Total sugars per 100 g
+      description: Total sugars per 100 g
+    total_sugars_per_serving:
+      name: Total sugars per serving
+      description: Total sugars per serving
     tote_handle_type:
       name: Tote handle type
       description: Identifies the style of handles on a tote bag, such as short or long
@@ -23303,6 +26615,9 @@ en:
     tow_strap_type:
       name: Tow strap type
       description: Indicates the functional tow strap construction, such as static tow strap vs kinetic recovery strap.
+    tow_strap_width:
+      name: Tow strap width
+      description: Tow strap width
     towable_tube_style:
       name: Towable tube style
       description: Identifies the general design or form factor of the towable tube, which dictates rider position and ride experience.
@@ -23321,6 +26636,9 @@ en:
     towel_weave:
       name: Towel weave
       description: Describes the construction or weave style of the towel fabric, which affects texture, absorbency, and drying time.
+    towing_capacity:
+      name: Towing capacity
+      description: Towing capacity
     toy/game_material:
       name: Toy/Game material
       description: Identifies the main material used in a toy or game, such as plastic or wood
@@ -23348,6 +26666,9 @@ en:
     toy_car_features:
       name: Toy car features
       description: Highlights play features integrated into the toy car (separate from propulsion), such as lights, sounds, or opening parts.
+    toy_dimensions:
+      name: Toy dimensions
+      description: Toy dimensions
     toy_drawing_tablet_accessories_included:
       name: Toy drawing tablet accessories included
       description: Additional included accessories beyond the tablet itself (e.g., extra stylus, stamps).
@@ -23384,6 +26705,9 @@ en:
     toy_helicopter_features:
       name: Toy helicopter features
       description: Key functional features of a toy helicopter (especially RC models) that impact usability and play value.
+    toy_jack_size:
+      name: Toy jack size
+      description: Toy jack size
     toy_jacks_set_items_included:
       name: Toy jacks set items included
       description: Specifies which core items are included with the toy jacks set (e.g., jacks, ball, bag).
@@ -23399,6 +26723,9 @@ en:
     toy_kitchen_assembly_requirement:
       name: Toy kitchen assembly requirement
       description: Indicates whether assembly is needed and the approximate assembly complexity.
+    toy_kitchen_counter_height:
+      name: Toy kitchen counter height
+      description: Toy kitchen counter height
     toy_kitchen_interactive_features:
       name: Toy kitchen interactive features
       description: Highlights interactive elements commonly found in toy kitchens and related accessories.
@@ -23408,6 +26735,9 @@ en:
     toy_motorcycle_scale:
       name: Toy motorcycle scale
       description: Scale ratio for toy/collectible motorcycles (e.g., 1:12).
+    toy_parachute_canopy_diameter:
+      name: Toy parachute canopy diameter
+      description: Toy parachute canopy diameter
     toy_parachute_launch_method:
       name: Toy parachute launch method
       description: How the toy is intended to be launched/deployed for flight.
@@ -23483,6 +26813,9 @@ en:
     track_system_standard:
       name: Track system standard
       description: Identifies the physical track standard the power feed fits, allowing shoppers to match components to their track (e.g., H, J, or L-track).
+    track_width:
+      name: Track width
+      description: Track width
     tracker_form_factor:
       name: Tracker form factor
       description: Defines the physical style and shape of the tracker hardware
@@ -23531,6 +26864,9 @@ en:
     trailer_hitch_mounting_location_method:
       name: Trailer hitch mounting location/method
       description: Specifies where and how the trailer hitch is mounted on the vehicle (e.g., rear receiver, front receiver, frame-mounted, bumper-mounted, bed-mounted).
+    trailer_interior_width:
+      name: Trailer interior width
+      description: Trailer interior width
     trailer_light_function:
       name: Trailer light function
       description: Primary function/position of the trailer light.
@@ -23585,9 +26921,15 @@ en:
     trampoline_enclosure_type:
       name: Trampoline enclosure type
       description: Specifies the enclosure configuration used on the trampoline, including how/where the net is mounted.
+    trampoline_padding_thickness:
+      name: Trampoline padding thickness
+      description: Trampoline padding thickness
     trampoline_safety_certifications:
       name: Trampoline safety certifications
       description: Indicates which trampoline-relevant safety standards/certifications the product claims compliance with.
+    trampoline_size:
+      name: Trampoline size
+      description: Specifies the diameter or dimensions of rebounding surfaces, determining exercise space and safety requirements.
     transceiver_form_factor:
       name: Transceiver form factor
       description: Defines the physical module standard of the networking transceiver (e.g., SFP, QSFP28)
@@ -23615,18 +26957,27 @@ en:
     transfer_peel_temperature:
       name: Transfer peel temperature
       description: Specifies the recommended temperature state (hot, warm, or cold) at which the carrier sheet should be removed after pressing.
+    transfer_time:
+      name: Transfer time
+      description: Indicates how quickly backup power activates, determining protection level against data loss during power interruptions.
     transmission_cooler_construction:
       name: Transmission cooler construction
       description: Specifies the construction design of a transmission cooler core.
     transmission_fluid_specification:
       name: Transmission fluid specification
       description: OEM/spec standard the transmission fluid meets (e.g., Dexron/Mercon families, ATF+4, JWS 3309).
+    transmission_frequency:
+      name: Transmission frequency
+      description: Specifies the electromagnetic wave rate used for communication, determining compatibility with receivers and regulatory compliance.
     transmission_mount_bushing_material:
       name: Transmission mount bushing material
       description: Specifies the elastomer or isolator material used in the mount bushing/isolator (the vibration-damping element).
     transmission_mount_type:
       name: Transmission mount type
       description: Specifies the construction/design of a transmission mount (e.g., hydraulic vs solid) to help determine fit, NVH characteristics, and intended use.
+    transmission_power:
+      name: Transmission power
+      description: Indicates the energy used to broadcast signals, determining effective range and penetration through obstacles.
     transmission_type:
       name: Transmission type
       description: Identifies the type of transmission in vehicles or parts, like manual or automatic
@@ -23723,6 +27074,15 @@ en:
     trellis_design:
       name: Trellis design
       description: Identifies the design of lattice in fencing or barriers, e.g. square, diamond
+    trench_depth:
+      name: Trench depth
+      description: Specifies the vertical dimension of excavations, determining burial depth capability for pipes and cables.
+    trench_width:
+      name: Trench width
+      description: Indicates the horizontal dimension of excavations, determining accommodation capacity for utilities and drainage systems.
+    triangle_striker_length:
+      name: Triangle striker length
+      description: Triangle striker length
     triangle_striker_material:
       name: Triangle striker material
       description: Material of the included striker/beater.
@@ -23756,6 +27116,12 @@ en:
     trim_finish:
       name: Trim finish
       description: Surface finish treatment applied to the trim (e.g., metallic, glitter, reflective).
+    trim_header_width:
+      name: Trim header width
+      description: Trim header width
+    trim_length:
+      name: Trim length
+      description: Specifies the total linear measurement of decorative edging, determining project coverage and design possibilities.
     trim_tilt_type:
       name: Trim & tilt type
       description: Whether and how the motor supports trim/tilt adjustment.
@@ -23783,6 +27149,9 @@ en:
     trophy_design:
       name: Trophy design
       description: Describes the specific style or shape of a trophy, such as a cup or star
+    truck_axle_width:
+      name: Truck axle width
+      description: Truck axle width
     truck_bed_body_type:
       name: Truck bed/body type
       description: Configuration of the cargo bed or body behind the cab.
@@ -23825,6 +27194,12 @@ en:
     tube_configuration:
       name: Tube configuration
       description: Describes the arrangement of tubes in a musical instrument amplifier, like single tube or matched pair
+    tube_diameter:
+      name: Tube diameter
+      description: Tube diameter
+    tube_length:
+      name: Tube length
+      description: Specifies the distance from objective to eyepiece, determining optical characteristics and magnification capabilities.
     tube_matching_grade:
       name: Tube matching grade
       description: Indicates whether tubes are tested/matched as a set and the type of matching provided.
@@ -23837,6 +27212,9 @@ en:
     tubing_shape:
       name: Tubing shape
       description: Specifies the cross-sectional shape of the stand's support tubing.
+    tubing_size_before_shrinking:
+      name: Tubing size (before shrinking)
+      description: Indicates the initial diameter of thermal-reactive insulation, determining compatibility with wires and components.
     tubular_construction_type:
       name: Tubular construction type
       description: Specifies the construction style of tubular bicycle tires, distinguishing between traditional glued tubulars and newer variations.
@@ -23864,6 +27242,9 @@ en:
     tuning_modes:
       name: Tuning modes
       description: Identifies the specific instrument settings for electronic tuners, like guitar or violin
+    tuning_peg_post_diameter:
+      name: Tuning peg post diameter
+      description: Tuning peg post diameter
     tuning_pitch:
       name: Tuning pitch
       description: Specifies the tuning pitch of an instrument, such as C# or Ab
@@ -23873,6 +27254,12 @@ en:
     tuning_system:
       name: Tuning system
       description: How the goblet drum is tuned or whether it is tunable.
+    tunnel_diameter:
+      name: Tunnel diameter
+      description: Tunnel diameter
+    turn_radius:
+      name: Turn radius
+      description: Turn radius
     turn_signal_lens_color:
       name: Turn signal lens color
       description: Color of the visible lens/cover on the turn signal housing (not emitted light color).
@@ -23897,9 +27284,15 @@ en:
     tweeter_mount_type:
       name: Tweeter mount type
       description: Specifies how the tweeter is intended to be installed in the vehicle (mounting method/hardware).
+    tweeter_sensitivity:
+      name: Tweeter sensitivity
+      description: Tweeter sensitivity
     twill_direction:
       name: Twill direction
       description: Indicates the twill line direction of a denim weave.
+    twine_thickness:
+      name: Twine thickness
+      description: Twine thickness
     twist_direction:
       name: Twist direction
       description: Direction of ply twist used in the yarn/thread (S-twist or Z-twist).
@@ -23987,6 +27380,12 @@ en:
     under_bed_features:
       name: Under-bed features
       description: Identifies the primary functional element located under the bed platform.
+    underbed_clearance:
+      name: Underbed clearance
+      description: Underbed clearance
+    underbed_clearance_height:
+      name: Underbed clearance height
+      description: Underbed clearance height
     underfoot_strap_type:
       name: Underfoot strap type
       description: Identifies the material or design used for the strap that runs under the footwear.
@@ -24035,6 +27434,9 @@ en:
     upholstery_pattern:
       name: Upholstery pattern
       description: Describes the visual design on furniture fabric, for example, stripes or checkered
+    uplink_gain:
+      name: Uplink gain
+      description: Specifies the signal amplification for transmissions to remote receivers, determining effective communication range.
     uplink_port_type:
       name: Uplink port type
       description: Defines the highest-speed uplink connector present on the switch (e.g., SFP+, QSFP28, 10GBase-T)
@@ -24074,6 +27476,9 @@ en:
     us_womens_shoe_size:
       name: US women's shoe size
       description: Specifies the US women's shoe size, such as 8 or 8 Wide
+    usable_fabric_width:
+      name: Usable fabric width
+      description: Usable fabric width
     usage:
       name: Usage
       description: Describes the intended use case/tune of the camshaft.
@@ -24161,6 +27566,12 @@ en:
     valve_guard_coverage_area:
       name: Valve guard coverage area
       description: Indicates which parts of the valve section the guard protects.
+    valve_length:
+      name: Valve length
+      description: Valve length
+    valve_lift:
+      name: Valve lift
+      description: Valve lift
     valve_stem_angle:
       name: Valve stem angle
       description: Specifies the orientation/angle of the valve stem relative to the tube, affecting ease of inflation and rim fit.
@@ -24233,6 +27644,9 @@ en:
     vehicle_cover_size_class:
       name: Vehicle cover size class
       description: General size grouping indicating what vehicle size the cover is designed to fit.
+    vehicle_curb_weight:
+      name: Vehicle curb weight
+      description: Vehicle curb weight
     vehicle_decor_features:
       name: Vehicle decor features
       description: Describes the characteristics of vehicle decor items, such as UV resistant or waterproof
@@ -24293,6 +27707,9 @@ en:
     vehicle_hitch_cover_mounting_type:
       name: Vehicle hitch cover mounting type
       description: Indicates the method used to retain/attach the hitch cover in the hitch receiver.
+    vehicle_length:
+      name: Vehicle length
+      description: Vehicle length
     vehicle_license_plate_finish:
       name: Vehicle license plate finish
       description: Surface finish of the plate.
@@ -24338,6 +27755,9 @@ en:
     vehicle_magnet_intended_use:
       name: Vehicle magnet intended use
       description: Indicates the primary intended use case of the vehicle magnet.
+    vehicle_mileage:
+      name: Vehicle mileage
+      description: Vehicle mileage
     vehicle_mirror_adjustment_type:
       name: Vehicle mirror adjustment type
       description: Specifies how the mirror is adjusted/controlled.
@@ -24407,6 +27827,15 @@ en:
     vehicle_wax_polish_product_form:
       name: Vehicle wax/polish product form
       description: The physical form/dispensing format of the wax, polish, protectant, or sealant.
+    vehicle_wheel_backspacing:
+      name: Vehicle wheel backspacing
+      description: Vehicle wheel backspacing
+    vehicle_wheel_load_rating:
+      name: Vehicle wheel load rating
+      description: Vehicle wheel load rating
+    vehicle_wheel_offset:
+      name: Vehicle wheel offset
+      description: Vehicle wheel offset
     vehicle_wheel_valve_stem_type:
       name: Vehicle wheel valve stem type
       description: Specifies the valve stem type supported or included.
@@ -24443,9 +27872,15 @@ en:
     verification_technology:
       name: Verification technology
       description: Identifies the technology used in banknote verifiers, such as magnetic or infrared
+    vertical_drop_distance:
+      name: Vertical drop distance
+      description: Vertical drop distance
     vesa_mounting_pattern:
       name: VESA mounting pattern
       description: Defines the VESA hole spacing on the back of the monitor for compatibility with mounts, arms, and stands
+    vestibule_floor_area:
+      name: Vestibule floor area
+      description: Vestibule floor area
     vestibule_type:
       name: Vestibule type
       description: Classifies the vestibule’s layout relative to the tent.
@@ -24467,6 +27902,9 @@ en:
     vibraphone_tuning_standard:
       name: Vibraphone tuning standard
       description: Reference pitch used for tuning (A=440 Hz, etc.).
+    vibration_amplitude:
+      name: Vibration amplitude
+      description: Vibration amplitude
     video_codecs/formats_supported:
       name: Video codecs/formats supported
       description: Defines the video codecs and formats a device supports, such as MP4 or H.264
@@ -24527,6 +27965,9 @@ en:
     vintage_classic_truck_cab_type:
       name: Vintage & classic truck cab type
       description: Cab configuration/body style of the truck’s passenger compartment.
+    viola_body_length:
+      name: Viola body length
+      description: Viola body length
     virginia_tech_helmet_star_rating:
       name: Virginia Tech helmet star rating
       description: Safety rating assigned by the Virginia Tech Helmet Lab (0–5 stars).
@@ -24575,6 +28016,9 @@ en:
     voice_coil_configuration:
       name: Voice coil configuration
       description: Number/arrangement of voice coils for wiring flexibility and impedance options.
+    voice_coil_diameter:
+      name: Voice coil diameter
+      description: Voice coil diameter
     voice_effects:
       name: Voice effects
       description: Built-in vocal effect types supported by the karaoke set.
@@ -24584,27 +28028,45 @@ en:
     voip_protocol_support:
       name: VoIP protocol support
       description: Specifies the Voice over Internet Protocol (VoIP) protocols a device can support, such as SIP or IAX
+    voltage:
+      name: Voltage
+      description: Indicates the electrical potential required for operation, determining compatibility with power sources and safety requirements.
     voltage_rating_type:
       name: Voltage rating type
       description: Specifies whether the fuse’s voltage rating applies to AC, DC, or both.
     voltage_regulator_connector_type:
       name: Voltage regulator connector type
       description: Specifies the connection/terminal style used to connect the regulator to the vehicle wiring/alternator/generator.
+    volume:
+      name: Volume
+      description: Specifies the total fluid capacity of containers, determining habitat size and appropriate stocking levels for aquatic life.
+    vpn_throughput:
+      name: VPN throughput
+      description: Indicates the data processing speed of encrypted connections, determining performance for secure remote access.
     wader_foot_type:
       name: Wader foot type
       description: Specifies whether the waders have integrated boots or separate stocking feet.
     wader_sole_type:
       name: Wader sole type
       description: Specifies the outsole material or traction type used on wading boots or bootfoot waders.
+    wader_thickness:
+      name: Wader thickness
+      description: Wader thickness
     wader_type:
       name: Wader type
       description: Defines the specific style of fishing or hunting waders, such as hip or waist
     waffle_style:
       name: Waffle style
       description: Identifies the waffle grid or pattern produced by the plates.
+    waist_reduction_potential:
+      name: Waist reduction potential
+      description: Waist reduction potential
     waist_rise:
       name: Waist rise
       description: Indicates where on the waist a garment sits, like low, medium or high
+    waist_size:
+      name: Waist size
+      description: Measures the circumference at the narrowest part of the torso, essential for determining proper fit in pants, skirts, and dresses.
     waistband_style:
       name: Waistband style
       description: Describes the construction of the waistband and how it is secured or adjusted for fit and comfort.
@@ -24614,6 +28076,9 @@ en:
     wakeboard_riding_style:
       name: Wakeboard riding style
       description: Classifies the intended environment or usage style of the wakeboard.
+    wakeboard_size:
+      name: Wakeboard size
+      description: Indicates the dimensions of water sports equipment, determining buoyancy, maneuverability, and rider weight compatibility.
     walker_brake_type:
       name: Walker brake type
       description: Describes the braking mechanism incorporated in the walker
@@ -24704,6 +28169,9 @@ en:
     waste_container_sign_message:
       name: Waste container sign message
       description: Defines the specific waste stream or warning text printed on the label or sign.
+    waste_tank_capacity:
+      name: Waste tank capacity
+      description: Waste tank capacity
     watch/band_material:
       name: Watch/Band material
       description: Specifies the type of material for watch bands, such as nylon or silicone
@@ -24728,9 +28196,15 @@ en:
     water_activation:
       name: Water activation
       description: Whether the beacon can automatically activate upon water immersion (common for Category I/II EPIRBs).
+    water_capacity:
+      name: Water capacity
+      description: Water capacity
     water_chamber_configuration:
       name: Water chamber configuration
       description: Describes the internal bladder layout of the mattress, such as single or dual chambers, which affects support, temperature control, and partner disturbance.
+    water_consumption_per_cycle:
+      name: Water consumption per cycle
+      description: Specifies the volume of water used during operation, determining resource efficiency and utility costs.
     water_dispensing_mechanism:
       name: Water dispensing mechanism
       description: Defines how water is released from the unit, such as spigots, spray nozzles, or gravity pour.
@@ -24788,6 +28262,9 @@ en:
     water_pump_mounting_type:
       name: Water pump mounting type
       description: Specifies the water pump’s mounting/form-factor style for engine fitment (e.g., bolt-on housing vs cartridge/insert).
+    water_pump_outlet_port_diameter:
+      name: Water pump outlet port diameter
+      description: Water pump outlet port diameter
     water_purification_method:
       name: Water purification method
       description: Identifies the primary mechanism by which the product makes water safe to drink in the field (e.g., pump versus gravity feed versus UV light).
@@ -24818,6 +28295,9 @@ en:
     water_ski_fin_type:
       name: Water ski fin type
       description: Specifies the fin configuration of a water ski, which affects tracking and maneuverability.
+    water_ski_size:
+      name: Water ski size
+      description: Indicates the dimensions of towed water sports equipment, determining stability, maneuverability, and rider weight compatibility.
     water_source:
       name: Water source
       description: Identifies the origin of the water prior to carbonation.
@@ -24839,15 +28319,30 @@ en:
     water_table_water_source_type:
       name: Water table water source type
       description: Specifies how the water table is filled or supplied with water.
+    water_tank_capacity:
+      name: Water tank capacity
+      description: Specifies the fluid volume that can be stored, determining usage duration before refilling is required.
+    water_treatment_capacity:
+      name: Water treatment capacity
+      description: Water treatment capacity
+    water_volume_treated_per_tablet:
+      name: Water volume treated per tablet
+      description: Water volume treated per tablet
     waterbed_stabilization_level:
       name: Waterbed stabilization level
       description: Indicates the degree of wave reduction or motion control provided by the waterbed mattress.
     watercolor_ink_water_resistance_after_drying:
       name: Watercolor ink water resistance (after drying)
       description: Indicates whether the watercolor ink becomes water-resistant/waterproof after drying (per manufacturer claim).
+    watercraft_beam:
+      name: Watercraft beam
+      description: Watercraft beam
     watercraft_care_application_area:
       name: Watercraft care application area
       description: Indicates the main area or component of a watercraft the product is intended to be used on.
+    watercraft_care_coverage_area:
+      name: Watercraft care coverage area
+      description: Watercraft care coverage area
     watercraft_drive_mechanism:
       name: Watercraft drive mechanism
       description: Describes the specific on-board propulsion mechanism installed or supported.
@@ -24857,12 +28352,21 @@ en:
     watercraft_features:
       name: Watercraft features
       description: Describes amenities or systems on a watercraft, such as a kitchen or brake system
+    watercraft_fuel_tank_feed_connection_diameter:
+      name: Watercraft fuel tank feed connection diameter
+      description: Watercraft fuel tank feed connection diameter
+    watercraft_fuel_tank_fill_neck_diameter:
+      name: Watercraft fuel tank fill neck diameter
+      description: Watercraft fuel tank fill neck diameter
     watercraft_fuel_tank_sending_unit_pattern:
       name: Watercraft fuel tank sending unit pattern
       description: Specifies the mounting pattern/standard for fuel tank sending units and compatible gauges (e.g., common marine bolt patterns).
     watercraft_fuel_tank_shape:
       name: Watercraft fuel tank shape
       description: Describes the overall physical form factor of the fuel tank to support space/fit planning.
+    watercraft_fuel_tank_vent_connection_diameter:
+      name: Watercraft fuel tank vent connection diameter
+      description: Watercraft fuel tank vent connection diameter
     watercraft_hull_material:
       name: Watercraft hull material
       description: Specifies the primary material of the hull construction.
@@ -24872,9 +28376,18 @@ en:
     watercraft_impeller_material_grade:
       name: Watercraft impeller material grade
       description: Specifies the material of the watercraft impeller (e.g., neoprene rubber, nitrile, bronze).
+    watercraft_impeller_outer_diameter:
+      name: Watercraft impeller outer diameter
+      description: Watercraft impeller outer diameter
+    watercraft_impeller_thickness_overall_width:
+      name: Watercraft impeller thickness (overall width)
+      description: Watercraft impeller thickness (overall width)
     watercraft_lighting_certification_compliance:
       name: Watercraft lighting certification / compliance
       description: Indicates the regulatory/standards compliance the light is certified to for marine use (e.g., USCG/ABYC/COLREGs compliant).
+    watercraft_motor_lock_shackle_bolt_diameter:
+      name: Watercraft motor lock shackle/bolt diameter
+      description: Watercraft motor lock shackle/bolt diameter
     watercraft_motor_mount_adjustment_features:
       name: Watercraft motor mount adjustment features
       description: Adjustment capabilities of the mount (e.g., tilt, lift, slide) that affect usability and fit.
@@ -24887,6 +28400,12 @@ en:
     watercraft_propeller_blade_rake:
       name: Watercraft propeller blade rake
       description: Specifies blade rake (blade angle relative to hub), which affects bow lift and performance.
+    watercraft_propeller_diameter:
+      name: Watercraft propeller diameter
+      description: Watercraft propeller diameter
+    watercraft_propeller_pitch:
+      name: Watercraft propeller pitch
+      description: Watercraft propeller pitch
     watercraft_propeller_rotation_direction:
       name: Watercraft propeller rotation direction
       description: Indicates the required propeller rotation direction/handedness for drivetrain compatibility (e.g., right-hand/standard vs left-hand/counter-rotating).
@@ -24908,6 +28427,9 @@ en:
     watercraft_steering_cable_hardware_included:
       name: Watercraft steering cable hardware included
       description: Specifies which installation hardware and accessories are included with the steering cable.
+    watercraft_steering_cable_stroke:
+      name: Watercraft steering cable stroke
+      description: Watercraft steering cable stroke
     watercraft_steering_cable_system_type:
       name: Watercraft steering cable system type
       description: Specifies the steering system architecture the cable is designed for (e.g., rotary, rack).
@@ -24929,9 +28451,15 @@ en:
     waterproof_level:
       name: Waterproof level
       description: Indicates the water-protection level of the footwear, including any warranty-backed waterproof claims.
+    waterproof_rating_hydrostatic_head:
+      name: Waterproof rating (hydrostatic head)
+      description: Indicates the water pressure a fabric can withstand before leaking, determining weather protection capability.
     waveski_features:
       name: Waveski features
       description: Describes the unique characteristics of a waveski, such as adjustable strap or anti-slip
+    waveski_size:
+      name: Waveski size
+      description: Specifies the dimensions of hybrid water sports equipment, determining buoyancy, maneuverability, and rider weight compatibility.
     wax_application_method:
       name: Wax application method
       description: Specifies the technique used to apply wax to winter sports gear, such as cold or hot
@@ -24944,6 +28472,12 @@ en:
     wax_hardness:
       name: Wax hardness
       description: Indicates the relative hardness of the wax, affecting durability and glide on different snow types.
+    wax_included_weight:
+      name: Wax included weight
+      description: Wax included weight
+    wax_melt_point_temperature:
+      name: Wax melt point temperature
+      description: Wax melt point temperature
     wax_paper_form:
       name: Wax paper form
       description: Specifies whether the wax paper is sold as a continuous roll or as pre-cut sheets.
@@ -24995,6 +28529,9 @@ en:
     weaving_beater_edge_type:
       name: Weaving beater edge type
       description: Describes the working edge profile of the flat beater that contacts the weft (e.g., straight vs serrated).
+    weaving_beater_edge_width:
+      name: Weaving beater edge width
+      description: Weaving beater edge width
     weaving_beater_style:
       name: Weaving beater style
       description: Identifies the functional style/format of the flat weaving beater.
@@ -25004,6 +28541,9 @@ en:
     weaving_shuttle_use_case:
       name: Weaving shuttle use case
       description: Specifies the intended weaving application the shuttle is designed or optimized for.
+    weaving_width:
+      name: Weaving width
+      description: Weaving width
     webbing_construction_type:
       name: Webbing construction type
       description: Describes the physical weave or braid style of the webbing, which affects handling, strength, and intended use.
@@ -25013,6 +28553,9 @@ en:
     webcam_design:
       name: Webcam design
       description: Identifies the type of webcam, such as conference, laptop, or plug-and-play
+    weight:
+      name: Weight
+      description: Indicates the mass of materials, determining shipping costs, handling requirements, and application suitability.
     weight_adjustability:
       name: Weight adjustability
       description: Describes whether the product’s resistance can be changed by the user (e.g., selectorized or loadable) or is fixed at a single weight.
@@ -25028,12 +28571,21 @@ en:
     weight_loss_mechanism:
       name: Weight loss mechanism
       description: Identifies the primary physiological approach the supplement uses to support weight loss
+    weight_measurement_accuracy:
+      name: Weight measurement accuracy
+      description: Specifies the precision of mass determination devices, determining reliability for critical weighing applications.
+    weight_packed:
+      name: Weight (packed)
+      description: Weight (packed)
     weight_plate_compatibility:
       name: Weight plate compatibility
       description: Defines which diameter weight plates the machine accepts (Olympic, Standard, or both).
     weight_plate_style:
       name: Weight plate style
       description: Classifies the design/type of the weight plate (e.g., Olympic, bumper, selectorized) for quick compatibility filtering.
+    weight_stack:
+      name: Weight stack
+      description: Weight stack
     weight_type:
       name: Weight type
       description: Describes the weight of items, such as light, medium, or heavy
@@ -25052,6 +28604,9 @@ en:
     wet_bag_features:
       name: Wet bag features
       description: Describes specific characteristics of diaper wet bags, such as leakproof or eco-friendly
+    wet_boiling_point:
+      name: Wet boiling point
+      description: Wet boiling point
     wetsuit_boot_height:
       name: Wetsuit boot height
       description: Classifies the height/cut of the boot on the leg, influencing coverage, mobility and water entry.
@@ -25061,12 +28616,18 @@ en:
     wetsuit_seam_construction:
       name: Wetsuit seam construction
       description: Specifies how the seams are built and sealed, affecting warmth, flexibility, and durability.
+    wetsuit_thickness:
+      name: Wetsuit thickness
+      description: Indicates the depth measurement of neoprene material, determining thermal insulation and buoyancy in water.
     wheat_product_form:
       name: Wheat product form
       description: Specifies the physical or processed form of the wheat product.
     wheel_arrangement:
       name: Wheel arrangement
       description: Specifies the steam locomotive wheel arrangement (Whyte notation), which is a defining characteristic and common collector/search term.
+    wheel_base:
+      name: Wheel base
+      description: Specifies the distance between front and rear wheels, determining turning radius and stability characteristics.
     wheel_bearing_type:
       name: Wheel bearing type
       description: Identifies the internal bearing or bushing construction of the wheel, affecting rolling smoothness and maintenance requirements.
@@ -25109,6 +28670,9 @@ en:
     wheel_material:
       name: Wheel material
       description: Identifies the primary composition of the wheels, which affects durability, grip and vibration dampening.
+    wheel_offset:
+      name: Wheel offset
+      description: Wheel offset
     wheel_part_type:
       name: Wheel part type
       description: Identifies the specific component of a vehicle's wheel system, like wheel bearing or wheel hub
@@ -25118,6 +28682,12 @@ en:
     wheel_setup_type:
       name: Wheel setup type
       description: Defines the wheel configuration style used on the skates.
+    wheel_size:
+      name: Wheel size
+      description: Indicates the diameter of rolling components, determining speed, obstacle clearance, and ride smoothness.
+    wheel_spacer_thickness:
+      name: Wheel spacer thickness
+      description: Wheel spacer thickness
     wheel_style:
       name: Wheel style
       description: Describes the physical rim shape or driving discipline style
@@ -25130,9 +28700,15 @@ en:
     wheel_type:
       name: Wheel type
       description: Specifies the kind of wheel for cycling products, such as inflatable or solid
+    wheel_width:
+      name: Wheel width
+      description: Wheel width
     wheelchair_type:
       name: Wheelchair type
       description: Distinguishes between different types of wheelchairs, e.g. electric, manual
+    whip_diameter:
+      name: Whip diameter
+      description: Whip diameter
     whip_style:
       name: Whip style
       description: Classifies the product by its specific equestrian whip or crop style or intended discipline.
@@ -25175,6 +28751,9 @@ en:
     whitewater_rating_class:
       name: Whitewater rating (class)
       description: Highest International Scale of River Difficulty class the raft is rated to handle.
+    whorl_diameter:
+      name: Whorl diameter
+      description: Whorl diameter
     whorl_mounting_interface:
       name: Whorl mounting interface
       description: How the whorl attaches to the spinning wheel (shaft style/connection).
@@ -25190,6 +28769,15 @@ en:
     wick_core_type:
       name: Wick core type
       description: Whether the wick is coreless or includes a core material (e.g., paper-cored or zinc-cored) affecting rigidity and burn characteristics.
+    wick_diameter:
+      name: Wick diameter
+      description: Wick diameter
+    wick_hole_diameter:
+      name: Wick hole diameter
+      description: Wick hole diameter
+    wick_length:
+      name: Wick length
+      description: Wick length
     wick_material:
       name: Wick material
       description: Identifies the composition of the wick used (e.g. cotton, fiberglass).
@@ -25199,15 +28787,36 @@ en:
     wick_tab_material:
       name: Wick tab material
       description: Material of the attached tab/sustainer (commonly tinplate), relevant for corrosion resistance and regulatory preferences (e.g., avoiding lead).
+    wick_tab_neck_height:
+      name: Wick tab neck height
+      description: Wick tab neck height
+    wick_tab_neck_inner_diameter:
+      name: Wick tab neck inner diameter
+      description: Wick tab neck inner diameter
     wick_tab_shape:
       name: Wick tab shape
       description: Shape/form factor of the wick tab plate.
+    wick_tab_size:
+      name: Wick tab size
+      description: Wick tab size
     wick_type_included:
       name: Wick type included
       description: Specifies the wick material/type included in the kit.
+    width:
+      name: Width
+      description: Specifies the horizontal measurement from side to side, determining fit, coverage, or space requirements.
     width_adjustment:
       name: Width adjustment
       description: Indicates whether the equipment's width can be altered to fit different fixtures, beds, or users
+    width_folded:
+      name: Width (folded)
+      description: Indicates the side-to-side dimension when collapsed for storage, determining space efficiency and transport requirements.
+    width_packed:
+      name: Width (packed)
+      description: Specifies the horizontal measurement when prepared for transport, determining storage and shipping space requirements.
+    width_pitched:
+      name: Width (pitched)
+      description: Indicates the side-to-side measurement when fully assembled, determining floor space and sleeping capacity.
     wig_fiber_material:
       name: Wig fiber material
       description: Identifies the primary fiber used for the wig hair so shoppers can easily choose between human hair varieties and synthetic options with different styling and longevity characteristics.
@@ -25220,6 +28829,9 @@ en:
     willow_type:
       name: Willow type
       description: Identifies the kind of willow or alternative material used for the bat blade, which greatly affects performance, durability, and price.
+    wind_speed_accuracy:
+      name: Wind speed accuracy
+      description: Specifies the precision of air movement measurements, determining reliability for weather monitoring and safety applications.
     wind_up_mechanism_type:
       name: Wind-up mechanism type
       description: Specifies how the toy is wound or activated.
@@ -25295,6 +28907,9 @@ en:
     window_net_opening_direction:
       name: Window net opening direction
       description: Specifies how the window net opens/releases relative to the occupant for egress and rule compliance.
+    window_net_strap_width:
+      name: Window net strap width
+      description: Window net strap width
     window_regulator_operation:
       name: Window regulator operation
       description: Specifies how the window regulator is operated (manual crank or electric).
@@ -25316,12 +28931,21 @@ en:
     windshield_mount_attachment_method:
       name: Windshield mount attachment method
       description: Specifies how the mount adheres to or grips the windshield surface.
+    windshield_repair_kit_maximum_crack_length:
+      name: Windshield repair kit maximum crack length
+      description: Windshield repair kit maximum crack length
+    windshield_repair_kit_maximum_repair_diameter:
+      name: Windshield repair kit maximum repair diameter
+      description: Windshield repair kit maximum repair diameter
     windshield_washer_fluid_seasonality:
       name: Windshield washer fluid seasonality
       description: Indicates the intended season/climate or primary use case of the windshield washer fluid formulation (e.g., winter de-icer, summer bug wash, all-season).
     windsurf_fin_style:
       name: Windsurf fin style
       description: Classifies the fin by the intended sailing discipline or usage style (e.g., wave, slalom, weed).
+    windsurfing_board_size:
+      name: Windsurfing board size
+      description: Indicates the dimensions of wind-powered water sports equipment, determining buoyancy, maneuverability, and rider compatibility.
     windsurfing_board_style:
       name: Windsurfing board style
       description: Specifies the type of windsurfing board, such as freestyle or slalom
@@ -25367,6 +28991,9 @@ en:
     winemaking_process_stage:
       name: Winemaking process stage
       description: Indicates the primary stage of the winemaking process the supply is intended for.
+    wing_area:
+      name: Wing area
+      description: Wing area
     wing_count:
       name: Wing count
       description: Number of wings/arms on the boomerang.
@@ -25379,9 +29006,15 @@ en:
     wing_style:
       name: Wing style
       description: Indicates whether the pad includes stabilizing wings and, if so, what style
+    wingfoil_board_length:
+      name: Wingfoil board length
+      description: Wingfoil board length
     wingfoiling_style:
       name: Wingfoiling style
       description: Indicates the specific wingfoiling discipline or riding style the product targets.
+    wingspan:
+      name: Wingspan
+      description: Wingspan
     wipe_dispenser/warmer_features:
       name: Wipe dispenser/warmer features
       description: Describes the special features of wipe dispensers and warmers, i.e. travel friendly
@@ -25403,12 +29036,18 @@ en:
     wiper_arm_finish:
       name: Wiper arm finish
       description: Surface finish or protective coating applied to the wiper arm, impacting corrosion resistance and appearance.
+    wiper_arm_length:
+      name: Wiper arm length
+      description: Wiper arm length
     wiper_arm_pivot_mount_type:
       name: Wiper arm pivot mount type
       description: Specifies how the wiper arm mounts to the vehicle’s wiper linkage or pivot.
     wiper_blade_attachment_type:
       name: Wiper blade attachment type
       description: Specifies the connector/attachment style used to mount the wiper blade to the wiper arm.
+    wiper_blade_length:
+      name: Wiper blade length
+      description: Wiper blade length
     wiper_blade_rubber_material:
       name: Wiper blade rubber material
       description: Material of the wiping element (insert/refill) that contacts the glass.
@@ -25436,12 +29075,18 @@ en:
     wire_insulation_material:
       name: Wire insulation material
       description: Material of the wire insulation/jacket used in the harness (impacts temperature/chemical resistance).
+    wire_length:
+      name: Wire length
+      description: Specifies the total linear measurement of flexible material, determining project capability and craft possibilities.
     wire_packaging_type:
       name: Wire packaging type
       description: Specifies the way the wire is sold/packaged.
     wire_shape_profile:
       name: Wire shape/profile
       description: Describes the cross-sectional shape of the wire.
+    wire_spool_length:
+      name: Wire spool length
+      description: Wire spool length
     wire_thickness:
       name: Wire thickness
       description: Specifies the thickness of wires, like thick or fine
@@ -25478,6 +29123,9 @@ en:
     wood_seasoning_method:
       name: Wood seasoning method
       description: Indicates how the wood fuel was dried or seasoned, influencing moisture content and burn quality.
+    wood_slice_diameter:
+      name: Wood slice diameter
+      description: Wood slice diameter
     wood_slice_edge_style:
       name: Wood slice edge style
       description: Edge condition of the slice, such as natural bark edge vs. smooth/sanded edge.
@@ -25496,18 +29144,45 @@ en:
     woodwind_small_part_type:
       name: Woodwind small part type
       description: Specifies what kind of clarinet small replacement part the item is (e.g., keywork hardware, pads/cork/felts, rings).
+    woofer_diameter:
+      name: Woofer diameter
+      description: Woofer diameter
+    woofer_mounting_cutout_diameter:
+      name: Woofer mounting cutout diameter
+      description: Woofer mounting cutout diameter
+    woofer_mounting_depth:
+      name: Woofer mounting depth
+      description: Woofer mounting depth
     woofer_mounting_type:
       name: Woofer mounting type
       description: How the woofer is intended to be mounted/used (free-air vs enclosure) and common automotive mounting forms.
+    woofer_sensitivity:
+      name: Woofer sensitivity
+      description: Woofer sensitivity
     woofer_surround_material:
       name: Woofer surround material
       description: Material used for the woofer surround (outer suspension ring).
     work_capacity:
       name: Work capacity
       description: Describes the performance level of a product, such as heavy-duty or light-duty
+    working_area_height:
+      name: Working area height
+      description: Indicates the vertical dimension of active surfaces, determining usable space for signature capture and data entry.
+    working_area_length:
+      name: Working area length
+      description: Working area length
+    working_area_width:
+      name: Working area width
+      description: Specifies the horizontal dimension of active surfaces, determining usable space for signature capture and data entry.
+    working_distance:
+      name: Working distance
+      description: Indicates the optimal separation between lens and specimen, determining practical usage and specimen manipulation space.
     worn_on_finger:
       name: Worn-on finger
       description: Specifies which finger the thimble guide is intended to be worn on.
+    wrap_coverage_area:
+      name: Wrap coverage area
+      description: Wrap coverage area
     wrap_format:
       name: Wrap format
       description: Specifies the physical form in which the food wrap is supplied, such as rolls or pre-cut sheets.
@@ -25523,12 +29198,21 @@ en:
     wreath_design:
       name: Wreath design
       description: Identifies the primary material or shape of a wreath, such as metal or hoop
+    wrench_flat_size:
+      name: Wrench flat size
+      description: Wrench flat size
     wrestling_dummy_design:
       name: Wrestling dummy design
       description: Overall body shape or posture of the dummy, such as standing human shape or throwing bag, which dictates applicable training drills.
     wrestling_mat_safety_certifications:
       name: Wrestling mat safety certifications
       description: Lists any industry or sports body safety certifications or standards the mat meets.
+    wrist_pin_diameter:
+      name: Wrist pin diameter
+      description: Wrist pin diameter
+    wrist_pin_length:
+      name: Wrist pin length
+      description: Wrist pin length
     wrist_rest_features:
       name: Wrist rest features
       description: Lists special functional or design characteristics that add value
@@ -25565,12 +29249,18 @@ en:
     yarn_guide_style:
       name: Yarn guide style
       description: The physical style of the yarn guiding component.
+    yarn_length:
+      name: Yarn length
+      description: Specifies the total linear measurement of fiber material, determining project capability and fly tying possibilities.
     yarn_swift_adjustability:
       name: Yarn swift adjustability
       description: Indicates whether and how the swift can be adjusted (expandable, collapsible/foldable), affecting storage and the range of skein sizes it can handle.
     yarn_swift_bearing_type:
       name: Yarn swift bearing type
       description: Describes the rotation support mechanism (e.g., ball bearing) that affects smoothness and winding speed.
+    yarn_swift_maximum_skein_circumference:
+      name: Yarn swift maximum skein circumference
+      description: Yarn swift maximum skein circumference
     yarn_weight_category:
       name: Yarn weight category
       description: Identifies the thickness of yarn, like super bulky or craft
@@ -25580,6 +29270,9 @@ en:
     yo_yo_accessory_part_type:
       name: Yo-yo accessory/part type
       description: Identifies what kind of yo-yo replacement part or accessory the product is (e.g., string, bearing, response pads).
+    yo_yo_axle_length:
+      name: Yo-yo axle length
+      description: Yo-yo axle length
     yo_yo_axle_system_type:
       name: Yo-yo axle system type
       description: Construction approach for the yo-yo axle (e.g., fixed axle vs transaxle), impacting play feel and maintenance.
@@ -25616,12 +29309,18 @@ en:
     zills_strap_adjustability:
       name: Zills strap adjustability
       description: Whether and how the included strap/elastic can be adjusted for fit.
+    zills_weight:
+      name: Zills weight
+      description: Zills weight
     zipper_application:
       name: Zipper application
       description: Specifies the intended project or application the zipper is designed for.
     zipper_chain_type:
       name: Zipper chain type
       description: Specifies the construction/type of the zipper chain/teeth.
+    zipper_chain_width:
+      name: Zipper chain width
+      description: Zipper chain width
     zipper_end_type:
       name: Zipper end type
       description: Indicates how the zipper terminates and whether it separates (open-end) or is closed-end (non-separating), including common separating-end hardware used in craft zippers.
@@ -25664,6 +29363,9 @@ en:
     zipper_tape_material:
       name: Zipper tape material
       description: Specifies the primary material of the zipper tape (fabric sides) that is sewn into the project.
+    zipper_tape_width:
+      name: Zipper tape width
+      description: Zipper tape width
     zipper_teeth_type:
       name: Zipper teeth type
       description: Specifies the construction style of the zipper chain/teeth (e.g., coil, molded plastic, metal, invisible), which affects flexibility, strength, and typical applications.

--- a/dev/lib/product_taxonomy/commands/generate_dist_command.rb
+++ b/dev/lib/product_taxonomy/commands/generate_dist_command.rb
@@ -80,7 +80,8 @@ module ProductTaxonomy
         Serializers::ReturnReason::Dist::JsonSerializer.serialize_all(version: @version, locale:)
       end
 
-      File.write("#{OUTPUT_PATH}/#{locale}/#{type}.json", JSON.pretty_generate(json_data) + "\n")
+      json_output = type == "taxonomy" ? JSON.generate(json_data) : JSON.pretty_generate(json_data)
+      File.write("#{OUTPUT_PATH}/#{locale}/#{type}.json", json_output + "\n")
     end
   end
 end

--- a/dev/test/integration/all_data_files_import_test.rb
+++ b/dev/test/integration/all_data_files_import_test.rb
@@ -104,17 +104,24 @@ module ProductTaxonomy
       assert_equal ["Snowskates", "Splitboards"], snowboard.children.map(&:name).sort
 
       real_attribute_friendly_ids = snowboard.attributes.map(&:friendly_id)
-      assert_equal 10, real_attribute_friendly_ids.size
-      assert_includes real_attribute_friendly_ids, "age_group"
-      assert_includes real_attribute_friendly_ids, "color"
-      assert_includes real_attribute_friendly_ids, "pattern"
-      assert_includes real_attribute_friendly_ids, "recommended_skill_level"
-      assert_includes real_attribute_friendly_ids, "snowboard_design"
-      assert_includes real_attribute_friendly_ids, "snowboarding_style"
-      assert_includes real_attribute_friendly_ids, "target_gender"
-      assert_includes real_attribute_friendly_ids, "snowboard_construction"
-      assert_includes real_attribute_friendly_ids, "snowboard_base_material"
-      assert_includes real_attribute_friendly_ids, "snowboard_width_class"
+      assert_equal [
+        "age_group",
+        "color",
+        "effective_edge_length",
+        "height",
+        "length",
+        "pattern",
+        "recommended_skill_level",
+        "sidecut_radius",
+        "snowboard_base_material",
+        "snowboard_construction",
+        "snowboard_design",
+        "snowboard_size",
+        "snowboard_width_class",
+        "snowboarding_style",
+        "target_gender",
+        "width",
+      ], real_attribute_friendly_ids.sort
     end
 
     # more fragile, but easier sanity check

--- a/dist/en/attributes.txt
+++ b/dist/en/attributes.txt
@@ -10,6 +10,7 @@ gid://shopify/TaxonomyAttribute/5668  : 80 Plus efficiency rating
 gid://shopify/TaxonomyAttribute/6976  : ABEC rating
 gid://shopify/TaxonomyAttribute/8005  : AC compressor mounting style
 gid://shopify/TaxonomyAttribute/8006  : AC compressor oil type
+gid://shopify/TaxonomyAttribute/11250 : AC onboard charger power
 gid://shopify/TaxonomyAttribute/5507  : ADC resolution
 gid://shopify/TaxonomyAttribute/2649  : AI application
 gid://shopify/TaxonomyAttribute/7015  : ART security rating
@@ -22,7 +23,9 @@ gid://shopify/TaxonomyAttribute/2184  : Abrasive material
 gid://shopify/TaxonomyAttribute/7610  : Absinthe accessories included
 gid://shopify/TaxonomyAttribute/1460  : Absinthe style
 gid://shopify/TaxonomyAttribute/1461  : Absinthe variety
+gid://shopify/TaxonomyAttribute/11247 : Absorbency capacity
 gid://shopify/TaxonomyAttribute/894   : Absorbency level
+gid://shopify/TaxonomyAttribute/11249 : Absorbent capacity (volume)
 gid://shopify/TaxonomyAttribute/2972  : Absorbent hygiene product features
 gid://shopify/TaxonomyAttribute/2529  : Academic level
 gid://shopify/TaxonomyAttribute/8942  : Accent modes
@@ -38,6 +41,7 @@ gid://shopify/TaxonomyAttribute/8943  : Acoustic amplifier feedback control feat
 gid://shopify/TaxonomyAttribute/8944  : Acoustic drum kit components included
 gid://shopify/TaxonomyAttribute/8945  : Acoustic guitar body shape
 gid://shopify/TaxonomyAttribute/8946  : Acoustic guitar string core design
+gid://shopify/TaxonomyAttribute/12282 : Acoustic material thickness
 gid://shopify/TaxonomyAttribute/8947  : Acoustic piano key material
 gid://shopify/TaxonomyAttribute/8948  : Acoustic piano lid type
 gid://shopify/TaxonomyAttribute/8949  : Acoustic piano plate/frame material
@@ -54,10 +58,15 @@ gid://shopify/TaxonomyAttribute/6978  : Actuation mechanism
 gid://shopify/TaxonomyAttribute/8008  : Actuation method
 gid://shopify/TaxonomyAttribute/1543  : Acupuncture model format
 gid://shopify/TaxonomyAttribute/1544  : Acupuncture model type
+gid://shopify/TaxonomyAttribute/11253 : Adapter case interior height
+gid://shopify/TaxonomyAttribute/11254 : Adapter case interior length
+gid://shopify/TaxonomyAttribute/11255 : Adapter case interior width
 gid://shopify/TaxonomyAttribute/5562  : Adapter directionality
 gid://shopify/TaxonomyAttribute/5424  : Adapter operating modes
 gid://shopify/TaxonomyAttribute/6979  : Adapter orientation
 gid://shopify/TaxonomyAttribute/5391  : Adaptive sync technology
+gid://shopify/TaxonomyAttribute/11256 : Added length
+gid://shopify/TaxonomyAttribute/11257 : Added warmth
 gid://shopify/TaxonomyAttribute/3376  : Additional animation software features
 gid://shopify/TaxonomyAttribute/5144  : Additional cleaning technology
 gid://shopify/TaxonomyAttribute/3378  : Additional design software type
@@ -89,6 +98,7 @@ gid://shopify/TaxonomyAttribute/8957  : Aftertouch support
 gid://shopify/TaxonomyAttribute/7611  : Agave content classification
 gid://shopify/TaxonomyAttribute/30    : Age group
 gid://shopify/TaxonomyAttribute/2274  : Age restrictions
+gid://shopify/TaxonomyAttribute/12283 : Aging
 gid://shopify/TaxonomyAttribute/8958  : Aida cloth count
 gid://shopify/TaxonomyAttribute/8959  : Aida cloth pre-cut format
 gid://shopify/TaxonomyAttribute/6338  : Air & water rocket kit items included
@@ -103,6 +113,7 @@ gid://shopify/TaxonomyAttribute/8013  : Air intake temperature sensor mounting s
 gid://shopify/TaxonomyAttribute/6984  : Air integration capability
 gid://shopify/TaxonomyAttribute/3182  : Air mattress features
 gid://shopify/TaxonomyAttribute/6985  : Air mattress valve type
+gid://shopify/TaxonomyAttribute/12284 : Air purification rate (CADR)
 gid://shopify/TaxonomyAttribute/5690  : Air purifier filter technology
 gid://shopify/TaxonomyAttribute/5691  : Air purifier filtration rating
 gid://shopify/TaxonomyAttribute/5103  : Air tube configuration
@@ -114,7 +125,9 @@ gid://shopify/TaxonomyAttribute/8015  : Aircraft ADS-B capability
 gid://shopify/TaxonomyAttribute/8016  : Aircraft airframe material
 gid://shopify/TaxonomyAttribute/8017  : Aircraft cabin configuration
 gid://shopify/TaxonomyAttribute/8018  : Aircraft documentation included
+gid://shopify/TaxonomyAttribute/11260 : Aircraft empty weight
 gid://shopify/TaxonomyAttribute/4683  : Aircraft engine configuration
+gid://shopify/TaxonomyAttribute/11261 : Aircraft engine time since overhaul (TSO)
 gid://shopify/TaxonomyAttribute/4682  : Aircraft engine type
 gid://shopify/TaxonomyAttribute/8019  : Aircraft galley configuration
 gid://shopify/TaxonomyAttribute/8020  : Aircraft installation location
@@ -122,14 +135,20 @@ gid://shopify/TaxonomyAttribute/8021  : Aircraft internet connection
 gid://shopify/TaxonomyAttribute/8022  : Aircraft landing gear type
 gid://shopify/TaxonomyAttribute/8023  : Aircraft lavatory configuration
 gid://shopify/TaxonomyAttribute/8024  : Aircraft maintenance program enrollment
+gid://shopify/TaxonomyAttribute/11262 : Aircraft maximum payload
 gid://shopify/TaxonomyAttribute/8025  : Aircraft operational certification
 gid://shopify/TaxonomyAttribute/8026  : Aircraft protective gear certification
+gid://shopify/TaxonomyAttribute/11264 : Aircraft service ceiling
 gid://shopify/TaxonomyAttribute/8027  : Aircraft system application
 gid://shopify/TaxonomyAttribute/5211  : Airflow opening design
 gid://shopify/TaxonomyAttribute/8962  : Airflow resistance level
+gid://shopify/TaxonomyAttribute/12285 : Airflow system diameter
+gid://shopify/TaxonomyAttribute/12286 : Airflow system length
+gid://shopify/TaxonomyAttribute/11265 : Airframe total time
 gid://shopify/TaxonomyAttribute/8028  : Airship envelope material
 gid://shopify/TaxonomyAttribute/6986  : Airsoft part type
 gid://shopify/TaxonomyAttribute/8029  : Airworthiness approval basis
+gid://shopify/TaxonomyAttribute/11266 : Alarm siren loudness
 gid://shopify/TaxonomyAttribute/6987  : Alarm volume adjustability
 gid://shopify/TaxonomyAttribute/2287  : Album type
 gid://shopify/TaxonomyAttribute/5290  : Alcohol content
@@ -151,8 +170,10 @@ gid://shopify/TaxonomyAttribute/6989  : Altitude suitability
 gid://shopify/TaxonomyAttribute/8036  : Ambulance stretcher mount type
 gid://shopify/TaxonomyAttribute/6990  : American football safety certification
 gid://shopify/TaxonomyAttribute/5126  : Amino acid subtype
+gid://shopify/TaxonomyAttribute/12288 : Amperage
 gid://shopify/TaxonomyAttribute/1800  : Amplifier class
 gid://shopify/TaxonomyAttribute/2690  : Amplifier configuration
+gid://shopify/TaxonomyAttribute/11269 : Amplifier fuse rating
 gid://shopify/TaxonomyAttribute/8964  : Amplifier tube function
 gid://shopify/TaxonomyAttribute/1808  : Amplifier/Booster suitable location
 gid://shopify/TaxonomyAttribute/5088  : Amputation level
@@ -162,7 +183,10 @@ gid://shopify/TaxonomyAttribute/5100  : Analyte measured
 gid://shopify/TaxonomyAttribute/4998  : Anamorphic squeeze ratio
 gid://shopify/TaxonomyAttribute/5043  : Anatomical detail displayed
 gid://shopify/TaxonomyAttribute/6991  : Anchor configuration
+gid://shopify/TaxonomyAttribute/11270 : Anchor line diameter
+gid://shopify/TaxonomyAttribute/11271 : Anchor shank length
 gid://shopify/TaxonomyAttribute/1258  : Anchor type
+gid://shopify/TaxonomyAttribute/11272 : Anchor weight
 gid://shopify/TaxonomyAttribute/2198  : Anemometer application
 gid://shopify/TaxonomyAttribute/1883  : Angles supported
 gid://shopify/TaxonomyAttribute/1289  : Angling style
@@ -173,6 +197,7 @@ gid://shopify/TaxonomyAttribute/6340  : Animal species
 gid://shopify/TaxonomyAttribute/6992  : Animal trap jaw style
 gid://shopify/TaxonomyAttribute/6993  : Animal trap type
 gid://shopify/TaxonomyAttribute/1308  : Animal type
+gid://shopify/TaxonomyAttribute/12289 : Ankle circumference
 gid://shopify/TaxonomyAttribute/6994  : Ankle collar style
 gid://shopify/TaxonomyAttribute/6995  : Ankle guard protection level
 gid://shopify/TaxonomyAttribute/6996  : Ankle strap padding type
@@ -199,6 +224,7 @@ gid://shopify/TaxonomyAttribute/2710  : Antifreeze type
 gid://shopify/TaxonomyAttribute/4680  : Antique car design
 gid://shopify/TaxonomyAttribute/8967  : Antique gun ignition system
 gid://shopify/TaxonomyAttribute/4679  : Antique vehicle era
+gid://shopify/TaxonomyAttribute/12290 : Aperture
 gid://shopify/TaxonomyAttribute/7614  : Apple variety
 gid://shopify/TaxonomyAttribute/5501  : Appliance board function
 gid://shopify/TaxonomyAttribute/5500  : Appliance unit location
@@ -217,6 +243,7 @@ gid://shopify/TaxonomyAttribute/3228  : Aquarium overflow box design
 gid://shopify/TaxonomyAttribute/5695  : Aquatic plant growth habit
 gid://shopify/TaxonomyAttribute/5696  : Arbor top design
 gid://shopify/TaxonomyAttribute/6999  : Arbor type
+gid://shopify/TaxonomyAttribute/11274 : Arch height
 gid://shopify/TaxonomyAttribute/7000  : Archery accessory type
 gid://shopify/TaxonomyAttribute/1302  : Archery activity
 gid://shopify/TaxonomyAttribute/2888  : Archery equipment included
@@ -226,10 +253,12 @@ gid://shopify/TaxonomyAttribute/1303  : Archery style
 gid://shopify/TaxonomyAttribute/7003  : Archery target features
 gid://shopify/TaxonomyAttribute/4365  : Archery target type
 gid://shopify/TaxonomyAttribute/7004  : Archery tool type
+gid://shopify/TaxonomyAttribute/11275 : Arm circumference range
 gid://shopify/TaxonomyAttribute/7005  : Armband features
 gid://shopify/TaxonomyAttribute/7006  : Armguard style
 gid://shopify/TaxonomyAttribute/8043  : Armor protection type
 gid://shopify/TaxonomyAttribute/6863  : Armrest adjustability
+gid://shopify/TaxonomyAttribute/12291 : Armrest height
 gid://shopify/TaxonomyAttribute/6864  : Armrest type
 gid://shopify/TaxonomyAttribute/2496  : Arrangement
 gid://shopify/TaxonomyAttribute/7008  : Arrow component type
@@ -240,6 +269,8 @@ gid://shopify/TaxonomyAttribute/7011  : Arrow nock groove size
 gid://shopify/TaxonomyAttribute/7012  : Arrow nock type
 gid://shopify/TaxonomyAttribute/7013  : Arrow rest style
 gid://shopify/TaxonomyAttribute/7014  : Arrow shaft compatibility
+gid://shopify/TaxonomyAttribute/11276 : Arrow spine rating
+gid://shopify/TaxonomyAttribute/11277 : Arrow straightness tolerance
 gid://shopify/TaxonomyAttribute/2969  : Arrow/Bolt material
 gid://shopify/TaxonomyAttribute/7007  : Arrow/bolt point type
 gid://shopify/TaxonomyAttribute/2299  : Art fixative application method
@@ -259,8 +290,11 @@ gid://shopify/TaxonomyAttribute/2666  : Artwork type
 gid://shopify/TaxonomyAttribute/7018  : Ascender/descender type
 gid://shopify/TaxonomyAttribute/5697  : Ashtray type
 gid://shopify/TaxonomyAttribute/8044  : Aspiration type
+gid://shopify/TaxonomyAttribute/11278 : Assembled toy kitchen dimensions
+gid://shopify/TaxonomyAttribute/11279 : Assembled track length
 gid://shopify/TaxonomyAttribute/12755 : Assembly required
 gid://shopify/TaxonomyAttribute/6865  : Assembly state
+gid://shopify/TaxonomyAttribute/11280 : Assembly time
 gid://shopify/TaxonomyAttribute/7019  : Assistance mechanism
 gid://shopify/TaxonomyAttribute/3387  : Assisted braking technology
 gid://shopify/TaxonomyAttribute/7617  : Atemoya cultivar
@@ -304,6 +338,8 @@ gid://shopify/TaxonomyAttribute/8975  : Autograph authentication
 gid://shopify/TaxonomyAttribute/8976  : Autograph format
 gid://shopify/TaxonomyAttribute/2361  : Autograph type
 gid://shopify/TaxonomyAttribute/8047  : Autogyro cockpit enclosure
+gid://shopify/TaxonomyAttribute/11281 : Autogyro landing distance
+gid://shopify/TaxonomyAttribute/11283 : Autogyro rotor diameter
 gid://shopify/TaxonomyAttribute/2583  : Automation
 gid://shopify/TaxonomyAttribute/7023  : Available firing modes
 gid://shopify/TaxonomyAttribute/7618  : Avocado variety
@@ -313,6 +349,7 @@ gid://shopify/TaxonomyAttribute/8978  : Award material
 gid://shopify/TaxonomyAttribute/8979  : Award mounting/display type
 gid://shopify/TaxonomyAttribute/2525  : Award occasion
 gid://shopify/TaxonomyAttribute/8980  : Award plaque plate material
+gid://shopify/TaxonomyAttribute/11284 : Award plaque plate size
 gid://shopify/TaxonomyAttribute/8981  : Award ribbon attachment type
 gid://shopify/TaxonomyAttribute/8982  : Award ribbon imprint method
 gid://shopify/TaxonomyAttribute/8983  : Award ribbon material
@@ -321,6 +358,14 @@ gid://shopify/TaxonomyAttribute/1426  : Awning construction type
 gid://shopify/TaxonomyAttribute/2823  : Awning design
 gid://shopify/TaxonomyAttribute/5699  : Awning operation type
 gid://shopify/TaxonomyAttribute/7024  : Axle compatibility
+gid://shopify/TaxonomyAttribute/11285 : Axle diameter
+gid://shopify/TaxonomyAttribute/11286 : Axle shaft diameter
+gid://shopify/TaxonomyAttribute/11287 : Axle shaft length
+gid://shopify/TaxonomyAttribute/11288 : Axle spacing (dropout width)
+gid://shopify/TaxonomyAttribute/11292 : Axle width
+gid://shopify/TaxonomyAttribute/11289 : Axle-to-axle length
+gid://shopify/TaxonomyAttribute/11290 : Axle-to-axle width (cocked)
+gid://shopify/TaxonomyAttribute/11291 : Axle-to-axle width (uncocked)
 gid://shopify/TaxonomyAttribute/7069  : BB gun action type
 gid://shopify/TaxonomyAttribute/7070  : BB gun caliber
 gid://shopify/TaxonomyAttribute/7071  : BB gun part type
@@ -344,16 +389,20 @@ gid://shopify/TaxonomyAttribute/3246  : Baby/Toddler sleepwear style
 gid://shopify/TaxonomyAttribute/8986  : Back & sides material
 gid://shopify/TaxonomyAttribute/8985  : Back beam type
 gid://shopify/TaxonomyAttribute/6636  : Back design
+gid://shopify/TaxonomyAttribute/12292 : Back length
 gid://shopify/TaxonomyAttribute/6866  : Back panel type
 gid://shopify/TaxonomyAttribute/1531  : Back type
 gid://shopify/TaxonomyAttribute/5329  : Backboard material
+gid://shopify/TaxonomyAttribute/11293 : Backboard width
 gid://shopify/TaxonomyAttribute/2047  : Background design
 gid://shopify/TaxonomyAttribute/2185  : Backing material
 gid://shopify/TaxonomyAttribute/8987  : Backing type
 gid://shopify/TaxonomyAttribute/5617  : Backlighting type
 gid://shopify/TaxonomyAttribute/1527  : Backrest type
+gid://shopify/TaxonomyAttribute/11295 : Backup camera minimum illumination
 gid://shopify/TaxonomyAttribute/8048  : Backup camera mounting location
 gid://shopify/TaxonomyAttribute/8049  : Backup camera video interface
+gid://shopify/TaxonomyAttribute/12293 : Backup runtime
 gid://shopify/TaxonomyAttribute/7025  : Badminton set components included
 gid://shopify/TaxonomyAttribute/7026  : Bag attachment method
 gid://shopify/TaxonomyAttribute/5700  : Bag clip style
@@ -366,6 +415,7 @@ gid://shopify/TaxonomyAttribute/5702  : Bag insulation
 gid://shopify/TaxonomyAttribute/8990  : Bag material
 gid://shopify/TaxonomyAttribute/7028  : Bag padding level
 gid://shopify/TaxonomyAttribute/6638  : Bag size descriptor
+gid://shopify/TaxonomyAttribute/11300 : Bag strap drop length
 gid://shopify/TaxonomyAttribute/2222  : Bag strap type
 gid://shopify/TaxonomyAttribute/3365  : Bag style
 gid://shopify/TaxonomyAttribute/2725  : Bag type
@@ -373,15 +423,20 @@ gid://shopify/TaxonomyAttribute/3006  : Bag/Case features
 gid://shopify/TaxonomyAttribute/2784  : Bag/Case material
 gid://shopify/TaxonomyAttribute/3258  : Bag/Case storage features
 gid://shopify/TaxonomyAttribute/8988  : Bag/case carrying style
+gid://shopify/TaxonomyAttribute/11297 : Bag/case interior height
+gid://shopify/TaxonomyAttribute/11298 : Bag/case interior length
+gid://shopify/TaxonomyAttribute/11299 : Bag/case interior width
 gid://shopify/TaxonomyAttribute/7619  : Bagel size
 gid://shopify/TaxonomyAttribute/8991  : Bagpipe accessories included
 gid://shopify/TaxonomyAttribute/8992  : Bagpipes playing mode
 gid://shopify/TaxonomyAttribute/7029  : Bait compatibility
+gid://shopify/TaxonomyAttribute/11301 : Bait length
 gid://shopify/TaxonomyAttribute/7030  : Bait species
 gid://shopify/TaxonomyAttribute/3100  : Bakery items included
 gid://shopify/TaxonomyAttribute/3360  : Bakeware items included
 gid://shopify/TaxonomyAttribute/1394  : Bakeware pieces included
 gid://shopify/TaxonomyAttribute/2813  : Bakeware shape
+gid://shopify/TaxonomyAttribute/12294 : Bakeware size
 gid://shopify/TaxonomyAttribute/7620  : Baking chip form
 gid://shopify/TaxonomyAttribute/5703  : Baking liner size
 gid://shopify/TaxonomyAttribute/1486  : Baking purpose
@@ -389,14 +444,18 @@ gid://shopify/TaxonomyAttribute/2812  : Baking sheet material
 gid://shopify/TaxonomyAttribute/5704  : Baking sheet style
 gid://shopify/TaxonomyAttribute/7031  : Balance board style
 gid://shopify/TaxonomyAttribute/7032  : Balance cushion accessories included
+gid://shopify/TaxonomyAttribute/11302 : Balance point
 gid://shopify/TaxonomyAttribute/8050  : Balance type
 gid://shopify/TaxonomyAttribute/6346  : Ball & cup game included pieces
 gid://shopify/TaxonomyAttribute/7033  : Ball bladder material
 gid://shopify/TaxonomyAttribute/7034  : Ball certification
+gid://shopify/TaxonomyAttribute/11303 : Ball circumference
 gid://shopify/TaxonomyAttribute/7035  : Ball construction
 gid://shopify/TaxonomyAttribute/7036  : Ball core construction
 gid://shopify/TaxonomyAttribute/7037  : Ball core type
+gid://shopify/TaxonomyAttribute/11304 : Ball diameter
 gid://shopify/TaxonomyAttribute/7038  : Ball drilling state
+gid://shopify/TaxonomyAttribute/11305 : Ball feed interval
 gid://shopify/TaxonomyAttribute/7039  : Ball holder type
 gid://shopify/TaxonomyAttribute/2844  : Ball material
 gid://shopify/TaxonomyAttribute/6347  : Ball pit ball surface finish
@@ -408,19 +467,24 @@ gid://shopify/TaxonomyAttribute/1206  : Ball size
 gid://shopify/TaxonomyAttribute/7043  : Ball speed rating
 gid://shopify/TaxonomyAttribute/7044  : Ball surface texture
 gid://shopify/TaxonomyAttribute/7045  : Ball surface type
+gid://shopify/TaxonomyAttribute/12295 : Ball weight
 gid://shopify/TaxonomyAttribute/6283  : Ballast material
 gid://shopify/TaxonomyAttribute/8051  : Ballonet configuration
 gid://shopify/TaxonomyAttribute/8993  : Balloon closure/valve type
+gid://shopify/TaxonomyAttribute/11306 : Balloon kit diameter
 gid://shopify/TaxonomyAttribute/8994  : Balloon kit finish
 gid://shopify/TaxonomyAttribute/2505  : Balloon kit items included
 gid://shopify/TaxonomyAttribute/8995  : Balloon kit material
 gid://shopify/TaxonomyAttribute/2506  : Balloon shape
 gid://shopify/TaxonomyAttribute/7621  : Banana variety
+gid://shopify/TaxonomyAttribute/12296 : Band length
 gid://shopify/TaxonomyAttribute/2242  : Band strength
+gid://shopify/TaxonomyAttribute/12297 : Band width
 gid://shopify/TaxonomyAttribute/5123  : Bandage shape
 gid://shopify/TaxonomyAttribute/8996  : Banjo head type
 gid://shopify/TaxonomyAttribute/8997  : Banjo neck material
 gid://shopify/TaxonomyAttribute/8998  : Banjo pickup configuration
+gid://shopify/TaxonomyAttribute/11307 : Banjo rim diameter
 gid://shopify/TaxonomyAttribute/8999  : Banjo rim material
 gid://shopify/TaxonomyAttribute/9000  : Banjo tone ring type
 gid://shopify/TaxonomyAttribute/9001  : Banjo tuning machine type
@@ -448,21 +512,27 @@ gid://shopify/TaxonomyAttribute/1902  : Barcode scanner interface
 gid://shopify/TaxonomyAttribute/1903  : Barcode supported
 gid://shopify/TaxonomyAttribute/7624  : Barista suitability
 gid://shopify/TaxonomyAttribute/7049  : Barre rail configuration
+gid://shopify/TaxonomyAttribute/11308 : Barrel bore diameter
+gid://shopify/TaxonomyAttribute/11309 : Barrel length
 gid://shopify/TaxonomyAttribute/1648  : Barrel material
 gid://shopify/TaxonomyAttribute/7625  : Barrel or cask type
 gid://shopify/TaxonomyAttribute/7050  : Barrel profile
 gid://shopify/TaxonomyAttribute/5155  : Barrel shape
+gid://shopify/TaxonomyAttribute/12298 : Barrel size
 gid://shopify/TaxonomyAttribute/7051  : Barrel thread standard
 gid://shopify/TaxonomyAttribute/3359  : Barware items included
 gid://shopify/TaxonomyAttribute/2810  : Barware material
 gid://shopify/TaxonomyAttribute/7052  : Base anchoring method
 gid://shopify/TaxonomyAttribute/7053  : Base ballast method
 gid://shopify/TaxonomyAttribute/6868  : Base configuration
+gid://shopify/TaxonomyAttribute/12299 : Base curve (BC)
 gid://shopify/TaxonomyAttribute/6284  : Base features
+gid://shopify/TaxonomyAttribute/11310 : Base fill capacity
 gid://shopify/TaxonomyAttribute/7054  : Base fill material
 gid://shopify/TaxonomyAttribute/7626  : Base ingredient
 gid://shopify/TaxonomyAttribute/1660  : Base oil
 gid://shopify/TaxonomyAttribute/8053  : Base oil type
+gid://shopify/TaxonomyAttribute/11311 : Base plate thickness
 gid://shopify/TaxonomyAttribute/1471  : Base spirit
 gid://shopify/TaxonomyAttribute/6869  : Base storage type
 gid://shopify/TaxonomyAttribute/1795  : Base type
@@ -483,7 +553,11 @@ gid://shopify/TaxonomyAttribute/9012  : Bass clarinet body material
 gid://shopify/TaxonomyAttribute/9013  : Bass clarinet lowest written note
 gid://shopify/TaxonomyAttribute/9014  : Bass drum beater head shape
 gid://shopify/TaxonomyAttribute/9015  : Bass drum beater shaft material
+gid://shopify/TaxonomyAttribute/11314 : Bass drum beater weight
+gid://shopify/TaxonomyAttribute/11315 : Bass drum depth
+gid://shopify/TaxonomyAttribute/11316 : Bass drum diameter
 gid://shopify/TaxonomyAttribute/9016  : Bass drum head built-in muffling
+gid://shopify/TaxonomyAttribute/11317 : Bass drum head collar depth
 gid://shopify/TaxonomyAttribute/9017  : Bass drum head configuration
 gid://shopify/TaxonomyAttribute/9018  : Bass drum head surface finish
 gid://shopify/TaxonomyAttribute/9019  : Bass drum head type
@@ -493,6 +567,7 @@ gid://shopify/TaxonomyAttribute/9022  : Bass harmonica comb material
 gid://shopify/TaxonomyAttribute/9023  : Bass harmonica mouthpiece style
 gid://shopify/TaxonomyAttribute/9024  : Bass harmonica reed material
 gid://shopify/TaxonomyAttribute/9025  : Bass harmonica tuning system
+gid://shopify/TaxonomyAttribute/11318 : Bass harmonica weight
 gid://shopify/TaxonomyAttribute/9026  : Bass recorder bocal type
 gid://shopify/TaxonomyAttribute/9027  : Bass recorder included accessories
 gid://shopify/TaxonomyAttribute/9028  : Bass recorder keywork material
@@ -502,19 +577,30 @@ gid://shopify/TaxonomyAttribute/9031  : Bass ukulele string type
 gid://shopify/TaxonomyAttribute/6870  : Bassinet & cradle accessory features
 gid://shopify/TaxonomyAttribute/9032  : Bassoon bell material
 gid://shopify/TaxonomyAttribute/9033  : Bassoon bocal system
+gid://shopify/TaxonomyAttribute/11319 : Bassoon bocal tenon diameter
+gid://shopify/TaxonomyAttribute/11320 : Bassoon bocal tip opening diameter
+gid://shopify/TaxonomyAttribute/11321 : Bassoon case interior height
+gid://shopify/TaxonomyAttribute/11322 : Bassoon case interior length
+gid://shopify/TaxonomyAttribute/11323 : Bassoon case interior width
 gid://shopify/TaxonomyAttribute/9034  : Bassoon case shell type
 gid://shopify/TaxonomyAttribute/9035  : Bassoon keywork material
 gid://shopify/TaxonomyAttribute/9036  : Bassoon model level
 gid://shopify/TaxonomyAttribute/9037  : Bassoon performance level
+gid://shopify/TaxonomyAttribute/11324 : Bassoon reed length
 gid://shopify/TaxonomyAttribute/9038  : Bassoon reed scrape style
+gid://shopify/TaxonomyAttribute/11325 : Bassoon reed staple length
 gid://shopify/TaxonomyAttribute/9039  : Bassoon reed thread color
+gid://shopify/TaxonomyAttribute/11326 : Bassoon reed tip opening
 gid://shopify/TaxonomyAttribute/9040  : Bassoon reed type
+gid://shopify/TaxonomyAttribute/11327 : Bassoon reed width
 gid://shopify/TaxonomyAttribute/9041  : Bassoon system
 gid://shopify/TaxonomyAttribute/5705  : Baster tip type
 gid://shopify/TaxonomyAttribute/7062  : Bat construction
 gid://shopify/TaxonomyAttribute/7063  : Bat handle size compatibility
+gid://shopify/TaxonomyAttribute/12300 : Bat length
 gid://shopify/TaxonomyAttribute/2845  : Bat material
 gid://shopify/TaxonomyAttribute/1209  : Bat standard
+gid://shopify/TaxonomyAttribute/11329 : Batch yield volume
 gid://shopify/TaxonomyAttribute/6351  : Bath book interactive features
 gid://shopify/TaxonomyAttribute/5238  : Bath brush style
 gid://shopify/TaxonomyAttribute/6352  : Bath bubble machine features
@@ -539,9 +625,13 @@ gid://shopify/TaxonomyAttribute/7065  : Battery configuration
 gid://shopify/TaxonomyAttribute/5574  : Battery connector type
 gid://shopify/TaxonomyAttribute/3087  : Battery features
 gid://shopify/TaxonomyAttribute/8056  : Battery group size
+gid://shopify/TaxonomyAttribute/11331 : Battery life (active transmission)
 gid://shopify/TaxonomyAttribute/3196  : Battery management features
 gid://shopify/TaxonomyAttribute/5572  : Battery mounting type
+gid://shopify/TaxonomyAttribute/11332 : Battery pack operating voltage (nominal)
 gid://shopify/TaxonomyAttribute/8057  : Battery polarity
+gid://shopify/TaxonomyAttribute/12302 : Battery range
+gid://shopify/TaxonomyAttribute/11333 : Battery service life
 gid://shopify/TaxonomyAttribute/1682  : Battery size
 gid://shopify/TaxonomyAttribute/8058  : Battery standards supported
 gid://shopify/TaxonomyAttribute/1856  : Battery technology
@@ -551,6 +641,8 @@ gid://shopify/TaxonomyAttribute/8059  : Battery voltage class
 gid://shopify/TaxonomyAttribute/9042  : Batting & stuffing form factor
 gid://shopify/TaxonomyAttribute/9043  : Batting & stuffing loft level
 gid://shopify/TaxonomyAttribute/9044  : Batting & stuffing thermal insulation level
+gid://shopify/TaxonomyAttribute/11335 : Batting & stuffing weight per area
+gid://shopify/TaxonomyAttribute/11334 : Batting and stuffing coverage area
 gid://shopify/TaxonomyAttribute/7066  : Batting cage components included
 gid://shopify/TaxonomyAttribute/7067  : Batting helmet accessories included
 gid://shopify/TaxonomyAttribute/7068  : Batting tee base design
@@ -563,6 +655,7 @@ gid://shopify/TaxonomyAttribute/6362  : Beach & sand toy items included
 gid://shopify/TaxonomyAttribute/6360  : Beach ball features
 gid://shopify/TaxonomyAttribute/6361  : Beach bucket features
 gid://shopify/TaxonomyAttribute/8060  : Bead breaker type
+gid://shopify/TaxonomyAttribute/11339 : Bead diameter
 gid://shopify/TaxonomyAttribute/7072  : Bead hole style
 gid://shopify/TaxonomyAttribute/2318  : Bead shape
 gid://shopify/TaxonomyAttribute/9047  : Bead type
@@ -579,6 +672,7 @@ gid://shopify/TaxonomyAttribute/9057  : Beading thread use case
 gid://shopify/TaxonomyAttribute/9058  : Beading wire coating material
 gid://shopify/TaxonomyAttribute/9059  : Beading wire strand count
 gid://shopify/TaxonomyAttribute/8061  : Beadlock type
+gid://shopify/TaxonomyAttribute/11340 : Beam distance
 gid://shopify/TaxonomyAttribute/9060  : Beam material
 gid://shopify/TaxonomyAttribute/8062  : Beam pattern
 gid://shopify/TaxonomyAttribute/7073  : Bean bag fabric material
@@ -589,6 +683,7 @@ gid://shopify/TaxonomyAttribute/6639  : Beanie style
 gid://shopify/TaxonomyAttribute/5196  : Beard care benefits
 gid://shopify/TaxonomyAttribute/7074  : Bearing clearance
 gid://shopify/TaxonomyAttribute/7075  : Bearing construction type
+gid://shopify/TaxonomyAttribute/12303 : Bearing diameter
 gid://shopify/TaxonomyAttribute/9061  : Bearing edge type
 gid://shopify/TaxonomyAttribute/7076  : Bearing lubrication
 gid://shopify/TaxonomyAttribute/7077  : Bearing material
@@ -597,6 +692,7 @@ gid://shopify/TaxonomyAttribute/7079  : Bearing seal code
 gid://shopify/TaxonomyAttribute/7080  : Bearing seal type
 gid://shopify/TaxonomyAttribute/7081  : Bearing shield type
 gid://shopify/TaxonomyAttribute/7082  : Bearing size code
+gid://shopify/TaxonomyAttribute/11341 : Bearing thickness
 gid://shopify/TaxonomyAttribute/7083  : Bearing type
 gid://shopify/TaxonomyAttribute/2401  : Beat subdivisions
 gid://shopify/TaxonomyAttribute/9062  : Beater head material
@@ -621,6 +717,7 @@ gid://shopify/TaxonomyAttribute/7630  : Beer-based cocktail variety
 gid://shopify/TaxonomyAttribute/7631  : Beet variety
 gid://shopify/TaxonomyAttribute/7084  : Bell actuation mechanism
 gid://shopify/TaxonomyAttribute/2579  : Bell design
+gid://shopify/TaxonomyAttribute/11343 : Bell diameter
 gid://shopify/TaxonomyAttribute/9064  : Bell guard coverage area
 gid://shopify/TaxonomyAttribute/9065  : Bell material
 gid://shopify/TaxonomyAttribute/2580  : Bell sound
@@ -629,6 +726,7 @@ gid://shopify/TaxonomyAttribute/9066  : Bellows material
 gid://shopify/TaxonomyAttribute/9067  : Bellows orientation
 gid://shopify/TaxonomyAttribute/6640  : Belly panel style
 gid://shopify/TaxonomyAttribute/6641  : Belt buckle type
+gid://shopify/TaxonomyAttribute/11344 : Belt pitch
 gid://shopify/TaxonomyAttribute/5712  : Belt profile
 gid://shopify/TaxonomyAttribute/2721  : Belt type
 gid://shopify/TaxonomyAttribute/6642  : Beret style
@@ -670,6 +768,8 @@ gid://shopify/TaxonomyAttribute/7105  : Billiard rack style
 gid://shopify/TaxonomyAttribute/7106  : Billiard table type
 gid://shopify/TaxonomyAttribute/7107  : Billiards discipline
 gid://shopify/TaxonomyAttribute/2233  : Binder ring shape
+gid://shopify/TaxonomyAttribute/12304 : Binder ring size
+gid://shopify/TaxonomyAttribute/12305 : Binding comb size
 gid://shopify/TaxonomyAttribute/7108  : Binding compatibility standard
 gid://shopify/TaxonomyAttribute/7109  : Binding inclusion
 gid://shopify/TaxonomyAttribute/7110  : Binding interface
@@ -694,6 +794,8 @@ gid://shopify/TaxonomyAttribute/3221  : Bird treat type
 gid://shopify/TaxonomyAttribute/2508  : Birthday candle design
 gid://shopify/TaxonomyAttribute/3293  : Birthday candle type
 gid://shopify/TaxonomyAttribute/7116  : Bit attachment type
+gid://shopify/TaxonomyAttribute/12306 : Bit diameter
+gid://shopify/TaxonomyAttribute/11345 : Bit length
 gid://shopify/TaxonomyAttribute/7117  : Bit mouthpiece design
 gid://shopify/TaxonomyAttribute/7118  : Bit ring style
 gid://shopify/TaxonomyAttribute/3099  : Bitter variety
@@ -702,21 +804,28 @@ gid://shopify/TaxonomyAttribute/7120  : Blade attachment type
 gid://shopify/TaxonomyAttribute/5205  : Blade coating
 gid://shopify/TaxonomyAttribute/5714  : Blade construction method
 gid://shopify/TaxonomyAttribute/1220  : Blade curve
+gid://shopify/TaxonomyAttribute/11346 : Blade cut length
 gid://shopify/TaxonomyAttribute/2189  : Blade design
 gid://shopify/TaxonomyAttribute/5204  : Blade edge configuration
 gid://shopify/TaxonomyAttribute/5715  : Blade finish
 gid://shopify/TaxonomyAttribute/7121  : Blade finish/coating
+gid://shopify/TaxonomyAttribute/11347 : Blade hollow radius
 gid://shopify/TaxonomyAttribute/7122  : Blade hosel type
+gid://shopify/TaxonomyAttribute/12307 : Blade length
 gid://shopify/TaxonomyAttribute/7123  : Blade length type
 gid://shopify/TaxonomyAttribute/7124  : Blade lie
 gid://shopify/TaxonomyAttribute/1388  : Blade material
+gid://shopify/TaxonomyAttribute/11348 : Blade rocker radius
 gid://shopify/TaxonomyAttribute/5716  : Blade shape
 gid://shopify/TaxonomyAttribute/7125  : Blade sharpness
 gid://shopify/TaxonomyAttribute/5717  : Blade sidedness
+gid://shopify/TaxonomyAttribute/12308 : Blade size
 gid://shopify/TaxonomyAttribute/7126  : Blade size category
 gid://shopify/TaxonomyAttribute/7127  : Blade size class
 gid://shopify/TaxonomyAttribute/7128  : Blade size number
+gid://shopify/TaxonomyAttribute/11349 : Blade thickness
 gid://shopify/TaxonomyAttribute/1251  : Blade type
+gid://shopify/TaxonomyAttribute/12309 : Blade width
 gid://shopify/TaxonomyAttribute/7129  : Blaster mechanism
 gid://shopify/TaxonomyAttribute/5718  : Bleach formulation
 gid://shopify/TaxonomyAttribute/5719  : Bleach type
@@ -738,12 +847,15 @@ gid://shopify/TaxonomyAttribute/9075  : Bloom stage
 gid://shopify/TaxonomyAttribute/5721  : Blooming season
 gid://shopify/TaxonomyAttribute/8067  : Blower motor bearing type
 gid://shopify/TaxonomyAttribute/8068  : Blower motor mounting position
+gid://shopify/TaxonomyAttribute/11351 : Blower motor rotational speed
+gid://shopify/TaxonomyAttribute/11352 : Blowout extension length
 gid://shopify/TaxonomyAttribute/9076  : Blowpipe valve type
 gid://shopify/TaxonomyAttribute/5442  : Bluetooth functionality
 gid://shopify/TaxonomyAttribute/7130  : Bo staff style
 gid://shopify/TaxonomyAttribute/1255  : Board concave shape
 gid://shopify/TaxonomyAttribute/3191  : Board game features
 gid://shopify/TaxonomyAttribute/2759  : Board game mechanics
+gid://shopify/TaxonomyAttribute/11353 : Board game set-up time
 gid://shopify/TaxonomyAttribute/6367  : Board game theme
 gid://shopify/TaxonomyAttribute/2092  : Board material
 gid://shopify/TaxonomyAttribute/2264  : Board mounting type
@@ -759,13 +871,16 @@ gid://shopify/TaxonomyAttribute/8070  : Boat ladder stowage style
 gid://shopify/TaxonomyAttribute/8071  : Boat trailer construction type
 gid://shopify/TaxonomyAttribute/2754  : Boat type
 gid://shopify/TaxonomyAttribute/9077  : Boat weaving shuttle weft exit type
+gid://shopify/TaxonomyAttribute/11355 : Bobbin core diameter
 gid://shopify/TaxonomyAttribute/9078  : Bobbin loading type
+gid://shopify/TaxonomyAttribute/11356 : Bobbin shaft/bore diameter
 gid://shopify/TaxonomyAttribute/9079  : Bobbin system
 gid://shopify/TaxonomyAttribute/9080  : Bobbin type
 gid://shopify/TaxonomyAttribute/9081  : Bobbin winder winding direction
 gid://shopify/TaxonomyAttribute/6368  : Bobble mechanism
 gid://shopify/TaxonomyAttribute/9082  : Bocal material
 gid://shopify/TaxonomyAttribute/9083  : Bodhrán head material
+gid://shopify/TaxonomyAttribute/11358 : Bodhrán shell depth
 gid://shopify/TaxonomyAttribute/9084  : Bodhrán tuning system type
 gid://shopify/TaxonomyAttribute/1563  : Body area
 gid://shopify/TaxonomyAttribute/8072  : Body armor coverage area
@@ -779,13 +894,16 @@ gid://shopify/TaxonomyAttribute/8074  : Body panel finish state
 gid://shopify/TaxonomyAttribute/9085  : Body shape
 gid://shopify/TaxonomyAttribute/5089  : Body side
 gid://shopify/TaxonomyAttribute/1678  : Body/Facial hair type
+gid://shopify/TaxonomyAttribute/12310 : Bodyboard size
 gid://shopify/TaxonomyAttribute/6644  : Bodysuit bottom coverage
 gid://shopify/TaxonomyAttribute/1371  : Boiler system
 gid://shopify/TaxonomyAttribute/7136  : Boilie shape
 gid://shopify/TaxonomyAttribute/7137  : Boilie stop buoyancy
 gid://shopify/TaxonomyAttribute/7635  : Bok choy variety
+gid://shopify/TaxonomyAttribute/11359 : Bolt circle diameter
 gid://shopify/TaxonomyAttribute/7138  : Bolt drive style
 gid://shopify/TaxonomyAttribute/2123  : Bolt form
+gid://shopify/TaxonomyAttribute/11360 : Bolt/roll length
 gid://shopify/TaxonomyAttribute/7636  : Bone content
 gid://shopify/TaxonomyAttribute/5048  : Bone-anchored interface type
 gid://shopify/TaxonomyAttribute/9086  : Bongo center block material
@@ -798,6 +916,8 @@ gid://shopify/TaxonomyAttribute/2230  : Bookmark design
 gid://shopify/TaxonomyAttribute/2231  : Bookmark shape
 gid://shopify/TaxonomyAttribute/5461  : Boombox lighting effects
 gid://shopify/TaxonomyAttribute/5722  : Booster pump requirement
+gid://shopify/TaxonomyAttribute/11361 : Boot insulation weight
+gid://shopify/TaxonomyAttribute/11362 : Boot last width
 gid://shopify/TaxonomyAttribute/7139  : Boot liner type
 gid://shopify/TaxonomyAttribute/7140  : Boot sole compatibility
 gid://shopify/TaxonomyAttribute/1204  : Boot style
@@ -809,6 +929,8 @@ gid://shopify/TaxonomyAttribute/7143  : Bootie toe design
 gid://shopify/TaxonomyAttribute/9089  : Border type
 gid://shopify/TaxonomyAttribute/9090  : Bore cleaner format
 gid://shopify/TaxonomyAttribute/9091  : Bore cleaner safe for finish
+gid://shopify/TaxonomyAttribute/11363 : Bore cleaner volume
+gid://shopify/TaxonomyAttribute/11364 : Bore size
 gid://shopify/TaxonomyAttribute/5723  : Bore type
 gid://shopify/TaxonomyAttribute/2015  : Borescope design
 gid://shopify/TaxonomyAttribute/7144  : Bottle cage loading direction
@@ -820,13 +942,16 @@ gid://shopify/TaxonomyAttribute/5726  : Bottle fill state
 gid://shopify/TaxonomyAttribute/9092  : Bottle neck finish / closure size
 gid://shopify/TaxonomyAttribute/5727  : Bottle stopper mechanism
 gid://shopify/TaxonomyAttribute/9093  : Bottle style
+gid://shopify/TaxonomyAttribute/11365 : Bottle thread diameter
 gid://shopify/TaxonomyAttribute/1691  : Bottle type
 gid://shopify/TaxonomyAttribute/3044  : Bottle warmer/sterilizer features
 gid://shopify/TaxonomyAttribute/2221  : Bottle/Container closure
 gid://shopify/TaxonomyAttribute/7145  : Bottom bracket interface
 gid://shopify/TaxonomyAttribute/7146  : Bottom bracket standard
+gid://shopify/TaxonomyAttribute/11366 : Bottom depth
 gid://shopify/TaxonomyAttribute/8075  : Bottom type suitability
 gid://shopify/TaxonomyAttribute/7147  : Bounce level
+gid://shopify/TaxonomyAttribute/11368 : Bouncy ball bounce height
 gid://shopify/TaxonomyAttribute/6369  : Bouncy ball surface finish
 gid://shopify/TaxonomyAttribute/7148  : Boundary marker type
 gid://shopify/TaxonomyAttribute/9094  : Bouquet size tier
@@ -841,15 +966,20 @@ gid://shopify/TaxonomyAttribute/7150  : Bow type
 gid://shopify/TaxonomyAttribute/9099  : Bow winding material
 gid://shopify/TaxonomyAttribute/3187  : Bow/Crossbow features
 gid://shopify/TaxonomyAttribute/9100  : Bow/yo-yo embellishment style
+gid://shopify/TaxonomyAttribute/12311 : Bowl capacity
+gid://shopify/TaxonomyAttribute/11369 : Bowl depth
+gid://shopify/TaxonomyAttribute/11370 : Bowl diameter
 gid://shopify/TaxonomyAttribute/5728  : Bowl type
 gid://shopify/TaxonomyAttribute/7151  : Bowling ball core type
 gid://shopify/TaxonomyAttribute/7152  : Bowling ball coverstock type
+gid://shopify/TaxonomyAttribute/11371 : Bowling pin height
 gid://shopify/TaxonomyAttribute/7153  : Bowling set style
 gid://shopify/TaxonomyAttribute/9101  : Box lid type
 gid://shopify/TaxonomyAttribute/6876  : Box spring profile
 gid://shopify/TaxonomyAttribute/6877  : Box spring requirement
 gid://shopify/TaxonomyAttribute/2726  : Box type
 gid://shopify/TaxonomyAttribute/7154  : Boxing ring style
+gid://shopify/TaxonomyAttribute/11372 : Bra band size
 gid://shopify/TaxonomyAttribute/1195  : Bra closure type
 gid://shopify/TaxonomyAttribute/1196  : Bra coverage
 gid://shopify/TaxonomyAttribute/2996  : Bra features
@@ -858,6 +988,7 @@ gid://shopify/TaxonomyAttribute/6647  : Bra padding type
 gid://shopify/TaxonomyAttribute/1191  : Bra strap type
 gid://shopify/TaxonomyAttribute/3250  : Bra style
 gid://shopify/TaxonomyAttribute/1192  : Bra support level
+gid://shopify/TaxonomyAttribute/11373 : Brace height
 gid://shopify/TaxonomyAttribute/5091  : Brace support level
 gid://shopify/TaxonomyAttribute/3260  : Bracelet design
 gid://shopify/TaxonomyAttribute/7155  : Braces compatibility
@@ -866,23 +997,35 @@ gid://shopify/TaxonomyAttribute/2115  : Bracket/Brace design
 gid://shopify/TaxonomyAttribute/9102  : Brake band form
 gid://shopify/TaxonomyAttribute/9103  : Brake band material type
 gid://shopify/TaxonomyAttribute/9104  : Brake band style
+gid://shopify/TaxonomyAttribute/11374 : Brake band thickness
 gid://shopify/TaxonomyAttribute/8076  : Brake bleeding method
 gid://shopify/TaxonomyAttribute/8077  : Brake booster assist type
+gid://shopify/TaxonomyAttribute/11375 : Brake booster body diameter
 gid://shopify/TaxonomyAttribute/8078  : Brake booster diaphragm configuration
+gid://shopify/TaxonomyAttribute/11376 : Brake booster hose port size
 gid://shopify/TaxonomyAttribute/8079  : Brake caliper bleeder screw position
 gid://shopify/TaxonomyAttribute/8080  : Brake caliper finish
 gid://shopify/TaxonomyAttribute/8081  : Brake caliper included hardware
 gid://shopify/TaxonomyAttribute/8082  : Brake caliper mount type
+gid://shopify/TaxonomyAttribute/11377 : Brake caliper mounting bolt spacing
 gid://shopify/TaxonomyAttribute/8083  : Brake caliper paint base chemistry
 gid://shopify/TaxonomyAttribute/8084  : Brake caliper paint kit contents
+gid://shopify/TaxonomyAttribute/11378 : Brake caliper paint maximum temperature resistance
+gid://shopify/TaxonomyAttribute/11379 : Brake caliper piston bore diameter
 gid://shopify/TaxonomyAttribute/8085  : Brake circuit type
+gid://shopify/TaxonomyAttribute/11380 : Brake contact diameter
+gid://shopify/TaxonomyAttribute/11383 : Brake drum Maximum discard diameter
+gid://shopify/TaxonomyAttribute/11381 : Brake drum center bore diameter
 gid://shopify/TaxonomyAttribute/8088  : Brake drum finish/coating
+gid://shopify/TaxonomyAttribute/11382 : Brake drum inside diameter
 gid://shopify/TaxonomyAttribute/8089  : Brake drum type
+gid://shopify/TaxonomyAttribute/11384 : Brake drum width
 gid://shopify/TaxonomyAttribute/8091  : Brake fluid DOT specification
 gid://shopify/TaxonomyAttribute/7156  : Brake fluid base
 gid://shopify/TaxonomyAttribute/8090  : Brake fluid base chemistry
 gid://shopify/TaxonomyAttribute/8092  : Brake fluid standards compliance
 gid://shopify/TaxonomyAttribute/7157  : Brake fluid type
+gid://shopify/TaxonomyAttribute/11386 : Brake fluid wet boiling point
 gid://shopify/TaxonomyAttribute/8093  : Brake hose end fitting type
 gid://shopify/TaxonomyAttribute/7158  : Brake lever pull type
 gid://shopify/TaxonomyAttribute/8094  : Brake light switch actuation type
@@ -907,6 +1050,7 @@ gid://shopify/TaxonomyAttribute/8108  : Brake shoe friction material
 gid://shopify/TaxonomyAttribute/8109  : Brake shoe set contents
 gid://shopify/TaxonomyAttribute/7163  : Brake system type
 gid://shopify/TaxonomyAttribute/7164  : Brake type
+gid://shopify/TaxonomyAttribute/11387 : Brake width
 gid://shopify/TaxonomyAttribute/8087  : Brake/Clutch fluid DOT specification
 gid://shopify/TaxonomyAttribute/8086  : Brake/clutch fluid base chemistry
 gid://shopify/TaxonomyAttribute/7637  : Brandy age classification
@@ -914,6 +1058,8 @@ gid://shopify/TaxonomyAttribute/1462  : Brandy variety
 gid://shopify/TaxonomyAttribute/9105  : Brass cleaning tool type
 gid://shopify/TaxonomyAttribute/9106  : Brass instrument application area
 gid://shopify/TaxonomyAttribute/9107  : Brass instrument care kit purpose
+gid://shopify/TaxonomyAttribute/11388 : Brass instrument case interior height/depth
+gid://shopify/TaxonomyAttribute/11389 : Brass instrument case interior width
 gid://shopify/TaxonomyAttribute/9108  : Brass instrument case shell material
 gid://shopify/TaxonomyAttribute/9109  : Brass instrument lubricant additives/features
 gid://shopify/TaxonomyAttribute/9110  : Brass instrument lubricant base composition
@@ -923,6 +1069,7 @@ gid://shopify/TaxonomyAttribute/9113  : Brass instrument valve configuration
 gid://shopify/TaxonomyAttribute/9114  : Brass lubricant application area
 gid://shopify/TaxonomyAttribute/9115  : Brass mouthpiece backbore
 gid://shopify/TaxonomyAttribute/9116  : Brass mouthpiece cup depth
+gid://shopify/TaxonomyAttribute/11390 : Brass mouthpiece throat size
 gid://shopify/TaxonomyAttribute/9117  : Brass polishing cloth abrasiveness level
 gid://shopify/TaxonomyAttribute/7638  : Bread crumb base ingredient
 gid://shopify/TaxonomyAttribute/5729  : Bread storage ventilation
@@ -931,6 +1078,7 @@ gid://shopify/TaxonomyAttribute/5486  : Breadboard type
 gid://shopify/TaxonomyAttribute/7640  : Breadstick style
 gid://shopify/TaxonomyAttribute/5171  : Breath spray benefit
 gid://shopify/TaxonomyAttribute/1663  : Breath sprays certifications
+gid://shopify/TaxonomyAttribute/11393 : Breather port diameter
 gid://shopify/TaxonomyAttribute/5730  : Brew strength options
 gid://shopify/TaxonomyAttribute/7165  : Bridge head material
 gid://shopify/TaxonomyAttribute/7166  : Bridge head type
@@ -939,9 +1087,12 @@ gid://shopify/TaxonomyAttribute/3090  : Bridge/Router advanced features
 gid://shopify/TaxonomyAttribute/7167  : Bridle part type
 gid://shopify/TaxonomyAttribute/7168  : Bridle style
 gid://shopify/TaxonomyAttribute/2228  : Brightness levels
+gid://shopify/TaxonomyAttribute/12312 : Brim depth
+gid://shopify/TaxonomyAttribute/11394 : Brim width
 gid://shopify/TaxonomyAttribute/5732  : Briquette ignition type
 gid://shopify/TaxonomyAttribute/5198  : Bristle grade
 gid://shopify/TaxonomyAttribute/5183  : Bristle hardness
+gid://shopify/TaxonomyAttribute/11395 : Bristle length
 gid://shopify/TaxonomyAttribute/1408  : Bristle material
 gid://shopify/TaxonomyAttribute/1603  : Bristle shape
 gid://shopify/TaxonomyAttribute/5733  : Bristle stiffness
@@ -961,6 +1112,7 @@ gid://shopify/TaxonomyAttribute/5252  : Brush end type
 gid://shopify/TaxonomyAttribute/7173  : Brush format
 gid://shopify/TaxonomyAttribute/5186  : Brush head shape
 gid://shopify/TaxonomyAttribute/1613  : Brush head usage
+gid://shopify/TaxonomyAttribute/11398 : Brush head width
 gid://shopify/TaxonomyAttribute/2792  : Brush material
 gid://shopify/TaxonomyAttribute/7174  : Brush shape
 gid://shopify/TaxonomyAttribute/2346  : Brush size
@@ -981,11 +1133,13 @@ gid://shopify/TaxonomyAttribute/7646  : Buckwheat product form
 gid://shopify/TaxonomyAttribute/6377  : Bug collecting kit items included
 gid://shopify/TaxonomyAttribute/1391  : Bug type
 gid://shopify/TaxonomyAttribute/2912  : Building board material
+gid://shopify/TaxonomyAttribute/12314 : Building board thickness
 gid://shopify/TaxonomyAttribute/2076  : Building consumable form
 gid://shopify/TaxonomyAttribute/3397  : Building toy type
 gid://shopify/TaxonomyAttribute/6878  : Built-in storage type
 gid://shopify/TaxonomyAttribute/1437  : Bulb cap type
 gid://shopify/TaxonomyAttribute/5736  : Bulb finish
+gid://shopify/TaxonomyAttribute/12315 : Bulb power
 gid://shopify/TaxonomyAttribute/1438  : Bulb shape
 gid://shopify/TaxonomyAttribute/1435  : Bulb size
 gid://shopify/TaxonomyAttribute/2573  : Bulldozer blade type
@@ -1000,9 +1154,11 @@ gid://shopify/TaxonomyAttribute/7175  : Buoyancy
 gid://shopify/TaxonomyAttribute/6648  : Burkini pieces included
 gid://shopify/TaxonomyAttribute/7647  : Burn rate
 gid://shopify/TaxonomyAttribute/5737  : Burner shape
+gid://shopify/TaxonomyAttribute/12316 : Burner size
 gid://shopify/TaxonomyAttribute/5738  : Burr shape
 gid://shopify/TaxonomyAttribute/9118  : Bus model type
 gid://shopify/TaxonomyAttribute/6649  : Bust design
+gid://shopify/TaxonomyAttribute/12317 : Bust/Chest size
 gid://shopify/TaxonomyAttribute/1292  : Butt cap material
 gid://shopify/TaxonomyAttribute/7648  : Butter variety
 gid://shopify/TaxonomyAttribute/5739  : Butterfly feeder food type
@@ -1012,14 +1168,21 @@ gid://shopify/TaxonomyAttribute/9120  : Button attachment type
 gid://shopify/TaxonomyAttribute/9121  : Button finish
 gid://shopify/TaxonomyAttribute/5342  : Button surface profile
 gid://shopify/TaxonomyAttribute/2295  : Button/Snap closure type
+gid://shopify/TaxonomyAttribute/11402 : Button/Snap diameter
 gid://shopify/TaxonomyAttribute/9122  : Buttonhole elastic application
+gid://shopify/TaxonomyAttribute/11403 : Buttonhole size
+gid://shopify/TaxonomyAttribute/11404 : Buttonhole spacing
 gid://shopify/TaxonomyAttribute/3123  : CBD ingredients
+gid://shopify/TaxonomyAttribute/11457 : CO2 cartridge capacity
 gid://shopify/TaxonomyAttribute/5770  : CO2 cylinder compatibility
 gid://shopify/TaxonomyAttribute/5771  : CO2 supplementation requirement
 gid://shopify/TaxonomyAttribute/8244  : CV boot clamp type
 gid://shopify/TaxonomyAttribute/8245  : CV boot kit contents
+gid://shopify/TaxonomyAttribute/11538 : CV boot large end inner diameter
+gid://shopify/TaxonomyAttribute/11539 : CV boot length
 gid://shopify/TaxonomyAttribute/8246  : CV boot material
 gid://shopify/TaxonomyAttribute/8247  : CV boot position
+gid://shopify/TaxonomyAttribute/11540 : CV boot small end inner diameter
 gid://shopify/TaxonomyAttribute/8112  : Cab type
 gid://shopify/TaxonomyAttribute/9123  : Cabasa construction type
 gid://shopify/TaxonomyAttribute/7650  : Cabbage variety
@@ -1027,12 +1190,14 @@ gid://shopify/TaxonomyAttribute/6880  : Cabinet door style
 gid://shopify/TaxonomyAttribute/5740  : Cabinet light fixture style
 gid://shopify/TaxonomyAttribute/6881  : Cabinet overlay type
 gid://shopify/TaxonomyAttribute/1790  : Cabinet type
+gid://shopify/TaxonomyAttribute/12318 : Cable diameter
 gid://shopify/TaxonomyAttribute/7176  : Cable end type
 gid://shopify/TaxonomyAttribute/5606  : Cable form factor
 gid://shopify/TaxonomyAttribute/7177  : Cable housing construction
 gid://shopify/TaxonomyAttribute/7178  : Cable housing liner type
 gid://shopify/TaxonomyAttribute/2908  : Cable housing material
 gid://shopify/TaxonomyAttribute/5610  : Cable jacket rating
+gid://shopify/TaxonomyAttribute/12319 : Cable length
 gid://shopify/TaxonomyAttribute/6882  : Cable management type
 gid://shopify/TaxonomyAttribute/1892  : Cable shielding
 gid://shopify/TaxonomyAttribute/5613  : Cable style
@@ -1044,6 +1209,7 @@ gid://shopify/TaxonomyAttribute/9124  : Cabochon back type
 gid://shopify/TaxonomyAttribute/7651  : Cacao bean variety
 gid://shopify/TaxonomyAttribute/7652  : Cacao roast level
 gid://shopify/TaxonomyAttribute/5568  : Cache level
+gid://shopify/TaxonomyAttribute/12320 : Cache size
 gid://shopify/TaxonomyAttribute/3415  : Caffeine content
 gid://shopify/TaxonomyAttribute/7180  : Cage package type
 gid://shopify/TaxonomyAttribute/2720  : Cage type
@@ -1053,6 +1219,7 @@ gid://shopify/TaxonomyAttribute/9127  : Cajon corner/edge design
 gid://shopify/TaxonomyAttribute/9128  : Cajon feet type
 gid://shopify/TaxonomyAttribute/9129  : Cajon snare adjustability
 gid://shopify/TaxonomyAttribute/9130  : Cajon snare system type
+gid://shopify/TaxonomyAttribute/11406 : Cajon weight
 gid://shopify/TaxonomyAttribute/7653  : Cake shape
 gid://shopify/TaxonomyAttribute/7654  : Cake topping
 gid://shopify/TaxonomyAttribute/7655  : Cake type
@@ -1060,10 +1227,12 @@ gid://shopify/TaxonomyAttribute/3368  : Calculator accessory type
 gid://shopify/TaxonomyAttribute/3159  : Calculator features
 gid://shopify/TaxonomyAttribute/2238  : Calendar format
 gid://shopify/TaxonomyAttribute/3153  : Calendar/Organizer features
+gid://shopify/TaxonomyAttribute/12321 : Calf circumference
 gid://shopify/TaxonomyAttribute/5400  : Calibration sensor type
 gid://shopify/TaxonomyAttribute/7181  : Caliper mount type
 gid://shopify/TaxonomyAttribute/7182  : Caliper mounting standard
 gid://shopify/TaxonomyAttribute/5535  : Call blocking method
+gid://shopify/TaxonomyAttribute/12322 : Call storage capacity
 gid://shopify/TaxonomyAttribute/5520  : Caller ID compatibility
 gid://shopify/TaxonomyAttribute/5536  : Caller ID standard compatibility
 gid://shopify/TaxonomyAttribute/3390  : Cam system
@@ -1077,11 +1246,15 @@ gid://shopify/TaxonomyAttribute/1997  : Camera gear type
 gid://shopify/TaxonomyAttribute/1979  : Camera lens type
 gid://shopify/TaxonomyAttribute/8113  : Camera mounting location (vehicle exterior)
 gid://shopify/TaxonomyAttribute/1995  : Camera mounting type
+gid://shopify/TaxonomyAttribute/12323 : Camera probe length
 gid://shopify/TaxonomyAttribute/1998  : Camera sensor type
 gid://shopify/TaxonomyAttribute/1330  : Camera shape
 gid://shopify/TaxonomyAttribute/7183  : Camouflage environment type
 gid://shopify/TaxonomyAttribute/7184  : Camping oil application
+gid://shopify/TaxonomyAttribute/11407 : Camshaft base circle diameter
 gid://shopify/TaxonomyAttribute/8114  : Camshaft construction
+gid://shopify/TaxonomyAttribute/11408 : Camshaft journal diameter
+gid://shopify/TaxonomyAttribute/11409 : Camshaft lobe lift
 gid://shopify/TaxonomyAttribute/8115  : Camshaft material
 gid://shopify/TaxonomyAttribute/8116  : Camshaft position
 gid://shopify/TaxonomyAttribute/6285  : Candle container material
@@ -1112,6 +1285,7 @@ gid://shopify/TaxonomyAttribute/2334  : Canvas finish
 gid://shopify/TaxonomyAttribute/9136  : Canvas format
 gid://shopify/TaxonomyAttribute/2928  : Canvas material
 gid://shopify/TaxonomyAttribute/9137  : Canvas mounting/format
+gid://shopify/TaxonomyAttribute/11411 : Canvas roll core diameter
 gid://shopify/TaxonomyAttribute/9138  : Canvas stretcher assembly type
 gid://shopify/TaxonomyAttribute/9139  : Canvas stretcher corner joint type
 gid://shopify/TaxonomyAttribute/9140  : Canvas surface tone
@@ -1125,8 +1299,11 @@ gid://shopify/TaxonomyAttribute/8117  : Cap seal type
 gid://shopify/TaxonomyAttribute/6652  : Cap size
 gid://shopify/TaxonomyAttribute/8118  : Cap type
 gid://shopify/TaxonomyAttribute/5490  : Capacitance tolerance
+gid://shopify/TaxonomyAttribute/12324 : Capacitance value
 gid://shopify/TaxonomyAttribute/5492  : Capacitor application
 gid://shopify/TaxonomyAttribute/5489  : Capacitor polarity
+gid://shopify/TaxonomyAttribute/12325 : Capacity
+gid://shopify/TaxonomyAttribute/11414 : Caper size
 gid://shopify/TaxonomyAttribute/7659  : Caper size grade
 gid://shopify/TaxonomyAttribute/9144  : Capo clamping mechanism
 gid://shopify/TaxonomyAttribute/9145  : Capo finish
@@ -1144,11 +1321,14 @@ gid://shopify/TaxonomyAttribute/8120  : Car shampoo application method
 gid://shopify/TaxonomyAttribute/2746  : Car type
 gid://shopify/TaxonomyAttribute/8121  : Car wash solution form
 gid://shopify/TaxonomyAttribute/8122  : Car wash solution scent
+gid://shopify/TaxonomyAttribute/11415 : Carabiner gate opening clearance
 gid://shopify/TaxonomyAttribute/1266  : Carabiner gate type
 gid://shopify/TaxonomyAttribute/2872  : Carabiner shape
+gid://shopify/TaxonomyAttribute/11416 : Carbohydrates per 100 g
 gid://shopify/TaxonomyAttribute/7660  : Carbonated water variety
 gid://shopify/TaxonomyAttribute/7661  : Carbonation
 gid://shopify/TaxonomyAttribute/5745  : Carbonation level adjustment
+gid://shopify/TaxonomyAttribute/11418 : Carburetor airflow rating
 gid://shopify/TaxonomyAttribute/8123  : Carburetor barrel count
 gid://shopify/TaxonomyAttribute/8124  : Carburetor choke type
 gid://shopify/TaxonomyAttribute/8125  : Carburetor mounting flange type
@@ -1166,6 +1346,8 @@ gid://shopify/TaxonomyAttribute/6381  : Card sleeve size / format compatibility
 gid://shopify/TaxonomyAttribute/5534  : Card usage status
 gid://shopify/TaxonomyAttribute/3312  : Card/Adapter installation
 gid://shopify/TaxonomyAttribute/9151  : Carding surface pin material
+gid://shopify/TaxonomyAttribute/11420 : Carding surface width
+gid://shopify/TaxonomyAttribute/11421 : Carding width
 gid://shopify/TaxonomyAttribute/9152  : Care durability
 gid://shopify/TaxonomyAttribute/2336  : Care instructions
 gid://shopify/TaxonomyAttribute/9153  : Care label attachment type
@@ -1178,6 +1360,8 @@ gid://shopify/TaxonomyAttribute/8128  : Cargo net stretch type
 gid://shopify/TaxonomyAttribute/8129  : Cargo net style
 gid://shopify/TaxonomyAttribute/8130  : Cargo rack finish
 gid://shopify/TaxonomyAttribute/8131  : Carpet cleaner application method
+gid://shopify/TaxonomyAttribute/11424 : Carpet kit thickness
+gid://shopify/TaxonomyAttribute/11425 : Carpet pile height
 gid://shopify/TaxonomyAttribute/8132  : Carrier style
 gid://shopify/TaxonomyAttribute/7662  : Carrot size
 gid://shopify/TaxonomyAttribute/7663  : Carrot variety
@@ -1193,15 +1377,19 @@ gid://shopify/TaxonomyAttribute/7664  : Cartridge thread compatibility
 gid://shopify/TaxonomyAttribute/1825  : Cartridge type
 gid://shopify/TaxonomyAttribute/5376  : Cartridge yield type
 gid://shopify/TaxonomyAttribute/7190  : Case capacity (butts × shafts)
+gid://shopify/TaxonomyAttribute/12327 : Case depth
 gid://shopify/TaxonomyAttribute/9156  : Case features
 gid://shopify/TaxonomyAttribute/9157  : Case humidifier refill type
+gid://shopify/TaxonomyAttribute/11426 : Case interior length
 gid://shopify/TaxonomyAttribute/9158  : Case lining material
 gid://shopify/TaxonomyAttribute/6653  : Case material
 gid://shopify/TaxonomyAttribute/9159  : Case mounting method
+gid://shopify/TaxonomyAttribute/11427 : Case padding thickness
 gid://shopify/TaxonomyAttribute/7191  : Case structure
 gid://shopify/TaxonomyAttribute/9160  : Case style (cymbal/drum)
 gid://shopify/TaxonomyAttribute/5001  : Case transparency level
 gid://shopify/TaxonomyAttribute/1798  : Case type
+gid://shopify/TaxonomyAttribute/12328 : Case width
 gid://shopify/TaxonomyAttribute/7192  : Casing material
 gid://shopify/TaxonomyAttribute/6382  : Casino set chip material
 gid://shopify/TaxonomyAttribute/6383  : Casino set layout included
@@ -1230,6 +1418,7 @@ gid://shopify/TaxonomyAttribute/7669  : Celery form
 gid://shopify/TaxonomyAttribute/7670  : Celery variety
 gid://shopify/TaxonomyAttribute/5558  : Cellular capability
 gid://shopify/TaxonomyAttribute/5748  : Center hole shape
+gid://shopify/TaxonomyAttribute/11429 : Center stick diameter
 gid://shopify/TaxonomyAttribute/7671  : Cereal bar texture
 gid://shopify/TaxonomyAttribute/7672  : Cereal type
 gid://shopify/TaxonomyAttribute/9165  : Certificate border style
@@ -1239,15 +1428,20 @@ gid://shopify/TaxonomyAttribute/8135  : Certification standard
 gid://shopify/TaxonomyAttribute/5320  : Cervix height suitability
 gid://shopify/TaxonomyAttribute/7197  : Chain coating/finish
 gid://shopify/TaxonomyAttribute/7198  : Chain connection type
+gid://shopify/TaxonomyAttribute/12329 : Chain diameter
+gid://shopify/TaxonomyAttribute/12330 : Chain length
 gid://shopify/TaxonomyAttribute/98    : Chain link type
 gid://shopify/TaxonomyAttribute/7199  : Chain tier configuration
 gid://shopify/TaxonomyAttribute/7200  : Chain tool type
 gid://shopify/TaxonomyAttribute/2728  : Chain type
+gid://shopify/TaxonomyAttribute/11431 : Chainline offset
 gid://shopify/TaxonomyAttribute/7201  : Chainring shape
 gid://shopify/TaxonomyAttribute/5749  : Chainsaw bar mount type
 gid://shopify/TaxonomyAttribute/5750  : Chainsaw bar nose type
 gid://shopify/TaxonomyAttribute/5751  : Chainsaw bar type
 gid://shopify/TaxonomyAttribute/5752  : Chainsaw cutter type
+gid://shopify/TaxonomyAttribute/12331 : Chainsaw gauge
+gid://shopify/TaxonomyAttribute/12332 : Chainsaw pitch
 gid://shopify/TaxonomyAttribute/6885  : Chair accessories included
 gid://shopify/TaxonomyAttribute/9168  : Chair sash care instructions
 gid://shopify/TaxonomyAttribute/9169  : Chair sash finish
@@ -1271,6 +1465,7 @@ gid://shopify/TaxonomyAttribute/2682  : Charging cable type
 gid://shopify/TaxonomyAttribute/5002  : Charging interface type
 gid://shopify/TaxonomyAttribute/2683  : Charging level
 gid://shopify/TaxonomyAttribute/8136  : Charging port location
+gid://shopify/TaxonomyAttribute/11432 : Charging time
 gid://shopify/TaxonomyAttribute/8137  : Chassis construction type
 gid://shopify/TaxonomyAttribute/1870  : Chassis type
 gid://shopify/TaxonomyAttribute/6654  : Checkbook loading orientation
@@ -1296,6 +1491,8 @@ gid://shopify/TaxonomyAttribute/7203  : Child seat accessory type
 gid://shopify/TaxonomyAttribute/7204  : Child seat mounting type
 gid://shopify/TaxonomyAttribute/2874  : Child seat placement
 gid://shopify/TaxonomyAttribute/9174  : Chime sound character
+gid://shopify/TaxonomyAttribute/11434 : Chime tube diameter
+gid://shopify/TaxonomyAttribute/11433 : Chime tube/bar length
 gid://shopify/TaxonomyAttribute/7205  : Chin cup type
 gid://shopify/TaxonomyAttribute/5208  : Chin strap style
 gid://shopify/TaxonomyAttribute/6656  : Chin strap type
@@ -1312,6 +1509,7 @@ gid://shopify/TaxonomyAttribute/5110  : Cholesterol analyte measured
 gid://shopify/TaxonomyAttribute/5757  : Chopstick style
 gid://shopify/TaxonomyAttribute/6286  : Chopstick trainer design
 gid://shopify/TaxonomyAttribute/7684  : Choy sum variety
+gid://shopify/TaxonomyAttribute/12333 : Chuck size
 gid://shopify/TaxonomyAttribute/2192  : Chuck type
 gid://shopify/TaxonomyAttribute/1502  : Cigar body
 gid://shopify/TaxonomyAttribute/5758  : Cigar cutter type
@@ -1327,18 +1525,28 @@ gid://shopify/TaxonomyAttribute/2163  : Circuit breaker panel form
 gid://shopify/TaxonomyAttribute/2165  : Circuit breaker type
 gid://shopify/TaxonomyAttribute/9177  : Circular knitting needle cable type
 gid://shopify/TaxonomyAttribute/9178  : Circular knitting needles tip material
+gid://shopify/TaxonomyAttribute/12334 : Circumference
 gid://shopify/TaxonomyAttribute/9179  : Circumference adjustment mechanism
 gid://shopify/TaxonomyAttribute/7208  : Clamp design
+gid://shopify/TaxonomyAttribute/11436 : Clamp opening
+gid://shopify/TaxonomyAttribute/11437 : Clamp rod diameter
 gid://shopify/TaxonomyAttribute/9180  : Clamp sheet music clip features
 gid://shopify/TaxonomyAttribute/9181  : Clamping/closure type
+gid://shopify/TaxonomyAttribute/11438 : Clarinet barrel length
 gid://shopify/TaxonomyAttribute/9182  : Clarinet bell acoustic design
 gid://shopify/TaxonomyAttribute/9183  : Clarinet bell adjustment mechanism
+gid://shopify/TaxonomyAttribute/11439 : Clarinet bell opening diameter
 gid://shopify/TaxonomyAttribute/9184  : Clarinet bell ring material
+gid://shopify/TaxonomyAttribute/11440 : Clarinet bell throat/tenon diameter
 gid://shopify/TaxonomyAttribute/9185  : Clarinet bell tuning effect
+gid://shopify/TaxonomyAttribute/11441 : Clarinet bell weight
 gid://shopify/TaxonomyAttribute/9186  : Clarinet body type
 gid://shopify/TaxonomyAttribute/9187  : Clarinet bore type
 gid://shopify/TaxonomyAttribute/9188  : Clarinet cap style
 gid://shopify/TaxonomyAttribute/9189  : Clarinet care kit intended use
+gid://shopify/TaxonomyAttribute/11442 : Clarinet case interior height
+gid://shopify/TaxonomyAttribute/11443 : Clarinet case interior length
+gid://shopify/TaxonomyAttribute/11444 : Clarinet case interior width
 gid://shopify/TaxonomyAttribute/9190  : Clarinet included accessories
 gid://shopify/TaxonomyAttribute/2482  : Clarinet key system
 gid://shopify/TaxonomyAttribute/9191  : Clarinet keywork material
@@ -1373,6 +1581,7 @@ gid://shopify/TaxonomyAttribute/1779  : Cleaning instructions
 gid://shopify/TaxonomyAttribute/5381  : Cleaning kit components included
 gid://shopify/TaxonomyAttribute/5173  : Cleaning mode
 gid://shopify/TaxonomyAttribute/1387  : Cleaning purpose
+gid://shopify/TaxonomyAttribute/11445 : Cleaning rod length
 gid://shopify/TaxonomyAttribute/5763  : Cleaning solution concentration
 gid://shopify/TaxonomyAttribute/1378  : Cleaning surfaces
 gid://shopify/TaxonomyAttribute/8138  : Cleaning task focus
@@ -1380,6 +1589,7 @@ gid://shopify/TaxonomyAttribute/5185  : Cleaning technology
 gid://shopify/TaxonomyAttribute/5140  : Cleanse focus
 gid://shopify/TaxonomyAttribute/5298  : Cleanser type
 gid://shopify/TaxonomyAttribute/9211  : Cleanup method
+gid://shopify/TaxonomyAttribute/12335 : Clear aperture
 gid://shopify/TaxonomyAttribute/9212  : Clear glue application method
 gid://shopify/TaxonomyAttribute/9213  : Clear glue finish (after drying)
 gid://shopify/TaxonomyAttribute/7210  : Cleat bolt pattern
@@ -1394,6 +1604,8 @@ gid://shopify/TaxonomyAttribute/1268  : Climbing activity
 gid://shopify/TaxonomyAttribute/7215  : Climbing hold mounting type
 gid://shopify/TaxonomyAttribute/7216  : Climbing hold type
 gid://shopify/TaxonomyAttribute/7217  : Climbing protection device type
+gid://shopify/TaxonomyAttribute/12336 : Climbing rope diameter
+gid://shopify/TaxonomyAttribute/12337 : Climbing rope length
 gid://shopify/TaxonomyAttribute/7218  : Climbing rope middle marking
 gid://shopify/TaxonomyAttribute/7219  : Climbing rope treatment
 gid://shopify/TaxonomyAttribute/7220  : Climbing rope type
@@ -1421,12 +1633,16 @@ gid://shopify/TaxonomyAttribute/5143  : Cloth treatment
 gid://shopify/TaxonomyAttribute/5769  : Clothespin type
 gid://shopify/TaxonomyAttribute/2779  : Clothing accessory material
 gid://shopify/TaxonomyAttribute/3001  : Clothing features
+gid://shopify/TaxonomyAttribute/12338 : Clothing weight
 gid://shopify/TaxonomyAttribute/7224  : Club head material
 gid://shopify/TaxonomyAttribute/1298  : Club subset
 gid://shopify/TaxonomyAttribute/1299  : Club type
 gid://shopify/TaxonomyAttribute/8141  : Clutch hydraulic system type
 gid://shopify/TaxonomyAttribute/8142  : Clutch line connection type
+gid://shopify/TaxonomyAttribute/11453 : Clutch master cylinder bore diameter
 gid://shopify/TaxonomyAttribute/8143  : Clutch pressure plate actuation type
+gid://shopify/TaxonomyAttribute/11454 : Clutch pressure plate bolt circle diameter (BCD)
+gid://shopify/TaxonomyAttribute/11455 : Clutch pressure plate diameter
 gid://shopify/TaxonomyAttribute/8144  : Clutch pressure plate release mechanism type
 gid://shopify/TaxonomyAttribute/8145  : Clutch pressure plate surface type
 gid://shopify/TaxonomyAttribute/8146  : Clutch slave cylinder connection type
@@ -1436,15 +1652,19 @@ gid://shopify/TaxonomyAttribute/7689  : Coating type
 gid://shopify/TaxonomyAttribute/2070  : Coating/Sealant application
 gid://shopify/TaxonomyAttribute/5611  : Coaxial cable series
 gid://shopify/TaxonomyAttribute/7225  : Cocking mechanism
+gid://shopify/TaxonomyAttribute/11459 : Cockpit dimensions
 gid://shopify/TaxonomyAttribute/4685  : Cockpit type
 gid://shopify/TaxonomyAttribute/2509  : Cocktail decoration design
 gid://shopify/TaxonomyAttribute/9216  : Cocktail garnish form
 gid://shopify/TaxonomyAttribute/7690  : Cocktail mix variety
 gid://shopify/TaxonomyAttribute/9217  : Cocktail napkin features
+gid://shopify/TaxonomyAttribute/11460 : Cocktail napkin unfolded size
+gid://shopify/TaxonomyAttribute/11461 : Cocktail pick length
 gid://shopify/TaxonomyAttribute/9218  : Cocktail pick tip style
 gid://shopify/TaxonomyAttribute/9219  : Cocktail pick top/handle style
 gid://shopify/TaxonomyAttribute/5773  : Cocktail strainer type
 gid://shopify/TaxonomyAttribute/7691  : Cocktail type
+gid://shopify/TaxonomyAttribute/11462 : Cocktail umbrella canopy diameter
 gid://shopify/TaxonomyAttribute/9220  : Cocktail umbrella handle/pick material
 gid://shopify/TaxonomyAttribute/7692  : Cocoa processing method
 gid://shopify/TaxonomyAttribute/7693  : Cocoa product form
@@ -1454,6 +1674,7 @@ gid://shopify/TaxonomyAttribute/7696  : Coconut oil refinement type
 gid://shopify/TaxonomyAttribute/7697  : Coconut preparation form
 gid://shopify/TaxonomyAttribute/5774  : Code technology
 gid://shopify/TaxonomyAttribute/7698  : Coffee bean species
+gid://shopify/TaxonomyAttribute/12339 : Coffee beans capacity
 gid://shopify/TaxonomyAttribute/7699  : Coffee beverage variety
 gid://shopify/TaxonomyAttribute/1490  : Coffee creamer variety
 gid://shopify/TaxonomyAttribute/5775  : Coffee decanter warmer features
@@ -1461,6 +1682,7 @@ gid://shopify/TaxonomyAttribute/5776  : Coffee filter basket size
 gid://shopify/TaxonomyAttribute/5777  : Coffee filter shape
 gid://shopify/TaxonomyAttribute/5778  : Coffee filter type
 gid://shopify/TaxonomyAttribute/5779  : Coffee grinder accessory type
+gid://shopify/TaxonomyAttribute/11464 : Coffee growing altitude
 gid://shopify/TaxonomyAttribute/1398  : Coffee input type
 gid://shopify/TaxonomyAttribute/7700  : Coffee processing method
 gid://shopify/TaxonomyAttribute/1977  : Coffee product form
@@ -1470,23 +1692,31 @@ gid://shopify/TaxonomyAttribute/1509  : Coil connection
 gid://shopify/TaxonomyAttribute/7701  : Coil material
 gid://shopify/TaxonomyAttribute/8148  : Coil spring design
 gid://shopify/TaxonomyAttribute/8149  : Coil spring finish/coating
+gid://shopify/TaxonomyAttribute/11465 : Coil spring free length
+gid://shopify/TaxonomyAttribute/11466 : Coil spring lift height
 gid://shopify/TaxonomyAttribute/8150  : Coil spring material
+gid://shopify/TaxonomyAttribute/11468 : Coil spring wire diameter
 gid://shopify/TaxonomyAttribute/6890  : Coil system type
 gid://shopify/TaxonomyAttribute/7702  : Coil type
+gid://shopify/TaxonomyAttribute/11469 : Coin diameter
 gid://shopify/TaxonomyAttribute/9221  : Coin grade (numismatic)
 gid://shopify/TaxonomyAttribute/2931  : Coin material
 gid://shopify/TaxonomyAttribute/9222  : Coin strike or finish
 gid://shopify/TaxonomyAttribute/9223  : Coin strike type
+gid://shopify/TaxonomyAttribute/11470 : Coin thickness
+gid://shopify/TaxonomyAttribute/11471 : Coin weight
 gid://shopify/TaxonomyAttribute/5780  : Colander style
 gid://shopify/TaxonomyAttribute/5129  : Collagen source
 gid://shopify/TaxonomyAttribute/5130  : Collagen type
 gid://shopify/TaxonomyAttribute/2861  : Collar lock type
+gid://shopify/TaxonomyAttribute/12340 : Collar size
 gid://shopify/TaxonomyAttribute/6659  : Collar style
 gid://shopify/TaxonomyAttribute/2011  : Collar/Mount compatible device
 gid://shopify/TaxonomyAttribute/2012  : Collar/Mount design
 gid://shopify/TaxonomyAttribute/9224  : Collectible gun accessories included
 gid://shopify/TaxonomyAttribute/9225  : Collectible gun firing mechanism
 gid://shopify/TaxonomyAttribute/9226  : Collectible knife blade finish
+gid://shopify/TaxonomyAttribute/12341 : Collet size
 gid://shopify/TaxonomyAttribute/1     : Color
 gid://shopify/TaxonomyAttribute/1962  : Color accuracy standards
 gid://shopify/TaxonomyAttribute/9227  : Color code system
@@ -1535,7 +1765,9 @@ gid://shopify/TaxonomyAttribute/9234  : Compatible amplifier fit method
 gid://shopify/TaxonomyAttribute/7233  : Compatible apparatus
 gid://shopify/TaxonomyAttribute/1705  : Compatible aquarium
 gid://shopify/TaxonomyAttribute/7234  : Compatible archery tool
+gid://shopify/TaxonomyAttribute/11477 : Compatible arrow shaft diameter
 gid://shopify/TaxonomyAttribute/5782  : Compatible awning rail type
+gid://shopify/TaxonomyAttribute/11478 : Compatible axle diameter
 gid://shopify/TaxonomyAttribute/7235  : Compatible axle size
 gid://shopify/TaxonomyAttribute/7236  : Compatible axle type
 gid://shopify/TaxonomyAttribute/8155  : Compatible axle weight rating
@@ -1543,11 +1775,17 @@ gid://shopify/TaxonomyAttribute/1764  : Compatible baby bottle design
 gid://shopify/TaxonomyAttribute/1749  : Compatible baby carrier type
 gid://shopify/TaxonomyAttribute/1752  : Compatible baby chair type
 gid://shopify/TaxonomyAttribute/1751  : Compatible baby transport type
+gid://shopify/TaxonomyAttribute/11479 : Compatible backboard width
 gid://shopify/TaxonomyAttribute/7237  : Compatible bait type
+gid://shopify/TaxonomyAttribute/11480 : Compatible ball diameter
 gid://shopify/TaxonomyAttribute/1212  : Compatible ball type
+gid://shopify/TaxonomyAttribute/12342 : Compatible bar diameter
+gid://shopify/TaxonomyAttribute/12343 : Compatible bar size
 gid://shopify/TaxonomyAttribute/9235  : Compatible bass scale length
 gid://shopify/TaxonomyAttribute/1924  : Compatible battery technology
 gid://shopify/TaxonomyAttribute/6386  : Compatible battle top system
+gid://shopify/TaxonomyAttribute/11481 : Compatible bead hole size
+gid://shopify/TaxonomyAttribute/11482 : Compatible beam width
 gid://shopify/TaxonomyAttribute/6891  : Compatible bed frame style
 gid://shopify/TaxonomyAttribute/1231  : Compatible bench positions
 gid://shopify/TaxonomyAttribute/5783  : Compatible beverage type
@@ -1559,14 +1797,19 @@ gid://shopify/TaxonomyAttribute/7242  : Compatible billiard table size
 gid://shopify/TaxonomyAttribute/7243  : Compatible bit type
 gid://shopify/TaxonomyAttribute/7244  : Compatible blade hosel
 gid://shopify/TaxonomyAttribute/9236  : Compatible blade system
+gid://shopify/TaxonomyAttribute/11483 : Compatible board length
 gid://shopify/TaxonomyAttribute/9237  : Compatible boat weaving shuttle loom
+gid://shopify/TaxonomyAttribute/11484 : Compatible bobbin diameter
 gid://shopify/TaxonomyAttribute/9238  : Compatible bobbin type
+gid://shopify/TaxonomyAttribute/11485 : Compatible boilie diameter
 gid://shopify/TaxonomyAttribute/7245  : Compatible bottle mouth
+gid://shopify/TaxonomyAttribute/11486 : Compatible bottle volume
 gid://shopify/TaxonomyAttribute/7246  : Compatible bow attachment system
 gid://shopify/TaxonomyAttribute/7247  : Compatible bow/crossbow type
 gid://shopify/TaxonomyAttribute/8156  : Compatible brake fluid
 gid://shopify/TaxonomyAttribute/7248  : Compatible brake pad
 gid://shopify/TaxonomyAttribute/8157  : Compatible brake service system
+gid://shopify/TaxonomyAttribute/11487 : Compatible brake shoe width
 gid://shopify/TaxonomyAttribute/8158  : Compatible brake system
 gid://shopify/TaxonomyAttribute/7249  : Compatible brake type
 gid://shopify/TaxonomyAttribute/2396  : Compatible brass instrument
@@ -1577,6 +1820,7 @@ gid://shopify/TaxonomyAttribute/5784  : Compatible can size
 gid://shopify/TaxonomyAttribute/9240  : Compatible capo fretboard radius
 gid://shopify/TaxonomyAttribute/9241  : Compatible capo number of strings
 gid://shopify/TaxonomyAttribute/7250  : Compatible cardio machine type
+gid://shopify/TaxonomyAttribute/12344 : Compatible case width
 gid://shopify/TaxonomyAttribute/7251  : Compatible chain link type
 gid://shopify/TaxonomyAttribute/7252  : Compatible chain size
 gid://shopify/TaxonomyAttribute/7253  : Compatible chain width
@@ -1589,6 +1833,7 @@ gid://shopify/TaxonomyAttribute/9243  : Compatible classical guitar string scale
 gid://shopify/TaxonomyAttribute/7254  : Compatible clay target size
 gid://shopify/TaxonomyAttribute/7255  : Compatible cleat system
 gid://shopify/TaxonomyAttribute/7256  : Compatible clipless pedal system
+gid://shopify/TaxonomyAttribute/11488 : Compatible clutch disc diameter
 gid://shopify/TaxonomyAttribute/8159  : Compatible clutch type
 gid://shopify/TaxonomyAttribute/5786  : Compatible coffee capsule system
 gid://shopify/TaxonomyAttribute/5787  : Compatible coffee maker type
@@ -1596,10 +1841,12 @@ gid://shopify/TaxonomyAttribute/7704  : Compatible coffee pod system
 gid://shopify/TaxonomyAttribute/6389  : Compatible construction set system
 gid://shopify/TaxonomyAttribute/5218  : Compatible contact lens type
 gid://shopify/TaxonomyAttribute/5220  : Compatible contact lenses
+gid://shopify/TaxonomyAttribute/11489 : Compatible container capacity
 gid://shopify/TaxonomyAttribute/9244  : Compatible contra-bass clarinet peg/stand
 gid://shopify/TaxonomyAttribute/5788  : Compatible cooking thermometer type
 gid://shopify/TaxonomyAttribute/8160  : Compatible coolant chemistry
 gid://shopify/TaxonomyAttribute/8161  : Compatible cooling system material
+gid://shopify/TaxonomyAttribute/11490 : Compatible cord diameter
 gid://shopify/TaxonomyAttribute/1600  : Compatible cosmetic tools
 gid://shopify/TaxonomyAttribute/6287  : Compatible coupler size
 gid://shopify/TaxonomyAttribute/6892  : Compatible crib format
@@ -1617,6 +1864,7 @@ gid://shopify/TaxonomyAttribute/9248  : Compatible drawing ink surface
 gid://shopify/TaxonomyAttribute/7258  : Compatible drivetrain brand
 gid://shopify/TaxonomyAttribute/7259  : Compatible drivetrain speeds
 gid://shopify/TaxonomyAttribute/2426  : Compatible drum configuration
+gid://shopify/TaxonomyAttribute/11491 : Compatible drum inside diameter
 gid://shopify/TaxonomyAttribute/2416  : Compatible electric/acoustic instrument
 gid://shopify/TaxonomyAttribute/1905  : Compatible electronic card type
 gid://shopify/TaxonomyAttribute/7260  : Compatible equipment
@@ -1637,16 +1885,21 @@ gid://shopify/TaxonomyAttribute/7264  : Compatible fishing reel type
 gid://shopify/TaxonomyAttribute/2456  : Compatible flute type
 gid://shopify/TaxonomyAttribute/7265  : Compatible fly line weight
 gid://shopify/TaxonomyAttribute/8166  : Compatible flywheel type
+gid://shopify/TaxonomyAttribute/11492 : Compatible foam roller diameter
 gid://shopify/TaxonomyAttribute/7266  : Compatible football kick type
 gid://shopify/TaxonomyAttribute/5791  : Compatible footwear material
+gid://shopify/TaxonomyAttribute/11493 : Compatible fuel cap neck outer diameter
 gid://shopify/TaxonomyAttribute/8167  : Compatible fuel system type
 gid://shopify/TaxonomyAttribute/6288  : Compatible fuel type
 gid://shopify/TaxonomyAttribute/1967  : Compatible game format
 gid://shopify/TaxonomyAttribute/1420  : Compatible gardening tool
 gid://shopify/TaxonomyAttribute/5792  : Compatible garment steamer design
 gid://shopify/TaxonomyAttribute/7267  : Compatible gas type
+gid://shopify/TaxonomyAttribute/11494 : Compatible gel ball size
 gid://shopify/TaxonomyAttribute/9252  : Compatible gel wax additives
 gid://shopify/TaxonomyAttribute/9253  : Compatible glaze layering
+gid://shopify/TaxonomyAttribute/11495 : Compatible glue stick diameter
+gid://shopify/TaxonomyAttribute/11496 : Compatible goal frame size
 gid://shopify/TaxonomyAttribute/7268  : Compatible golf bag type
 gid://shopify/TaxonomyAttribute/5793  : Compatible grill type
 gid://shopify/TaxonomyAttribute/8168  : Compatible ground polarity
@@ -1656,9 +1909,11 @@ gid://shopify/TaxonomyAttribute/9256  : Compatible guitar scale length
 gid://shopify/TaxonomyAttribute/7269  : Compatible gun platform
 gid://shopify/TaxonomyAttribute/6662  : Compatible hair length
 gid://shopify/TaxonomyAttribute/1430  : Compatible hammock design
+gid://shopify/TaxonomyAttribute/12345 : Compatible handlebar size
 gid://shopify/TaxonomyAttribute/2457  : Compatible harmonica type
 gid://shopify/TaxonomyAttribute/5794  : Compatible hazardous waste type
 gid://shopify/TaxonomyAttribute/8169  : Compatible head and neck restraint system
+gid://shopify/TaxonomyAttribute/11497 : Compatible headstock thickness
 gid://shopify/TaxonomyAttribute/8170  : Compatible helmet certification standard
 gid://shopify/TaxonomyAttribute/8171  : Compatible helmet shell size
 gid://shopify/TaxonomyAttribute/7270  : Compatible helmet size
@@ -1678,6 +1933,7 @@ gid://shopify/TaxonomyAttribute/7272  : Compatible kayak type
 gid://shopify/TaxonomyAttribute/2421  : Compatible keyboard configuration
 gid://shopify/TaxonomyAttribute/5796  : Compatible lawn mower type
 gid://shopify/TaxonomyAttribute/5797  : Compatible leaf blower style
+gid://shopify/TaxonomyAttribute/12346 : Compatible lens diameter
 gid://shopify/TaxonomyAttribute/8177  : Compatible license plate hole pattern
 gid://shopify/TaxonomyAttribute/8178  : Compatible license plate size
 gid://shopify/TaxonomyAttribute/9261  : Compatible loom
@@ -1687,9 +1943,15 @@ gid://shopify/TaxonomyAttribute/5798  : Compatible mailbox size
 gid://shopify/TaxonomyAttribute/5799  : Compatible mailbox type
 gid://shopify/TaxonomyAttribute/1605  : Compatible makeup
 gid://shopify/TaxonomyAttribute/7273  : Compatible mast type
+gid://shopify/TaxonomyAttribute/11499 : Compatible mat length
+gid://shopify/TaxonomyAttribute/11500 : Compatible mat thickness
+gid://shopify/TaxonomyAttribute/11501 : Compatible mat width
+gid://shopify/TaxonomyAttribute/11502 : Compatible mattress dimensions
 gid://shopify/TaxonomyAttribute/2019  : Compatible memory cards
+gid://shopify/TaxonomyAttribute/12347 : Compatible microphone size
 gid://shopify/TaxonomyAttribute/1794  : Compatible microphone thread
 gid://shopify/TaxonomyAttribute/9264  : Compatible model system (train scale)
+gid://shopify/TaxonomyAttribute/12348 : Compatible monitor size
 gid://shopify/TaxonomyAttribute/1898  : Compatible motherboard form factor
 gid://shopify/TaxonomyAttribute/9265  : Compatible mounting surface
 gid://shopify/TaxonomyAttribute/9266  : Compatible mouthpiece patch
@@ -1708,12 +1970,14 @@ gid://shopify/TaxonomyAttribute/7274  : Compatible pedal type
 gid://shopify/TaxonomyAttribute/2423  : Compatible percussion instrument
 gid://shopify/TaxonomyAttribute/9272  : Compatible pin type
 gid://shopify/TaxonomyAttribute/5330  : Compatible pinball machine edition
+gid://shopify/TaxonomyAttribute/12349 : Compatible pipe diameter
 gid://shopify/TaxonomyAttribute/7705  : Compatible pipe filter size
 gid://shopify/TaxonomyAttribute/7275  : Compatible plate size
 gid://shopify/TaxonomyAttribute/6391  : Compatible play vehicle scale
 gid://shopify/TaxonomyAttribute/2774  : Compatible play vehicle type
 gid://shopify/TaxonomyAttribute/2692  : Compatible player
 gid://shopify/TaxonomyAttribute/7276  : Compatible playing surface
+gid://shopify/TaxonomyAttribute/11503 : Compatible poker chip diameter
 gid://shopify/TaxonomyAttribute/7277  : Compatible pole dimensions
 gid://shopify/TaxonomyAttribute/7278  : Compatible pole shape
 gid://shopify/TaxonomyAttribute/5276  : Compatible polish thinner type
@@ -1722,6 +1986,7 @@ gid://shopify/TaxonomyAttribute/5584  : Compatible power supply form factor
 gid://shopify/TaxonomyAttribute/7279  : Compatible powerplant type
 gid://shopify/TaxonomyAttribute/9273  : Compatible presser foot
 gid://shopify/TaxonomyAttribute/2338  : Compatible printer
+gid://shopify/TaxonomyAttribute/12350 : Compatible printer filament size
 gid://shopify/TaxonomyAttribute/1837  : Compatible processor series
 gid://shopify/TaxonomyAttribute/2642  : Compatible programming languages
 gid://shopify/TaxonomyAttribute/8181  : Compatible protective gear
@@ -1740,6 +2005,9 @@ gid://shopify/TaxonomyAttribute/5802  : Compatible refrigerator compartment
 gid://shopify/TaxonomyAttribute/5372  : Compatible resin type
 gid://shopify/TaxonomyAttribute/1968  : Compatible resolution
 gid://shopify/TaxonomyAttribute/7282  : Compatible ride equipment
+gid://shopify/TaxonomyAttribute/11504 : Compatible rim diameter
+gid://shopify/TaxonomyAttribute/12351 : Compatible rivet size
+gid://shopify/TaxonomyAttribute/11505 : Compatible rod length
 gid://shopify/TaxonomyAttribute/8185  : Compatible roof height
 gid://shopify/TaxonomyAttribute/8186  : Compatible roof rail type
 gid://shopify/TaxonomyAttribute/7283  : Compatible rope count
@@ -1750,11 +2018,14 @@ gid://shopify/TaxonomyAttribute/9278  : Compatible saxophone size
 gid://shopify/TaxonomyAttribute/9279  : Compatible saxophone type
 gid://shopify/TaxonomyAttribute/9280  : Compatible scale length
 gid://shopify/TaxonomyAttribute/8187  : Compatible seat airbag
+gid://shopify/TaxonomyAttribute/11506 : Compatible seat belt tongue width
 gid://shopify/TaxonomyAttribute/1748  : Compatible seat type
 gid://shopify/TaxonomyAttribute/6893  : Compatible seating capacity
+gid://shopify/TaxonomyAttribute/11507 : Compatible seatpost diameter
 gid://shopify/TaxonomyAttribute/8188  : Compatible sensor port type
 gid://shopify/TaxonomyAttribute/8189  : Compatible shifter type
 gid://shopify/TaxonomyAttribute/7287  : Compatible skating discipline
+gid://shopify/TaxonomyAttribute/11508 : Compatible ski width
 gid://shopify/TaxonomyAttribute/7288  : Compatible snowshoe deck type
 gid://shopify/TaxonomyAttribute/2667  : Compatible software platform
 gid://shopify/TaxonomyAttribute/2524  : Compatible special effects device
@@ -1775,6 +2046,10 @@ gid://shopify/TaxonomyAttribute/1750  : Compatible stroller type
 gid://shopify/TaxonomyAttribute/8193  : Compatible substrate material
 gid://shopify/TaxonomyAttribute/9286  : Compatible surface
 gid://shopify/TaxonomyAttribute/8194  : Compatible surface material
+gid://shopify/TaxonomyAttribute/11509 : Compatible table length
+gid://shopify/TaxonomyAttribute/11510 : Compatible table size
+gid://shopify/TaxonomyAttribute/11511 : Compatible table width
+gid://shopify/TaxonomyAttribute/12352 : Compatible tape size
 gid://shopify/TaxonomyAttribute/8195  : Compatible tear-off system
 gid://shopify/TaxonomyAttribute/8196  : Compatible thermostat type
 gid://shopify/TaxonomyAttribute/9287  : Compatible thread
@@ -1787,7 +2062,9 @@ gid://shopify/TaxonomyAttribute/6393  : Compatible toy vehicle scale
 gid://shopify/TaxonomyAttribute/5805  : Compatible tractor type
 gid://shopify/TaxonomyAttribute/7290  : Compatible training equipment
 gid://shopify/TaxonomyAttribute/7291  : Compatible treadmill design
+gid://shopify/TaxonomyAttribute/11512 : Compatible truck bed length
 gid://shopify/TaxonomyAttribute/7292  : Compatible tube
+gid://shopify/TaxonomyAttribute/11513 : Compatible tube diameter
 gid://shopify/TaxonomyAttribute/5806  : Compatible umbrella type
 gid://shopify/TaxonomyAttribute/1369  : Compatible vacuum type
 gid://shopify/TaxonomyAttribute/6394  : Compatible valve type
@@ -1807,9 +2084,11 @@ gid://shopify/TaxonomyAttribute/8202  : Compatible watercraft communication stan
 gid://shopify/TaxonomyAttribute/8203  : Compatible watercraft engine type
 gid://shopify/TaxonomyAttribute/5201  : Compatible wax container size
 gid://shopify/TaxonomyAttribute/5202  : Compatible wax form
+gid://shopify/TaxonomyAttribute/11514 : Compatible weaving shuttle bobbin length
 gid://shopify/TaxonomyAttribute/1235  : Compatible weight lifting accessory
 gid://shopify/TaxonomyAttribute/7294  : Compatible weight plate diameter
 gid://shopify/TaxonomyAttribute/8204  : Compatible wheel finish
+gid://shopify/TaxonomyAttribute/12353 : Compatible wheel size
 gid://shopify/TaxonomyAttribute/9291  : Compatible whorl drive band type
 gid://shopify/TaxonomyAttribute/9292  : Compatible wick series
 gid://shopify/TaxonomyAttribute/9293  : Compatible winder head/bit
@@ -1844,6 +2123,8 @@ gid://shopify/TaxonomyAttribute/8209  : Concentration type
 gid://shopify/TaxonomyAttribute/9297  : Concert bass drum mounting stand type
 gid://shopify/TaxonomyAttribute/9298  : Concert pitch standard
 gid://shopify/TaxonomyAttribute/2463  : Concertina button configuration
+gid://shopify/TaxonomyAttribute/11516 : Condenser inlet port diameter
+gid://shopify/TaxonomyAttribute/11517 : Condenser outlet port diameter
 gid://shopify/TaxonomyAttribute/7708  : Condiment form
 gid://shopify/TaxonomyAttribute/7709  : Condiment texture
 gid://shopify/TaxonomyAttribute/2360  : Condition
@@ -1853,7 +2134,9 @@ gid://shopify/TaxonomyAttribute/5113  : Condom fit type
 gid://shopify/TaxonomyAttribute/1557  : Condom type
 gid://shopify/TaxonomyAttribute/5114  : Conductivity gel application
 gid://shopify/TaxonomyAttribute/5481  : Conductor core type
+gid://shopify/TaxonomyAttribute/11518 : Cone height
 gid://shopify/TaxonomyAttribute/9299  : Confetti format
+gid://shopify/TaxonomyAttribute/11519 : Confetti piece size
 gid://shopify/TaxonomyAttribute/9300  : Conga head tensioning system
 gid://shopify/TaxonomyAttribute/9301  : Conga set included drum types
 gid://shopify/TaxonomyAttribute/2144  : Connecting thread
@@ -1863,6 +2146,7 @@ gid://shopify/TaxonomyAttribute/1272  : Connectivity technology
 gid://shopify/TaxonomyAttribute/5485  : Connectivity type
 gid://shopify/TaxonomyAttribute/5561  : Connector 1 type
 gid://shopify/TaxonomyAttribute/5560  : Connector 2 type
+gid://shopify/TaxonomyAttribute/11520 : Connector case internal dimensions
 gid://shopify/TaxonomyAttribute/8210  : Connector case style
 gid://shopify/TaxonomyAttribute/5550  : Connector contact plating
 gid://shopify/TaxonomyAttribute/2129  : Connector design
@@ -1937,6 +2221,7 @@ gid://shopify/TaxonomyAttribute/5818  : Cookware coating material
 gid://shopify/TaxonomyAttribute/5819  : Cookware coating type
 gid://shopify/TaxonomyAttribute/3361  : Cookware items included
 gid://shopify/TaxonomyAttribute/5820  : Cookware lid style
+gid://shopify/TaxonomyAttribute/12354 : Cookware size
 gid://shopify/TaxonomyAttribute/3147  : Cookware/Bakeware features
 gid://shopify/TaxonomyAttribute/2811  : Cookware/Bakeware material
 gid://shopify/TaxonomyAttribute/8223  : Coolant additive purpose
@@ -1944,6 +2229,7 @@ gid://shopify/TaxonomyAttribute/8224  : Coolant base fluid
 gid://shopify/TaxonomyAttribute/8225  : Coolant outlet connection style
 gid://shopify/TaxonomyAttribute/8226  : Coolant outlet neck angle
 gid://shopify/TaxonomyAttribute/8227  : Coolant technology
+gid://shopify/TaxonomyAttribute/11521 : Coolant temperature sensor hex size
 gid://shopify/TaxonomyAttribute/8228  : Coolant temperature sensor port
 gid://shopify/TaxonomyAttribute/8229  : Coolant temperature sensor seal type
 gid://shopify/TaxonomyAttribute/5821  : Cooler style
@@ -1951,7 +2237,9 @@ gid://shopify/TaxonomyAttribute/8230  : Cooling system component included
 gid://shopify/TaxonomyAttribute/8231  : Cooling system flush application step
 gid://shopify/TaxonomyAttribute/8232  : Cooling system type
 gid://shopify/TaxonomyAttribute/1872  : Cooling technology
+gid://shopify/TaxonomyAttribute/12355 : Cord diameter
 gid://shopify/TaxonomyAttribute/2118  : Cord fastening system
+gid://shopify/TaxonomyAttribute/12356 : Cord length
 gid://shopify/TaxonomyAttribute/9311  : Cord material
 gid://shopify/TaxonomyAttribute/5003  : Cordless phone frequency band
 gid://shopify/TaxonomyAttribute/9312  : Core type (bass strings)
@@ -1992,10 +2280,14 @@ gid://shopify/TaxonomyAttribute/7307  : Cover fit style
 gid://shopify/TaxonomyAttribute/8235  : Cover fit type
 gid://shopify/TaxonomyAttribute/1341  : Cover material
 gid://shopify/TaxonomyAttribute/2707  : Cover type
+gid://shopify/TaxonomyAttribute/11522 : Coverage area per container
 gid://shopify/TaxonomyAttribute/5261  : Coverage level
+gid://shopify/TaxonomyAttribute/12358 : Coverage radius
 gid://shopify/TaxonomyAttribute/2659  : Coverage region
 gid://shopify/TaxonomyAttribute/9318  : Cowbell beater type
 gid://shopify/TaxonomyAttribute/9319  : Cowbell mounting method
+gid://shopify/TaxonomyAttribute/11523 : Cowbell mouth opening width
+gid://shopify/TaxonomyAttribute/11524 : Cowbell opening size
 gid://shopify/TaxonomyAttribute/9320  : Cowbell sound character
 gid://shopify/TaxonomyAttribute/6897  : Cradle capacity
 gid://shopify/TaxonomyAttribute/9321  : Craft cutter/embosser machine operation
@@ -2018,10 +2310,13 @@ gid://shopify/TaxonomyAttribute/9332  : Craft wood surface preparation
 gid://shopify/TaxonomyAttribute/2329  : Craft/Sculpting project type
 gid://shopify/TaxonomyAttribute/3015  : Crafting frame/stretcher features
 gid://shopify/TaxonomyAttribute/3013  : Crafting mat/pad features
+gid://shopify/TaxonomyAttribute/11525 : Crafting wire diameter
 gid://shopify/TaxonomyAttribute/2873  : Crampon attachment type
+gid://shopify/TaxonomyAttribute/11526 : Crank arm length
 gid://shopify/TaxonomyAttribute/7308  : Crank spindle interface
 gid://shopify/TaxonomyAttribute/8236  : Crankshaft balance type
 gid://shopify/TaxonomyAttribute/8237  : Crankshaft bolt pattern
+gid://shopify/TaxonomyAttribute/11527 : Crankshaft main bearing journal diameter
 gid://shopify/TaxonomyAttribute/8238  : Crankshaft sensor reluctor type
 gid://shopify/TaxonomyAttribute/6395  : Craps accessories included
 gid://shopify/TaxonomyAttribute/9333  : Crash cymbal profile
@@ -2061,14 +2356,17 @@ gid://shopify/TaxonomyAttribute/7325  : Cross-country binding system
 gid://shopify/TaxonomyAttribute/9337  : Cross-stitch frame fabric holding mechanism
 gid://shopify/TaxonomyAttribute/9338  : Cross-stitch frame included components
 gid://shopify/TaxonomyAttribute/9339  : Cross-stitch frame type
+gid://shopify/TaxonomyAttribute/11528 : Crossbar height
 gid://shopify/TaxonomyAttribute/8240  : Crossbar shape/profile
 gid://shopify/TaxonomyAttribute/7326  : Crossbar style
 gid://shopify/TaxonomyAttribute/7327  : Crossbow type
 gid://shopify/TaxonomyAttribute/8241  : Crossover component type
 gid://shopify/TaxonomyAttribute/8242  : Crossover configuration
 gid://shopify/TaxonomyAttribute/8243  : Crossover type
+gid://shopify/TaxonomyAttribute/11529 : Crown height
 gid://shopify/TaxonomyAttribute/6664  : Crown profile
 gid://shopify/TaxonomyAttribute/6665  : Crown style
+gid://shopify/TaxonomyAttribute/12359 : Crusher output size
 gid://shopify/TaxonomyAttribute/5825  : Crushing method
 gid://shopify/TaxonomyAttribute/5826  : Crust browning level
 gid://shopify/TaxonomyAttribute/7721  : Crust taste profile
@@ -2082,9 +2380,11 @@ gid://shopify/TaxonomyAttribute/7722  : Cucumber variety
 gid://shopify/TaxonomyAttribute/7328  : Cue compatibility
 gid://shopify/TaxonomyAttribute/7329  : Cue construction
 gid://shopify/TaxonomyAttribute/7330  : Cue head material
+gid://shopify/TaxonomyAttribute/12360 : Cue size
 gid://shopify/TaxonomyAttribute/7331  : Cue sport compatibility
 gid://shopify/TaxonomyAttribute/1239  : Cue style
 gid://shopify/TaxonomyAttribute/7332  : Cue thread size
+gid://shopify/TaxonomyAttribute/11533 : Cue tip diameter
 gid://shopify/TaxonomyAttribute/7333  : Cue tip hardness
 gid://shopify/TaxonomyAttribute/1240  : Cue type
 gid://shopify/TaxonomyAttribute/1241  : Cue wrap
@@ -2098,12 +2398,14 @@ gid://shopify/TaxonomyAttribute/1447  : Culinary botanical name
 gid://shopify/TaxonomyAttribute/5827  : Cultivar type
 gid://shopify/TaxonomyAttribute/7723  : Cultivation method
 gid://shopify/TaxonomyAttribute/5828  : Cultivator type
+gid://shopify/TaxonomyAttribute/11535 : Cup mute depth
 gid://shopify/TaxonomyAttribute/17    : Cup size
 gid://shopify/TaxonomyAttribute/9343  : Cup type
 gid://shopify/TaxonomyAttribute/5829  : Cup warmer features
 gid://shopify/TaxonomyAttribute/7724  : Cupcake size
 gid://shopify/TaxonomyAttribute/7725  : Curd size
 gid://shopify/TaxonomyAttribute/7336  : Cure method
+gid://shopify/TaxonomyAttribute/11536 : Cure time
 gid://shopify/TaxonomyAttribute/5278  : Curing method
 gid://shopify/TaxonomyAttribute/7726  : Curing or preparation method
 gid://shopify/TaxonomyAttribute/5246  : Curler pad material
@@ -2116,11 +2418,14 @@ gid://shopify/TaxonomyAttribute/7340  : Curling training aid type
 gid://shopify/TaxonomyAttribute/1791  : Currency
 gid://shopify/TaxonomyAttribute/2610  : Currency type
 gid://shopify/TaxonomyAttribute/7727  : Curry variety
+gid://shopify/TaxonomyAttribute/12361 : Curtain drop
 gid://shopify/TaxonomyAttribute/5830  : Curtain heading style
 gid://shopify/TaxonomyAttribute/5831  : Curtain lining type
 gid://shopify/TaxonomyAttribute/5832  : Curtain rod type
+gid://shopify/TaxonomyAttribute/12362 : Curtain width
 gid://shopify/TaxonomyAttribute/5328  : Cushion design
 gid://shopify/TaxonomyAttribute/7341  : Cushion rubber profile
+gid://shopify/TaxonomyAttribute/11537 : Cushion thickness
 gid://shopify/TaxonomyAttribute/6667  : Cushioning level
 gid://shopify/TaxonomyAttribute/9344  : Custom label content type
 gid://shopify/TaxonomyAttribute/2654  : Customer support channels
@@ -2130,6 +2435,8 @@ gid://shopify/TaxonomyAttribute/7342  : Cut resistance rating
 gid://shopify/TaxonomyAttribute/9346  : Cut type
 gid://shopify/TaxonomyAttribute/3367  : Cutter options
 gid://shopify/TaxonomyAttribute/9347  : Cutting application
+gid://shopify/TaxonomyAttribute/12363 : Cutting depth
+gid://shopify/TaxonomyAttribute/12364 : Cutting diameter
 gid://shopify/TaxonomyAttribute/5833  : Cutting disc function
 gid://shopify/TaxonomyAttribute/5834  : Cutting head type
 gid://shopify/TaxonomyAttribute/9348  : Cutting mat grid style
@@ -2138,17 +2445,21 @@ gid://shopify/TaxonomyAttribute/5835  : Cutting mechanism type
 gid://shopify/TaxonomyAttribute/1422  : Cutting method
 gid://shopify/TaxonomyAttribute/7343  : Cycling apparel fit
 gid://shopify/TaxonomyAttribute/1278  : Cycling style
+gid://shopify/TaxonomyAttribute/12365 : Cylinder bore
 gid://shopify/TaxonomyAttribute/5836  : Cylinder connector type
 gid://shopify/TaxonomyAttribute/8248  : Cylinder head assembly
 gid://shopify/TaxonomyAttribute/8249  : Cylinder head material grade
 gid://shopify/TaxonomyAttribute/8250  : Cylinder head position
 gid://shopify/TaxonomyAttribute/5083  : Cylinder size designation
+gid://shopify/TaxonomyAttribute/11541 : Cylinder thread size
 gid://shopify/TaxonomyAttribute/9355  : Cymbal & drum case wheel configuration
 gid://shopify/TaxonomyAttribute/9350  : Cymbal alloy
 gid://shopify/TaxonomyAttribute/9351  : Cymbal application
+gid://shopify/TaxonomyAttribute/11542 : Cymbal arm length
 gid://shopify/TaxonomyAttribute/9352  : Cymbal arm mounting interface
 gid://shopify/TaxonomyAttribute/9353  : Cymbal arm rotation/positioning features
 gid://shopify/TaxonomyAttribute/9354  : Cymbal arm style
+gid://shopify/TaxonomyAttribute/11543 : Cymbal bell size
 gid://shopify/TaxonomyAttribute/9356  : Cymbal hammering style
 gid://shopify/TaxonomyAttribute/9357  : Cymbal kit components included
 gid://shopify/TaxonomyAttribute/9358  : Cymbal kit items included
@@ -2157,6 +2468,7 @@ gid://shopify/TaxonomyAttribute/9360  : Cymbal playing style/genre
 gid://shopify/TaxonomyAttribute/9361  : Cymbal set configuration
 gid://shopify/TaxonomyAttribute/9362  : Cymbal sound character
 gid://shopify/TaxonomyAttribute/9363  : Cymbal sustain
+gid://shopify/TaxonomyAttribute/11545 : Cymbal thickness
 gid://shopify/TaxonomyAttribute/9364  : Cymbal type
 gid://shopify/TaxonomyAttribute/9365  : Cymbal volume level
 gid://shopify/TaxonomyAttribute/9366  : Cymbal weight class
@@ -2200,6 +2512,7 @@ gid://shopify/TaxonomyAttribute/8256  : Decal installation method
 gid://shopify/TaxonomyAttribute/8257  : Decal orientation
 gid://shopify/TaxonomyAttribute/8258  : Decal placement type
 gid://shopify/TaxonomyAttribute/8259  : Decal visibility property
+gid://shopify/TaxonomyAttribute/12366 : Decibel accuracy
 gid://shopify/TaxonomyAttribute/7352  : Deck concave level
 gid://shopify/TaxonomyAttribute/7353  : Deck flex rating
 gid://shopify/TaxonomyAttribute/7354  : Deck material
@@ -2244,14 +2557,17 @@ gid://shopify/TaxonomyAttribute/3353  : Denture design
 gid://shopify/TaxonomyAttribute/5193  : Denture retention mechanism
 gid://shopify/TaxonomyAttribute/1668  : Denture teeth color
 gid://shopify/TaxonomyAttribute/2650  : Deployment type
+gid://shopify/TaxonomyAttribute/12367 : Depth
 gid://shopify/TaxonomyAttribute/7361  : Derailleur cage length
 gid://shopify/TaxonomyAttribute/7362  : Derailleur mounting style
 gid://shopify/TaxonomyAttribute/7363  : Derailleur type
 gid://shopify/TaxonomyAttribute/7364  : Deshedder tool type
 gid://shopify/TaxonomyAttribute/5839  : Desiccant material
+gid://shopify/TaxonomyAttribute/11547 : Desk lip depth
 gid://shopify/TaxonomyAttribute/3154  : Desk organizer features
 gid://shopify/TaxonomyAttribute/1570  : Detailed ingredients
 gid://shopify/TaxonomyAttribute/1579  : Detectable drugs
+gid://shopify/TaxonomyAttribute/12368 : Detection range
 gid://shopify/TaxonomyAttribute/5058  : Detection technology
 gid://shopify/TaxonomyAttribute/3357  : Detector operation mode
 gid://shopify/TaxonomyAttribute/2582  : Detector sensitivity
@@ -2260,12 +2576,15 @@ gid://shopify/TaxonomyAttribute/5163  : Developer strength
 gid://shopify/TaxonomyAttribute/3027  : Developmental features
 gid://shopify/TaxonomyAttribute/845   : Device interface
 gid://shopify/TaxonomyAttribute/2197  : Device technology
+gid://shopify/TaxonomyAttribute/11549 : Devil stick weight
 gid://shopify/TaxonomyAttribute/3392  : Dexterity skills
 gid://shopify/TaxonomyAttribute/9383  : Diabolo axle system
+gid://shopify/TaxonomyAttribute/11550 : Diabolo cup width
 gid://shopify/TaxonomyAttribute/8261  : Diagnostic functions supported
 gid://shopify/TaxonomyAttribute/8262  : Diagnostic interface type
 gid://shopify/TaxonomyAttribute/5840  : Dial finish
 gid://shopify/TaxonomyAttribute/5005  : Dialing method
+gid://shopify/TaxonomyAttribute/12369 : Diameter
 gid://shopify/TaxonomyAttribute/6671  : Diamond color grade
 gid://shopify/TaxonomyAttribute/3364  : Diaper bag additional features
 gid://shopify/TaxonomyAttribute/6672  : Diaper cover style
@@ -2278,7 +2597,9 @@ gid://shopify/TaxonomyAttribute/9385  : Diatonic harmonica tuning system
 gid://shopify/TaxonomyAttribute/2761  : Dice shape
 gid://shopify/TaxonomyAttribute/6396  : Dice sides
 gid://shopify/TaxonomyAttribute/9386  : Didgeridoo construction type
+gid://shopify/TaxonomyAttribute/11552 : Didgeridoo length
 gid://shopify/TaxonomyAttribute/1834  : Dielectric type
+gid://shopify/TaxonomyAttribute/11553 : Dietary fiber per serving
 gid://shopify/TaxonomyAttribute/7365  : Dietary formulation claim
 gid://shopify/TaxonomyAttribute/1452  : Dietary preferences
 gid://shopify/TaxonomyAttribute/3098  : Dietary supplements
@@ -2286,6 +2607,7 @@ gid://shopify/TaxonomyAttribute/1567  : Dietary use
 gid://shopify/TaxonomyAttribute/2768  : Difficulty level
 gid://shopify/TaxonomyAttribute/2048  : Diffuser design
 gid://shopify/TaxonomyAttribute/5132  : Digestive supplement type
+gid://shopify/TaxonomyAttribute/11554 : Digit height
 gid://shopify/TaxonomyAttribute/1809  : Digital sound processing
 gid://shopify/TaxonomyAttribute/5653  : Digitizer surface finish
 gid://shopify/TaxonomyAttribute/5841  : Dinnerware features
@@ -2324,12 +2646,16 @@ gid://shopify/TaxonomyAttribute/3054  : Disposable glove features
 gid://shopify/TaxonomyAttribute/9389  : Disposable/Compostable claim
 gid://shopify/TaxonomyAttribute/2994  : Disposable/Reusable bag features
 gid://shopify/TaxonomyAttribute/2950  : Disposable/Reusable item material
+gid://shopify/TaxonomyAttribute/12372 : Distance measurement accuracy
+gid://shopify/TaxonomyAttribute/12373 : Distance per charge
+gid://shopify/TaxonomyAttribute/12374 : Distance range
 gid://shopify/TaxonomyAttribute/7733  : Distillation method
 gid://shopify/TaxonomyAttribute/7734  : Distilled water intended use
 gid://shopify/TaxonomyAttribute/8264  : Distress transmission frequency
 gid://shopify/TaxonomyAttribute/6673  : Distressing level
 gid://shopify/TaxonomyAttribute/6674  : Distressing style
 gid://shopify/TaxonomyAttribute/8265  : Distributor advance mechanism
+gid://shopify/TaxonomyAttribute/11556 : Distributor cap diameter
 gid://shopify/TaxonomyAttribute/8266  : Distributor cap terminal type
 gid://shopify/TaxonomyAttribute/8267  : Distributor gear material
 gid://shopify/TaxonomyAttribute/8268  : Distributor ignition type
@@ -2355,6 +2681,7 @@ gid://shopify/TaxonomyAttribute/6402  : Doll accessory type
 gid://shopify/TaxonomyAttribute/6403  : Doll eye type
 gid://shopify/TaxonomyAttribute/6404  : Doll hair fiber type
 gid://shopify/TaxonomyAttribute/9393  : Doll making kit components included
+gid://shopify/TaxonomyAttribute/12375 : Doll size
 gid://shopify/TaxonomyAttribute/3399  : Doll type
 gid://shopify/TaxonomyAttribute/3192  : Doll/Playset features
 gid://shopify/TaxonomyAttribute/6405  : Dollhouse installation/placement type
@@ -2363,6 +2690,7 @@ gid://shopify/TaxonomyAttribute/6407  : Dollhouse lighting type
 gid://shopify/TaxonomyAttribute/6408  : Dollhouse room type
 gid://shopify/TaxonomyAttribute/6409  : Dollhouse scale
 gid://shopify/TaxonomyAttribute/6410  : Dollhouse style/theme
+gid://shopify/TaxonomyAttribute/12376 : Domestic hot water flow
 gid://shopify/TaxonomyAttribute/9394  : Donnos playing technique
 gid://shopify/TaxonomyAttribute/9395  : Donnos tuning system
 gid://shopify/TaxonomyAttribute/8270  : Door assembly type
@@ -2418,6 +2746,9 @@ gid://shopify/TaxonomyAttribute/2146  : Drain location
 gid://shopify/TaxonomyAttribute/5853  : Drainage design
 gid://shopify/TaxonomyAttribute/5172  : Drainage feature
 gid://shopify/TaxonomyAttribute/5854  : Drainage method
+gid://shopify/TaxonomyAttribute/11558 : Drained weight
+gid://shopify/TaxonomyAttribute/12377 : Draw length
+gid://shopify/TaxonomyAttribute/12378 : Draw weight
 gid://shopify/TaxonomyAttribute/6902  : Drawer features
 gid://shopify/TaxonomyAttribute/5855  : Drawer organizer features
 gid://shopify/TaxonomyAttribute/6903  : Drawer slide type
@@ -2426,10 +2757,12 @@ gid://shopify/TaxonomyAttribute/9409  : Drawing ink permanence
 gid://shopify/TaxonomyAttribute/2280  : Drawing/Painting kit items included
 gid://shopify/TaxonomyAttribute/6675  : Dress embellishment
 gid://shopify/TaxonomyAttribute/3014  : Dress form features
+gid://shopify/TaxonomyAttribute/12379 : Dress length
 gid://shopify/TaxonomyAttribute/3244  : Dress occasion
 gid://shopify/TaxonomyAttribute/3245  : Dress style
 gid://shopify/TaxonomyAttribute/6676  : Dress train type
 gid://shopify/TaxonomyAttribute/9410  : Dried surface finish
+gid://shopify/TaxonomyAttribute/12380 : Drill bit size
 gid://shopify/TaxonomyAttribute/3120  : Drill features
 gid://shopify/TaxonomyAttribute/2604  : Drilling method
 gid://shopify/TaxonomyAttribute/2605  : Drilling rig orientation
@@ -2444,13 +2777,16 @@ gid://shopify/TaxonomyAttribute/5859  : Dripper design
 gid://shopify/TaxonomyAttribute/9411  : Drive band cross-section shape
 gid://shopify/TaxonomyAttribute/9412  : Drive band join type
 gid://shopify/TaxonomyAttribute/9413  : Drive band material type
+gid://shopify/TaxonomyAttribute/12381 : Drive diameter
 gid://shopify/TaxonomyAttribute/5661  : Drive form factor
 gid://shopify/TaxonomyAttribute/7378  : Drive location
 gid://shopify/TaxonomyAttribute/7379  : Drive mechanism
+gid://shopify/TaxonomyAttribute/11559 : Drive shaft length
 gid://shopify/TaxonomyAttribute/8280  : Drive shaft material
 gid://shopify/TaxonomyAttribute/2217  : Drive size
 gid://shopify/TaxonomyAttribute/7380  : Drive system
 gid://shopify/TaxonomyAttribute/2576  : Drive type
+gid://shopify/TaxonomyAttribute/11560 : Drive wheel hub bore diameter
 gid://shopify/TaxonomyAttribute/5348  : Driver configuration
 gid://shopify/TaxonomyAttribute/5450  : Driver technology
 gid://shopify/TaxonomyAttribute/7381  : Drivetrain configuration
@@ -2459,7 +2795,9 @@ gid://shopify/TaxonomyAttribute/5496  : Drone board function
 gid://shopify/TaxonomyAttribute/4684  : Drone features
 gid://shopify/TaxonomyAttribute/8281  : Drone positioning system
 gid://shopify/TaxonomyAttribute/8282  : Drone transmission type
+gid://shopify/TaxonomyAttribute/12382 : Drop
 gid://shopify/TaxonomyAttribute/9414  : Drop spindle whorl position
+gid://shopify/TaxonomyAttribute/11561 : Drum brush bristle/wire length
 gid://shopify/TaxonomyAttribute/9415  : Drum carder accessories included
 gid://shopify/TaxonomyAttribute/9416  : Drum clamp locking mechanism
 gid://shopify/TaxonomyAttribute/9417  : Drum clamp mount interface
@@ -2469,6 +2807,7 @@ gid://shopify/TaxonomyAttribute/5860  : Drum grating styles included
 gid://shopify/TaxonomyAttribute/3287  : Drum hardware adjustability
 gid://shopify/TaxonomyAttribute/2934  : Drum hardware material
 gid://shopify/TaxonomyAttribute/9419  : Drum head application (batter/resonant)
+gid://shopify/TaxonomyAttribute/11562 : Drum head collar depth
 gid://shopify/TaxonomyAttribute/9420  : Drum head collar type
 gid://shopify/TaxonomyAttribute/9421  : Drum head damping control
 gid://shopify/TaxonomyAttribute/9422  : Drum head film material
@@ -2480,11 +2819,13 @@ gid://shopify/TaxonomyAttribute/9427  : Drum head muffling type
 gid://shopify/TaxonomyAttribute/9428  : Drum head ply count
 gid://shopify/TaxonomyAttribute/9429  : Drum head position
 gid://shopify/TaxonomyAttribute/9430  : Drum head reinforcement type
+gid://shopify/TaxonomyAttribute/12383 : Drum head size
 gid://shopify/TaxonomyAttribute/9431  : Drum head surface finish
 gid://shopify/TaxonomyAttribute/9432  : Drum head type
 gid://shopify/TaxonomyAttribute/9433  : Drum key design type
 gid://shopify/TaxonomyAttribute/9434  : Drum key drive type
 gid://shopify/TaxonomyAttribute/9435  : Drum key handle style
+gid://shopify/TaxonomyAttribute/11563 : Drum kit bass drum diameter
 gid://shopify/TaxonomyAttribute/9436  : Drum kit included items
 gid://shopify/TaxonomyAttribute/9437  : Drum kit portability
 gid://shopify/TaxonomyAttribute/9438  : Drum kit shell construction features
@@ -2495,19 +2836,24 @@ gid://shopify/TaxonomyAttribute/9442  : Drum pad triggering zones
 gid://shopify/TaxonomyAttribute/9443  : Drum pedal accessories included
 gid://shopify/TaxonomyAttribute/9444  : Drum pedal baseplate type
 gid://shopify/TaxonomyAttribute/9445  : Drum pedal bearing type
+gid://shopify/TaxonomyAttribute/11564 : Drum pedal beater shaft length
 gid://shopify/TaxonomyAttribute/9446  : Drum pedal cam type
 gid://shopify/TaxonomyAttribute/9447  : Drum pedal chain configuration
 gid://shopify/TaxonomyAttribute/9448  : Drum pedal chain type
 gid://shopify/TaxonomyAttribute/9449  : Drum pedal clamp type
+gid://shopify/TaxonomyAttribute/11565 : Drum pedal footboard length
 gid://shopify/TaxonomyAttribute/9450  : Drum pedal intended use
 gid://shopify/TaxonomyAttribute/9451  : Drum pedal spring adjustment method
 gid://shopify/TaxonomyAttribute/9452  : Drum pedal spring type
+gid://shopify/TaxonomyAttribute/11566 : Drum rack tube diameter
 gid://shopify/TaxonomyAttribute/9453  : Drum shell material
 gid://shopify/TaxonomyAttribute/9454  : Drum shell wood species
 gid://shopify/TaxonomyAttribute/9455  : Drumhead type
 gid://shopify/TaxonomyAttribute/9456  : Drumstick model
 gid://shopify/TaxonomyAttribute/9457  : Drumstick taper
 gid://shopify/TaxonomyAttribute/1492  : Dry bean variety
+gid://shopify/TaxonomyAttribute/11567 : Dry boiling point
+gid://shopify/TaxonomyAttribute/12384 : Dry weight
 gid://shopify/TaxonomyAttribute/1380  : Dry/Wet cleaning
 gid://shopify/TaxonomyAttribute/5861  : Dryer drum material
 gid://shopify/TaxonomyAttribute/5862  : Dryer sheet features
@@ -2516,16 +2862,23 @@ gid://shopify/TaxonomyAttribute/5863  : Dryer venting type
 gid://shopify/TaxonomyAttribute/5181  : Drying method
 gid://shopify/TaxonomyAttribute/1601  : Drying speed
 gid://shopify/TaxonomyAttribute/5864  : Drying system
+gid://shopify/TaxonomyAttribute/11568 : Drying time
 gid://shopify/TaxonomyAttribute/7383  : Drysuit footwear style
+gid://shopify/TaxonomyAttribute/12385 : Drywall thickness
 gid://shopify/TaxonomyAttribute/3326  : Duct design
+gid://shopify/TaxonomyAttribute/12386 : Duct diameter
+gid://shopify/TaxonomyAttribute/12387 : Duct length
 gid://shopify/TaxonomyAttribute/2135  : Duct shape
 gid://shopify/TaxonomyAttribute/7384  : Dumbbell style
+gid://shopify/TaxonomyAttribute/12388 : Dumbbell weight
 gid://shopify/TaxonomyAttribute/9458  : Dundun playing position
 gid://shopify/TaxonomyAttribute/5377  : Duplex component type
 gid://shopify/TaxonomyAttribute/5378  : Duplexer installation type
 gid://shopify/TaxonomyAttribute/1950  : Duplexing technology
 gid://shopify/TaxonomyAttribute/5654  : Duplication operation mode
 gid://shopify/TaxonomyAttribute/3111  : Durability features
+gid://shopify/TaxonomyAttribute/12389 : Duration
+gid://shopify/TaxonomyAttribute/11569 : Durometer hardness (Shore A)
 gid://shopify/TaxonomyAttribute/1381  : Dust container type
 gid://shopify/TaxonomyAttribute/2638  : Dust mask type
 gid://shopify/TaxonomyAttribute/5865  : Duster head material
@@ -2542,6 +2895,7 @@ gid://shopify/TaxonomyAttribute/7385  : E-bike certification class
 gid://shopify/TaxonomyAttribute/7386  : E-bike speed rating
 gid://shopify/TaxonomyAttribute/1878  : E-book formats supported
 gid://shopify/TaxonomyAttribute/1510  : E-cigarette/Vaporizer style
+gid://shopify/TaxonomyAttribute/11570 : E-liquid capacity
 gid://shopify/TaxonomyAttribute/1506  : E-liquid flavor
 gid://shopify/TaxonomyAttribute/1507  : E-liquid variety
 gid://shopify/TaxonomyAttribute/2904  : E-reader display technology
@@ -2582,6 +2936,7 @@ gid://shopify/TaxonomyAttribute/6679  : Earring closure type
 gid://shopify/TaxonomyAttribute/3261  : Earring design
 gid://shopify/TaxonomyAttribute/6414  : Easel & art desk features
 gid://shopify/TaxonomyAttribute/6415  : Easel & art desk surface type
+gid://shopify/TaxonomyAttribute/11571 : Easel & art desk working surface dimensions
 gid://shopify/TaxonomyAttribute/9464  : Eb clarinet body type
 gid://shopify/TaxonomyAttribute/7392  : Eco material type
 gid://shopify/TaxonomyAttribute/7393  : Edge construction
@@ -2593,6 +2948,9 @@ gid://shopify/TaxonomyAttribute/7736  : Edible plant part
 gid://shopify/TaxonomyAttribute/2657  : Education level
 gid://shopify/TaxonomyAttribute/6416  : Educational guide included
 gid://shopify/TaxonomyAttribute/6417  : Educational topic
+gid://shopify/TaxonomyAttribute/12390 : Effect duration
+gid://shopify/TaxonomyAttribute/11572 : Effective edge length
+gid://shopify/TaxonomyAttribute/12391 : Effective focal length (EFL)
 gid://shopify/TaxonomyAttribute/5453  : Effects processor form factor
 gid://shopify/TaxonomyAttribute/7737  : Egg component
 gid://shopify/TaxonomyAttribute/7738  : Egg component replaced
@@ -2611,6 +2969,7 @@ gid://shopify/TaxonomyAttribute/3296  : Egg turning
 gid://shopify/TaxonomyAttribute/7747  : Egg white processing method
 gid://shopify/TaxonomyAttribute/7748  : Eggplant variety
 gid://shopify/TaxonomyAttribute/7749  : Eggshell color
+gid://shopify/TaxonomyAttribute/11573 : Elastic band width
 gid://shopify/TaxonomyAttribute/9465  : Elastic edge finish/type
 gid://shopify/TaxonomyAttribute/9466  : Elastic intended use
 gid://shopify/TaxonomyAttribute/9467  : Elastic recovery performance
@@ -2648,6 +3007,7 @@ gid://shopify/TaxonomyAttribute/9483  : Electronics power source
 gid://shopify/TaxonomyAttribute/5077  : Electrotherapy modality
 gid://shopify/TaxonomyAttribute/8288  : Eligible race series
 gid://shopify/TaxonomyAttribute/7398  : Elliptical trainer part type
+gid://shopify/TaxonomyAttribute/12392 : Embellishment height
 gid://shopify/TaxonomyAttribute/6680  : Embellishment technique
 gid://shopify/TaxonomyAttribute/6681  : Embellishment type
 gid://shopify/TaxonomyAttribute/2927  : Embellishment/Trim material
@@ -2655,11 +3015,13 @@ gid://shopify/TaxonomyAttribute/2288  : Embellishments
 gid://shopify/TaxonomyAttribute/9484  : Embossing pen ink color
 gid://shopify/TaxonomyAttribute/2327  : Embossing project type
 gid://shopify/TaxonomyAttribute/9485  : Embossing stylus tip shape
+gid://shopify/TaxonomyAttribute/11575 : Embossing tip size
 gid://shopify/TaxonomyAttribute/2454  : Embouchure hole shape
 gid://shopify/TaxonomyAttribute/9486  : Embroidered coverage level
 gid://shopify/TaxonomyAttribute/9487  : Embroidered patch backing type
 gid://shopify/TaxonomyAttribute/9488  : Embroidery hoop type
 gid://shopify/TaxonomyAttribute/9489  : Embroidery machine bobbin type
+gid://shopify/TaxonomyAttribute/11576 : Embroidery machine maximum embroidery area
 gid://shopify/TaxonomyAttribute/5871  : Emergency blanket features
 gid://shopify/TaxonomyAttribute/1363  : Emergency items included
 gid://shopify/TaxonomyAttribute/8289  : Emergency lighting configuration
@@ -2681,6 +3043,11 @@ gid://shopify/TaxonomyAttribute/5313  : Enema nozzle type
 gid://shopify/TaxonomyAttribute/1370  : Energy efficiency class
 gid://shopify/TaxonomyAttribute/1956  : Energy efficiency class (HDR)
 gid://shopify/TaxonomyAttribute/1957  : Energy efficiency class (SDR)
+gid://shopify/TaxonomyAttribute/12393 : Energy per 100 g
+gid://shopify/TaxonomyAttribute/12394 : Energy per 100 ml
+gid://shopify/TaxonomyAttribute/12395 : Energy per serving
+gid://shopify/TaxonomyAttribute/12396 : Energy selection (adult mode)
+gid://shopify/TaxonomyAttribute/12397 : Energy selection (child mode)
 gid://shopify/TaxonomyAttribute/8298  : Engine bay mounting location
 gid://shopify/TaxonomyAttribute/8299  : Engine bearing coating
 gid://shopify/TaxonomyAttribute/8300  : Engine bearing position
@@ -2699,10 +3066,12 @@ gid://shopify/TaxonomyAttribute/8310  : Engine rotation direction
 gid://shopify/TaxonomyAttribute/8311  : Engine timing system drive type
 gid://shopify/TaxonomyAttribute/2694  : Engine type
 gid://shopify/TaxonomyAttribute/8312  : Engine valve coating
+gid://shopify/TaxonomyAttribute/11578 : Engine valve length
 gid://shopify/TaxonomyAttribute/8313  : Engine valve position
 gid://shopify/TaxonomyAttribute/8314  : Engine valve stem tip type
 gid://shopify/TaxonomyAttribute/8315  : Engine valvetrain type
 gid://shopify/TaxonomyAttribute/2527  : Engraving
+gid://shopify/TaxonomyAttribute/11579 : Engraving plate size
 gid://shopify/TaxonomyAttribute/6682  : Enhancement level
 gid://shopify/TaxonomyAttribute/5873  : Entrance slot design
 gid://shopify/TaxonomyAttribute/5335  : Entry orientation
@@ -2718,6 +3087,7 @@ gid://shopify/TaxonomyAttribute/9491  : Equipment contact material (brew/wine)
 gid://shopify/TaxonomyAttribute/2371  : Era
 gid://shopify/TaxonomyAttribute/5571  : Error correction type
 gid://shopify/TaxonomyAttribute/5874  : Espresso boiler type
+gid://shopify/TaxonomyAttribute/11580 : Estimated max altitude
 gid://shopify/TaxonomyAttribute/1936  : Ethernet LAN interface type
 gid://shopify/TaxonomyAttribute/5609  : Ethernet cable category
 gid://shopify/TaxonomyAttribute/9492  : Euphonium included accessories
@@ -2729,6 +3099,8 @@ gid://shopify/TaxonomyAttribute/8320  : Evaporator core type
 gid://shopify/TaxonomyAttribute/2275  : Event type
 gid://shopify/TaxonomyAttribute/9496  : Evenweave fabric finish/treatment
 gid://shopify/TaxonomyAttribute/9497  : Evenweave fabric package format
+gid://shopify/TaxonomyAttribute/11581 : Exercise ball maximum user weight
+gid://shopify/TaxonomyAttribute/12398 : Exercise ball size
 gid://shopify/TaxonomyAttribute/7403  : Exercise bike accessory/part type
 gid://shopify/TaxonomyAttribute/7404  : Exercise bike cushion component
 gid://shopify/TaxonomyAttribute/7405  : Exercise bike metrics tracked
@@ -2743,6 +3115,7 @@ gid://shopify/TaxonomyAttribute/5296  : Exfoliation method
 gid://shopify/TaxonomyAttribute/8321  : Exhaust cooling type
 gid://shopify/TaxonomyAttribute/8322  : Exhaust installation position
 gid://shopify/TaxonomyAttribute/8323  : Exhaust outlet configuration
+gid://shopify/TaxonomyAttribute/11582 : Exhaust runner volume
 gid://shopify/TaxonomyAttribute/1838  : Expansion slots
 gid://shopify/TaxonomyAttribute/8324  : Expansion tank cap connection type
 gid://shopify/TaxonomyAttribute/8325  : Expansion tank cap pressure relief feature
@@ -2752,16 +3125,19 @@ gid://shopify/TaxonomyAttribute/2492  : Extended saxophone range
 gid://shopify/TaxonomyAttribute/7407  : Extension attachment method
 gid://shopify/TaxonomyAttribute/7408  : Extension bend type
 gid://shopify/TaxonomyAttribute/6904  : Extension mechanism
+gid://shopify/TaxonomyAttribute/11584 : Extension rise
 gid://shopify/TaxonomyAttribute/9498  : Extension table features
 gid://shopify/TaxonomyAttribute/5392  : External antenna connector type
 gid://shopify/TaxonomyAttribute/3051  : External defibrillator features
 gid://shopify/TaxonomyAttribute/1365  : Extinguisher rating
 gid://shopify/TaxonomyAttribute/1366  : Extinguishing agent type
+gid://shopify/TaxonomyAttribute/12399 : Extinguishing agent volume
 gid://shopify/TaxonomyAttribute/5128  : Extraction method
 gid://shopify/TaxonomyAttribute/5260  : Extraction technology
 gid://shopify/TaxonomyAttribute/1404  : Extraction type
 gid://shopify/TaxonomyAttribute/5259  : Extractor items included
 gid://shopify/TaxonomyAttribute/1609  : Extractor tip style
+gid://shopify/TaxonomyAttribute/12400 : Extruder shaft size
 gid://shopify/TaxonomyAttribute/5293  : Eye care applicator type
 gid://shopify/TaxonomyAttribute/5226  : Eye condition treated
 gid://shopify/TaxonomyAttribute/1656  : Eye pillow shape
@@ -2798,6 +3174,7 @@ gid://shopify/TaxonomyAttribute/9503  : Fabric finish
 gid://shopify/TaxonomyAttribute/9504  : Fabric intended use
 gid://shopify/TaxonomyAttribute/9505  : Fabric opacity level
 gid://shopify/TaxonomyAttribute/9506  : Fabric patch shape
+gid://shopify/TaxonomyAttribute/11589 : Fabric piece size
 gid://shopify/TaxonomyAttribute/9507  : Fabric repair kit application method
 gid://shopify/TaxonomyAttribute/9508  : Fabric repair kit components included
 gid://shopify/TaxonomyAttribute/9509  : Fabric repair kit intended use
@@ -2811,6 +3188,7 @@ gid://shopify/TaxonomyAttribute/6685  : Fabric texture
 gid://shopify/TaxonomyAttribute/9512  : Fabric use case
 gid://shopify/TaxonomyAttribute/5878  : Fabric weave
 gid://shopify/TaxonomyAttribute/9513  : Fabric weight class
+gid://shopify/TaxonomyAttribute/11591 : Fabric width (selvage-to-selvage)
 gid://shopify/TaxonomyAttribute/3342  : Face area
 gid://shopify/TaxonomyAttribute/7411  : Face mask material
 gid://shopify/TaxonomyAttribute/6686  : Face mask style
@@ -2827,15 +3205,21 @@ gid://shopify/TaxonomyAttribute/5441  : Fader type
 gid://shopify/TaxonomyAttribute/5248  : False eyelash adhesive formulation
 gid://shopify/TaxonomyAttribute/5277  : False nail adhesive type
 gid://shopify/TaxonomyAttribute/3337  : False nail application method
+gid://shopify/TaxonomyAttribute/12401 : Fan diameter
 gid://shopify/TaxonomyAttribute/8328  : Fan shroud type
 gid://shopify/TaxonomyAttribute/7750  : Farming method
 gid://shopify/TaxonomyAttribute/7751  : Farming practice
 gid://shopify/TaxonomyAttribute/6687  : Fascinator style
+gid://shopify/TaxonomyAttribute/12402 : Fastener diameter
 gid://shopify/TaxonomyAttribute/2122  : Fastener finish
 gid://shopify/TaxonomyAttribute/7414  : Fastener grade
+gid://shopify/TaxonomyAttribute/11592 : Fastener hole spacing
+gid://shopify/TaxonomyAttribute/12403 : Fastener length
 gid://shopify/TaxonomyAttribute/2926  : Fastener material
 gid://shopify/TaxonomyAttribute/1219  : Fastener type
 gid://shopify/TaxonomyAttribute/1479  : Fat content
+gid://shopify/TaxonomyAttribute/11593 : Fat per 100 g
+gid://shopify/TaxonomyAttribute/11594 : Fat per serving
 gid://shopify/TaxonomyAttribute/7752  : Fat rendering state
 gid://shopify/TaxonomyAttribute/7753  : Fat source
 gid://shopify/TaxonomyAttribute/6905  : Faucet hole configuration
@@ -2854,15 +3238,18 @@ gid://shopify/TaxonomyAttribute/9525  : Feather product form
 gid://shopify/TaxonomyAttribute/9526  : Feather quantity unit
 gid://shopify/TaxonomyAttribute/7415  : Feather source
 gid://shopify/TaxonomyAttribute/9527  : Feather stiffness
+gid://shopify/TaxonomyAttribute/11595 : Feather width
 gid://shopify/TaxonomyAttribute/2989  : Features
 gid://shopify/TaxonomyAttribute/7416  : Feed mechanism
 gid://shopify/TaxonomyAttribute/7417  : Feed purpose
+gid://shopify/TaxonomyAttribute/12404 : Feed size
 gid://shopify/TaxonomyAttribute/2261  : Feed system
 gid://shopify/TaxonomyAttribute/5879  : Feeder design
 gid://shopify/TaxonomyAttribute/7418  : Feeder mechanism type
 gid://shopify/TaxonomyAttribute/1851  : Feet type
 gid://shopify/TaxonomyAttribute/7754  : Feijoa cultivar
 gid://shopify/TaxonomyAttribute/7419  : Felt duty
+gid://shopify/TaxonomyAttribute/11596 : Felting mold cavity depth
 gid://shopify/TaxonomyAttribute/9528  : Felting mold intended use
 gid://shopify/TaxonomyAttribute/9529  : Felting pad surface material
 gid://shopify/TaxonomyAttribute/3133  : Feminine sanitary supply features
@@ -2884,6 +3271,7 @@ gid://shopify/TaxonomyAttribute/7426  : Ferrule material
 gid://shopify/TaxonomyAttribute/5111  : Fertility metrics measured
 gid://shopify/TaxonomyAttribute/9531  : Fiber animal/source type
 gid://shopify/TaxonomyAttribute/2310  : Fiber art project type
+gid://shopify/TaxonomyAttribute/12405 : Fiber length
 gid://shopify/TaxonomyAttribute/9532  : Fiber luster level
 gid://shopify/TaxonomyAttribute/5007  : Fiber optic mode
 gid://shopify/TaxonomyAttribute/9533  : Fiber preparation / processing stage
@@ -2917,6 +3305,7 @@ gid://shopify/TaxonomyAttribute/2027  : Film type
 gid://shopify/TaxonomyAttribute/5882  : Filter bleaching method
 gid://shopify/TaxonomyAttribute/5374  : Filter form factor
 gid://shopify/TaxonomyAttribute/5537  : Filter installation type
+gid://shopify/TaxonomyAttribute/11601 : Filter lifetime capacity
 gid://shopify/TaxonomyAttribute/2816  : Filter material
 gid://shopify/TaxonomyAttribute/5452  : Filter slope
 gid://shopify/TaxonomyAttribute/5883  : Filter technology
@@ -2927,6 +3316,7 @@ gid://shopify/TaxonomyAttribute/7762  : Filtration and mother status
 gid://shopify/TaxonomyAttribute/2633  : Filtration class
 gid://shopify/TaxonomyAttribute/7763  : Filtration method
 gid://shopify/TaxonomyAttribute/5375  : Filtration technology
+gid://shopify/TaxonomyAttribute/11603 : Fin base length
 gid://shopify/TaxonomyAttribute/7437  : Fin box system
 gid://shopify/TaxonomyAttribute/7438  : Fin buoyancy
 gid://shopify/TaxonomyAttribute/7439  : Fin flex rating
@@ -2949,7 +3339,10 @@ gid://shopify/TaxonomyAttribute/9541  : Finger pick size
 gid://shopify/TaxonomyAttribute/9542  : Finger pick wear location
 gid://shopify/TaxonomyAttribute/7448  : Finger protection
 gid://shopify/TaxonomyAttribute/6421  : Fingerboard bearing type
+gid://shopify/TaxonomyAttribute/11605 : Fingerboard deck length
+gid://shopify/TaxonomyAttribute/11606 : Fingerboard deck width
 gid://shopify/TaxonomyAttribute/6422  : Fingerboard grip type
+gid://shopify/TaxonomyAttribute/11607 : Fingerboard truck width
 gid://shopify/TaxonomyAttribute/1906  : Fingerprint capture method
 gid://shopify/TaxonomyAttribute/1346  : Finial shape
 gid://shopify/TaxonomyAttribute/9543  : Fining agent active ingredient
@@ -2958,7 +3351,12 @@ gid://shopify/TaxonomyAttribute/2062  : Finish
 gid://shopify/TaxonomyAttribute/9545  : Finish after baking
 gid://shopify/TaxonomyAttribute/9546  : Finish effect
 gid://shopify/TaxonomyAttribute/9547  : Finish type
+gid://shopify/TaxonomyAttribute/11608 : Finished item size
 gid://shopify/TaxonomyAttribute/9548  : Finished product format
+gid://shopify/TaxonomyAttribute/11609 : Finished project width
+gid://shopify/TaxonomyAttribute/11610 : Finished puzzle height
+gid://shopify/TaxonomyAttribute/11611 : Finished puzzle length
+gid://shopify/TaxonomyAttribute/11612 : Finished puzzle width
 gid://shopify/TaxonomyAttribute/5884  : Fire alarm panel type
 gid://shopify/TaxonomyAttribute/3358  : Fire extinguisher items included
 gid://shopify/TaxonomyAttribute/6906  : Fire pit accessories included
@@ -2967,10 +3365,13 @@ gid://shopify/TaxonomyAttribute/5886  : Fire starter type
 gid://shopify/TaxonomyAttribute/5612  : FireWire standard
 gid://shopify/TaxonomyAttribute/5887  : Fireplace fuel form
 gid://shopify/TaxonomyAttribute/5888  : Fireplace tool items included
+gid://shopify/TaxonomyAttribute/12407 : Firewall throughput
 gid://shopify/TaxonomyAttribute/5889  : Firewood seasoning
 gid://shopify/TaxonomyAttribute/9549  : Firework assortment launch type
 gid://shopify/TaxonomyAttribute/9550  : Firework assortment types included
+gid://shopify/TaxonomyAttribute/11613 : Firework burn duration
 gid://shopify/TaxonomyAttribute/9551  : Firework effect types
+gid://shopify/TaxonomyAttribute/11614 : Firework fountain height
 gid://shopify/TaxonomyAttribute/9552  : Firework ignition method
 gid://shopify/TaxonomyAttribute/9553  : Firework visual intensity level
 gid://shopify/TaxonomyAttribute/7449  : Firing mode
@@ -2999,10 +3400,12 @@ gid://shopify/TaxonomyAttribute/7457  : Fit profile
 gid://shopify/TaxonomyAttribute/2696  : Fit type
 gid://shopify/TaxonomyAttribute/7458  : Fit volume classification
 gid://shopify/TaxonomyAttribute/8331  : Fitting angle
+gid://shopify/TaxonomyAttribute/12409 : Fitting size
 gid://shopify/TaxonomyAttribute/1352  : Fixation type
 gid://shopify/TaxonomyAttribute/5890  : Flag attachment style
 gid://shopify/TaxonomyAttribute/7459  : Flag base type
 gid://shopify/TaxonomyAttribute/8332  : Flag design theme
+gid://shopify/TaxonomyAttribute/11615 : Flag dimensions
 gid://shopify/TaxonomyAttribute/8333  : Flag mounting method
 gid://shopify/TaxonomyAttribute/1347  : Flag shape
 gid://shopify/TaxonomyAttribute/7460  : Flag type
@@ -3020,6 +3423,7 @@ gid://shopify/TaxonomyAttribute/6423  : Flash card included features
 gid://shopify/TaxonomyAttribute/3400  : Flash card theme
 gid://shopify/TaxonomyAttribute/5569  : Flash cell type
 gid://shopify/TaxonomyAttribute/1993  : Flash modes
+gid://shopify/TaxonomyAttribute/11617 : Flash point
 gid://shopify/TaxonomyAttribute/1994  : Flash type
 gid://shopify/TaxonomyAttribute/2915  : Flashing material
 gid://shopify/TaxonomyAttribute/5892  : Flask insulation type
@@ -3037,12 +3441,14 @@ gid://shopify/TaxonomyAttribute/9562  : Fleece preparation method
 gid://shopify/TaxonomyAttribute/7766  : Flesh color
 gid://shopify/TaxonomyAttribute/7462  : Fletching orientation
 gid://shopify/TaxonomyAttribute/7463  : Fletching profile
+gid://shopify/TaxonomyAttribute/11618 : Flex strength
 gid://shopify/TaxonomyAttribute/1320  : Flexibility rating
 gid://shopify/TaxonomyAttribute/7464  : Flight system type
 gid://shopify/TaxonomyAttribute/7465  : Float attachment method
 gid://shopify/TaxonomyAttribute/7466  : Float design
 gid://shopify/TaxonomyAttribute/6424  : Float/raft use environment
 gid://shopify/TaxonomyAttribute/8336  : Floatation
+gid://shopify/TaxonomyAttribute/11619 : Floor area
 gid://shopify/TaxonomyAttribute/5214  : Floor configuration
 gid://shopify/TaxonomyAttribute/7467  : Floor construction type
 gid://shopify/TaxonomyAttribute/7468  : Floor design
@@ -3062,6 +3468,8 @@ gid://shopify/TaxonomyAttribute/7769  : Flour grind texture
 gid://shopify/TaxonomyAttribute/7770  : Flour processing method
 gid://shopify/TaxonomyAttribute/1484  : Flour/Grain type
 gid://shopify/TaxonomyAttribute/5897  : Flow control type
+gid://shopify/TaxonomyAttribute/12410 : Flow rate
+gid://shopify/TaxonomyAttribute/12411 : Flow rate accuracy
 gid://shopify/TaxonomyAttribute/1765  : Flow rate type
 gid://shopify/TaxonomyAttribute/9563  : Flower care instructions
 gid://shopify/TaxonomyAttribute/5898  : Flue outlet position
@@ -3077,6 +3485,7 @@ gid://shopify/TaxonomyAttribute/5178  : Fluoride content
 gid://shopify/TaxonomyAttribute/7471  : Fluorocarbon content
 gid://shopify/TaxonomyAttribute/2157  : Flush system
 gid://shopify/TaxonomyAttribute/9567  : Flute case capacity
+gid://shopify/TaxonomyAttribute/11620 : Flute case interior length
 gid://shopify/TaxonomyAttribute/9568  : Flute cleaning rod tip type
 gid://shopify/TaxonomyAttribute/2484  : Flute configuration
 gid://shopify/TaxonomyAttribute/9569  : Flute footjoint type
@@ -3085,6 +3494,7 @@ gid://shopify/TaxonomyAttribute/9571  : Flute key system
 gid://shopify/TaxonomyAttribute/9572  : Flute keywork material
 gid://shopify/TaxonomyAttribute/9573  : Flute offset G
 gid://shopify/TaxonomyAttribute/9574  : Flute wall thickness
+gid://shopify/TaxonomyAttribute/11621 : Flutophone tuning pitch reference
 gid://shopify/TaxonomyAttribute/7472  : Fly pattern type
 gid://shopify/TaxonomyAttribute/7473  : Fly rod style
 gid://shopify/TaxonomyAttribute/6690  : Fly style
@@ -3099,10 +3509,16 @@ gid://shopify/TaxonomyAttribute/9579  : Flyer orifice type
 gid://shopify/TaxonomyAttribute/6425  : Flying disc feature set
 gid://shopify/TaxonomyAttribute/7475  : Flysheet material
 gid://shopify/TaxonomyAttribute/8341  : Flywheel balance type
+gid://shopify/TaxonomyAttribute/11623 : Flywheel outer diameter
+gid://shopify/TaxonomyAttribute/11624 : Flywheel thickness
+gid://shopify/TaxonomyAttribute/11625 : Flywheel weight
 gid://shopify/TaxonomyAttribute/6426  : Foam blocks size class
 gid://shopify/TaxonomyAttribute/6427  : Foam blocks surface texture
+gid://shopify/TaxonomyAttribute/11627 : Foam cube size
 gid://shopify/TaxonomyAttribute/2307  : Foam form
 gid://shopify/TaxonomyAttribute/9580  : Foam surface effect
+gid://shopify/TaxonomyAttribute/12412 : Focal length (telephoto)
+gid://shopify/TaxonomyAttribute/12413 : Focal length (wide)
 gid://shopify/TaxonomyAttribute/1981  : Focus adjustment
 gid://shopify/TaxonomyAttribute/1996  : Focus device type
 gid://shopify/TaxonomyAttribute/1982  : Focus type
@@ -3115,10 +3531,13 @@ gid://shopify/TaxonomyAttribute/7478  : Foil mast fuselage connection type
 gid://shopify/TaxonomyAttribute/7479  : Foil mounting interface
 gid://shopify/TaxonomyAttribute/7480  : Foil mounting system
 gid://shopify/TaxonomyAttribute/7481  : Foil mounting type
+gid://shopify/TaxonomyAttribute/11629 : Foil stabilizer span
+gid://shopify/TaxonomyAttribute/11631 : Foil wingspan
 gid://shopify/TaxonomyAttribute/2262  : Fold type
 gid://shopify/TaxonomyAttribute/9583  : Fold-over elastic application
 gid://shopify/TaxonomyAttribute/6907  : Foldability
 gid://shopify/TaxonomyAttribute/8342  : Foldability (stow)
+gid://shopify/TaxonomyAttribute/12414 : Folded length
 gid://shopify/TaxonomyAttribute/1744  : Folding mechanism
 gid://shopify/TaxonomyAttribute/7482  : Folding style
 gid://shopify/TaxonomyAttribute/5903  : Foliage color
@@ -3169,8 +3588,10 @@ gid://shopify/TaxonomyAttribute/2783  : Footwear material
 gid://shopify/TaxonomyAttribute/6697  : Footwear size system
 gid://shopify/TaxonomyAttribute/6698  : Footwear support type
 gid://shopify/TaxonomyAttribute/5915  : Footwear type compatibility
+gid://shopify/TaxonomyAttribute/11633 : Footwear weight
 gid://shopify/TaxonomyAttribute/5640  : Force feedback type
 gid://shopify/TaxonomyAttribute/7491  : Fork material
+gid://shopify/TaxonomyAttribute/12415 : Fork offset
 gid://shopify/TaxonomyAttribute/9587  : Form factor
 gid://shopify/TaxonomyAttribute/1392  : Format supported
 gid://shopify/TaxonomyAttribute/8343  : Formula car series/class
@@ -3179,6 +3600,7 @@ gid://shopify/TaxonomyAttribute/5916  : Formulation concentration
 gid://shopify/TaxonomyAttribute/5118  : Formulation strength
 gid://shopify/TaxonomyAttribute/7774  : Formulation style
 gid://shopify/TaxonomyAttribute/9588  : Formulation type
+gid://shopify/TaxonomyAttribute/11634 : Forward offset
 gid://shopify/TaxonomyAttribute/9589  : Fossil preparation level
 gid://shopify/TaxonomyAttribute/9590  : Fossil preservation type
 gid://shopify/TaxonomyAttribute/9591  : Fossil restoration status
@@ -3198,6 +3620,7 @@ gid://shopify/TaxonomyAttribute/9593  : Frame drum jingle configuration
 gid://shopify/TaxonomyAttribute/9594  : Frame drum tuning system
 gid://shopify/TaxonomyAttribute/7492  : Frame finish
 gid://shopify/TaxonomyAttribute/7493  : Frame mounting standard
+gid://shopify/TaxonomyAttribute/12416 : Frame size
 gid://shopify/TaxonomyAttribute/7494  : Frame steel gauge
 gid://shopify/TaxonomyAttribute/3137  : Frame style
 gid://shopify/TaxonomyAttribute/7495  : Frame suspension type
@@ -3206,7 +3629,9 @@ gid://shopify/TaxonomyAttribute/9595  : Free-reed instrument orientation
 gid://shopify/TaxonomyAttribute/7497  : Freehub body type
 gid://shopify/TaxonomyAttribute/7498  : Freehub driver standard
 gid://shopify/TaxonomyAttribute/7499  : Freewheel thread standard
+gid://shopify/TaxonomyAttribute/11636 : Freeze protection temperature (minimum)
 gid://shopify/TaxonomyAttribute/5921  : Freezer configuration
+gid://shopify/TaxonomyAttribute/12417 : Freezing capacity
 gid://shopify/TaxonomyAttribute/5922  : Freezing method
 gid://shopify/TaxonomyAttribute/9596  : French horn bell construction
 gid://shopify/TaxonomyAttribute/9597  : French horn bell material
@@ -3223,6 +3648,7 @@ gid://shopify/TaxonomyAttribute/8344  : Friction surface included
 gid://shopify/TaxonomyAttribute/9604  : Fringe curtain finish
 gid://shopify/TaxonomyAttribute/9605  : Fringe curtain material
 gid://shopify/TaxonomyAttribute/9606  : Fringe curtain use location
+gid://shopify/TaxonomyAttribute/11637 : Fringe drop length
 gid://shopify/TaxonomyAttribute/9607  : Fringe trim style
 gid://shopify/TaxonomyAttribute/7500  : Front axle standard
 gid://shopify/TaxonomyAttribute/6699  : Front button configuration
@@ -3231,6 +3657,7 @@ gid://shopify/TaxonomyAttribute/6701  : Front decoration type
 gid://shopify/TaxonomyAttribute/7501  : Front point configuration
 gid://shopify/TaxonomyAttribute/8345  : Front seat position
 gid://shopify/TaxonomyAttribute/6702  : Front style
+gid://shopify/TaxonomyAttribute/11638 : Front suspension travel
 gid://shopify/TaxonomyAttribute/7775  : Frosting or icing type
 gid://shopify/TaxonomyAttribute/7776  : Fruit cultivar or variety
 gid://shopify/TaxonomyAttribute/7777  : Fruit cut style
@@ -3247,11 +3674,13 @@ gid://shopify/TaxonomyAttribute/8348  : Fuel cap type
 gid://shopify/TaxonomyAttribute/8349  : Fuel cap venting
 gid://shopify/TaxonomyAttribute/5923  : Fuel compatibility
 gid://shopify/TaxonomyAttribute/3114  : Fuel container features
+gid://shopify/TaxonomyAttribute/12418 : Fuel efficiency (typical)
 gid://shopify/TaxonomyAttribute/8350  : Fuel filter features
 gid://shopify/TaxonomyAttribute/8351  : Fuel filter media material
 gid://shopify/TaxonomyAttribute/8352  : Fuel filter mounting/connection type
 gid://shopify/TaxonomyAttribute/2110  : Fuel grade
 gid://shopify/TaxonomyAttribute/8353  : Fuel injection cleaning method
+gid://shopify/TaxonomyAttribute/11643 : Fuel injector O-ring size
 gid://shopify/TaxonomyAttribute/8354  : Fuel injector electrical connector type
 gid://shopify/TaxonomyAttribute/8355  : Fuel injector seat type
 gid://shopify/TaxonomyAttribute/8356  : Fuel injector spray pattern
@@ -3264,15 +3693,18 @@ gid://shopify/TaxonomyAttribute/8362  : Fuel pressure regulator mounting type
 gid://shopify/TaxonomyAttribute/8363  : Fuel pump inlet type
 gid://shopify/TaxonomyAttribute/8364  : Fuel pump mounting location
 gid://shopify/TaxonomyAttribute/8365  : Fuel pump outlet connection type
+gid://shopify/TaxonomyAttribute/11645 : Fuel pump outlet diameter
 gid://shopify/TaxonomyAttribute/2113  : Fuel purity
 gid://shopify/TaxonomyAttribute/1927  : Fuel source
 gid://shopify/TaxonomyAttribute/2177  : Fuel supply
 gid://shopify/TaxonomyAttribute/8366  : Fuel system application
 gid://shopify/TaxonomyAttribute/8367  : Fuel system connection type
 gid://shopify/TaxonomyAttribute/8368  : Fuel system type
+gid://shopify/TaxonomyAttribute/12419 : Fuel tank capacity
 gid://shopify/TaxonomyAttribute/8369  : Fuel tank installation position
 gid://shopify/TaxonomyAttribute/8370  : Fuel tank orientation
 gid://shopify/TaxonomyAttribute/8371  : Fuel tank shape
+gid://shopify/TaxonomyAttribute/11646 : Fuel volume treated
 gid://shopify/TaxonomyAttribute/5924  : Funnel type
 gid://shopify/TaxonomyAttribute/6703  : Fur type
 gid://shopify/TaxonomyAttribute/5925  : Furnace configuration
@@ -3280,6 +3712,7 @@ gid://shopify/TaxonomyAttribute/5926  : Furniture anchor type
 gid://shopify/TaxonomyAttribute/6913  : Furniture finish
 gid://shopify/TaxonomyAttribute/3102  : Furniture/Fixture features
 gid://shopify/TaxonomyAttribute/2786  : Furniture/Fixture material
+gid://shopify/TaxonomyAttribute/11647 : Fuse delay time
 gid://shopify/TaxonomyAttribute/8372  : Fuse form factor
 gid://shopify/TaxonomyAttribute/8373  : Fuse terminal or mount style
 gid://shopify/TaxonomyAttribute/9608  : Fusible application method
@@ -3302,10 +3735,12 @@ gid://shopify/TaxonomyAttribute/5420  : Game console skin coverage
 gid://shopify/TaxonomyAttribute/2511  : Game difficulty
 gid://shopify/TaxonomyAttribute/3190  : Game features
 gid://shopify/TaxonomyAttribute/2512  : Game name
+gid://shopify/TaxonomyAttribute/11648 : Game setup time
 gid://shopify/TaxonomyAttribute/7502  : Game variation
 gid://shopify/TaxonomyAttribute/2760  : Gameplay skills
 gid://shopify/TaxonomyAttribute/1245  : Games included
 gid://shopify/TaxonomyAttribute/5436  : Gaming enhancement features
+gid://shopify/TaxonomyAttribute/12420 : Gap size
 gid://shopify/TaxonomyAttribute/5927  : Garage floor mat style
 gid://shopify/TaxonomyAttribute/5928  : Garbage disposal feed type
 gid://shopify/TaxonomyAttribute/5929  : Garbage disposal stopper style
@@ -3317,16 +3752,20 @@ gid://shopify/TaxonomyAttribute/6293  : Garland style
 gid://shopify/TaxonomyAttribute/7783  : Garlic preparation style
 gid://shopify/TaxonomyAttribute/7784  : Garlic variety
 gid://shopify/TaxonomyAttribute/6705  : Garment back style
+gid://shopify/TaxonomyAttribute/12421 : Garment length
 gid://shopify/TaxonomyAttribute/9616  : Garment pattern type
 gid://shopify/TaxonomyAttribute/1375  : Garment steamer design
 gid://shopify/TaxonomyAttribute/9617  : Garnish type
 gid://shopify/TaxonomyAttribute/6915  : Gas lift class
 gid://shopify/TaxonomyAttribute/7503  : Gas propellant type
+gid://shopify/TaxonomyAttribute/11649 : Gas strut compressed length
 gid://shopify/TaxonomyAttribute/6294  : Gas type
 gid://shopify/TaxonomyAttribute/2962  : Gases detected
 gid://shopify/TaxonomyAttribute/5933  : Gasket profile type
 gid://shopify/TaxonomyAttribute/1727  : Gate mounting type
+gid://shopify/TaxonomyAttribute/11650 : Gate opening clearance
 gid://shopify/TaxonomyAttribute/9618  : Gatta (tabla tuning block) material
+gid://shopify/TaxonomyAttribute/11651 : Gauge cutout diameter
 gid://shopify/TaxonomyAttribute/8374  : Gauge mounting type
 gid://shopify/TaxonomyAttribute/7504  : Gauge style
 gid://shopify/TaxonomyAttribute/2697  : Gauge type
@@ -3337,6 +3776,7 @@ gid://shopify/TaxonomyAttribute/1290  : Gear ratio
 gid://shopify/TaxonomyAttribute/1282  : Gearing type
 gid://shopify/TaxonomyAttribute/1488  : Gel strength
 gid://shopify/TaxonomyAttribute/9619  : Gel wax density grade
+gid://shopify/TaxonomyAttribute/11654 : Gel wax melt temperature
 gid://shopify/TaxonomyAttribute/9620  : Gel wax transparency level
 gid://shopify/TaxonomyAttribute/7785  : Gelatin form
 gid://shopify/TaxonomyAttribute/7786  : Gelatin or gelling agent source
@@ -3350,6 +3790,7 @@ gid://shopify/TaxonomyAttribute/5032  : Gemstone type
 gid://shopify/TaxonomyAttribute/2535  : Genre
 gid://shopify/TaxonomyAttribute/2377  : Geological era
 gid://shopify/TaxonomyAttribute/9623  : Geological period
+gid://shopify/TaxonomyAttribute/11656 : Gift bag gusset depth
 gid://shopify/TaxonomyAttribute/2502  : Gift bag handle design
 gid://shopify/TaxonomyAttribute/9624  : Gift box/tin insert type
 gid://shopify/TaxonomyAttribute/9625  : Gift box/tin sustainability features
@@ -3365,6 +3806,7 @@ gid://shopify/TaxonomyAttribute/5936  : Glass cleaner features
 gid://shopify/TaxonomyAttribute/9627  : Glass kiln controller type
 gid://shopify/TaxonomyAttribute/9628  : Glass kiln firing application
 gid://shopify/TaxonomyAttribute/9629  : Glass stone application method
+gid://shopify/TaxonomyAttribute/12422 : Glass thickness
 gid://shopify/TaxonomyAttribute/9630  : Glass tint
 gid://shopify/TaxonomyAttribute/2302  : Glaze finish
 gid://shopify/TaxonomyAttribute/9631  : Glaze firing atmosphere
@@ -3392,12 +3834,15 @@ gid://shopify/TaxonomyAttribute/7506  : Glove finger coverage
 gid://shopify/TaxonomyAttribute/7507  : Glove finger design
 gid://shopify/TaxonomyAttribute/7508  : Glove fit profile
 gid://shopify/TaxonomyAttribute/8382  : Glove insulation
+gid://shopify/TaxonomyAttribute/11658 : Glove length
 gid://shopify/TaxonomyAttribute/8383  : Glove palm material
 gid://shopify/TaxonomyAttribute/7509  : Glove size
 gid://shopify/TaxonomyAttribute/7510  : Glove webbing style
 gid://shopify/TaxonomyAttribute/7511  : Glow effect
 gid://shopify/TaxonomyAttribute/8384  : Glow plug connector type
 gid://shopify/TaxonomyAttribute/8385  : Glow plug heating element type
+gid://shopify/TaxonomyAttribute/11659 : Glow plug reach length
+gid://shopify/TaxonomyAttribute/11660 : Glow plug voltage
 gid://shopify/TaxonomyAttribute/5108  : Glucose measurement units
 gid://shopify/TaxonomyAttribute/9640  : Glue application format
 gid://shopify/TaxonomyAttribute/9641  : Glue applicator type
@@ -3447,6 +3892,7 @@ gid://shopify/TaxonomyAttribute/7535  : Golf tee style
 gid://shopify/TaxonomyAttribute/7536  : Golf training focus
 gid://shopify/TaxonomyAttribute/7537  : Golf training objective
 gid://shopify/TaxonomyAttribute/9648  : Gong profile type
+gid://shopify/TaxonomyAttribute/11661 : Gooseneck length
 gid://shopify/TaxonomyAttribute/5940  : Grab bar shape
 gid://shopify/TaxonomyAttribute/2367  : Grading
 gid://shopify/TaxonomyAttribute/9649  : Grading scale
@@ -3481,11 +3927,13 @@ gid://shopify/TaxonomyAttribute/5944  : Grill grate material
 gid://shopify/TaxonomyAttribute/5945  : Grill thermometer type
 gid://shopify/TaxonomyAttribute/8394  : Grille emblem provision
 gid://shopify/TaxonomyAttribute/8395  : Grille mounting method
+gid://shopify/TaxonomyAttribute/11663 : Grille opening dimensions
 gid://shopify/TaxonomyAttribute/8396  : Grille style
 gid://shopify/TaxonomyAttribute/3416  : Grind size
 gid://shopify/TaxonomyAttribute/5946  : Grinding mechanism material
 gid://shopify/TaxonomyAttribute/6296  : Grinding mechanism type
 gid://shopify/TaxonomyAttribute/7540  : Grip chalk form
+gid://shopify/TaxonomyAttribute/11664 : Grip circumference
 gid://shopify/TaxonomyAttribute/6708  : Grip coverage
 gid://shopify/TaxonomyAttribute/7541  : Grip design
 gid://shopify/TaxonomyAttribute/7542  : Grip enhancer effect
@@ -3510,7 +3958,9 @@ gid://shopify/TaxonomyAttribute/1721  : Grooming kit format
 gid://shopify/TaxonomyAttribute/9661  : Groove orientation
 gid://shopify/TaxonomyAttribute/9662  : Groove sampler onboard effects
 gid://shopify/TaxonomyAttribute/9663  : Groove sampler storage expansion type
+gid://shopify/TaxonomyAttribute/11665 : Groove sampler weight
 gid://shopify/TaxonomyAttribute/7551  : Ground attachment method
+gid://shopify/TaxonomyAttribute/11666 : Ground clearance
 gid://shopify/TaxonomyAttribute/7552  : Groupset components included
 gid://shopify/TaxonomyAttribute/5947  : Growing media buffering
 gid://shopify/TaxonomyAttribute/5948  : Growing media form
@@ -3528,7 +3978,11 @@ gid://shopify/TaxonomyAttribute/9664  : Guiro scraper material
 gid://shopify/TaxonomyAttribute/9665  : Guiro surface style
 gid://shopify/TaxonomyAttribute/9666  : Guitar body finish type
 gid://shopify/TaxonomyAttribute/9667  : Guitar bridge system type
+gid://shopify/TaxonomyAttribute/11667 : Guitar case internal depth
+gid://shopify/TaxonomyAttribute/11668 : Guitar case internal length
+gid://shopify/TaxonomyAttribute/11669 : Guitar case internal width
 gid://shopify/TaxonomyAttribute/9668  : Guitar case style
+gid://shopify/TaxonomyAttribute/11670 : Guitar fitting/part mounting hole spacing
 gid://shopify/TaxonomyAttribute/3288  : Guitar fitting/part type
 gid://shopify/TaxonomyAttribute/9669  : Guitar humidifier placement
 gid://shopify/TaxonomyAttribute/9670  : Guitar pedal I/O configuration
@@ -3544,11 +3998,14 @@ gid://shopify/TaxonomyAttribute/9678  : Guitar string coating
 gid://shopify/TaxonomyAttribute/9679  : Guitar string gauge type
 gid://shopify/TaxonomyAttribute/9680  : Guitar string set gauge category
 gid://shopify/TaxonomyAttribute/9681  : Guitar string winding type
+gid://shopify/TaxonomyAttribute/11672 : Guitar tuning peg bushing outer diameter
 gid://shopify/TaxonomyAttribute/9682  : Guitar tuning peg button shape
 gid://shopify/TaxonomyAttribute/9683  : Guitar tuning peg configuration
 gid://shopify/TaxonomyAttribute/9684  : Guitar tuning peg mounting style
+gid://shopify/TaxonomyAttribute/11673 : Guitar tuning peg post height
 gid://shopify/TaxonomyAttribute/9685  : Guitar tuning peg shaft type
 gid://shopify/TaxonomyAttribute/9686  : Guitar tuning peg style
+gid://shopify/TaxonomyAttribute/11674 : Gullet width
 gid://shopify/TaxonomyAttribute/9687  : Gum condition
 gid://shopify/TaxonomyAttribute/9688  : Gun action type
 gid://shopify/TaxonomyAttribute/9689  : Gun operational status
@@ -3573,6 +4030,7 @@ gid://shopify/TaxonomyAttribute/5165  : Hair concealer fiber material
 gid://shopify/TaxonomyAttribute/5156  : Hair dryer motor type
 gid://shopify/TaxonomyAttribute/5164  : Hair dye type removed
 gid://shopify/TaxonomyAttribute/6710  : Hair extension texture
+gid://shopify/TaxonomyAttribute/11675 : Hair length
 gid://shopify/TaxonomyAttribute/1643  : Hair loss type
 gid://shopify/TaxonomyAttribute/6711  : Hair net style
 gid://shopify/TaxonomyAttribute/5159  : Hair oil application
@@ -3607,6 +4065,7 @@ gid://shopify/TaxonomyAttribute/9697  : Hand percussion set configuration
 gid://shopify/TaxonomyAttribute/9698  : Hand percussion size class
 gid://shopify/TaxonomyAttribute/1208  : Hand side
 gid://shopify/TaxonomyAttribute/5241  : Hand soap features
+gid://shopify/TaxonomyAttribute/11676 : Hand spindle weight
 gid://shopify/TaxonomyAttribute/7563  : Hand support level
 gid://shopify/TaxonomyAttribute/7564  : Hand support size
 gid://shopify/TaxonomyAttribute/3183  : Hand warmer type
@@ -3622,10 +4081,12 @@ gid://shopify/TaxonomyAttribute/7568  : Handle configuration
 gid://shopify/TaxonomyAttribute/5952  : Handle connection type
 gid://shopify/TaxonomyAttribute/2194  : Handle design
 gid://shopify/TaxonomyAttribute/9701  : Handle ergonomics
+gid://shopify/TaxonomyAttribute/11677 : Handle grip diameter
 gid://shopify/TaxonomyAttribute/7569  : Handle grip material
 gid://shopify/TaxonomyAttribute/5953  : Handle grip style
 gid://shopify/TaxonomyAttribute/1669  : Handle grip texture
 gid://shopify/TaxonomyAttribute/7570  : Handle grip type
+gid://shopify/TaxonomyAttribute/12423 : Handle length
 gid://shopify/TaxonomyAttribute/5954  : Handle length adjustability
 gid://shopify/TaxonomyAttribute/1295  : Handle material
 gid://shopify/TaxonomyAttribute/5955  : Handle position
@@ -3633,6 +4094,8 @@ gid://shopify/TaxonomyAttribute/7571  : Handle shape
 gid://shopify/TaxonomyAttribute/5070  : Handle style
 gid://shopify/TaxonomyAttribute/1597  : Handle type
 gid://shopify/TaxonomyAttribute/7572  : Handlebar design
+gid://shopify/TaxonomyAttribute/11678 : Handlebar drop
+gid://shopify/TaxonomyAttribute/11679 : Handlebar rise
 gid://shopify/TaxonomyAttribute/7573  : Handlebar type
 gid://shopify/TaxonomyAttribute/5956  : Handrail configuration
 gid://shopify/TaxonomyAttribute/1849  : Handset type
@@ -3647,6 +4110,7 @@ gid://shopify/TaxonomyAttribute/7576  : Hang glider design
 gid://shopify/TaxonomyAttribute/7577  : Hanger thread size
 gid://shopify/TaxonomyAttribute/5957  : Hanging attachment type
 gid://shopify/TaxonomyAttribute/1530  : Hanging chair design
+gid://shopify/TaxonomyAttribute/11680 : Hanging drop length
 gid://shopify/TaxonomyAttribute/6916  : Hanging suspension method
 gid://shopify/TaxonomyAttribute/5639  : Haptic feedback type
 gid://shopify/TaxonomyAttribute/1459  : Hard cider variety
@@ -3689,6 +4153,7 @@ gid://shopify/TaxonomyAttribute/8411  : Hazard signal mode
 gid://shopify/TaxonomyAttribute/5959  : Hazards detected
 gid://shopify/TaxonomyAttribute/2636  : Hazmat suit design
 gid://shopify/TaxonomyAttribute/7581  : Head configuration
+gid://shopify/TaxonomyAttribute/12424 : Head diameter
 gid://shopify/TaxonomyAttribute/9716  : Head material
 gid://shopify/TaxonomyAttribute/7582  : Head movement type
 gid://shopify/TaxonomyAttribute/9717  : Head side
@@ -3699,6 +4164,8 @@ gid://shopify/TaxonomyAttribute/7584  : Headgear strap configuration
 gid://shopify/TaxonomyAttribute/9718  : Headjoint crown style
 gid://shopify/TaxonomyAttribute/2485  : Headjoint cut
 gid://shopify/TaxonomyAttribute/9719  : Headjoint pitch standard
+gid://shopify/TaxonomyAttribute/11683 : Headjoint wall thickness
+gid://shopify/TaxonomyAttribute/11684 : Headliner backing thickness
 gid://shopify/TaxonomyAttribute/8412  : Headliner product form
 gid://shopify/TaxonomyAttribute/5426  : Headphone cushion shape
 gid://shopify/TaxonomyAttribute/5448  : Headphone driver technology
@@ -3734,13 +4201,20 @@ gid://shopify/TaxonomyAttribute/1499  : Heating instructions
 gid://shopify/TaxonomyAttribute/1772  : Heating method
 gid://shopify/TaxonomyAttribute/5122  : Heating pad design
 gid://shopify/TaxonomyAttribute/5120  : Heating pad features
+gid://shopify/TaxonomyAttribute/12426 : Heating power
 gid://shopify/TaxonomyAttribute/1773  : Heating speed
 gid://shopify/TaxonomyAttribute/5960  : Heating stages
 gid://shopify/TaxonomyAttribute/7799  : Heating technology
+gid://shopify/TaxonomyAttribute/12427 : Heating time
+gid://shopify/TaxonomyAttribute/12428 : Heel height
 gid://shopify/TaxonomyAttribute/128   : Heel height type
 gid://shopify/TaxonomyAttribute/6718  : Heel shape
 gid://shopify/TaxonomyAttribute/3267  : Heel shoe type
+gid://shopify/TaxonomyAttribute/11685 : Heel-to-toe drop
 gid://shopify/TaxonomyAttribute/12429 : Height
+gid://shopify/TaxonomyAttribute/12430 : Height (folded)
+gid://shopify/TaxonomyAttribute/12431 : Height (packed)
+gid://shopify/TaxonomyAttribute/12432 : Height (pitched)
 gid://shopify/TaxonomyAttribute/2404  : Height adjustment
 gid://shopify/TaxonomyAttribute/5060  : Helicobacter pylori detection method
 gid://shopify/TaxonomyAttribute/8418  : Helicopter mission type
@@ -3765,6 +4239,7 @@ gid://shopify/TaxonomyAttribute/8431  : Helmet ventilation configuration
 gid://shopify/TaxonomyAttribute/8433  : Helmet visor (shield) optical features
 gid://shopify/TaxonomyAttribute/8432  : Helmet visor/peak adjustability
 gid://shopify/TaxonomyAttribute/8434  : Helmet visor/shield type
+gid://shopify/TaxonomyAttribute/11687 : Helmet weight
 gid://shopify/TaxonomyAttribute/6719  : Hem style
 gid://shopify/TaxonomyAttribute/6430  : Hemisphere compatibility
 gid://shopify/TaxonomyAttribute/6720  : Hemline style
@@ -3775,9 +4250,16 @@ gid://shopify/TaxonomyAttribute/9720  : Hi-hat pair type
 gid://shopify/TaxonomyAttribute/9721  : Hi-hat sound character
 gid://shopify/TaxonomyAttribute/6721  : High-visibility class
 gid://shopify/TaxonomyAttribute/7595  : Highback style
+gid://shopify/TaxonomyAttribute/12433 : Hip size
 gid://shopify/TaxonomyAttribute/8436  : Hitch ball diameter
 gid://shopify/TaxonomyAttribute/8437  : Hitch ball mounting style
+gid://shopify/TaxonomyAttribute/11688 : Hitch ball threaded shank diameter
+gid://shopify/TaxonomyAttribute/11689 : Hitch ball threaded shank length
+gid://shopify/TaxonomyAttribute/11690 : Hitch ball tongue weight rating
+gid://shopify/TaxonomyAttribute/11691 : Hitch ball weight rating (GTW)
 gid://shopify/TaxonomyAttribute/2717  : Hitch class
+gid://shopify/TaxonomyAttribute/11692 : Hitch mount drop
+gid://shopify/TaxonomyAttribute/11693 : Hitch mount rise
 gid://shopify/TaxonomyAttribute/1274  : Hitch type
 gid://shopify/TaxonomyAttribute/6431  : Hobby horse handle type
 gid://shopify/TaxonomyAttribute/6432  : Hobby horse sound features
@@ -3787,7 +4269,10 @@ gid://shopify/TaxonomyAttribute/7597  : Hockey size category
 gid://shopify/TaxonomyAttribute/7598  : Hockey size segment
 gid://shopify/TaxonomyAttribute/1646  : Hold level
 gid://shopify/TaxonomyAttribute/7599  : Hold surface texture
+gid://shopify/TaxonomyAttribute/11694 : Hole diameter
 gid://shopify/TaxonomyAttribute/5484  : Hole plating type
+gid://shopify/TaxonomyAttribute/12434 : Hole punch size
+gid://shopify/TaxonomyAttribute/11695 : Hole spacing
 gid://shopify/TaxonomyAttribute/5961  : Home alarm features
 gid://shopify/TaxonomyAttribute/9722  : Home decor sewing pattern project type
 gid://shopify/TaxonomyAttribute/8438  : Homologation / rule set
@@ -3808,6 +4293,7 @@ gid://shopify/TaxonomyAttribute/7602  : Hook configuration
 gid://shopify/TaxonomyAttribute/2130  : Hook design
 gid://shopify/TaxonomyAttribute/7603  : Hook eye style
 gid://shopify/TaxonomyAttribute/7604  : Hook eye type
+gid://shopify/TaxonomyAttribute/11696 : Hook gap size
 gid://shopify/TaxonomyAttribute/2352  : Hook grip design
 gid://shopify/TaxonomyAttribute/7605  : Hook material
 gid://shopify/TaxonomyAttribute/9729  : Hook organizer style
@@ -3815,10 +4301,13 @@ gid://shopify/TaxonomyAttribute/7606  : Hook point configuration
 gid://shopify/TaxonomyAttribute/7607  : Hook point type
 gid://shopify/TaxonomyAttribute/7608  : Hook shank length
 gid://shopify/TaxonomyAttribute/2353  : Hook size
+gid://shopify/TaxonomyAttribute/11697 : Hook strength rating
 gid://shopify/TaxonomyAttribute/5962  : Hook style
 gid://shopify/TaxonomyAttribute/2731  : Hook type
+gid://shopify/TaxonomyAttribute/11698 : Hook wire diameter
 gid://shopify/TaxonomyAttribute/9725  : Hook-and-loop fastener format
 gid://shopify/TaxonomyAttribute/9730  : Hooks & eyes attachment method
+gid://shopify/TaxonomyAttribute/11699 : Hooks & eyes strip length
 gid://shopify/TaxonomyAttribute/1288  : Hoop shape
 gid://shopify/TaxonomyAttribute/7609  : Hop-up type
 gid://shopify/TaxonomyAttribute/10582 : Horse blanket type
@@ -3830,6 +4319,11 @@ gid://shopify/TaxonomyAttribute/10586 : Horse groomer type
 gid://shopify/TaxonomyAttribute/2879  : Horse grooming accessories included
 gid://shopify/TaxonomyAttribute/10587 : Horse leg protection type
 gid://shopify/TaxonomyAttribute/9731  : Horse model breed
+gid://shopify/TaxonomyAttribute/12435 : Horsepower
+gid://shopify/TaxonomyAttribute/11700 : Horsepower RPM
+gid://shopify/TaxonomyAttribute/11701 : Horseshoe weight
+gid://shopify/TaxonomyAttribute/12436 : Hose diameter
+gid://shopify/TaxonomyAttribute/12437 : Hose length
 gid://shopify/TaxonomyAttribute/2919  : Hose material
 gid://shopify/TaxonomyAttribute/6725  : Hosiery toe style
 gid://shopify/TaxonomyAttribute/1919  : Host interface
@@ -3839,10 +4333,13 @@ gid://shopify/TaxonomyAttribute/8441  : Hot air balloon envelope material
 gid://shopify/TaxonomyAttribute/9732  : Hotfix application tool
 gid://shopify/TaxonomyAttribute/10588 : Hub axle type
 gid://shopify/TaxonomyAttribute/10589 : Hub motor type
+gid://shopify/TaxonomyAttribute/12438 : Hub size
+gid://shopify/TaxonomyAttribute/11702 : Hub spacing
 gid://shopify/TaxonomyAttribute/3317  : Hub/Switch storage options
 gid://shopify/TaxonomyAttribute/6433  : Hula hoop construction type
 gid://shopify/TaxonomyAttribute/6434  : Hula hoop features
 gid://shopify/TaxonomyAttribute/10590 : Hull design
+gid://shopify/TaxonomyAttribute/11703 : Hull rocker length
 gid://shopify/TaxonomyAttribute/8442  : Hull type
 gid://shopify/TaxonomyAttribute/5084  : Humidification system
 gid://shopify/TaxonomyAttribute/3289  : Humidifier design
@@ -3859,6 +4356,7 @@ gid://shopify/TaxonomyAttribute/3391  : Hunting blind design
 gid://shopify/TaxonomyAttribute/10591 : Hunting call type
 gid://shopify/TaxonomyAttribute/10592 : Hunting dog collar function
 gid://shopify/TaxonomyAttribute/2870  : Hunting/Survival knife design
+gid://shopify/TaxonomyAttribute/11704 : Hybrid battery warranty period
 gid://shopify/TaxonomyAttribute/8444  : Hybrid drivetrain configuration
 gid://shopify/TaxonomyAttribute/8445  : Hybrid system type
 gid://shopify/TaxonomyAttribute/8446  : Hybrid truck cab type
@@ -3867,9 +4365,11 @@ gid://shopify/TaxonomyAttribute/10594 : Hydration belt features
 gid://shopify/TaxonomyAttribute/10595 : Hydration bladder compatibility
 gid://shopify/TaxonomyAttribute/10596 : Hydration mouthpiece style
 gid://shopify/TaxonomyAttribute/10597 : Hydration pack style
+gid://shopify/TaxonomyAttribute/11705 : Hydration reservoir capacity
 gid://shopify/TaxonomyAttribute/10598 : Hydration system insulation
 gid://shopify/TaxonomyAttribute/10599 : Hydration valve type
 gid://shopify/TaxonomyAttribute/10600 : Hydraulic fluid type
+gid://shopify/TaxonomyAttribute/11706 : Hydrofoil mast length
 gid://shopify/TaxonomyAttribute/7805  : Hydrogenation level
 gid://shopify/TaxonomyAttribute/8447  : Hydrophobicity level
 gid://shopify/TaxonomyAttribute/5965  : Hydroponic nutrient system
@@ -3879,18 +4379,21 @@ gid://shopify/TaxonomyAttribute/5968  : Ice bucket insulation
 gid://shopify/TaxonomyAttribute/7806  : Ice cream format
 gid://shopify/TaxonomyAttribute/5969  : Ice cream maker accessories included
 gid://shopify/TaxonomyAttribute/1565  : Ice pack type
+gid://shopify/TaxonomyAttribute/12439 : Ice production rate
 gid://shopify/TaxonomyAttribute/5970  : Ice shape
 gid://shopify/TaxonomyAttribute/10601 : Ice skate sharpener type
 gid://shopify/TaxonomyAttribute/10602 : Ice temperature suitability
 gid://shopify/TaxonomyAttribute/7807  : Icing sugar variety
 gid://shopify/TaxonomyAttribute/2664  : Icon type
 gid://shopify/TaxonomyAttribute/5528  : Identity verification requirement
+gid://shopify/TaxonomyAttribute/12440 : Idle speed
 gid://shopify/TaxonomyAttribute/8448  : Ignition coil configuration
 gid://shopify/TaxonomyAttribute/8449  : Ignition lead compliance standard
 gid://shopify/TaxonomyAttribute/8450  : Ignition lead insulation material
 gid://shopify/TaxonomyAttribute/8451  : Ignition lead set type
 gid://shopify/TaxonomyAttribute/8452  : Ignition lead terminal type
 gid://shopify/TaxonomyAttribute/2169  : Ignition system
+gid://shopify/TaxonomyAttribute/12441 : Illuminance
 gid://shopify/TaxonomyAttribute/2620  : Illumination technique
 gid://shopify/TaxonomyAttribute/10603 : Illumination type
 gid://shopify/TaxonomyAttribute/2020  : Image formats supported
@@ -3902,6 +4405,10 @@ gid://shopify/TaxonomyAttribute/10604 : Impact protection certifications
 gid://shopify/TaxonomyAttribute/8455  : Impact protection level
 gid://shopify/TaxonomyAttribute/10605 : Impact protection rating
 gid://shopify/TaxonomyAttribute/6435  : Impact surface material
+gid://shopify/TaxonomyAttribute/12442 : Impedance
+gid://shopify/TaxonomyAttribute/11708 : Impeller height
+gid://shopify/TaxonomyAttribute/11709 : Impression height
+gid://shopify/TaxonomyAttribute/11710 : Impression width
 gid://shopify/TaxonomyAttribute/9736  : Incense base material
 gid://shopify/TaxonomyAttribute/2282  : Incense fragrance
 gid://shopify/TaxonomyAttribute/5971  : Incense holder style
@@ -3932,6 +4439,7 @@ gid://shopify/TaxonomyAttribute/9746  : Inflatable decoration type
 gid://shopify/TaxonomyAttribute/6438  : Inflatable raft/float features
 gid://shopify/TaxonomyAttribute/3385  : Inflation method
 gid://shopify/TaxonomyAttribute/8457  : Inflation method included
+gid://shopify/TaxonomyAttribute/12443 : Inflation time
 gid://shopify/TaxonomyAttribute/10610 : Infused scent
 gid://shopify/TaxonomyAttribute/5972  : Infuser type
 gid://shopify/TaxonomyAttribute/9747  : Ingredient base type
@@ -3943,6 +4451,7 @@ gid://shopify/TaxonomyAttribute/1385  : Ingredients
 gid://shopify/TaxonomyAttribute/5010  : Ingress protection (IP) rating
 gid://shopify/TaxonomyAttribute/2347  : Ink application technique
 gid://shopify/TaxonomyAttribute/6439  : Ink colors included
+gid://shopify/TaxonomyAttribute/11712 : Ink dry time
 gid://shopify/TaxonomyAttribute/2301  : Ink form
 gid://shopify/TaxonomyAttribute/9749  : Ink pad application method
 gid://shopify/TaxonomyAttribute/9750  : Ink pad permanence
@@ -3951,17 +4460,23 @@ gid://shopify/TaxonomyAttribute/9752  : Ink pad special effects
 gid://shopify/TaxonomyAttribute/9753  : Ink permanence
 gid://shopify/TaxonomyAttribute/9754  : Ink preparation required
 gid://shopify/TaxonomyAttribute/2305  : Ink type
+gid://shopify/TaxonomyAttribute/11713 : Inlet port diameter
+gid://shopify/TaxonomyAttribute/11714 : Inlet port inner diameter
 gid://shopify/TaxonomyAttribute/10611 : Inline skate brake type
 gid://shopify/TaxonomyAttribute/1310  : Inline skating style
+gid://shopify/TaxonomyAttribute/12444 : Inner diameter
 gid://shopify/TaxonomyAttribute/5973  : Inner pot coating
 gid://shopify/TaxonomyAttribute/10612 : Inner tent configuration
 gid://shopify/TaxonomyAttribute/6919  : Innerspring coil type
 gid://shopify/TaxonomyAttribute/5540  : Input connection type
 gid://shopify/TaxonomyAttribute/9755  : Input connector type
+gid://shopify/TaxonomyAttribute/11715 : Input shaft diameter
 gid://shopify/TaxonomyAttribute/5543  : Input signal interface
 gid://shopify/TaxonomyAttribute/10613 : Input valve type
 gid://shopify/TaxonomyAttribute/5546  : Input video interface
+gid://shopify/TaxonomyAttribute/12445 : Input voltage
 gid://shopify/TaxonomyAttribute/2419  : Input/Output ports
+gid://shopify/TaxonomyAttribute/12446 : Inseam length
 gid://shopify/TaxonomyAttribute/10614 : Insecticide treatment
 gid://shopify/TaxonomyAttribute/6726  : Insert coverage area
 gid://shopify/TaxonomyAttribute/6727  : Insert length type
@@ -3989,10 +4504,12 @@ gid://shopify/TaxonomyAttribute/2940  : Instrument material
 gid://shopify/TaxonomyAttribute/2936  : Instrument part material
 gid://shopify/TaxonomyAttribute/9763  : Instrument part mounting method
 gid://shopify/TaxonomyAttribute/9764  : Instrument parts included
+gid://shopify/TaxonomyAttribute/11716 : Instrument playing surface thickness
 gid://shopify/TaxonomyAttribute/9765  : Instrument playing technique
 gid://shopify/TaxonomyAttribute/9766  : Instrument size class
 gid://shopify/TaxonomyAttribute/2937  : Instrument string material
 gid://shopify/TaxonomyAttribute/3285  : Instrument support type
+gid://shopify/TaxonomyAttribute/11717 : Instrument weight
 gid://shopify/TaxonomyAttribute/2776  : Instrument/Accessory finish
 gid://shopify/TaxonomyAttribute/5974  : Insulation capability
 gid://shopify/TaxonomyAttribute/6730  : Insulation fill material
@@ -4000,6 +4517,8 @@ gid://shopify/TaxonomyAttribute/2913  : Insulation material
 gid://shopify/TaxonomyAttribute/5975  : Insulation status
 gid://shopify/TaxonomyAttribute/5976  : Insulation technology
 gid://shopify/TaxonomyAttribute/5977  : Insulation type
+gid://shopify/TaxonomyAttribute/11718 : Insulation weight
+gid://shopify/TaxonomyAttribute/11720 : Intake valve diameter
 gid://shopify/TaxonomyAttribute/5349  : Integrated LED lighting
 gid://shopify/TaxonomyAttribute/6731  : Integrated bottom type
 gid://shopify/TaxonomyAttribute/6920  : Integrated charging options
@@ -4039,13 +4558,21 @@ gid://shopify/TaxonomyAttribute/9772  : Interfacing application area
 gid://shopify/TaxonomyAttribute/9773  : Interfacing color family
 gid://shopify/TaxonomyAttribute/9774  : Interfacing selling format
 gid://shopify/TaxonomyAttribute/9775  : Interfacing stiffness level
+gid://shopify/TaxonomyAttribute/11721 : Interior length
 gid://shopify/TaxonomyAttribute/5146  : Interior lining material
 gid://shopify/TaxonomyAttribute/8466  : Interior padding type
 gid://shopify/TaxonomyAttribute/8467  : Interior stall configuration
 gid://shopify/TaxonomyAttribute/5206  : Interior texture
+gid://shopify/TaxonomyAttribute/11722 : Interior width
 gid://shopify/TaxonomyAttribute/1874  : Internal drive form factor supported
+gid://shopify/TaxonomyAttribute/11723 : Internal fit dimensions
+gid://shopify/TaxonomyAttribute/11724 : Internal height
 gid://shopify/TaxonomyAttribute/5979  : Internal membrane type
+gid://shopify/TaxonomyAttribute/12447 : Internal memory
+gid://shopify/TaxonomyAttribute/11725 : Internal rim width
+gid://shopify/TaxonomyAttribute/12448 : Internal storage capacity
 gid://shopify/TaxonomyAttribute/5468  : Internet radio form factor
+gid://shopify/TaxonomyAttribute/12449 : Interrupt rating
 gid://shopify/TaxonomyAttribute/3000  : Intimate apparel features
 gid://shopify/TaxonomyAttribute/2689  : Inverter type
 gid://shopify/TaxonomyAttribute/2518  : Invitation personalization design
@@ -4055,8 +4582,12 @@ gid://shopify/TaxonomyAttribute/9777  : Iridescence level
 gid://shopify/TaxonomyAttribute/9778  : Irish warpipe set configuration
 gid://shopify/TaxonomyAttribute/5980  : Iron cleaner purpose
 gid://shopify/TaxonomyAttribute/9779  : Iron-on applique application method
+gid://shopify/TaxonomyAttribute/11726 : Iron-on applique application temperature
+gid://shopify/TaxonomyAttribute/11727 : Iron-on applique press time
 gid://shopify/TaxonomyAttribute/5981  : Ironing board form factor
+gid://shopify/TaxonomyAttribute/11728 : Ironing board length
 gid://shopify/TaxonomyAttribute/5982  : Ironing board pad shape
+gid://shopify/TaxonomyAttribute/11729 : Ironing board width
 gid://shopify/TaxonomyAttribute/6923  : Ironing center features
 gid://shopify/TaxonomyAttribute/3142  : Ironing features
 gid://shopify/TaxonomyAttribute/2680  : Item condition
@@ -4068,7 +4599,9 @@ gid://shopify/TaxonomyAttribute/6733  : Jacket vent style
 gid://shopify/TaxonomyAttribute/7813  : Jam and jelly consistency
 gid://shopify/TaxonomyAttribute/6298  : Jar shape
 gid://shopify/TaxonomyAttribute/5210  : Jaw advancement adjustability
+gid://shopify/TaxonomyAttribute/12450 : Jaw opening
 gid://shopify/TaxonomyAttribute/10622 : Jaw shape
+gid://shopify/TaxonomyAttribute/11730 : Jaw width
 gid://shopify/TaxonomyAttribute/7814  : Jerky form
 gid://shopify/TaxonomyAttribute/9780  : Jersey style
 gid://shopify/TaxonomyAttribute/9781  : Jew harp accessories included
@@ -4087,7 +4620,9 @@ gid://shopify/TaxonomyAttribute/6442  : Jigsaw puzzle piece shape
 gid://shopify/TaxonomyAttribute/6735  : Jockstrap design features
 gid://shopify/TaxonomyAttribute/3172  : Joint connection
 gid://shopify/TaxonomyAttribute/3173  : Joint face type
+gid://shopify/TaxonomyAttribute/11731 : Joint size
 gid://shopify/TaxonomyAttribute/1242  : Joint style
+gid://shopify/TaxonomyAttribute/12451 : Joule rating
 gid://shopify/TaxonomyAttribute/5033  : Journey type
 gid://shopify/TaxonomyAttribute/5336  : Joystick mounting style
 gid://shopify/TaxonomyAttribute/5642  : Joystick sensor technology
@@ -4099,6 +4634,7 @@ gid://shopify/TaxonomyAttribute/7815  : Juice form
 gid://shopify/TaxonomyAttribute/7816  : Juice processing method
 gid://shopify/TaxonomyAttribute/5983  : Juicer type
 gid://shopify/TaxonomyAttribute/3382  : Jump rope design
+gid://shopify/TaxonomyAttribute/12452 : Jump rope size
 gid://shopify/TaxonomyAttribute/6443  : Jump rope style
 gid://shopify/TaxonomyAttribute/2765  : Jumping surface material
 gid://shopify/TaxonomyAttribute/7817  : Kale variety
@@ -4112,6 +4648,7 @@ gid://shopify/TaxonomyAttribute/10627 : Kayak style
 gid://shopify/TaxonomyAttribute/8468  : Keel type
 gid://shopify/TaxonomyAttribute/2112  : Kerosene application
 gid://shopify/TaxonomyAttribute/10628 : Kettlebell style
+gid://shopify/TaxonomyAttribute/12453 : Kettlebell weight
 gid://shopify/TaxonomyAttribute/6736  : Key attachment mechanism
 gid://shopify/TaxonomyAttribute/5984  : Key blade type
 gid://shopify/TaxonomyAttribute/2138  : Key purpose
@@ -4121,7 +4658,10 @@ gid://shopify/TaxonomyAttribute/9788  : Keyboard amplifier inputs
 gid://shopify/TaxonomyAttribute/9789  : Keyboard amplifier output types
 gid://shopify/TaxonomyAttribute/5649  : Keyboard assembly type
 gid://shopify/TaxonomyAttribute/5644  : Keyboard backlight type
+gid://shopify/TaxonomyAttribute/11732 : Keyboard case empty weight
 gid://shopify/TaxonomyAttribute/9790  : Keyboard case handle type
+gid://shopify/TaxonomyAttribute/11733 : Keyboard case interior height
+gid://shopify/TaxonomyAttribute/11734 : Keyboard case interior length
 gid://shopify/TaxonomyAttribute/9791  : Keyboard case interior padding type
 gid://shopify/TaxonomyAttribute/9792  : Keyboard case protection level
 gid://shopify/TaxonomyAttribute/9793  : Keyboard case wheel type
@@ -4133,15 +4673,18 @@ gid://shopify/TaxonomyAttribute/9794  : Keyboard pedal connector type
 gid://shopify/TaxonomyAttribute/1914  : Keyboard port type
 gid://shopify/TaxonomyAttribute/9795  : Keyboard power supply type
 gid://shopify/TaxonomyAttribute/3082  : Keyboard specialized features
+gid://shopify/TaxonomyAttribute/11735 : Keyboard stand crossbar depth
 gid://shopify/TaxonomyAttribute/9796  : Keyboard stand tier type
 gid://shopify/TaxonomyAttribute/9797  : Keyboard stand tiers
 gid://shopify/TaxonomyAttribute/1912  : Keyboard switch type
 gid://shopify/TaxonomyAttribute/1879  : Keyboard type
+gid://shopify/TaxonomyAttribute/11736 : Keyboard weight
 gid://shopify/TaxonomyAttribute/5631  : Keycap legend printing method
 gid://shopify/TaxonomyAttribute/5646  : Keycap material
 gid://shopify/TaxonomyAttribute/5630  : Keycap profile
 gid://shopify/TaxonomyAttribute/9798  : Keychain attachment type
 gid://shopify/TaxonomyAttribute/9799  : Keychain style
+gid://shopify/TaxonomyAttribute/12454 : Keyhole cylinder size
 gid://shopify/TaxonomyAttribute/1335  : Keypad style
 gid://shopify/TaxonomyAttribute/5393  : Keystone correction type
 gid://shopify/TaxonomyAttribute/9800  : Keywork finish
@@ -4151,6 +4694,8 @@ gid://shopify/TaxonomyAttribute/10632 : Kickboard features
 gid://shopify/TaxonomyAttribute/10633 : Kickboard handle style
 gid://shopify/TaxonomyAttribute/10634 : Kickstand mounting position
 gid://shopify/TaxonomyAttribute/10635 : Kickstand type
+gid://shopify/TaxonomyAttribute/11737 : Kicktail height
+gid://shopify/TaxonomyAttribute/11738 : Kidney belt panel height
 gid://shopify/TaxonomyAttribute/8469  : Kidney belt support level
 gid://shopify/TaxonomyAttribute/5038  : Kiln features
 gid://shopify/TaxonomyAttribute/9801  : Kiln firing atmosphere
@@ -4168,10 +4713,14 @@ gid://shopify/TaxonomyAttribute/5985  : Kitchen layout
 gid://shopify/TaxonomyAttribute/5986  : Kitchen linen items included
 gid://shopify/TaxonomyAttribute/1411  : Kitchen utensil items included
 gid://shopify/TaxonomyAttribute/3320  : Kitchen/Dining furniture items included
+gid://shopify/TaxonomyAttribute/11742 : Kite area
 gid://shopify/TaxonomyAttribute/10638 : Kite inflation system
 gid://shopify/TaxonomyAttribute/10639 : Kite line configuration
+gid://shopify/TaxonomyAttribute/11743 : Kite line length
+gid://shopify/TaxonomyAttribute/11744 : Kite line strength rating
 gid://shopify/TaxonomyAttribute/10640 : Kite type
 gid://shopify/TaxonomyAttribute/10641 : Kiteboard bag style
+gid://shopify/TaxonomyAttribute/12455 : Kiteboard size
 gid://shopify/TaxonomyAttribute/1253  : Kitesurfing style
 gid://shopify/TaxonomyAttribute/7818  : Kiwifruit variety
 gid://shopify/TaxonomyAttribute/5092  : Knee brace style
@@ -4247,7 +4796,10 @@ gid://shopify/TaxonomyAttribute/6744  : Lapel style
 gid://shopify/TaxonomyAttribute/5648  : Laptop cable type
 gid://shopify/TaxonomyAttribute/5647  : Laptop housing part type
 gid://shopify/TaxonomyAttribute/2270  : Laser light source
+gid://shopify/TaxonomyAttribute/11745 : Laser output power
 gid://shopify/TaxonomyAttribute/9817  : Laser safety class
+gid://shopify/TaxonomyAttribute/11747 : Last width
+gid://shopify/TaxonomyAttribute/12457 : Latency
 gid://shopify/TaxonomyAttribute/6925  : Latex processing method
 gid://shopify/TaxonomyAttribute/6926  : Latex type
 gid://shopify/TaxonomyAttribute/2196  : Lathe application
@@ -4263,12 +4815,20 @@ gid://shopify/TaxonomyAttribute/5998  : Lawn spreader type
 gid://shopify/TaxonomyAttribute/6300  : Lawn tractor tread type
 gid://shopify/TaxonomyAttribute/6745  : Layer construction
 gid://shopify/TaxonomyAttribute/6746  : Layer design
+gid://shopify/TaxonomyAttribute/11750 : Lazy kate rod usable length
+gid://shopify/TaxonomyAttribute/11749 : Lazy kate rod/dowel diameter
 gid://shopify/TaxonomyAttribute/9818  : Lazy kate tension control type
 gid://shopify/TaxonomyAttribute/2254  : Lead grade
 gid://shopify/TaxonomyAttribute/10658 : Lead hardware type
+gid://shopify/TaxonomyAttribute/12459 : Lead size
 gid://shopify/TaxonomyAttribute/7822  : Leaf gelatin grade
 gid://shopify/TaxonomyAttribute/7823  : Leaf preparation
+gid://shopify/TaxonomyAttribute/11751 : Leaf spring bushing inside diameter
+gid://shopify/TaxonomyAttribute/11752 : Leaf spring center bolt diameter
+gid://shopify/TaxonomyAttribute/11753 : Leaf spring eye-to-eye length
+gid://shopify/TaxonomyAttribute/11754 : Leaf spring free arch height
 gid://shopify/TaxonomyAttribute/8472  : Leaf spring material
+gid://shopify/TaxonomyAttribute/11755 : Leaf spring width
 gid://shopify/TaxonomyAttribute/6747  : Leak protection layer
 gid://shopify/TaxonomyAttribute/10659 : Leash clip type
 gid://shopify/TaxonomyAttribute/3233  : Leash design
@@ -4284,9 +4844,11 @@ gid://shopify/TaxonomyAttribute/10665 : Leg coverage
 gid://shopify/TaxonomyAttribute/6748  : Leg cuff style
 gid://shopify/TaxonomyAttribute/6749  : Leg cut height
 gid://shopify/TaxonomyAttribute/6750  : Leg cut style
+gid://shopify/TaxonomyAttribute/11756 : Leg guard length
 gid://shopify/TaxonomyAttribute/6751  : Leg length
 gid://shopify/TaxonomyAttribute/1852  : Leg lock type
 gid://shopify/TaxonomyAttribute/10666 : Leg loop type
+gid://shopify/TaxonomyAttribute/12460 : Leg opening
 gid://shopify/TaxonomyAttribute/6752  : Leg opening style
 gid://shopify/TaxonomyAttribute/1853  : Leg sections
 gid://shopify/TaxonomyAttribute/6927  : Leg style
@@ -4295,6 +4857,10 @@ gid://shopify/TaxonomyAttribute/6753  : Legging foot design
 gid://shopify/TaxonomyAttribute/6754  : Leggings waistband style
 gid://shopify/TaxonomyAttribute/6755  : Lei closure style
 gid://shopify/TaxonomyAttribute/7827  : Lemon variety
+gid://shopify/TaxonomyAttribute/12461 : Length
+gid://shopify/TaxonomyAttribute/12462 : Length (folded)
+gid://shopify/TaxonomyAttribute/12463 : Length (packed)
+gid://shopify/TaxonomyAttribute/12464 : Length (pitched)
 gid://shopify/TaxonomyAttribute/5230  : Length adjustability
 gid://shopify/TaxonomyAttribute/6446  : Length adjustment method
 gid://shopify/TaxonomyAttribute/1985  : Lens cap compatible device
@@ -4305,6 +4871,7 @@ gid://shopify/TaxonomyAttribute/5397  : Lens color combination
 gid://shopify/TaxonomyAttribute/10667 : Lens color/tint
 gid://shopify/TaxonomyAttribute/2249  : Lens configuration
 gid://shopify/TaxonomyAttribute/10668 : Lens construction
+gid://shopify/TaxonomyAttribute/12465 : Lens diameter
 gid://shopify/TaxonomyAttribute/5234  : Lens filter category
 gid://shopify/TaxonomyAttribute/1987  : Lens filter effects
 gid://shopify/TaxonomyAttribute/1988  : Lens filter type
@@ -4329,6 +4896,7 @@ gid://shopify/TaxonomyAttribute/9820  : License/usage terms
 gid://shopify/TaxonomyAttribute/9821  : Licensed sports property
 gid://shopify/TaxonomyAttribute/5999  : Lid features
 gid://shopify/TaxonomyAttribute/6928  : Lid hinge mechanism
+gid://shopify/TaxonomyAttribute/12466 : Lid size
 gid://shopify/TaxonomyAttribute/9822  : Lid support positions
 gid://shopify/TaxonomyAttribute/1786  : Lid type
 gid://shopify/TaxonomyAttribute/6000  : Lid vent type
@@ -4337,10 +4905,13 @@ gid://shopify/TaxonomyAttribute/10671 : Life jacket certification standard
 gid://shopify/TaxonomyAttribute/3175  : Life jacket features
 gid://shopify/TaxonomyAttribute/8476  : Life raft certification standard
 gid://shopify/TaxonomyAttribute/8477  : Life raft container type
+gid://shopify/TaxonomyAttribute/11759 : Life raft packed dimensions
+gid://shopify/TaxonomyAttribute/11760 : Life raft packed weight
 gid://shopify/TaxonomyAttribute/8478  : Life vest approval standard
 gid://shopify/TaxonomyAttribute/8479  : Life vest intended user
 gid://shopify/TaxonomyAttribute/8480  : Lifebuoy approval standard
 gid://shopify/TaxonomyAttribute/8481  : Lifebuoy features
+gid://shopify/TaxonomyAttribute/11761 : Lifebuoy weight
 gid://shopify/TaxonomyAttribute/6001  : Lift mechanism
 gid://shopify/TaxonomyAttribute/6929  : Lift mechanism type
 gid://shopify/TaxonomyAttribute/8482  : Lift/stand support point
@@ -4381,6 +4952,7 @@ gid://shopify/TaxonomyAttribute/9832  : Lily variety
 gid://shopify/TaxonomyAttribute/10674 : Limb articulation
 gid://shopify/TaxonomyAttribute/10675 : Limb material
 gid://shopify/TaxonomyAttribute/7829  : Lime variety
+gid://shopify/TaxonomyAttribute/11762 : Limit temperature rating
 gid://shopify/TaxonomyAttribute/10676 : Line buoyancy
 gid://shopify/TaxonomyAttribute/10677 : Line purpose
 gid://shopify/TaxonomyAttribute/2247  : Line spacing options
@@ -4411,6 +4983,7 @@ gid://shopify/TaxonomyAttribute/2551  : Livestock food ingredients
 gid://shopify/TaxonomyAttribute/6931  : Living room furniture items included
 gid://shopify/TaxonomyAttribute/2117  : Load capacity
 gid://shopify/TaxonomyAttribute/10681 : Load mechanism
+gid://shopify/TaxonomyAttribute/12467 : Loadable sleeve length
 gid://shopify/TaxonomyAttribute/2723  : Loading ramp type
 gid://shopify/TaxonomyAttribute/1374  : Loading type
 gid://shopify/TaxonomyAttribute/8489  : Lock cylinder type
@@ -4420,9 +4993,11 @@ gid://shopify/TaxonomyAttribute/8490  : Lock security level
 gid://shopify/TaxonomyAttribute/8491  : Lock system
 gid://shopify/TaxonomyAttribute/1236  : Lock type
 gid://shopify/TaxonomyAttribute/6932  : Locker bench configuration
+gid://shopify/TaxonomyAttribute/11765 : Locking bolt diameter
 gid://shopify/TaxonomyAttribute/1726  : Locking mechanism
 gid://shopify/TaxonomyAttribute/9835  : Locomotive prototype power type
 gid://shopify/TaxonomyAttribute/9836  : Locomotive wheel arrangement (Whyte notation)
+gid://shopify/TaxonomyAttribute/11767 : Loft (uncompressed thickness)
 gid://shopify/TaxonomyAttribute/6933  : Loft bed height classification
 gid://shopify/TaxonomyAttribute/5483  : Logic family
 gid://shopify/TaxonomyAttribute/6761  : Logo application method
@@ -4449,9 +5024,12 @@ gid://shopify/TaxonomyAttribute/2397  : Lubricant form
 gid://shopify/TaxonomyAttribute/6007  : Lubricant requirement
 gid://shopify/TaxonomyAttribute/10683 : Lubrication requirement
 gid://shopify/TaxonomyAttribute/8493  : Lubrication type
+gid://shopify/TaxonomyAttribute/11770 : Luff length
 gid://shopify/TaxonomyAttribute/8494  : Lug nut seat profile
 gid://shopify/TaxonomyAttribute/6934  : Lumbar support type
+gid://shopify/TaxonomyAttribute/12468 : Lumber/Wood thickness
 gid://shopify/TaxonomyAttribute/2914  : Lumber/Wood type
+gid://shopify/TaxonomyAttribute/12469 : Luminous flux
 gid://shopify/TaxonomyAttribute/6008  : Lunch set items included
 gid://shopify/TaxonomyAttribute/10684 : Lunge trainer style
 gid://shopify/TaxonomyAttribute/10685 : Lure buoyancy
@@ -4473,6 +5051,7 @@ gid://shopify/TaxonomyAttribute/2547  : MPAA rating
 gid://shopify/TaxonomyAttribute/6009  : Machete blade style
 gid://shopify/TaxonomyAttribute/5014  : MagSafe compatibility
 gid://shopify/TaxonomyAttribute/10686 : Magazine compatibility
+gid://shopify/TaxonomyAttribute/11772 : Magnet pull force
 gid://shopify/TaxonomyAttribute/10687 : Magnet requirement
 gid://shopify/TaxonomyAttribute/6448  : Magnet toy storage included
 gid://shopify/TaxonomyAttribute/1350  : Magnet type
@@ -4507,8 +5086,11 @@ gid://shopify/TaxonomyAttribute/6450  : Map size (sheet)
 gid://shopify/TaxonomyAttribute/6010  : Map style
 gid://shopify/TaxonomyAttribute/5676  : Map update policy
 gid://shopify/TaxonomyAttribute/9859  : Marabou feather form
+gid://shopify/TaxonomyAttribute/11774 : Marabou feather length
 gid://shopify/TaxonomyAttribute/9860  : Marabou feather treatment
+gid://shopify/TaxonomyAttribute/12470 : Marble size
 gid://shopify/TaxonomyAttribute/6451  : Marble track set feature modules
+gid://shopify/TaxonomyAttribute/11775 : Marching bass drum weight
 gid://shopify/TaxonomyAttribute/8497  : Marine flare certification/standard
 gid://shopify/TaxonomyAttribute/3089  : Marine navigator features
 gid://shopify/TaxonomyAttribute/10691 : Marine safety standard compliance
@@ -4548,6 +5130,7 @@ gid://shopify/TaxonomyAttribute/10701 : Mast attachment interface
 gid://shopify/TaxonomyAttribute/10702 : Mast base type
 gid://shopify/TaxonomyAttribute/10703 : Mast bend curve
 gid://shopify/TaxonomyAttribute/10704 : Mast diameter type
+gid://shopify/TaxonomyAttribute/11777 : Mast length
 gid://shopify/TaxonomyAttribute/10705 : Mat backing type
 gid://shopify/TaxonomyAttribute/2964  : Mat base material
 gid://shopify/TaxonomyAttribute/10706 : Mat installation method
@@ -4566,12 +5149,115 @@ gid://shopify/TaxonomyAttribute/3109  : Mattress features
 gid://shopify/TaxonomyAttribute/6012  : Mattress protector features
 gid://shopify/TaxonomyAttribute/6936  : Mattress top type
 gid://shopify/TaxonomyAttribute/7837  : Maturation vessel material
+gid://shopify/TaxonomyAttribute/12471 : Mature height
+gid://shopify/TaxonomyAttribute/12497 : Maximum Ethernet port speed
+gid://shopify/TaxonomyAttribute/12472 : Maximum airflow
+gid://shopify/TaxonomyAttribute/12473 : Maximum aperture (telephoto)
+gid://shopify/TaxonomyAttribute/12474 : Maximum aperture (wide)
+gid://shopify/TaxonomyAttribute/11778 : Maximum arm reach
+gid://shopify/TaxonomyAttribute/11779 : Maximum assisted speed
+gid://shopify/TaxonomyAttribute/12476 : Maximum ball speed
+gid://shopify/TaxonomyAttribute/12477 : Maximum battery life
 gid://shopify/TaxonomyAttribute/5544  : Maximum bit depth
+gid://shopify/TaxonomyAttribute/11780 : Maximum board length
+gid://shopify/TaxonomyAttribute/11781 : Maximum boiling protection temperature
+gid://shopify/TaxonomyAttribute/11782 : Maximum boost and cut per band
+gid://shopify/TaxonomyAttribute/12478 : Maximum bread weight
+gid://shopify/TaxonomyAttribute/11783 : Maximum cable length supported
+gid://shopify/TaxonomyAttribute/12479 : Maximum chuck capacity
+gid://shopify/TaxonomyAttribute/11786 : Maximum compatible neck width
+gid://shopify/TaxonomyAttribute/11787 : Maximum compatible rope or band diameter
+gid://shopify/TaxonomyAttribute/11788 : Maximum compatible strap width
+gid://shopify/TaxonomyAttribute/12481 : Maximum cord length
+gid://shopify/TaxonomyAttribute/12482 : Maximum current rating
+gid://shopify/TaxonomyAttribute/12483 : Maximum cut-off frequency
+gid://shopify/TaxonomyAttribute/12484 : Maximum cutting diameter
+gid://shopify/TaxonomyAttribute/12485 : Maximum cutting height
+gid://shopify/TaxonomyAttribute/12486 : Maximum data transfer rate
+gid://shopify/TaxonomyAttribute/12487 : Maximum delivery height
+gid://shopify/TaxonomyAttribute/12488 : Maximum detection depth
+gid://shopify/TaxonomyAttribute/12490 : Maximum distance
+gid://shopify/TaxonomyAttribute/11789 : Maximum dive depth
+gid://shopify/TaxonomyAttribute/12491 : Maximum door leaf thickness
+gid://shopify/TaxonomyAttribute/12492 : Maximum door weight
+gid://shopify/TaxonomyAttribute/12493 : Maximum door width
+gid://shopify/TaxonomyAttribute/12494 : Maximum drag
+gid://shopify/TaxonomyAttribute/12495 : Maximum drilling diameter
+gid://shopify/TaxonomyAttribute/11790 : Maximum effective range
+gid://shopify/TaxonomyAttribute/11792 : Maximum extended length
+gid://shopify/TaxonomyAttribute/12499 : Maximum flow rate
+gid://shopify/TaxonomyAttribute/12500 : Maximum frequency
+gid://shopify/TaxonomyAttribute/11794 : Maximum fretboard width supported
+gid://shopify/TaxonomyAttribute/12501 : Maximum gain level
+gid://shopify/TaxonomyAttribute/11795 : Maximum heat output
+gid://shopify/TaxonomyAttribute/12502 : Maximum heater power
+gid://shopify/TaxonomyAttribute/12503 : Maximum height
+gid://shopify/TaxonomyAttribute/12504 : Maximum idle speed
+gid://shopify/TaxonomyAttribute/12507 : Maximum inductance
+gid://shopify/TaxonomyAttribute/11797 : Maximum kayak width
+gid://shopify/TaxonomyAttribute/11798 : Maximum launch height
+gid://shopify/TaxonomyAttribute/12509 : Maximum length
+gid://shopify/TaxonomyAttribute/12511 : Maximum load capacity
+gid://shopify/TaxonomyAttribute/11799 : Maximum load capacity per shelf
+gid://shopify/TaxonomyAttribute/12512 : Maximum log diameter
+gid://shopify/TaxonomyAttribute/12513 : Maximum log length
 gid://shopify/TaxonomyAttribute/2617  : Maximum magnification
+gid://shopify/TaxonomyAttribute/11800 : Maximum mattress thickness
+gid://shopify/TaxonomyAttribute/11801 : Maximum operating depth
+gid://shopify/TaxonomyAttribute/12514 : Maximum operating distance
+gid://shopify/TaxonomyAttribute/12515 : Maximum operating pressure
+gid://shopify/TaxonomyAttribute/12516 : Maximum operating temperature
+gid://shopify/TaxonomyAttribute/12517 : Maximum operating voltage
+gid://shopify/TaxonomyAttribute/12518 : Maximum pool capacity
+gid://shopify/TaxonomyAttribute/11802 : Maximum power output
+gid://shopify/TaxonomyAttribute/11803 : Maximum preamp output voltage
+gid://shopify/TaxonomyAttribute/12519 : Maximum pressure
+gid://shopify/TaxonomyAttribute/11804 : Maximum projectile speed rating
+gid://shopify/TaxonomyAttribute/12521 : Maximum projection distance
+gid://shopify/TaxonomyAttribute/11805 : Maximum puncture diameter sealed
+gid://shopify/TaxonomyAttribute/11806 : Maximum puncture size supported
 gid://shopify/TaxonomyAttribute/9862  : Maximum quilt size supported
+gid://shopify/TaxonomyAttribute/11807 : Maximum range
 gid://shopify/TaxonomyAttribute/5472  : Maximum reel diameter supported
+gid://shopify/TaxonomyAttribute/12522 : Maximum refresh rate
+gid://shopify/TaxonomyAttribute/11809 : Maximum resistance power
+gid://shopify/TaxonomyAttribute/12523 : Maximum resistance weight
+gid://shopify/TaxonomyAttribute/12525 : Maximum room area
+gid://shopify/TaxonomyAttribute/11810 : Maximum rope length
+gid://shopify/TaxonomyAttribute/12527 : Maximum rotational speed
+gid://shopify/TaxonomyAttribute/12528 : Maximum screen height
+gid://shopify/TaxonomyAttribute/12529 : Maximum screen size
+gid://shopify/TaxonomyAttribute/12530 : Maximum screen width
+gid://shopify/TaxonomyAttribute/12531 : Maximum sound detection level
+gid://shopify/TaxonomyAttribute/11813 : Maximum sound output level
+gid://shopify/TaxonomyAttribute/12532 : Maximum sound pressure level (SPL)
+gid://shopify/TaxonomyAttribute/12533 : Maximum speed
+gid://shopify/TaxonomyAttribute/12534 : Maximum spin speed
+gid://shopify/TaxonomyAttribute/11814 : Maximum spool/bobbin diameter supported
+gid://shopify/TaxonomyAttribute/11815 : Maximum spool/bobbin width supported
+gid://shopify/TaxonomyAttribute/11816 : Maximum stencil width
+gid://shopify/TaxonomyAttribute/11817 : Maximum stick length
+gid://shopify/TaxonomyAttribute/11818 : Maximum stitch length
+gid://shopify/TaxonomyAttribute/11819 : Maximum stitch width
+gid://shopify/TaxonomyAttribute/11820 : Maximum stitch/yarn thickness supported
+gid://shopify/TaxonomyAttribute/11821 : Maximum string tension
+gid://shopify/TaxonomyAttribute/11822 : Maximum suitable water depth
+gid://shopify/TaxonomyAttribute/11823 : Maximum supported kayak length
+gid://shopify/TaxonomyAttribute/11824 : Maximum table thickness
+gid://shopify/TaxonomyAttribute/11825 : Maximum takeoff weight (MTOW)
+gid://shopify/TaxonomyAttribute/12535 : Maximum tank rim size
+gid://shopify/TaxonomyAttribute/12536 : Maximum temperature
+gid://shopify/TaxonomyAttribute/12537 : Maximum thickness
+gid://shopify/TaxonomyAttribute/11826 : Maximum tire clearance
+gid://shopify/TaxonomyAttribute/11827 : Maximum tire diameter supported
+gid://shopify/TaxonomyAttribute/11828 : Maximum tire width supported
+gid://shopify/TaxonomyAttribute/12538 : Maximum transmission distance
+gid://shopify/TaxonomyAttribute/12539 : Maximum tube diameter
+gid://shopify/TaxonomyAttribute/12540 : Maximum user height
+gid://shopify/TaxonomyAttribute/11830 : Maximum wheelbase supported
 gid://shopify/TaxonomyAttribute/7838  : Meal course
 gid://shopify/TaxonomyAttribute/7839  : Meal preparation state
+gid://shopify/TaxonomyAttribute/11832 : Measurable speed range
 gid://shopify/TaxonomyAttribute/5579  : Measured parameters
 gid://shopify/TaxonomyAttribute/1550  : Measuring method
 gid://shopify/TaxonomyAttribute/6301  : Measuring spoon features
@@ -4617,7 +5303,10 @@ gid://shopify/TaxonomyAttribute/9875  : Melodica reed plate material
 gid://shopify/TaxonomyAttribute/9876  : Melodica size class
 gid://shopify/TaxonomyAttribute/2487  : Melodica style
 gid://shopify/TaxonomyAttribute/7843  : Melon variety
+gid://shopify/TaxonomyAttribute/12544 : Memory capacity
+gid://shopify/TaxonomyAttribute/12545 : Memory card size
 gid://shopify/TaxonomyAttribute/1900  : Memory channels
+gid://shopify/TaxonomyAttribute/12546 : Memory clock speed
 gid://shopify/TaxonomyAttribute/6937  : Memory foam infusion material
 gid://shopify/TaxonomyAttribute/1875  : Memory form factor
 gid://shopify/TaxonomyAttribute/5567  : Memory rank
@@ -4625,10 +5314,12 @@ gid://shopify/TaxonomyAttribute/2031  : Memory storage type
 gid://shopify/TaxonomyAttribute/1840  : Memory technology
 gid://shopify/TaxonomyAttribute/9877  : Memory wire gauge
 gid://shopify/TaxonomyAttribute/9878  : Memory wire project size
+gid://shopify/TaxonomyAttribute/11833 : Memory wire wire diameter
 gid://shopify/TaxonomyAttribute/1638  : Menstrual cup shape
 gid://shopify/TaxonomyAttribute/5322  : Menstrual cup size
 gid://shopify/TaxonomyAttribute/5321  : Menstrual cup stem type
 gid://shopify/TaxonomyAttribute/5351  : Mesh networking technology
+gid://shopify/TaxonomyAttribute/11835 : Mesh opening size
 gid://shopify/TaxonomyAttribute/3737  : Mesh type
 gid://shopify/TaxonomyAttribute/3050  : Metal detector features
 gid://shopify/TaxonomyAttribute/2131  : Metal molding application
@@ -4645,6 +5336,7 @@ gid://shopify/TaxonomyAttribute/1796  : Microphone thread
 gid://shopify/TaxonomyAttribute/6454  : Microphone toy feature set
 gid://shopify/TaxonomyAttribute/1815  : Microphone type
 gid://shopify/TaxonomyAttribute/5428  : Microphone windshield type
+gid://shopify/TaxonomyAttribute/12548 : Microscope slide thickness
 gid://shopify/TaxonomyAttribute/6015  : Microwave compatibility
 gid://shopify/TaxonomyAttribute/6016  : Microwave oven functions
 gid://shopify/TaxonomyAttribute/6766  : Military branch
@@ -4660,7 +5352,28 @@ gid://shopify/TaxonomyAttribute/7849  : Millet variety
 gid://shopify/TaxonomyAttribute/7850  : Milling process
 gid://shopify/TaxonomyAttribute/2378  : Mineral class
 gid://shopify/TaxonomyAttribute/5134  : Mineral compound form
+gid://shopify/TaxonomyAttribute/12549 : Minimum ball speed
+gid://shopify/TaxonomyAttribute/11838 : Minimum ceiling height
+gid://shopify/TaxonomyAttribute/12550 : Minimum chuck capacity
+gid://shopify/TaxonomyAttribute/11839 : Minimum curve radius
+gid://shopify/TaxonomyAttribute/12551 : Minimum cut-off frequency
+gid://shopify/TaxonomyAttribute/12552 : Minimum cutting height
+gid://shopify/TaxonomyAttribute/12553 : Minimum door leaf thickness supported
+gid://shopify/TaxonomyAttribute/12554 : Minimum drilling diameter
+gid://shopify/TaxonomyAttribute/12555 : Minimum frequency
+gid://shopify/TaxonomyAttribute/12556 : Minimum height
+gid://shopify/TaxonomyAttribute/12557 : Minimum inductance
+gid://shopify/TaxonomyAttribute/12559 : Minimum length
 gid://shopify/TaxonomyAttribute/2618  : Minimum magnification
+gid://shopify/TaxonomyAttribute/12560 : Minimum operating temperature
+gid://shopify/TaxonomyAttribute/12561 : Minimum pool capacity
+gid://shopify/TaxonomyAttribute/11841 : Minimum resistance weight
+gid://shopify/TaxonomyAttribute/11842 : Minimum skein circumference
+gid://shopify/TaxonomyAttribute/12562 : Minimum sound detection level
+gid://shopify/TaxonomyAttribute/12563 : Minimum speed
+gid://shopify/TaxonomyAttribute/12564 : Minimum temperature
+gid://shopify/TaxonomyAttribute/12565 : Minimum thickness
+gid://shopify/TaxonomyAttribute/11844 : Minimum user height
 gid://shopify/TaxonomyAttribute/9882  : Mint mark
 gid://shopify/TaxonomyAttribute/6938  : Mirror configuration
 gid://shopify/TaxonomyAttribute/6939  : Mirror coverage
@@ -4670,6 +5383,7 @@ gid://shopify/TaxonomyAttribute/2560  : Mirror handle design
 gid://shopify/TaxonomyAttribute/10710 : Mirror mounting location
 gid://shopify/TaxonomyAttribute/6940  : Mirror shape
 gid://shopify/TaxonomyAttribute/5247  : Mirror sides
+gid://shopify/TaxonomyAttribute/12567 : Mirror size
 gid://shopify/TaxonomyAttribute/6021  : Mirror type
 gid://shopify/TaxonomyAttribute/5283  : Mist application area
 gid://shopify/TaxonomyAttribute/6022  : Mist output mode
@@ -4694,11 +5408,13 @@ gid://shopify/TaxonomyAttribute/2395  : Model control technology
 gid://shopify/TaxonomyAttribute/5042  : Model gender representation
 gid://shopify/TaxonomyAttribute/9883  : Model making kit items included
 gid://shopify/TaxonomyAttribute/9884  : Model making product type
+gid://shopify/TaxonomyAttribute/11846 : Model rocket body tube diameter
 gid://shopify/TaxonomyAttribute/9885  : Model rocket kit contents
 gid://shopify/TaxonomyAttribute/9886  : Model rocket kit format
 gid://shopify/TaxonomyAttribute/9887  : Model rocket motor impulse class
 gid://shopify/TaxonomyAttribute/6456  : Model rocket motor mount size
 gid://shopify/TaxonomyAttribute/9888  : Model rocket power source required
+gid://shopify/TaxonomyAttribute/11847 : Model rocket predicted maximum altitude
 gid://shopify/TaxonomyAttribute/9889  : Model rocket propellant type
 gid://shopify/TaxonomyAttribute/9890  : Model rocket recommended launch rod or rail size
 gid://shopify/TaxonomyAttribute/9891  : Model rocket recovery method
@@ -4744,6 +5460,8 @@ gid://shopify/TaxonomyAttribute/1734  : Motion
 gid://shopify/TaxonomyAttribute/2793  : Motion sensor type
 gid://shopify/TaxonomyAttribute/10713 : Motor belt type
 gid://shopify/TaxonomyAttribute/10714 : Motor configuration
+gid://shopify/TaxonomyAttribute/12568 : Motor frequency
+gid://shopify/TaxonomyAttribute/11848 : Motor mount diameter
 gid://shopify/TaxonomyAttribute/8502  : Motor mounting configuration
 gid://shopify/TaxonomyAttribute/10715 : Motor mounting position
 gid://shopify/TaxonomyAttribute/10716 : Motor position
@@ -4758,9 +5476,12 @@ gid://shopify/TaxonomyAttribute/8508  : Motor vehicle oxygen sensor position
 gid://shopify/TaxonomyAttribute/8509  : Motor vehicle oxygen sensor sensor number
 gid://shopify/TaxonomyAttribute/8510  : Motor vehicle oxygen sensor type
 gid://shopify/TaxonomyAttribute/8511  : Motor vehicle paint application method
+gid://shopify/TaxonomyAttribute/11850 : Motor vehicle paint coverage area
 gid://shopify/TaxonomyAttribute/8512  : Motor vehicle paint system step
 gid://shopify/TaxonomyAttribute/2698  : Motor vehicle placement
+gid://shopify/TaxonomyAttribute/11851 : Motor vehicle speaker mounting depth
 gid://shopify/TaxonomyAttribute/8513  : Motor vehicle speaker mounting type
+gid://shopify/TaxonomyAttribute/11853 : Motor vehicle subwoofer sensitivity
 gid://shopify/TaxonomyAttribute/8514  : Motor vehicle subwoofer size
 gid://shopify/TaxonomyAttribute/8515  : Motor vehicle subwoofer voice coil configuration
 gid://shopify/TaxonomyAttribute/8516  : Motor vehicle subwoofer voice coil impedance (per coil)
@@ -4781,6 +5502,7 @@ gid://shopify/TaxonomyAttribute/8527  : Motorcycle luggage side
 gid://shopify/TaxonomyAttribute/8528  : Motorcycle protective gear size system
 gid://shopify/TaxonomyAttribute/8529  : Motorcycle rack carrier style
 gid://shopify/TaxonomyAttribute/8530  : Motorcycle riding discipline
+gid://shopify/TaxonomyAttribute/11854 : Motorcycle tire overall diameter
 gid://shopify/TaxonomyAttribute/8531  : Motorcycle tire speed rating
 gid://shopify/TaxonomyAttribute/2702  : Motorcycle tire type
 gid://shopify/TaxonomyAttribute/2751  : Motorcycle/Scooter type
@@ -4795,6 +5517,8 @@ gid://shopify/TaxonomyAttribute/10718 : Mountainboard truck type
 gid://shopify/TaxonomyAttribute/6030  : Mounting bolt pattern
 gid://shopify/TaxonomyAttribute/2794  : Mounting hardware
 gid://shopify/TaxonomyAttribute/8534  : Mounting hardware included (for installation)
+gid://shopify/TaxonomyAttribute/11855 : Mounting hole diameter
+gid://shopify/TaxonomyAttribute/11856 : Mounting hole spacing
 gid://shopify/TaxonomyAttribute/5430  : Mounting interface pattern
 gid://shopify/TaxonomyAttribute/5619  : Mounting interface standard
 gid://shopify/TaxonomyAttribute/8535  : Mounting location
@@ -4803,6 +5527,7 @@ gid://shopify/TaxonomyAttribute/8536  : Mounting method
 gid://shopify/TaxonomyAttribute/8537  : Mounting position
 gid://shopify/TaxonomyAttribute/10719 : Mounting rail type
 gid://shopify/TaxonomyAttribute/8538  : Mounting receiver size
+gid://shopify/TaxonomyAttribute/11857 : Mounting screw hole spacing
 gid://shopify/TaxonomyAttribute/5343  : Mounting style
 gid://shopify/TaxonomyAttribute/5506  : Mounting technology
 gid://shopify/TaxonomyAttribute/5521  : Mounting thread size
@@ -4819,12 +5544,15 @@ gid://shopify/TaxonomyAttribute/3381  : Mouthgard design
 gid://shopify/TaxonomyAttribute/10721 : Mouthguard mold type
 gid://shopify/TaxonomyAttribute/2483  : Mouthpiece
 gid://shopify/TaxonomyAttribute/9906  : Mouthpiece facing length
+gid://shopify/TaxonomyAttribute/11858 : Mouthpiece length
 gid://shopify/TaxonomyAttribute/9907  : Mouthpiece material
 gid://shopify/TaxonomyAttribute/9909  : Mouthpiece shank size
 gid://shopify/TaxonomyAttribute/9910  : Mouthpiece shank type
 gid://shopify/TaxonomyAttribute/9908  : Mouthpiece shank/receiver size
 gid://shopify/TaxonomyAttribute/6031  : Mouthpiece shape
 gid://shopify/TaxonomyAttribute/10722 : Mouthpiece style
+gid://shopify/TaxonomyAttribute/11859 : Mouthpiece thickness
+gid://shopify/TaxonomyAttribute/11860 : Mouthpiece tip opening
 gid://shopify/TaxonomyAttribute/9911  : Mouthpiece type
 gid://shopify/TaxonomyAttribute/6942  : Movement mechanism
 gid://shopify/TaxonomyAttribute/6032  : Mower deck material
@@ -4836,12 +5564,15 @@ gid://shopify/TaxonomyAttribute/3128  : Muscle stimulator design
 gid://shopify/TaxonomyAttribute/7854  : Mushroom variety
 gid://shopify/TaxonomyAttribute/1793  : Music genre
 gid://shopify/TaxonomyAttribute/2441  : Music stand design
+gid://shopify/TaxonomyAttribute/11861 : Music stand desk height
 gid://shopify/TaxonomyAttribute/9912  : Music stand desk tilt adjustment
+gid://shopify/TaxonomyAttribute/11862 : Music stand desk width
 gid://shopify/TaxonomyAttribute/9913  : Music stand intended use
 gid://shopify/TaxonomyAttribute/9914  : Musical block pitch type
 gid://shopify/TaxonomyAttribute/6459  : Musical box mechanism type
 gid://shopify/TaxonomyAttribute/2488  : Musical key
 gid://shopify/TaxonomyAttribute/9915  : Musical keyboard case fit type
+gid://shopify/TaxonomyAttribute/11863 : Musical ratchet handle length
 gid://shopify/TaxonomyAttribute/9916  : Musical ratchet sound character
 gid://shopify/TaxonomyAttribute/9917  : Musical scraper groove surface material
 gid://shopify/TaxonomyAttribute/9918  : Musical scraper type
@@ -4850,11 +5581,17 @@ gid://shopify/TaxonomyAttribute/9920  : Mute attenuation level
 gid://shopify/TaxonomyAttribute/9921  : Mute cork/padding material
 gid://shopify/TaxonomyAttribute/9922  : Mute coverage type
 gid://shopify/TaxonomyAttribute/9923  : Mute finish
+gid://shopify/TaxonomyAttribute/11864 : Mute thickness
+gid://shopify/TaxonomyAttribute/11865 : Mute weight
 gid://shopify/TaxonomyAttribute/5583  : NEMA enclosure rating
+gid://shopify/TaxonomyAttribute/12581 : NRR rating
+gid://shopify/TaxonomyAttribute/11866 : Nacre thickness
 gid://shopify/TaxonomyAttribute/3338  : Nail art items included
 gid://shopify/TaxonomyAttribute/5280  : Nail art medium type
 gid://shopify/TaxonomyAttribute/3131  : Nail care features
 gid://shopify/TaxonomyAttribute/1623  : Nail design
+gid://shopify/TaxonomyAttribute/12570 : Nail gauge
+gid://shopify/TaxonomyAttribute/12571 : Nail length
 gid://shopify/TaxonomyAttribute/3339  : Nail polish drying form
 gid://shopify/TaxonomyAttribute/1624  : Nail shape
 gid://shopify/TaxonomyAttribute/9924  : Name label text template
@@ -4869,6 +5606,7 @@ gid://shopify/TaxonomyAttribute/8540  : Neck brace fit system
 gid://shopify/TaxonomyAttribute/8541  : Neck brace size basis
 gid://shopify/TaxonomyAttribute/9926  : Neck configuration
 gid://shopify/TaxonomyAttribute/10723 : Neck coverage type
+gid://shopify/TaxonomyAttribute/11867 : Neck support circumference
 gid://shopify/TaxonomyAttribute/8542  : Neck support size system
 gid://shopify/TaxonomyAttribute/3262  : Necklace design
 gid://shopify/TaxonomyAttribute/6767  : Necklace length type
@@ -4877,6 +5615,7 @@ gid://shopify/TaxonomyAttribute/10724 : Needle balance zone
 gid://shopify/TaxonomyAttribute/9927  : Needle case format
 gid://shopify/TaxonomyAttribute/5044  : Needle coating type
 gid://shopify/TaxonomyAttribute/10725 : Needle damping type
+gid://shopify/TaxonomyAttribute/12572 : Needle diameter
 gid://shopify/TaxonomyAttribute/2354  : Needle eye type
 gid://shopify/TaxonomyAttribute/9928  : Needle felting needle profile
 gid://shopify/TaxonomyAttribute/2602  : Needle gauge
@@ -4902,6 +5641,7 @@ gid://shopify/TaxonomyAttribute/9944  : Needlepoint canvas mesh count
 gid://shopify/TaxonomyAttribute/9945  : Needlepoint frame canvas attachment method
 gid://shopify/TaxonomyAttribute/9946  : Needlepoint frame compatible stand type
 gid://shopify/TaxonomyAttribute/9947  : Needlepoint frame contents
+gid://shopify/TaxonomyAttribute/11868 : Needlepoint frame roller length
 gid://shopify/TaxonomyAttribute/9948  : Needlepoint frame tension adjustment type
 gid://shopify/TaxonomyAttribute/9949  : Needlepoint pattern chart format
 gid://shopify/TaxonomyAttribute/9950  : Needlepoint project type
@@ -4909,14 +5649,20 @@ gid://shopify/TaxonomyAttribute/2054  : Negative/Slide storage type
 gid://shopify/TaxonomyAttribute/10726 : Net design
 gid://shopify/TaxonomyAttribute/2848  : Net material
 gid://shopify/TaxonomyAttribute/10727 : Net mesh pattern
+gid://shopify/TaxonomyAttribute/11870 : Net mesh size
 gid://shopify/TaxonomyAttribute/2855  : Net mounting type
+gid://shopify/TaxonomyAttribute/11871 : Net rosin weight
 gid://shopify/TaxonomyAttribute/10728 : Net twine gauge
+gid://shopify/TaxonomyAttribute/11872 : Net volume
+gid://shopify/TaxonomyAttribute/12573 : Net weight
 gid://shopify/TaxonomyAttribute/1895  : Network cable interface
 gid://shopify/TaxonomyAttribute/5359  : Network layer support
 gid://shopify/TaxonomyAttribute/1937  : Network protocols supported
 gid://shopify/TaxonomyAttribute/1938  : Networking standards
 gid://shopify/TaxonomyAttribute/5522  : Neutral density rating
+gid://shopify/TaxonomyAttribute/12574 : Nicotine content
 gid://shopify/TaxonomyAttribute/7855  : Nicotine source
+gid://shopify/TaxonomyAttribute/12575 : Nicotine strength
 gid://shopify/TaxonomyAttribute/1198  : Nightgown style
 gid://shopify/TaxonomyAttribute/10729 : Nipple drive interface
 gid://shopify/TaxonomyAttribute/1769  : Nipple material
@@ -4930,20 +5676,24 @@ gid://shopify/TaxonomyAttribute/10733 : Nock transparency level
 gid://shopify/TaxonomyAttribute/10734 : Nock type
 gid://shopify/TaxonomyAttribute/5449  : Noise cancellation technology
 gid://shopify/TaxonomyAttribute/2516  : Noise intensity
+gid://shopify/TaxonomyAttribute/12577 : Noise level
 gid://shopify/TaxonomyAttribute/5473  : Noise reduction system
 gid://shopify/TaxonomyAttribute/8543  : Noise reduction type
 gid://shopify/TaxonomyAttribute/10735 : Noise suppression technology
+gid://shopify/TaxonomyAttribute/12578 : Nominal thermal power
 gid://shopify/TaxonomyAttribute/9951  : Non-slip base features
 gid://shopify/TaxonomyAttribute/6036  : Noodle core design
 gid://shopify/TaxonomyAttribute/10736 : Nose bridge type
 gid://shopify/TaxonomyAttribute/10737 : Nose clip accessories included
 gid://shopify/TaxonomyAttribute/10738 : Nose clip features
 gid://shopify/TaxonomyAttribute/10739 : Nose coverage style
+gid://shopify/TaxonomyAttribute/12579 : Nose size
 gid://shopify/TaxonomyAttribute/10740 : Noseband type
 gid://shopify/TaxonomyAttribute/3366  : Notepad design
 gid://shopify/TaxonomyAttribute/6037  : Nozzle adjustability
 gid://shopify/TaxonomyAttribute/5367  : Nozzle coating
 gid://shopify/TaxonomyAttribute/6038  : Nozzle material
+gid://shopify/TaxonomyAttribute/12580 : Nozzle size
 gid://shopify/TaxonomyAttribute/6039  : Nozzle style
 gid://shopify/TaxonomyAttribute/5368  : Nozzle thread type
 gid://shopify/TaxonomyAttribute/1666  : Nozzle type
@@ -4976,14 +5726,19 @@ gid://shopify/TaxonomyAttribute/7856  : Nut butter texture
 gid://shopify/TaxonomyAttribute/1491  : Nut butter variety
 gid://shopify/TaxonomyAttribute/2124  : Nut form
 gid://shopify/TaxonomyAttribute/1508  : Nut processing method
+gid://shopify/TaxonomyAttribute/11875 : Nut width
 gid://shopify/TaxonomyAttribute/3101  : Nut/Seed type
 gid://shopify/TaxonomyAttribute/1419  : Nutrient content
 gid://shopify/TaxonomyAttribute/7857  : Nutrient fortification
 gid://shopify/TaxonomyAttribute/9958  : Oak product form
 gid://shopify/TaxonomyAttribute/9959  : Oak toast level
+gid://shopify/TaxonomyAttribute/12582 : Objective diameter
 gid://shopify/TaxonomyAttribute/9960  : Oboe case capacity
 gid://shopify/TaxonomyAttribute/9961  : Oboe case carry configuration
 gid://shopify/TaxonomyAttribute/9962  : Oboe case design
+gid://shopify/TaxonomyAttribute/11876 : Oboe case interior height
+gid://shopify/TaxonomyAttribute/11877 : Oboe case interior length
+gid://shopify/TaxonomyAttribute/11878 : Oboe case interior width
 gid://shopify/TaxonomyAttribute/9963  : Oboe case internal fit type
 gid://shopify/TaxonomyAttribute/2489  : Oboe key system
 gid://shopify/TaxonomyAttribute/9964  : Oboe keywork plating
@@ -4995,12 +5750,15 @@ gid://shopify/TaxonomyAttribute/9968  : Ocarina chamber count
 gid://shopify/TaxonomyAttribute/9969  : Ocarina fingering system
 gid://shopify/TaxonomyAttribute/9970  : Ocarina finish type
 gid://shopify/TaxonomyAttribute/2490  : Ocarina style
+gid://shopify/TaxonomyAttribute/11879 : Ocarina tuning reference
 gid://shopify/TaxonomyAttribute/1627  : Occasion
 gid://shopify/TaxonomyAttribute/1203  : Occasion style
 gid://shopify/TaxonomyAttribute/8550  : Occupant classification sensor support
 gid://shopify/TaxonomyAttribute/9971  : Octave harmonica cover plate material
 gid://shopify/TaxonomyAttribute/9972  : Octave harmonica tuning system
 gid://shopify/TaxonomyAttribute/9973  : Octoban mounting system type
+gid://shopify/TaxonomyAttribute/11880 : Octoban shell depth
+gid://shopify/TaxonomyAttribute/11881 : Odometer unit
 gid://shopify/TaxonomyAttribute/8551  : Odor control features
 gid://shopify/TaxonomyAttribute/5323  : Odor remover application area
 gid://shopify/TaxonomyAttribute/3158  : Office cart features
@@ -5011,6 +5769,7 @@ gid://shopify/TaxonomyAttribute/8552  : Oil cooler core type
 gid://shopify/TaxonomyAttribute/8553  : Oil cooler mounting style
 gid://shopify/TaxonomyAttribute/8554  : Oil dipstick component type
 gid://shopify/TaxonomyAttribute/8555  : Oil dipstick measurement markings
+gid://shopify/TaxonomyAttribute/11882 : Oil dipstick tube inner diameter
 gid://shopify/TaxonomyAttribute/8556  : Oil dipstick tube mounting type
 gid://shopify/TaxonomyAttribute/6304  : Oil dispenser spout design
 gid://shopify/TaxonomyAttribute/8557  : Oil drain plug head drive type
@@ -5018,17 +5777,21 @@ gid://shopify/TaxonomyAttribute/8558  : Oil drain plug magnet type
 gid://shopify/TaxonomyAttribute/5294  : Oil extraction method
 gid://shopify/TaxonomyAttribute/8559  : Oil fill cap type
 gid://shopify/TaxonomyAttribute/8560  : Oil filler cap attachment type
+gid://shopify/TaxonomyAttribute/11884 : Oil filler cap diameter
 gid://shopify/TaxonomyAttribute/8561  : Oil filler cap installation position
 gid://shopify/TaxonomyAttribute/8562  : Oil filler cap locking type
 gid://shopify/TaxonomyAttribute/8563  : Oil filler cap tether type
 gid://shopify/TaxonomyAttribute/8564  : Oil filler cap venting type
+gid://shopify/TaxonomyAttribute/11886 : Oil filter gasket outer diameter
 gid://shopify/TaxonomyAttribute/8565  : Oil filter style
 gid://shopify/TaxonomyAttribute/8566  : Oil pan baffle/windage features
+gid://shopify/TaxonomyAttribute/11888 : Oil pan capacity
 gid://shopify/TaxonomyAttribute/8567  : Oil pan finish/coating
 gid://shopify/TaxonomyAttribute/8568  : Oil pressure sensor function type
 gid://shopify/TaxonomyAttribute/8569  : Oil pressure sensor signal output type
 gid://shopify/TaxonomyAttribute/7858  : Oil processing method
 gid://shopify/TaxonomyAttribute/8570  : Oil pump drive method
+gid://shopify/TaxonomyAttribute/11889 : Oil pump inlet port diameter
 gid://shopify/TaxonomyAttribute/8571  : Oil pump mounting style
 gid://shopify/TaxonomyAttribute/8572  : Oil system connection thread standard
 gid://shopify/TaxonomyAttribute/1440  : Oil type
@@ -5046,7 +5809,9 @@ gid://shopify/TaxonomyAttribute/1728  : Opening direction
 gid://shopify/TaxonomyAttribute/1729  : Opening mechanism
 gid://shopify/TaxonomyAttribute/2587  : Operating mode
 gid://shopify/TaxonomyAttribute/9977  : Operating modes
+gid://shopify/TaxonomyAttribute/11891 : Operating pressure
 gid://shopify/TaxonomyAttribute/1859  : Operating system
+gid://shopify/TaxonomyAttribute/12584 : Operating time
 gid://shopify/TaxonomyAttribute/8573  : Operating voltage
 gid://shopify/TaxonomyAttribute/5595  : Operation mechanism
 gid://shopify/TaxonomyAttribute/1373  : Operation method
@@ -5066,6 +5831,7 @@ gid://shopify/TaxonomyAttribute/9981  : Orchestral string instrument fitting/par
 gid://shopify/TaxonomyAttribute/9982  : Orchestral string instrument mute type
 gid://shopify/TaxonomyAttribute/9983  : Orchestral string instrument part position
 gid://shopify/TaxonomyAttribute/9984  : Orchestral string winding material
+gid://shopify/TaxonomyAttribute/11892 : Orchid flower size
 gid://shopify/TaxonomyAttribute/12756 : Organic certification
 gid://shopify/TaxonomyAttribute/6043  : Organizer application
 gid://shopify/TaxonomyAttribute/2727  : Organizer type
@@ -5080,6 +5846,7 @@ gid://shopify/TaxonomyAttribute/5327  : Orthotic coverage length
 gid://shopify/TaxonomyAttribute/6045  : Oscillation mode
 gid://shopify/TaxonomyAttribute/6046  : Oscillation type
 gid://shopify/TaxonomyAttribute/9990  : Ostrich feather part
+gid://shopify/TaxonomyAttribute/11893 : Outboard motor alternator output
 gid://shopify/TaxonomyAttribute/8574  : Outboard motor shaft type
 gid://shopify/TaxonomyAttribute/8575  : Outboard motor steering type
 gid://shopify/TaxonomyAttribute/2975  : Outdoor equipment features
@@ -5089,30 +5856,45 @@ gid://shopify/TaxonomyAttribute/1432  : Outdoor power accessories included
 gid://shopify/TaxonomyAttribute/6944  : Outdoor table functionality
 gid://shopify/TaxonomyAttribute/1264  : Outdoor walking activity
 gid://shopify/TaxonomyAttribute/2998  : Outerwear clothing features
+gid://shopify/TaxonomyAttribute/12587 : Outerwear length
 gid://shopify/TaxonomyAttribute/6771  : Outerwear length type
 gid://shopify/TaxonomyAttribute/6772  : Outerwear pieces included
 gid://shopify/TaxonomyAttribute/6462  : Outfit attachment mechanism
 gid://shopify/TaxonomyAttribute/6773  : Outfit items included
+gid://shopify/TaxonomyAttribute/11895 : Outlet port diameter
 gid://shopify/TaxonomyAttribute/8576  : Outlet thread type
 gid://shopify/TaxonomyAttribute/1931  : Outlet type
 gid://shopify/TaxonomyAttribute/5541  : Output connection type
+gid://shopify/TaxonomyAttribute/12588 : Output frequency
 gid://shopify/TaxonomyAttribute/9991  : Output jack type (instrument)
 gid://shopify/TaxonomyAttribute/2434  : Output level
 gid://shopify/TaxonomyAttribute/5542  : Output signal interface
 gid://shopify/TaxonomyAttribute/8577  : Output signal type
 gid://shopify/TaxonomyAttribute/5547  : Output video interface
+gid://shopify/TaxonomyAttribute/12589 : Output voltage
 gid://shopify/TaxonomyAttribute/1835  : Output waveform
+gid://shopify/TaxonomyAttribute/12590 : Outseam length
+gid://shopify/TaxonomyAttribute/12591 : Outside diameter
 gid://shopify/TaxonomyAttribute/10745 : Outsole marking type
 gid://shopify/TaxonomyAttribute/6774  : Outsole material
 gid://shopify/TaxonomyAttribute/10746 : Outsole stud type
 gid://shopify/TaxonomyAttribute/1403  : Oven accessories included
 gid://shopify/TaxonomyAttribute/6945  : Oven housing configuration
+gid://shopify/TaxonomyAttribute/11896 : Oven opening depth
+gid://shopify/TaxonomyAttribute/11897 : Oven opening height
+gid://shopify/TaxonomyAttribute/11898 : Oven opening width
 gid://shopify/TaxonomyAttribute/9992  : Oven-bake clay formulation
+gid://shopify/TaxonomyAttribute/11899 : Overall dimensions
+gid://shopify/TaxonomyAttribute/11900 : Overall exterior height
+gid://shopify/TaxonomyAttribute/11901 : Overall length
 gid://shopify/TaxonomyAttribute/5570  : Overclock profile support
+gid://shopify/TaxonomyAttribute/11902 : Overhang length
 gid://shopify/TaxonomyAttribute/8578  : Overhead mount installation method
 gid://shopify/TaxonomyAttribute/8579  : Oversize or undersize grade
+gid://shopify/TaxonomyAttribute/12592 : Oxygen capacity
 gid://shopify/TaxonomyAttribute/5082  : Oxygen cylinder outlet standard
 gid://shopify/TaxonomyAttribute/6048  : Oxygen indicator type
+gid://shopify/TaxonomyAttribute/11903 : Oxygen sensor hex size
 gid://shopify/TaxonomyAttribute/1593  : Oxygen tank valve type
 gid://shopify/TaxonomyAttribute/10747 : P-Tex application method
 gid://shopify/TaxonomyAttribute/10748 : P-Tex form
@@ -5123,11 +5905,15 @@ gid://shopify/TaxonomyAttribute/3311  : PCB type
 gid://shopify/TaxonomyAttribute/5624  : PCIe lane configuration
 gid://shopify/TaxonomyAttribute/2674  : PEGI rating
 gid://shopify/TaxonomyAttribute/4051  : PH level
+gid://shopify/TaxonomyAttribute/11929 : PHEV charging time
 gid://shopify/TaxonomyAttribute/1941  : PSTN connectivity options
 gid://shopify/TaxonomyAttribute/1723  : Pacifier/Teether design
 gid://shopify/TaxonomyAttribute/6775  : Packability
+gid://shopify/TaxonomyAttribute/11905 : Package length
+gid://shopify/TaxonomyAttribute/12593 : Package size
 gid://shopify/TaxonomyAttribute/1456  : Package type
 gid://shopify/TaxonomyAttribute/9993  : Packaging format
+gid://shopify/TaxonomyAttribute/11906 : Packaging length
 gid://shopify/TaxonomyAttribute/7862  : Packaging material
 gid://shopify/TaxonomyAttribute/6463  : Packaging type
 gid://shopify/TaxonomyAttribute/2272  : Packing materials included
@@ -5140,6 +5926,7 @@ gid://shopify/TaxonomyAttribute/10750 : Pad coverage area
 gid://shopify/TaxonomyAttribute/2608  : Pad display profile
 gid://shopify/TaxonomyAttribute/10751 : Pad material or technology
 gid://shopify/TaxonomyAttribute/10752 : Pad mounting or holding style
+gid://shopify/TaxonomyAttribute/11907 : Pad saver diameter
 gid://shopify/TaxonomyAttribute/9996  : Pad saver style
 gid://shopify/TaxonomyAttribute/10753 : Pad shape
 gid://shopify/TaxonomyAttribute/10754 : Pad shell type
@@ -5150,21 +5937,28 @@ gid://shopify/TaxonomyAttribute/5317  : Pad wing style
 gid://shopify/TaxonomyAttribute/10756 : Padding layers
 gid://shopify/TaxonomyAttribute/9997  : Padding level
 gid://shopify/TaxonomyAttribute/10757 : Padding material
+gid://shopify/TaxonomyAttribute/11909 : Padding thickness
 gid://shopify/TaxonomyAttribute/6464  : Paddle ball attachment type
 gid://shopify/TaxonomyAttribute/2891  : Paddle equipment included
+gid://shopify/TaxonomyAttribute/11910 : Paddle grip circumference
 gid://shopify/TaxonomyAttribute/10758 : Paddle leash style
 gid://shopify/TaxonomyAttribute/6465  : Paddle shape
 gid://shopify/TaxonomyAttribute/3383  : Paddle/Oar material
 gid://shopify/TaxonomyAttribute/10759 : Paddleboard intended use
+gid://shopify/TaxonomyAttribute/12594 : Paddleboard size
+gid://shopify/TaxonomyAttribute/11912 : Paddler weight range
 gid://shopify/TaxonomyAttribute/2232  : Page layout
 gid://shopify/TaxonomyAttribute/5515  : Pager application
 gid://shopify/TaxonomyAttribute/5200  : Pain reduction technology
 gid://shopify/TaxonomyAttribute/8580  : Paint application method
 gid://shopify/TaxonomyAttribute/2207  : Paint brush design
+gid://shopify/TaxonomyAttribute/12595 : Paint brush size
+gid://shopify/TaxonomyAttribute/11913 : Paint dry-to-touch time
 gid://shopify/TaxonomyAttribute/2712  : Paint finish
 gid://shopify/TaxonomyAttribute/9998  : Paint medium application method
 gid://shopify/TaxonomyAttribute/9999  : Paint medium intended effect
 gid://shopify/TaxonomyAttribute/2306  : Paint medium type
+gid://shopify/TaxonomyAttribute/12596 : Paint roller size
 gid://shopify/TaxonomyAttribute/2298  : Paint type
 gid://shopify/TaxonomyAttribute/6466  : Paint-by-number surface type
 gid://shopify/TaxonomyAttribute/8581  : Paint-safe bristles
@@ -5187,6 +5981,8 @@ gid://shopify/TaxonomyAttribute/10002 : Palette knife blade edge profile
 gid://shopify/TaxonomyAttribute/10003 : Palette knife flexibility
 gid://shopify/TaxonomyAttribute/2342  : Palette knife shape
 gid://shopify/TaxonomyAttribute/10004 : Palette surface finish
+gid://shopify/TaxonomyAttribute/11914 : Palette thickness
+gid://shopify/TaxonomyAttribute/11915 : Palm circumference
 gid://shopify/TaxonomyAttribute/10767 : Palm padding level
 gid://shopify/TaxonomyAttribute/10768 : Palm padding type
 gid://shopify/TaxonomyAttribute/10005 : Palm wax blend readiness
@@ -5194,6 +5990,7 @@ gid://shopify/TaxonomyAttribute/10006 : Palm wax form
 gid://shopify/TaxonomyAttribute/6050  : Pan bottom type
 gid://shopify/TaxonomyAttribute/10007 : Pan flute tuning standard
 gid://shopify/TaxonomyAttribute/6051  : Pan perforation type
+gid://shopify/TaxonomyAttribute/11916 : Panel cutout diameter
 gid://shopify/TaxonomyAttribute/1890  : Panel specification
 gid://shopify/TaxonomyAttribute/1891  : Panel termination
 gid://shopify/TaxonomyAttribute/5215  : Panel transparency
@@ -5228,6 +6025,7 @@ gid://shopify/TaxonomyAttribute/8582  : Parking camera mounting location
 gid://shopify/TaxonomyAttribute/8583  : Parking camera night vision technology
 gid://shopify/TaxonomyAttribute/8584  : Parking camera orientation
 gid://shopify/TaxonomyAttribute/8585  : Parking sensor finish
+gid://shopify/TaxonomyAttribute/11920 : Parking sensor hole diameter
 gid://shopify/TaxonomyAttribute/8586  : Parking sensor type
 gid://shopify/TaxonomyAttribute/2627  : Parking sign design
 gid://shopify/TaxonomyAttribute/7865  : Parsley root variety
@@ -5241,6 +6039,7 @@ gid://shopify/TaxonomyAttribute/10010 : Party favor type
 gid://shopify/TaxonomyAttribute/10011 : Party game format
 gid://shopify/TaxonomyAttribute/10012 : Party horn mouthpiece type
 gid://shopify/TaxonomyAttribute/10013 : Party horn style
+gid://shopify/TaxonomyAttribute/11921 : Party streamer/curtain coverage area
 gid://shopify/TaxonomyAttribute/5034  : Pass duration
 gid://shopify/TaxonomyAttribute/1832  : Passband
 gid://shopify/TaxonomyAttribute/10014 : Passenger car type
@@ -5265,9 +6064,13 @@ gid://shopify/TaxonomyAttribute/3     : Pattern
 gid://shopify/TaxonomyAttribute/2357  : Pattern distribution format
 gid://shopify/TaxonomyAttribute/6056  : Pattern match type
 gid://shopify/TaxonomyAttribute/10020 : Pattern sizing system
+gid://shopify/TaxonomyAttribute/11922 : Payload capacity
 gid://shopify/TaxonomyAttribute/5334  : Payment mechanism type
+gid://shopify/TaxonomyAttribute/11923 : Peak power handling
+gid://shopify/TaxonomyAttribute/12597 : Peak power per channel
 gid://shopify/TaxonomyAttribute/10776 : Peak style
 gid://shopify/TaxonomyAttribute/7873  : Pear variety
+gid://shopify/TaxonomyAttribute/11925 : Pearl hole size
 gid://shopify/TaxonomyAttribute/10021 : Pearl luster grade
 gid://shopify/TaxonomyAttribute/10022 : Pearl matching level
 gid://shopify/TaxonomyAttribute/10023 : Pearl shape
@@ -5285,7 +6088,10 @@ gid://shopify/TaxonomyAttribute/10780 : Pedal spindle thread size
 gid://shopify/TaxonomyAttribute/10781 : Pedal type
 gid://shopify/TaxonomyAttribute/10782 : Pellet accessory type
 gid://shopify/TaxonomyAttribute/10783 : Pellet grade
+gid://shopify/TaxonomyAttribute/11926 : Pellet weight
 gid://shopify/TaxonomyAttribute/10784 : Pen ink color
+gid://shopify/TaxonomyAttribute/12598 : Pen size
+gid://shopify/TaxonomyAttribute/11927 : Pen tip size
 gid://shopify/TaxonomyAttribute/2257  : Pen type
 gid://shopify/TaxonomyAttribute/2967  : Pen/Felt tip design
 gid://shopify/TaxonomyAttribute/3162  : Pen/Pencil features
@@ -5308,6 +6114,7 @@ gid://shopify/TaxonomyAttribute/2432  : Percussion stand design
 gid://shopify/TaxonomyAttribute/2429  : Percussion tip shape
 gid://shopify/TaxonomyAttribute/2652  : Performance metrics
 gid://shopify/TaxonomyAttribute/10032 : Perfumery base carrier type
+gid://shopify/TaxonomyAttribute/11928 : Perfumery base flash point
 gid://shopify/TaxonomyAttribute/10033 : Perfumery base intended application
 gid://shopify/TaxonomyAttribute/10034 : Perfumery ingredient carrier/solvent
 gid://shopify/TaxonomyAttribute/10035 : Perfumery ingredient form
@@ -5344,6 +6151,7 @@ gid://shopify/TaxonomyAttribute/6059  : Pet toxicity
 gid://shopify/TaxonomyAttribute/3236  : Pet trainer type
 gid://shopify/TaxonomyAttribute/1704  : Pet treat texture
 gid://shopify/TaxonomyAttribute/3224  : Pet treat type
+gid://shopify/TaxonomyAttribute/12599 : Petri dish size
 gid://shopify/TaxonomyAttribute/2557  : Phase type
 gid://shopify/TaxonomyAttribute/5532  : Phone camera position
 gid://shopify/TaxonomyAttribute/5018  : Phone card delivery format
@@ -5377,6 +6185,7 @@ gid://shopify/TaxonomyAttribute/7879  : Pie crust type
 gid://shopify/TaxonomyAttribute/6061  : Pie pan edge style
 gid://shopify/TaxonomyAttribute/10789 : Piece configuration
 gid://shopify/TaxonomyAttribute/2553  : Pig feed stage
+gid://shopify/TaxonomyAttribute/12600 : Pile depth
 gid://shopify/TaxonomyAttribute/1327  : Pile type
 gid://shopify/TaxonomyAttribute/5079  : Pillbox schedule
 gid://shopify/TaxonomyAttribute/10051 : Pillow form size
@@ -5388,10 +6197,14 @@ gid://shopify/TaxonomyAttribute/6780  : Pin backing type
 gid://shopify/TaxonomyAttribute/10053 : Pin cushion attachment style
 gid://shopify/TaxonomyAttribute/10054 : Pin cushion features
 gid://shopify/TaxonomyAttribute/10055 : Pin face customization method
+gid://shopify/TaxonomyAttribute/11931 : Pin gauge
+gid://shopify/TaxonomyAttribute/12601 : Pin length
 gid://shopify/TaxonomyAttribute/6062  : Pin shape
 gid://shopify/TaxonomyAttribute/2356  : Pin size
 gid://shopify/TaxonomyAttribute/5151  : Pin tip type
 gid://shopify/TaxonomyAttribute/10056 : Pin type
+gid://shopify/TaxonomyAttribute/12602 : Pin/Rod diameter
+gid://shopify/TaxonomyAttribute/12603 : Pin/Rod length
 gid://shopify/TaxonomyAttribute/5332  : Pinball machine edition
 gid://shopify/TaxonomyAttribute/5333  : Pinball machine format
 gid://shopify/TaxonomyAttribute/10790 : Ping pong certification
@@ -5402,15 +6215,24 @@ gid://shopify/TaxonomyAttribute/10793 : Ping pong robot accessory type
 gid://shopify/TaxonomyAttribute/3174  : Ping pong robot features
 gid://shopify/TaxonomyAttribute/10794 : Ping pong rubber surface type
 gid://shopify/TaxonomyAttribute/10795 : Ping pong rubber type
+gid://shopify/TaxonomyAttribute/11932 : Ping pong sponge thickness
 gid://shopify/TaxonomyAttribute/10796 : Ping pong table type
+gid://shopify/TaxonomyAttribute/12604 : Pipe brush size
 gid://shopify/TaxonomyAttribute/2140  : Pipe clamp design
 gid://shopify/TaxonomyAttribute/6307  : Pipe connection method
+gid://shopify/TaxonomyAttribute/12605 : Pipe diameter
+gid://shopify/TaxonomyAttribute/12606 : Pipe diameter supported
+gid://shopify/TaxonomyAttribute/11933 : Pipe inner diameter (musical instrument pipe)
 gid://shopify/TaxonomyAttribute/10057 : Pipe instrument voicing / sound production method
+gid://shopify/TaxonomyAttribute/12607 : Pipe length
 gid://shopify/TaxonomyAttribute/1503  : Pipe shape
 gid://shopify/TaxonomyAttribute/6063  : Piping tip shape
 gid://shopify/TaxonomyAttribute/8593  : Piston application type
 gid://shopify/TaxonomyAttribute/8594  : Piston crown/dish style
+gid://shopify/TaxonomyAttribute/11934 : Piston oversize
 gid://shopify/TaxonomyAttribute/8595  : Piston pin retention type
+gid://shopify/TaxonomyAttribute/11935 : Piston ring thickness
+gid://shopify/TaxonomyAttribute/12608 : Pit ball size
 gid://shopify/TaxonomyAttribute/10797 : Pit configuration
 gid://shopify/TaxonomyAttribute/10798 : Pit cover type
 gid://shopify/TaxonomyAttribute/7880  : Pitahaya flesh color
@@ -5441,6 +6263,7 @@ gid://shopify/TaxonomyAttribute/6473  : Planetarium projection content format
 gid://shopify/TaxonomyAttribute/6308  : Plant care difficulty
 gid://shopify/TaxonomyAttribute/1445  : Plant characteristics
 gid://shopify/TaxonomyAttribute/1338  : Plant class
+gid://shopify/TaxonomyAttribute/12609 : Plant container size
 gid://shopify/TaxonomyAttribute/6067  : Plant container type
 gid://shopify/TaxonomyAttribute/10064 : Plant fiber type
 gid://shopify/TaxonomyAttribute/6068  : Plant life cycle
@@ -5453,6 +6276,7 @@ gid://shopify/TaxonomyAttribute/10065 : Plaster gauze finish
 gid://shopify/TaxonomyAttribute/10066 : Plaster gauze grade
 gid://shopify/TaxonomyAttribute/10067 : Plaster gauze weave density
 gid://shopify/TaxonomyAttribute/10068 : Plastic canvas finish
+gid://shopify/TaxonomyAttribute/11937 : Plastic canvas hole size
 gid://shopify/TaxonomyAttribute/10069 : Plastic canvas sheet finish
 gid://shopify/TaxonomyAttribute/10070 : Plastic canvas transparency
 gid://shopify/TaxonomyAttribute/10805 : Plate bottom design
@@ -5463,6 +6287,8 @@ gid://shopify/TaxonomyAttribute/6071  : Plate purpose
 gid://shopify/TaxonomyAttribute/10808 : Plate size category
 gid://shopify/TaxonomyAttribute/6072  : Plate style
 gid://shopify/TaxonomyAttribute/1651  : Plate type
+gid://shopify/TaxonomyAttribute/12610 : Plate weight
+gid://shopify/TaxonomyAttribute/12611 : Platform height
 gid://shopify/TaxonomyAttribute/6474  : Play dough & putty kit contents
 gid://shopify/TaxonomyAttribute/6475  : Play dough tool set items included
 gid://shopify/TaxonomyAttribute/10809 : Play environment suitability
@@ -5474,6 +6300,7 @@ gid://shopify/TaxonomyAttribute/6479  : Play money set components included
 gid://shopify/TaxonomyAttribute/6480  : Play pattern
 gid://shopify/TaxonomyAttribute/3395  : Play slide design
 gid://shopify/TaxonomyAttribute/6481  : Play sprinkler mounting type
+gid://shopify/TaxonomyAttribute/11938 : Play sprinkler spray coverage diameter
 gid://shopify/TaxonomyAttribute/6482  : Play vehicle lights and sounds
 gid://shopify/TaxonomyAttribute/3402  : Play vehicle propulsion
 gid://shopify/TaxonomyAttribute/6483  : Play vehicle scale
@@ -5485,12 +6312,17 @@ gid://shopify/TaxonomyAttribute/1217  : Player position
 gid://shopify/TaxonomyAttribute/10810 : Player size category
 gid://shopify/TaxonomyAttribute/10071 : Player size range
 gid://shopify/TaxonomyAttribute/3095  : Player/Recorder specialized features
+gid://shopify/TaxonomyAttribute/11939 : Playfield thickness
+gid://shopify/TaxonomyAttribute/11940 : Playfield width
 gid://shopify/TaxonomyAttribute/2764  : Playhouse design
 gid://shopify/TaxonomyAttribute/10811 : Playing environment
 gid://shopify/TaxonomyAttribute/10072 : Playing method
 gid://shopify/TaxonomyAttribute/10073 : Playing surface material
+gid://shopify/TaxonomyAttribute/11941 : Playing surface size
 gid://shopify/TaxonomyAttribute/10074 : Playing surface type
+gid://shopify/TaxonomyAttribute/12612 : Playing time
 gid://shopify/TaxonomyAttribute/6484  : Playset activities included
+gid://shopify/TaxonomyAttribute/11942 : Playset deck height
 gid://shopify/TaxonomyAttribute/6485  : Playset installation type
 gid://shopify/TaxonomyAttribute/6486  : Playset items included
 gid://shopify/TaxonomyAttribute/10812 : Pliers jaw style
@@ -5506,6 +6338,7 @@ gid://shopify/TaxonomyAttribute/2585  : Pneumatic conveyor operation
 gid://shopify/TaxonomyAttribute/1943  : PoE standard
 gid://shopify/TaxonomyAttribute/6782  : Pocket closure type
 gid://shopify/TaxonomyAttribute/10076 : Pocket knife opening mechanism
+gid://shopify/TaxonomyAttribute/11943 : Pocket opening size
 gid://shopify/TaxonomyAttribute/6783  : Pocket style
 gid://shopify/TaxonomyAttribute/6784  : Pocket type
 gid://shopify/TaxonomyAttribute/10813 : Pod retention system
@@ -5529,6 +6362,8 @@ gid://shopify/TaxonomyAttribute/10816 : Pole anchoring method
 gid://shopify/TaxonomyAttribute/10817 : Pole basket type
 gid://shopify/TaxonomyAttribute/10818 : Pole connection system
 gid://shopify/TaxonomyAttribute/6073  : Pole construction type
+gid://shopify/TaxonomyAttribute/11944 : Pole diameter
+gid://shopify/TaxonomyAttribute/12613 : Pole length
 gid://shopify/TaxonomyAttribute/10819 : Pole system type
 gid://shopify/TaxonomyAttribute/2965  : Pole/Post material
 gid://shopify/TaxonomyAttribute/8596  : Police equipment fitment
@@ -5566,6 +6401,8 @@ gid://shopify/TaxonomyAttribute/6084  : Pool vacuum type
 gid://shopify/TaxonomyAttribute/7885  : Popcorn form
 gid://shopify/TaxonomyAttribute/6085  : Popcorn kernel variety
 gid://shopify/TaxonomyAttribute/7886  : Pork rind form
+gid://shopify/TaxonomyAttribute/11946 : Port diameter
+gid://shopify/TaxonomyAttribute/11947 : Port height
 gid://shopify/TaxonomyAttribute/1634  : Portability
 gid://shopify/TaxonomyAttribute/6946  : Portability features
 gid://shopify/TaxonomyAttribute/10088 : Portability/Frame type
@@ -5592,10 +6429,15 @@ gid://shopify/TaxonomyAttribute/6789  : Pouch style
 gid://shopify/TaxonomyAttribute/6088  : Pour spout design
 gid://shopify/TaxonomyAttribute/6089  : Pour spout style
 gid://shopify/TaxonomyAttribute/7890  : Powdered beverage variety
+gid://shopify/TaxonomyAttribute/12614 : Power
 gid://shopify/TaxonomyAttribute/5625  : Power connector type
+gid://shopify/TaxonomyAttribute/12615 : Power consumption (typical)
 gid://shopify/TaxonomyAttribute/5580  : Power conversion semiconductor type
+gid://shopify/TaxonomyAttribute/12616 : Power dissipation
 gid://shopify/TaxonomyAttribute/6090  : Power equipment hitch type
+gid://shopify/TaxonomyAttribute/12617 : Power output (typical)
 gid://shopify/TaxonomyAttribute/10821 : Power rack style
+gid://shopify/TaxonomyAttribute/12618 : Power rating
 gid://shopify/TaxonomyAttribute/1221  : Power source
 gid://shopify/TaxonomyAttribute/8600  : Power steering fluid formulation
 gid://shopify/TaxonomyAttribute/5554  : Power supply efficiency rating
@@ -5614,6 +6456,7 @@ gid://shopify/TaxonomyAttribute/6790  : Pregnancy stage suitability
 gid://shopify/TaxonomyAttribute/1580  : Pregnancy test sensitivity
 gid://shopify/TaxonomyAttribute/7891  : Preparation state
 gid://shopify/TaxonomyAttribute/7892  : Preparation style
+gid://shopify/TaxonomyAttribute/12619 : Preparation time
 gid://shopify/TaxonomyAttribute/6093  : Preparation type
 gid://shopify/TaxonomyAttribute/5306  : Prescription status
 gid://shopify/TaxonomyAttribute/3165  : Presentation supply features
@@ -5621,6 +6464,7 @@ gid://shopify/TaxonomyAttribute/7893  : Preservation medium
 gid://shopify/TaxonomyAttribute/6094  : Preservation method
 gid://shopify/TaxonomyAttribute/2621  : Preservation type
 gid://shopify/TaxonomyAttribute/10102 : Presser foot attachment method
+gid://shopify/TaxonomyAttribute/11948 : Presser foot lift height
 gid://shopify/TaxonomyAttribute/6309  : Pressure cooker handle type
 gid://shopify/TaxonomyAttribute/6095  : Pressure cooker safety features
 gid://shopify/TaxonomyAttribute/10822 : Pressure gauge type
@@ -5661,6 +6505,7 @@ gid://shopify/TaxonomyAttribute/6100  : Printed sides
 gid://shopify/TaxonomyAttribute/1947  : Printer accessories included
 gid://shopify/TaxonomyAttribute/5382  : Printer color capability
 gid://shopify/TaxonomyAttribute/5364  : Printer connection interface
+gid://shopify/TaxonomyAttribute/12620 : Printer filament size
 gid://shopify/TaxonomyAttribute/5383  : Printer form factor
 gid://shopify/TaxonomyAttribute/1952  : Printer functions
 gid://shopify/TaxonomyAttribute/3091  : Printer/Copier specialized features
@@ -5671,10 +6516,13 @@ gid://shopify/TaxonomyAttribute/8607  : Prisoner transport configuration
 gid://shopify/TaxonomyAttribute/8608  : Prisoner transport partition type
 gid://shopify/TaxonomyAttribute/5564  : Privacy filtering direction
 gid://shopify/TaxonomyAttribute/6947  : Privacy or acoustic feature
+gid://shopify/TaxonomyAttribute/12621 : Probe diameter
+gid://shopify/TaxonomyAttribute/12622 : Probe length
 gid://shopify/TaxonomyAttribute/5687  : Procedure
 gid://shopify/TaxonomyAttribute/10107 : Processing state
 gid://shopify/TaxonomyAttribute/1901  : Processor cores
 gid://shopify/TaxonomyAttribute/1869  : Processor family
+gid://shopify/TaxonomyAttribute/12623 : Processor frequency
 gid://shopify/TaxonomyAttribute/1845  : Processor socket
 gid://shopify/TaxonomyAttribute/1817  : Processor technology
 gid://shopify/TaxonomyAttribute/7900  : Produce grade
@@ -5691,9 +6539,11 @@ gid://shopify/TaxonomyAttribute/1566  : Product sterility
 gid://shopify/TaxonomyAttribute/5684  : Product use
 gid://shopify/TaxonomyAttribute/10108 : Profile/shape
 gid://shopify/TaxonomyAttribute/2515  : Program format
+gid://shopify/TaxonomyAttribute/11951 : Projectile caliber
 gid://shopify/TaxonomyAttribute/10824 : Projectile finish
 gid://shopify/TaxonomyAttribute/10825 : Projectile type
 gid://shopify/TaxonomyAttribute/6497  : Projectile/ammunition type
+gid://shopify/TaxonomyAttribute/11953 : Projection coverage area
 gid://shopify/TaxonomyAttribute/2051  : Projection design
 gid://shopify/TaxonomyAttribute/2907  : Projector light source
 gid://shopify/TaxonomyAttribute/6791  : Pronation support
@@ -5710,6 +6560,7 @@ gid://shopify/TaxonomyAttribute/5331  : Protected component
 gid://shopify/TaxonomyAttribute/6101  : Protected item type
 gid://shopify/TaxonomyAttribute/6792  : Protection coverage area
 gid://shopify/TaxonomyAttribute/10109 : Protection level
+gid://shopify/TaxonomyAttribute/12625 : Protection time
 gid://shopify/TaxonomyAttribute/2635  : Protection type
 gid://shopify/TaxonomyAttribute/8613  : Protective case interior protection type
 gid://shopify/TaxonomyAttribute/8614  : Protective case shell type
@@ -5729,6 +6580,8 @@ gid://shopify/TaxonomyAttribute/8617  : Protective shorts padding type
 gid://shopify/TaxonomyAttribute/8618  : Protective shorts padding zones
 gid://shopify/TaxonomyAttribute/10832 : Protective treatment
 gid://shopify/TaxonomyAttribute/8619  : Protector coverage area
+gid://shopify/TaxonomyAttribute/11955 : Protein per 100 g
+gid://shopify/TaxonomyAttribute/11956 : Protein per serving
 gid://shopify/TaxonomyAttribute/5136  : Protein processing type
 gid://shopify/TaxonomyAttribute/5135  : Protein source
 gid://shopify/TaxonomyAttribute/2541  : Publication frequency
@@ -5753,9 +6606,12 @@ gid://shopify/TaxonomyAttribute/10838 : Punching/training bag shape
 gid://shopify/TaxonomyAttribute/10839 : Puncture protection technology
 gid://shopify/TaxonomyAttribute/6499  : Puppet & puppet theater accessory type
 gid://shopify/TaxonomyAttribute/6498  : Puppet features
+gid://shopify/TaxonomyAttribute/12626 : Puppet size
 gid://shopify/TaxonomyAttribute/2772  : Puppet theme
 gid://shopify/TaxonomyAttribute/2773  : Puppet type
+gid://shopify/TaxonomyAttribute/11958 : Purification contact time
 gid://shopify/TaxonomyAttribute/10112 : Purity unit
+gid://shopify/TaxonomyAttribute/12627 : Push button size
 gid://shopify/TaxonomyAttribute/5340  : Push button terminal type
 gid://shopify/TaxonomyAttribute/10840 : Push-up bar design
 gid://shopify/TaxonomyAttribute/8620  : Pushrod end type
@@ -5767,6 +6623,7 @@ gid://shopify/TaxonomyAttribute/6504  : Puzzle accessory features
 gid://shopify/TaxonomyAttribute/2769  : Puzzle theme
 gid://shopify/TaxonomyAttribute/3396  : Puzzle type
 gid://shopify/TaxonomyAttribute/10113 : Pyrometric cone range
+gid://shopify/TaxonomyAttribute/11959 : Q factor
 gid://shopify/TaxonomyAttribute/8621  : Quarter panel coverage type
 gid://shopify/TaxonomyAttribute/8622  : Quarter panel set contents
 gid://shopify/TaxonomyAttribute/6106  : Quilt construction type
@@ -5775,11 +6632,13 @@ gid://shopify/TaxonomyAttribute/10115 : Quilting ruler non-slip feature
 gid://shopify/TaxonomyAttribute/10116 : Quilting ruler transparency
 gid://shopify/TaxonomyAttribute/10117 : Quilting thread usage
 gid://shopify/TaxonomyAttribute/10118 : Quilting thread weight system
+gid://shopify/TaxonomyAttribute/11962 : Quilting width capacity
 gid://shopify/TaxonomyAttribute/7904  : Quince variety
 gid://shopify/TaxonomyAttribute/7905  : Quinoa variety
 gid://shopify/TaxonomyAttribute/10119 : Quinto tuning system
 gid://shopify/TaxonomyAttribute/1307  : Quiver style
 gid://shopify/TaxonomyAttribute/5658  : RAID levels supported
+gid://shopify/TaxonomyAttribute/12631 : RAM memory
 gid://shopify/TaxonomyAttribute/6506  : RC airship lifting gas type
 gid://shopify/TaxonomyAttribute/6507  : RC helicopter control frequency
 gid://shopify/TaxonomyAttribute/6508  : RC helicopter stabilization features
@@ -5790,6 +6649,7 @@ gid://shopify/TaxonomyAttribute/6512  : RC vehicle scale
 gid://shopify/TaxonomyAttribute/6513  : RC vehicle terrain type
 gid://shopify/TaxonomyAttribute/5552  : RF output standard
 gid://shopify/TaxonomyAttribute/1337  : RFID frequency
+gid://shopify/TaxonomyAttribute/12639 : RMS rated power
 gid://shopify/TaxonomyAttribute/8623  : Race car class
 gid://shopify/TaxonomyAttribute/8624  : Racing balaclava face opening style
 gid://shopify/TaxonomyAttribute/8625  : Racing balaclava neck coverage length
@@ -5813,25 +6673,32 @@ gid://shopify/TaxonomyAttribute/5444  : Rack format
 gid://shopify/TaxonomyAttribute/5423  : Rack mounting style
 gid://shopify/TaxonomyAttribute/10841 : Rack side configuration
 gid://shopify/TaxonomyAttribute/10120 : Rack system configuration
+gid://shopify/TaxonomyAttribute/11964 : Rack tom diameters
 gid://shopify/TaxonomyAttribute/2722  : Rack type
 gid://shopify/TaxonomyAttribute/5669  : Rack width standard
 gid://shopify/TaxonomyAttribute/3426  : Racket balance
+gid://shopify/TaxonomyAttribute/11965 : Racket balance point
 gid://shopify/TaxonomyAttribute/10842 : Racket dampener type
 gid://shopify/TaxonomyAttribute/1227  : Racket gauge
 gid://shopify/TaxonomyAttribute/10843 : Racket grip size
 gid://shopify/TaxonomyAttribute/3427  : Racket head shape
+gid://shopify/TaxonomyAttribute/12628 : Racket head size
+gid://shopify/TaxonomyAttribute/12629 : Racket length
 gid://shopify/TaxonomyAttribute/2854  : Racket material
 gid://shopify/TaxonomyAttribute/10844 : Racket sport shoe court surface
 gid://shopify/TaxonomyAttribute/2856  : Racket string design
+gid://shopify/TaxonomyAttribute/12630 : Racket string gauge
 gid://shopify/TaxonomyAttribute/2857  : Racket string material
 gid://shopify/TaxonomyAttribute/10845 : Racket string pattern
 gid://shopify/TaxonomyAttribute/10846 : Racket stringing status
 gid://shopify/TaxonomyAttribute/10847 : Racket weight class
 gid://shopify/TaxonomyAttribute/6505  : Racquet toy set equipment included
 gid://shopify/TaxonomyAttribute/10848 : Racquetball & squash training aid type
+gid://shopify/TaxonomyAttribute/11966 : Racquetball grip size
 gid://shopify/TaxonomyAttribute/1954  : Radar bands
 gid://shopify/TaxonomyAttribute/3316  : Radar technology
 gid://shopify/TaxonomyAttribute/8641  : Radiator cap gasket material
+gid://shopify/TaxonomyAttribute/11967 : Radiator cap neck depth
 gid://shopify/TaxonomyAttribute/8642  : Radiator cap pressure-relief style
 gid://shopify/TaxonomyAttribute/6107  : Radiator design type
 gid://shopify/TaxonomyAttribute/8644  : Radiator fan control type
@@ -5840,6 +6707,7 @@ gid://shopify/TaxonomyAttribute/8646  : Radiator fan type
 gid://shopify/TaxonomyAttribute/8647  : Radiator hose end type
 gid://shopify/TaxonomyAttribute/8648  : Radiator hose position
 gid://shopify/TaxonomyAttribute/8649  : Radiator hose shape
+gid://shopify/TaxonomyAttribute/11968 : Radiator overflow tank hose port diameter
 gid://shopify/TaxonomyAttribute/8650  : Radiator overflow tank level sensor provision
 gid://shopify/TaxonomyAttribute/8651  : Radiator overflow tank shape
 gid://shopify/TaxonomyAttribute/8643  : Radiator/expansion tank cap application
@@ -5848,6 +6716,7 @@ gid://shopify/TaxonomyAttribute/5510  : Radio form factor
 gid://shopify/TaxonomyAttribute/5512  : Radio scanner form factor
 gid://shopify/TaxonomyAttribute/5095  : Radiology compatibility
 gid://shopify/TaxonomyAttribute/7906  : Radish variety
+gid://shopify/TaxonomyAttribute/11969 : Radius of gyration
 gid://shopify/TaxonomyAttribute/10849 : Radius of hollow
 gid://shopify/TaxonomyAttribute/6948  : Rail coverage configuration
 gid://shopify/TaxonomyAttribute/10850 : Rail mount standard
@@ -5863,6 +6732,7 @@ gid://shopify/TaxonomyAttribute/10122 : Rainstick fill material
 gid://shopify/TaxonomyAttribute/10123 : Rainstick playing technique
 gid://shopify/TaxonomyAttribute/10124 : Rainstick sound character
 gid://shopify/TaxonomyAttribute/7907  : Raising method
+gid://shopify/TaxonomyAttribute/11970 : Rake head width
 gid://shopify/TaxonomyAttribute/8653  : Rally competition class
 gid://shopify/TaxonomyAttribute/8654  : Rally surface setup
 gid://shopify/TaxonomyAttribute/10854 : Ramp surface texture
@@ -5872,12 +6742,15 @@ gid://shopify/TaxonomyAttribute/6111  : Range installation type
 gid://shopify/TaxonomyAttribute/1731  : Range type
 gid://shopify/TaxonomyAttribute/2368  : Rarity
 gid://shopify/TaxonomyAttribute/10125 : Ratchet mounting style
+gid://shopify/TaxonomyAttribute/12633 : Rated capacity (weight)
 gid://shopify/TaxonomyAttribute/10126 : Rattle element material
 gid://shopify/TaxonomyAttribute/10855 : Rattle type
 gid://shopify/TaxonomyAttribute/1679  : Razor flexibility
 gid://shopify/TaxonomyAttribute/1680  : Razor head design
 gid://shopify/TaxonomyAttribute/1686  : Razor type
+gid://shopify/TaxonomyAttribute/11972 : Reach
 gid://shopify/TaxonomyAttribute/10856 : Reach adjustment type
+gid://shopify/TaxonomyAttribute/12634 : Reaction time
 gid://shopify/TaxonomyAttribute/1918  : Read/Write speed
 gid://shopify/TaxonomyAttribute/3401  : Reading toy type
 gid://shopify/TaxonomyAttribute/10857 : Rear axle spacing
@@ -5886,11 +6759,13 @@ gid://shopify/TaxonomyAttribute/10859 : Rear axle type
 gid://shopify/TaxonomyAttribute/6796  : Rear coverage
 gid://shopify/TaxonomyAttribute/6797  : Rear opening type
 gid://shopify/TaxonomyAttribute/8655  : Rear seat configuration
+gid://shopify/TaxonomyAttribute/11973 : Rear suspension travel
 gid://shopify/TaxonomyAttribute/8656  : Rear view mirror ornament attachment type
 gid://shopify/TaxonomyAttribute/8657  : Rearview mirror mount attachment type
 gid://shopify/TaxonomyAttribute/10860 : Rebound board face type
 gid://shopify/TaxonomyAttribute/10861 : Rebound level
 gid://shopify/TaxonomyAttribute/10862 : Rebound surface configuration
+gid://shopify/TaxonomyAttribute/11974 : Rebound surface dimensions
 gid://shopify/TaxonomyAttribute/10863 : Rebounder design
 gid://shopify/TaxonomyAttribute/10864 : Rebounder design type
 gid://shopify/TaxonomyAttribute/10865 : Rebounder sides
@@ -5903,21 +6778,25 @@ gid://shopify/TaxonomyAttribute/1658  : Reclining function
 gid://shopify/TaxonomyAttribute/6951  : Reclining mechanism
 gid://shopify/TaxonomyAttribute/2758  : Recommended age group
 gid://shopify/TaxonomyAttribute/10128 : Recommended candle format
+gid://shopify/TaxonomyAttribute/11975 : Recommended child weight range
 gid://shopify/TaxonomyAttribute/10129 : Recommended container type
 gid://shopify/TaxonomyAttribute/10130 : Recommended fabric type
 gid://shopify/TaxonomyAttribute/10131 : Recommended fabric weight
 gid://shopify/TaxonomyAttribute/7908  : Recommended food pairing
+gid://shopify/TaxonomyAttribute/11976 : Recommended hoop size
 gid://shopify/TaxonomyAttribute/10867 : Recommended lane condition
 gid://shopify/TaxonomyAttribute/10132 : Recommended motor impulse class
 gid://shopify/TaxonomyAttribute/6514  : Recommended reading level
 gid://shopify/TaxonomyAttribute/1218  : Recommended skill level
 gid://shopify/TaxonomyAttribute/6952  : Recommended sleep position
+gid://shopify/TaxonomyAttribute/11978 : Recommended speed range
 gid://shopify/TaxonomyAttribute/7909  : Recommended storage
 gid://shopify/TaxonomyAttribute/10133 : Recommended surfaces
 gid://shopify/TaxonomyAttribute/2082  : Recommended use
 gid://shopify/TaxonomyAttribute/8658  : Recommended use case
 gid://shopify/TaxonomyAttribute/6515  : Recommended use location
 gid://shopify/TaxonomyAttribute/8659  : Recommended vehicle surfaces
+gid://shopify/TaxonomyAttribute/11980 : Recommended water temperature
 gid://shopify/TaxonomyAttribute/5434  : Record cleaning components included
 gid://shopify/TaxonomyAttribute/10134 : Recorder accessories included
 gid://shopify/TaxonomyAttribute/10135 : Recorder bore design
@@ -5932,6 +6811,7 @@ gid://shopify/TaxonomyAttribute/10142 : Recorder keywork
 gid://shopify/TaxonomyAttribute/10143 : Recorder mouthpiece type
 gid://shopify/TaxonomyAttribute/10144 : Recorder pitch standard (A4)
 gid://shopify/TaxonomyAttribute/10145 : Recorder thumb hole type
+gid://shopify/TaxonomyAttribute/11981 : Recorder total weight
 gid://shopify/TaxonomyAttribute/6112  : Recorder type
 gid://shopify/TaxonomyAttribute/1821  : Recording accessories included
 gid://shopify/TaxonomyAttribute/5396  : Recording capability type
@@ -5942,6 +6822,7 @@ gid://shopify/TaxonomyAttribute/5416  : Recording speed modes supported
 gid://shopify/TaxonomyAttribute/8660  : Recreational vehicle holding tank type
 gid://shopify/TaxonomyAttribute/8661  : Recreational vehicle leveling system
 gid://shopify/TaxonomyAttribute/2752  : Recreational vehicle type
+gid://shopify/TaxonomyAttribute/11982 : Recycle time
 gid://shopify/TaxonomyAttribute/6798  : Recycled material content
 gid://shopify/TaxonomyAttribute/10146 : Reed dent material
 gid://shopify/TaxonomyAttribute/2450  : Reed strength
@@ -5949,6 +6830,7 @@ gid://shopify/TaxonomyAttribute/10147 : Reed type
 gid://shopify/TaxonomyAttribute/10148 : Reeds included
 gid://shopify/TaxonomyAttribute/10868 : Reefing method
 gid://shopify/TaxonomyAttribute/2039  : Reel capacity
+gid://shopify/TaxonomyAttribute/11984 : Reel knob diameter
 gid://shopify/TaxonomyAttribute/10869 : Reel profile
 gid://shopify/TaxonomyAttribute/10870 : Reel seat material
 gid://shopify/TaxonomyAttribute/10871 : Reel seat type
@@ -5965,6 +6847,7 @@ gid://shopify/TaxonomyAttribute/1467  : Region
 gid://shopify/TaxonomyAttribute/2676  : Region code
 gid://shopify/TaxonomyAttribute/10874 : Regulation standard
 gid://shopify/TaxonomyAttribute/8663  : Regulator diaphragm material
+gid://shopify/TaxonomyAttribute/11986 : Regulator output pressure
 gid://shopify/TaxonomyAttribute/8664  : Regulator port thread standard
 gid://shopify/TaxonomyAttribute/10875 : Rein features
 gid://shopify/TaxonomyAttribute/10876 : Rein style
@@ -5997,6 +6880,7 @@ gid://shopify/TaxonomyAttribute/5281  : Removal target
 gid://shopify/TaxonomyAttribute/8668  : Repair compound type
 gid://shopify/TaxonomyAttribute/10880 : Repair kit components
 gid://shopify/TaxonomyAttribute/10881 : Repair method
+gid://shopify/TaxonomyAttribute/11987 : Repair patch size
 gid://shopify/TaxonomyAttribute/6116  : Repellent mechanism
 gid://shopify/TaxonomyAttribute/6117  : Replaceable brush head
 gid://shopify/TaxonomyAttribute/5408  : Replacement lamp type
@@ -6008,8 +6892,11 @@ gid://shopify/TaxonomyAttribute/10151 : Replica gun firing mechanism
 gid://shopify/TaxonomyAttribute/10152 : Replica gun moving parts
 gid://shopify/TaxonomyAttribute/3239  : Reptile/Amphibian food form
 gid://shopify/TaxonomyAttribute/3240  : Reptile/Amphibian habitat supply type
+gid://shopify/TaxonomyAttribute/11988 : Required safety clearance
+gid://shopify/TaxonomyAttribute/11989 : Required yardage
 gid://shopify/TaxonomyAttribute/2531  : Research focus
 gid://shopify/TaxonomyAttribute/2532  : Research methodology
+gid://shopify/TaxonomyAttribute/11990 : Reserve capacity (RC)
 gid://shopify/TaxonomyAttribute/10883 : Reservoir orientation
 gid://shopify/TaxonomyAttribute/8671  : Reservoir type
 gid://shopify/TaxonomyAttribute/10884 : Resin suitability
@@ -6019,7 +6906,9 @@ gid://shopify/TaxonomyAttribute/1230  : Resistance level
 gid://shopify/TaxonomyAttribute/10887 : Resistance loading type
 gid://shopify/TaxonomyAttribute/1229  : Resistance system
 gid://shopify/TaxonomyAttribute/5494  : Resistance tolerance
+gid://shopify/TaxonomyAttribute/12635 : Resistance value
 gid://shopify/TaxonomyAttribute/10153 : Response fields included
+gid://shopify/TaxonomyAttribute/12636 : Response time
 gid://shopify/TaxonomyAttribute/8672  : Restoration status
 gid://shopify/TaxonomyAttribute/5337  : Restrictor gate shape
 gid://shopify/TaxonomyAttribute/1581  : Result display
@@ -6034,6 +6923,7 @@ gid://shopify/TaxonomyAttribute/10157 : Rhinestone setting type
 gid://shopify/TaxonomyAttribute/7911  : Rhubarb product cut type
 gid://shopify/TaxonomyAttribute/6118  : Rib material
 gid://shopify/TaxonomyAttribute/10158 : Ribbon construction
+gid://shopify/TaxonomyAttribute/12637 : Ribbon length
 gid://shopify/TaxonomyAttribute/10159 : Ribbon packaging type
 gid://shopify/TaxonomyAttribute/10160 : Ribbon pattern style
 gid://shopify/TaxonomyAttribute/10161 : Ribbon sheen level
@@ -6049,17 +6939,23 @@ gid://shopify/TaxonomyAttribute/1318  : Riding style
 gid://shopify/TaxonomyAttribute/6526  : Riding toy features
 gid://shopify/TaxonomyAttribute/2775  : Riding toy propulsion type
 gid://shopify/TaxonomyAttribute/10166 : Rifle action type
+gid://shopify/TaxonomyAttribute/11991 : Rifle barrel length
 gid://shopify/TaxonomyAttribute/10167 : Rifle finish
 gid://shopify/TaxonomyAttribute/10168 : Rifle magazine type
 gid://shopify/TaxonomyAttribute/10169 : Rifle stock material
 gid://shopify/TaxonomyAttribute/8673  : Rim clamping method
+gid://shopify/TaxonomyAttribute/11992 : Rim depth
+gid://shopify/TaxonomyAttribute/11993 : Rim diameter
+gid://shopify/TaxonomyAttribute/11994 : Rim internal width
 gid://shopify/TaxonomyAttribute/10888 : Rim strip type
 gid://shopify/TaxonomyAttribute/10889 : Rim tubeless compatibility
 gid://shopify/TaxonomyAttribute/2700  : Rim/Wheel design
 gid://shopify/TaxonomyAttribute/3263  : Ring design
+gid://shopify/TaxonomyAttribute/11995 : Ring lock wheel clearance width
 gid://shopify/TaxonomyAttribute/105   : Ring size
 gid://shopify/TaxonomyAttribute/5297  : Rinse requirement
 gid://shopify/TaxonomyAttribute/7915  : Ripeness stage
+gid://shopify/TaxonomyAttribute/12638 : Rise
 gid://shopify/TaxonomyAttribute/5627  : Rise height class
 gid://shopify/TaxonomyAttribute/10890 : Riser pad type
 gid://shopify/TaxonomyAttribute/2125  : Rivet form
@@ -6075,6 +6971,7 @@ gid://shopify/TaxonomyAttribute/6530  : Robotic toy skill level
 gid://shopify/TaxonomyAttribute/6531  : Robotic toy sound features
 gid://shopify/TaxonomyAttribute/2379  : Rock composition
 gid://shopify/TaxonomyAttribute/2380  : Rock formation
+gid://shopify/TaxonomyAttribute/11997 : Rocker height
 gid://shopify/TaxonomyAttribute/1257  : Rocker type
 gid://shopify/TaxonomyAttribute/6122  : Rockwool form
 gid://shopify/TaxonomyAttribute/10891 : Rod butt style
@@ -6082,9 +6979,16 @@ gid://shopify/TaxonomyAttribute/10892 : Rod construction type
 gid://shopify/TaxonomyAttribute/10893 : Rod guide material
 gid://shopify/TaxonomyAttribute/10894 : Rod guide type
 gid://shopify/TaxonomyAttribute/10895 : Rod handle type
+gid://shopify/TaxonomyAttribute/11998 : Rod journal diameter
 gid://shopify/TaxonomyAttribute/1296  : Rod material
 gid://shopify/TaxonomyAttribute/1329  : Rod shape
+gid://shopify/TaxonomyAttribute/12640 : Rod size
 gid://shopify/TaxonomyAttribute/8674  : Roll cage tubing material
+gid://shopify/TaxonomyAttribute/11999 : Roll cage tubing wall thickness
+gid://shopify/TaxonomyAttribute/12641 : Roll diameter
+gid://shopify/TaxonomyAttribute/12000 : Roll length per unit
+gid://shopify/TaxonomyAttribute/12642 : Roll size
+gid://shopify/TaxonomyAttribute/12643 : Roll width
 gid://shopify/TaxonomyAttribute/1610  : Roller head
 gid://shopify/TaxonomyAttribute/1611  : Roller material
 gid://shopify/TaxonomyAttribute/10896 : Roller skate brake shape
@@ -6106,12 +7010,15 @@ gid://shopify/TaxonomyAttribute/5438  : Room correction technology
 gid://shopify/TaxonomyAttribute/7919  : Root variety
 gid://shopify/TaxonomyAttribute/10901 : Rope buoyancy
 gid://shopify/TaxonomyAttribute/8677  : Rope construction
+gid://shopify/TaxonomyAttribute/12002 : Rope diameter
+gid://shopify/TaxonomyAttribute/12644 : Rope length
 gid://shopify/TaxonomyAttribute/10173 : Rope material
 gid://shopify/TaxonomyAttribute/10902 : Rope strand compatibility
 gid://shopify/TaxonomyAttribute/10903 : Rope stretch type
 gid://shopify/TaxonomyAttribute/6124  : Rose attachment
 gid://shopify/TaxonomyAttribute/10174 : Rose bloom stage
 gid://shopify/TaxonomyAttribute/10175 : Rose grade
+gid://shopify/TaxonomyAttribute/12004 : Rose head diameter
 gid://shopify/TaxonomyAttribute/10176 : Rosette center type
 gid://shopify/TaxonomyAttribute/10177 : Rosin dust level
 gid://shopify/TaxonomyAttribute/2447  : Rosin form
@@ -6122,15 +7029,19 @@ gid://shopify/TaxonomyAttribute/2183  : Rotating direction
 gid://shopify/TaxonomyAttribute/5254  : Rotation direction
 gid://shopify/TaxonomyAttribute/10904 : Rotation mechanism type
 gid://shopify/TaxonomyAttribute/6532  : Rotation/motion features
+gid://shopify/TaxonomyAttribute/12645 : Rotational speed
 gid://shopify/TaxonomyAttribute/1884  : Rotator control technology
 gid://shopify/TaxonomyAttribute/6533  : Rotor configuration type
 gid://shopify/TaxonomyAttribute/10905 : Rotor construction type
+gid://shopify/TaxonomyAttribute/12646 : Rotor diameter
 gid://shopify/TaxonomyAttribute/10906 : Rotor mounting interface
 gid://shopify/TaxonomyAttribute/10907 : Rotor mounting standard
+gid://shopify/TaxonomyAttribute/12647 : Rotor weight
 gid://shopify/TaxonomyAttribute/6534  : Roulette set components included
 gid://shopify/TaxonomyAttribute/6535  : Roulette wheel ball track type
 gid://shopify/TaxonomyAttribute/6536  : Roulette wheel numbering system
 gid://shopify/TaxonomyAttribute/10908 : Rounders equipment included
+gid://shopify/TaxonomyAttribute/12005 : Rounders glove size
 gid://shopify/TaxonomyAttribute/10909 : Rounders governing body approval
 gid://shopify/TaxonomyAttribute/5124  : Route of administration
 gid://shopify/TaxonomyAttribute/10180 : Row counter format
@@ -6138,6 +7049,7 @@ gid://shopify/TaxonomyAttribute/10181 : Row counter mechanism
 gid://shopify/TaxonomyAttribute/10182 : Row counter mounting method
 gid://shopify/TaxonomyAttribute/6801  : Rowel type
 gid://shopify/TaxonomyAttribute/10910 : Rowing machine part type
+gid://shopify/TaxonomyAttribute/12648 : Rubber band size
 gid://shopify/TaxonomyAttribute/6537  : Rubber ducky character/theme
 gid://shopify/TaxonomyAttribute/6538  : Rubber ducky features
 gid://shopify/TaxonomyAttribute/6539  : Rubber ducky size class
@@ -6150,8 +7062,12 @@ gid://shopify/TaxonomyAttribute/10913 : Rugby variant
 gid://shopify/TaxonomyAttribute/10184 : Ruler edge type
 gid://shopify/TaxonomyAttribute/10185 : Ruler marking style
 gid://shopify/TaxonomyAttribute/1465  : Rum grade
+gid://shopify/TaxonomyAttribute/12006 : Rung spacing
 gid://shopify/TaxonomyAttribute/10914 : Runner configuration
 gid://shopify/TaxonomyAttribute/10915 : Runner material
+gid://shopify/TaxonomyAttribute/12007 : Running surface length
+gid://shopify/TaxonomyAttribute/12008 : Running surface width
+gid://shopify/TaxonomyAttribute/12649 : Running time
 gid://shopify/TaxonomyAttribute/2523  : SFX control technology
 gid://shopify/TaxonomyAttribute/1861  : SIM card capability
 gid://shopify/TaxonomyAttribute/1855  : SIM card type
@@ -6165,6 +7081,8 @@ gid://shopify/TaxonomyAttribute/10920 : Saddle pad shape
 gid://shopify/TaxonomyAttribute/10921 : Saddle pad style
 gid://shopify/TaxonomyAttribute/10922 : Saddle padding material
 gid://shopify/TaxonomyAttribute/10923 : Saddle rail material
+gid://shopify/TaxonomyAttribute/12009 : Saddle rail size
+gid://shopify/TaxonomyAttribute/12010 : Saddle seat size
 gid://shopify/TaxonomyAttribute/10924 : Saddle tree material
 gid://shopify/TaxonomyAttribute/10925 : Saddle tree width
 gid://shopify/TaxonomyAttribute/1716  : Safety certifications
@@ -6185,6 +7103,7 @@ gid://shopify/TaxonomyAttribute/7920  : Salad dressing type
 gid://shopify/TaxonomyAttribute/6126  : Salad spinner mechanism
 gid://shopify/TaxonomyAttribute/7921  : Salad topping base ingredient
 gid://shopify/TaxonomyAttribute/7922  : Salt level
+gid://shopify/TaxonomyAttribute/12650 : Sampling rate
 gid://shopify/TaxonomyAttribute/6545  : Sand & water mill items included
 gid://shopify/TaxonomyAttribute/6127  : Sand color
 gid://shopify/TaxonomyAttribute/6542  : Sand cup features
@@ -6193,6 +7112,7 @@ gid://shopify/TaxonomyAttribute/6544  : Sand toy set pieces included
 gid://shopify/TaxonomyAttribute/6310  : Sand type
 gid://shopify/TaxonomyAttribute/3264  : Sandal style
 gid://shopify/TaxonomyAttribute/10929 : Sandbag style
+gid://shopify/TaxonomyAttribute/12651 : Sandbag weight
 gid://shopify/TaxonomyAttribute/2181  : Sandblaster application
 gid://shopify/TaxonomyAttribute/6546  : Sandbox bottom type
 gid://shopify/TaxonomyAttribute/6547  : Sandbox drainage type
@@ -6201,11 +7121,13 @@ gid://shopify/TaxonomyAttribute/2182  : Sander type
 gid://shopify/TaxonomyAttribute/2187  : Sanding application
 gid://shopify/TaxonomyAttribute/7923  : Sapodillo variety
 gid://shopify/TaxonomyAttribute/7924  : Sapote variety
+gid://shopify/TaxonomyAttribute/12013 : Saree length
 gid://shopify/TaxonomyAttribute/1865  : Satellite coverage area
 gid://shopify/TaxonomyAttribute/5508  : Satellite messaging capability
 gid://shopify/TaxonomyAttribute/5023  : Satellite navigation systems supported
 gid://shopify/TaxonomyAttribute/1866  : Satellite network type
 gid://shopify/TaxonomyAttribute/10188 : Satin ribbon face type
+gid://shopify/TaxonomyAttribute/12652 : Saturation current
 gid://shopify/TaxonomyAttribute/7925  : Sauce consistency
 gid://shopify/TaxonomyAttribute/7926  : Sauce product form
 gid://shopify/TaxonomyAttribute/7927  : Sauce variety
@@ -6213,6 +7135,7 @@ gid://shopify/TaxonomyAttribute/6128  : Saucer functionality
 gid://shopify/TaxonomyAttribute/3363  : Sauna accessories included
 gid://shopify/TaxonomyAttribute/6129  : Sauna form factor
 gid://shopify/TaxonomyAttribute/6130  : Sauna heater type
+gid://shopify/TaxonomyAttribute/12653 : Saw size
 gid://shopify/TaxonomyAttribute/10189 : Saxophone body finish
 gid://shopify/TaxonomyAttribute/10190 : Saxophone body type
 gid://shopify/TaxonomyAttribute/10191 : Saxophone construction style
@@ -6220,6 +7143,7 @@ gid://shopify/TaxonomyAttribute/10192 : Saxophone included accessories
 gid://shopify/TaxonomyAttribute/10193 : Saxophone key system
 gid://shopify/TaxonomyAttribute/10194 : Saxophone key touch material
 gid://shopify/TaxonomyAttribute/10195 : Saxophone mouthpiece baffle type
+gid://shopify/TaxonomyAttribute/12014 : Saxophone neck bore diameter
 gid://shopify/TaxonomyAttribute/10196 : Saxophone neck type
 gid://shopify/TaxonomyAttribute/10197 : Saxophone package contents
 gid://shopify/TaxonomyAttribute/10198 : Saxophone reed cut
@@ -6227,8 +7151,10 @@ gid://shopify/TaxonomyAttribute/10199 : Saxophone reed material type
 gid://shopify/TaxonomyAttribute/10200 : Saxophone reed strength scale
 gid://shopify/TaxonomyAttribute/10201 : Saxophone small part thread size
 gid://shopify/TaxonomyAttribute/10202 : Saxophone swab application area
+gid://shopify/TaxonomyAttribute/12016 : Saxophone swab length
 gid://shopify/TaxonomyAttribute/10203 : Scabbard material
 gid://shopify/TaxonomyAttribute/2195  : Scaffolding mounting type
+gid://shopify/TaxonomyAttribute/12017 : Scale length
 gid://shopify/TaxonomyAttribute/2381  : Scale model accessory type
 gid://shopify/TaxonomyAttribute/10204 : Scale model assembly status
 gid://shopify/TaxonomyAttribute/10205 : Scale model car features
@@ -6251,6 +7177,7 @@ gid://shopify/TaxonomyAttribute/3092  : Scanner features
 gid://shopify/TaxonomyAttribute/5384  : Scanner grip compatibility
 gid://shopify/TaxonomyAttribute/5385  : Scanner maintenance kit type
 gid://shopify/TaxonomyAttribute/1904  : Scanner sensor type
+gid://shopify/TaxonomyAttribute/12018 : Scarf length (end-to-end)
 gid://shopify/TaxonomyAttribute/3256  : Scarf/Shawl style
 gid://shopify/TaxonomyAttribute/2024  : Scene modes
 gid://shopify/TaxonomyAttribute/10930 : Scent function
@@ -6270,6 +7197,7 @@ gid://shopify/TaxonomyAttribute/3305  : Scope lens type
 gid://shopify/TaxonomyAttribute/2037  : Scope/Sight design
 gid://shopify/TaxonomyAttribute/3063  : Scope/Sight features
 gid://shopify/TaxonomyAttribute/3170  : Scoreboard features
+gid://shopify/TaxonomyAttribute/12019 : Scoring groove spacing
 gid://shopify/TaxonomyAttribute/10933 : Scoring method
 gid://shopify/TaxonomyAttribute/10934 : Scoring pattern
 gid://shopify/TaxonomyAttribute/10935 : Scoring system type
@@ -6287,12 +7215,17 @@ gid://shopify/TaxonomyAttribute/5524  : Screen protector adhesion type
 gid://shopify/TaxonomyAttribute/5566  : Screen protector coverage style
 gid://shopify/TaxonomyAttribute/5565  : Screen protector features
 gid://shopify/TaxonomyAttribute/5419  : Screen protector finish
+gid://shopify/TaxonomyAttribute/12654 : Screen size
 gid://shopify/TaxonomyAttribute/5673  : Screen surface finish
+gid://shopify/TaxonomyAttribute/12655 : Screen width
 gid://shopify/TaxonomyAttribute/2003  : Screen/Display design
+gid://shopify/TaxonomyAttribute/12656 : Screw diameter
 gid://shopify/TaxonomyAttribute/10936 : Screw drive type
+gid://shopify/TaxonomyAttribute/12657 : Screw length
 gid://shopify/TaxonomyAttribute/10937 : Screw thread size
 gid://shopify/TaxonomyAttribute/6133  : Scrubber head type
 gid://shopify/TaxonomyAttribute/6134  : Scrubbing strength
+gid://shopify/TaxonomyAttribute/12020 : Sculpting clay bake/cure temperature
 gid://shopify/TaxonomyAttribute/10220 : Sculpting clay base type
 gid://shopify/TaxonomyAttribute/7928  : Seafood cut
 gid://shopify/TaxonomyAttribute/7929  : Seafood processing method
@@ -6303,6 +7236,7 @@ gid://shopify/TaxonomyAttribute/10938 : Seal material
 gid://shopify/TaxonomyAttribute/2384  : Seal stamp design
 gid://shopify/TaxonomyAttribute/8681  : Seal type
 gid://shopify/TaxonomyAttribute/10939 : Sealant formulation
+gid://shopify/TaxonomyAttribute/12022 : Sealant volume
 gid://shopify/TaxonomyAttribute/6136  : Sealing modes
 gid://shopify/TaxonomyAttribute/8682  : Seals leak type
 gid://shopify/TaxonomyAttribute/10940 : Seam construction
@@ -6325,11 +7259,15 @@ gid://shopify/TaxonomyAttribute/8689  : Seat belt cover placement
 gid://shopify/TaxonomyAttribute/8690  : Seat belt integration
 gid://shopify/TaxonomyAttribute/8691  : Seat belt provision
 gid://shopify/TaxonomyAttribute/8692  : Seat belt strap installation location
+gid://shopify/TaxonomyAttribute/12024 : Seat belt strap thickness
+gid://shopify/TaxonomyAttribute/12025 : Seat belt strap width
 gid://shopify/TaxonomyAttribute/8693  : Seat cover placement
 gid://shopify/TaxonomyAttribute/8694  : Seat cover securement method
 gid://shopify/TaxonomyAttribute/8695  : Seat cover set contents
 gid://shopify/TaxonomyAttribute/2405  : Seat cushioning
+gid://shopify/TaxonomyAttribute/12658 : Seat depth
 gid://shopify/TaxonomyAttribute/6953  : Seat fabric
+gid://shopify/TaxonomyAttribute/12659 : Seat height
 gid://shopify/TaxonomyAttribute/6954  : Seat height category
 gid://shopify/TaxonomyAttribute/6955  : Seat material
 gid://shopify/TaxonomyAttribute/8696  : Seat mounting type
@@ -6339,8 +7277,10 @@ gid://shopify/TaxonomyAttribute/2406  : Seat shape
 gid://shopify/TaxonomyAttribute/1537  : Seat structure
 gid://shopify/TaxonomyAttribute/5062  : Seat swivel mechanism
 gid://shopify/TaxonomyAttribute/1518  : Seat type
+gid://shopify/TaxonomyAttribute/12026 : Seat width
 gid://shopify/TaxonomyAttribute/6956  : Seating surface material
 gid://shopify/TaxonomyAttribute/10943 : Seatpost clamp mechanism
+gid://shopify/TaxonomyAttribute/12027 : Seatpost diameter
 gid://shopify/TaxonomyAttribute/6957  : Section orientation compatibility
 gid://shopify/TaxonomyAttribute/6958  : Sectional configuration
 gid://shopify/TaxonomyAttribute/6959  : Sectional shape
@@ -6348,6 +7288,7 @@ gid://shopify/TaxonomyAttribute/10944 : Secured components
 gid://shopify/TaxonomyAttribute/1939  : Security algorithms
 gid://shopify/TaxonomyAttribute/2139  : Security level
 gid://shopify/TaxonomyAttribute/6137  : Security sensor subtype
+gid://shopify/TaxonomyAttribute/12028 : See saw weight capacity per seat
 gid://shopify/TaxonomyAttribute/7932  : Seed content
 gid://shopify/TaxonomyAttribute/7933  : Seed size classification
 gid://shopify/TaxonomyAttribute/6138  : Seed treatment
@@ -6371,9 +7312,11 @@ gid://shopify/TaxonomyAttribute/5168  : Sensory effect
 gid://shopify/TaxonomyAttribute/6549  : Sensory modality
 gid://shopify/TaxonomyAttribute/6550  : Sensory toy fidget mechanism
 gid://shopify/TaxonomyAttribute/6551  : Sensory toy light features
+gid://shopify/TaxonomyAttribute/12029 : Sensory toy size
 gid://shopify/TaxonomyAttribute/6552  : Sensory toy texture type
 gid://shopify/TaxonomyAttribute/10229 : Sequin application method
 gid://shopify/TaxonomyAttribute/10230 : Sequin finish
+gid://shopify/TaxonomyAttribute/12030 : Sequin size
 gid://shopify/TaxonomyAttribute/2323  : Sequin/Glitter shape
 gid://shopify/TaxonomyAttribute/10231 : Serger stitch functions
 gid://shopify/TaxonomyAttribute/10232 : Serger thread count
@@ -6387,6 +7330,7 @@ gid://shopify/TaxonomyAttribute/7937  : Sesame seed variety
 gid://shopify/TaxonomyAttribute/10948 : Set classification
 gid://shopify/TaxonomyAttribute/10233 : Set components
 gid://shopify/TaxonomyAttribute/6804  : Set items included
+gid://shopify/TaxonomyAttribute/12661 : Set time
 gid://shopify/TaxonomyAttribute/10949 : Setup mechanism
 gid://shopify/TaxonomyAttribute/6553  : Setup type
 gid://shopify/TaxonomyAttribute/10234 : Sew-in interfacing elasticity
@@ -6408,17 +7352,24 @@ gid://shopify/TaxonomyAttribute/10247 : Sewing pattern notions required
 gid://shopify/TaxonomyAttribute/10248 : Sewing pattern recommended fabric
 gid://shopify/TaxonomyAttribute/10249 : Sewing pattern size range
 gid://shopify/TaxonomyAttribute/10250 : Sewing thread size system
+gid://shopify/TaxonomyAttribute/12033 : Shackle diameter
 gid://shopify/TaxonomyAttribute/10950 : Shaft curvature
+gid://shopify/TaxonomyAttribute/12662 : Shaft diameter
 gid://shopify/TaxonomyAttribute/1300  : Shaft flex
 gid://shopify/TaxonomyAttribute/10951 : Shaft kick point
+gid://shopify/TaxonomyAttribute/12663 : Shaft length
 gid://shopify/TaxonomyAttribute/10952 : Shaft length type
 gid://shopify/TaxonomyAttribute/2178  : Shaft orientation
 gid://shopify/TaxonomyAttribute/10953 : Shaft shape
+gid://shopify/TaxonomyAttribute/12664 : Shaft size
+gid://shopify/TaxonomyAttribute/12034 : Shaft tip diameter
 gid://shopify/TaxonomyAttribute/10251 : Shaker fill material
 gid://shopify/TaxonomyAttribute/6141  : Shaker set pieces included
 gid://shopify/TaxonomyAttribute/10252 : Shaker shell material
 gid://shopify/TaxonomyAttribute/7938  : Shallot variety
 gid://shopify/TaxonomyAttribute/1653  : Shampoo type
+gid://shopify/TaxonomyAttribute/12036 : Shank length
+gid://shopify/TaxonomyAttribute/12665 : Shank size
 gid://shopify/TaxonomyAttribute/10954 : Shank style
 gid://shopify/TaxonomyAttribute/73    : Shape
 gid://shopify/TaxonomyAttribute/6805  : Shapewear enhancement feature
@@ -6432,13 +7383,18 @@ gid://shopify/TaxonomyAttribute/5285  : Sheet mask material
 gid://shopify/TaxonomyAttribute/10254 : Sheet music clip padding material
 gid://shopify/TaxonomyAttribute/10255 : Sheet music clip spring tension level
 gid://shopify/TaxonomyAttribute/10256 : Sheet music clip use environment
+gid://shopify/TaxonomyAttribute/12037 : Sheet thickness
+gid://shopify/TaxonomyAttribute/12666 : Shelf life
 gid://shopify/TaxonomyAttribute/6143  : Shelf location in appliance
 gid://shopify/TaxonomyAttribute/2567  : Shelf material
 gid://shopify/TaxonomyAttribute/10257 : Shell construction
+gid://shopify/TaxonomyAttribute/12667 : Shell diameter
 gid://shopify/TaxonomyAttribute/10258 : Shell finish
+gid://shopify/TaxonomyAttribute/12668 : Shell width
 gid://shopify/TaxonomyAttribute/2890  : Shell/Frame material
 gid://shopify/TaxonomyAttribute/7939  : Shell/hull status
 gid://shopify/TaxonomyAttribute/8700  : Shift boot attachment method
+gid://shopify/TaxonomyAttribute/12038 : Shift boot inner opening diameter
 gid://shopify/TaxonomyAttribute/8701  : Shift boot installation hardware included
 gid://shopify/TaxonomyAttribute/8702  : Shift knob illumination
 gid://shopify/TaxonomyAttribute/8703  : Shift knob installation method
@@ -6450,12 +7406,14 @@ gid://shopify/TaxonomyAttribute/10957 : Shifting actuation type
 gid://shopify/TaxonomyAttribute/10958 : Shifting mechanism
 gid://shopify/TaxonomyAttribute/10959 : Shim purpose
 gid://shopify/TaxonomyAttribute/10960 : Shin guard attachment method
+gid://shopify/TaxonomyAttribute/12040 : Shin guard length
 gid://shopify/TaxonomyAttribute/2916  : Shingle/Tile material
 gid://shopify/TaxonomyAttribute/6806  : Shirt cuff style
 gid://shopify/TaxonomyAttribute/7941  : Shochu & soju variety
 gid://shopify/TaxonomyAttribute/7940  : Shochu base ingredient
 gid://shopify/TaxonomyAttribute/8706  : Shock absorber bushing material
 gid://shopify/TaxonomyAttribute/8707  : Shock absorber charge type
+gid://shopify/TaxonomyAttribute/12041 : Shock absorber compressed length
 gid://shopify/TaxonomyAttribute/8708  : Shock absorber mount type (lower)
 gid://shopify/TaxonomyAttribute/8709  : Shock absorber mount type (upper)
 gid://shopify/TaxonomyAttribute/8710  : Shock absorber position
@@ -6467,12 +7425,16 @@ gid://shopify/TaxonomyAttribute/10963 : Shoe cover height
 gid://shopify/TaxonomyAttribute/6145  : Shoe dryer technology
 gid://shopify/TaxonomyAttribute/3009  : Shoe features
 gid://shopify/TaxonomyAttribute/846   : Shoe fit
+gid://shopify/TaxonomyAttribute/12670 : Shoe height
+gid://shopify/TaxonomyAttribute/12671 : Shoe length
 gid://shopify/TaxonomyAttribute/6146  : Shoe organizer design
 gid://shopify/TaxonomyAttribute/6147  : Shoe polish form
 gid://shopify/TaxonomyAttribute/87    : Shoe size
 gid://shopify/TaxonomyAttribute/10964 : Shoe sizing system
 gid://shopify/TaxonomyAttribute/6148  : Shoe treatment purpose
 gid://shopify/TaxonomyAttribute/6149  : Shoe tree design
+gid://shopify/TaxonomyAttribute/12042 : Shoe weight
+gid://shopify/TaxonomyAttribute/12672 : Shoe width
 gid://shopify/TaxonomyAttribute/6807  : Shoelace aglet material
 gid://shopify/TaxonomyAttribute/2025  : Shooting modes
 gid://shopify/TaxonomyAttribute/10965 : Shooting rest design
@@ -6488,6 +7450,7 @@ gid://shopify/TaxonomyAttribute/10259 : Shotgun action type
 gid://shopify/TaxonomyAttribute/10260 : Shotgun choke type
 gid://shopify/TaxonomyAttribute/10261 : Shotgun gauge
 gid://shopify/TaxonomyAttribute/10262 : Shotgun stock material
+gid://shopify/TaxonomyAttribute/12673 : Shoulder width
 gid://shopify/TaxonomyAttribute/6150  : Shovel handle grip type
 gid://shopify/TaxonomyAttribute/6151  : Shovel head type
 gid://shopify/TaxonomyAttribute/2147  : Shower base design
@@ -6509,15 +7472,20 @@ gid://shopify/TaxonomyAttribute/10975 : Shuttlecock speed rating
 gid://shopify/TaxonomyAttribute/8714  : Side panel installation state
 gid://shopify/TaxonomyAttribute/5671  : Side panel style
 gid://shopify/TaxonomyAttribute/6960  : Side wall mechanism
+gid://shopify/TaxonomyAttribute/12043 : Sidecut radius
 gid://shopify/TaxonomyAttribute/2917  : Siding material
+gid://shopify/TaxonomyAttribute/12044 : Sieve opening size
 gid://shopify/TaxonomyAttribute/5445  : Signal path technology
+gid://shopify/TaxonomyAttribute/12674 : Signal range
 gid://shopify/TaxonomyAttribute/8715  : Signal source
 gid://shopify/TaxonomyAttribute/5585  : Signal technology
 gid://shopify/TaxonomyAttribute/5563  : Signal types blocked
+gid://shopify/TaxonomyAttribute/12675 : Signal-to-noise ratio (SNR)
 gid://shopify/TaxonomyAttribute/2363  : Signature placement
 gid://shopify/TaxonomyAttribute/6154  : Signature presence
 gid://shopify/TaxonomyAttribute/2004  : Silencer/Blimp type
 gid://shopify/TaxonomyAttribute/10263 : Silk fiber type
+gid://shopify/TaxonomyAttribute/12045 : Silk weight (momme)
 gid://shopify/TaxonomyAttribute/10976 : Simulated game species
 gid://shopify/TaxonomyAttribute/10977 : Singlet cut style
 gid://shopify/TaxonomyAttribute/6155  : Sink caddy features
@@ -6536,21 +7504,26 @@ gid://shopify/TaxonomyAttribute/10264 : Size designation
 gid://shopify/TaxonomyAttribute/10265 : Size system
 gid://shopify/TaxonomyAttribute/10266 : Sizzle mechanism
 gid://shopify/TaxonomyAttribute/10981 : Skate blade discipline
+gid://shopify/TaxonomyAttribute/12046 : Skate blade hollow radius
 gid://shopify/TaxonomyAttribute/10982 : Skate brake type
 gid://shopify/TaxonomyAttribute/5634  : Skate shape
 gid://shopify/TaxonomyAttribute/10983 : Skateboard nut thread size
 gid://shopify/TaxonomyAttribute/1313  : Skateboarding style
 gid://shopify/TaxonomyAttribute/10267 : Skein winder bearing/bushing type
 gid://shopify/TaxonomyAttribute/10268 : Skein winder drive type
+gid://shopify/TaxonomyAttribute/12047 : Skein winder maximum skein circumference
 gid://shopify/TaxonomyAttribute/6157  : Skewer tip type
 gid://shopify/TaxonomyAttribute/10984 : Ski binding mechanism
 gid://shopify/TaxonomyAttribute/10985 : Ski binding part type
 gid://shopify/TaxonomyAttribute/10986 : Ski boot sole standard
 gid://shopify/TaxonomyAttribute/2868  : Ski construction
+gid://shopify/TaxonomyAttribute/12676 : Ski size
+gid://shopify/TaxonomyAttribute/12048 : Ski waist width
 gid://shopify/TaxonomyAttribute/1317  : Skiing style
 gid://shopify/TaxonomyAttribute/10987 : Skill focus
 gid://shopify/TaxonomyAttribute/2358  : Skill level
 gid://shopify/TaxonomyAttribute/10988 : Skimboard construction
+gid://shopify/TaxonomyAttribute/12677 : Skimboard size
 gid://shopify/TaxonomyAttribute/1617  : Skin care effect
 gid://shopify/TaxonomyAttribute/2991  : Skin care features
 gid://shopify/TaxonomyAttribute/3343  : Skin care mask type
@@ -6558,11 +7531,13 @@ gid://shopify/TaxonomyAttribute/5256  : Skin care tool features
 gid://shopify/TaxonomyAttribute/7942  : Skin presence
 gid://shopify/TaxonomyAttribute/1615  : Skin tone
 gid://shopify/TaxonomyAttribute/1616  : Skin undertone
+gid://shopify/TaxonomyAttribute/12678 : Skirt length
 gid://shopify/TaxonomyAttribute/3253  : Skirt style
 gid://shopify/TaxonomyAttribute/1190  : Skirt/Dress length type
 gid://shopify/TaxonomyAttribute/10269 : Slapstick handle type
 gid://shopify/TaxonomyAttribute/10270 : Slapstick playing surface material
 gid://shopify/TaxonomyAttribute/1515  : Slat material
+gid://shopify/TaxonomyAttribute/12049 : Slate thickness
 gid://shopify/TaxonomyAttribute/10989 : Sled brake type
 gid://shopify/TaxonomyAttribute/10990 : Sled towing method
 gid://shopify/TaxonomyAttribute/6962  : Sleep position suitability
@@ -6571,22 +7546,30 @@ gid://shopify/TaxonomyAttribute/10992 : Sleeping pad type
 gid://shopify/TaxonomyAttribute/6158  : Sleeping position suitability
 gid://shopify/TaxonomyAttribute/6808  : Sleepwear set pieces included
 gid://shopify/TaxonomyAttribute/10993 : Sleeve bearing type
+gid://shopify/TaxonomyAttribute/12679 : Sleeve diameter
 gid://shopify/TaxonomyAttribute/6159  : Sleeve insulation
+gid://shopify/TaxonomyAttribute/12680 : Sleeve length
 gid://shopify/TaxonomyAttribute/15    : Sleeve length type
 gid://shopify/TaxonomyAttribute/6809  : Sleeve style
 gid://shopify/TaxonomyAttribute/5601  : Sleeving style
 gid://shopify/TaxonomyAttribute/6160  : Slice style
 gid://shopify/TaxonomyAttribute/10994 : Slide board accessories included
+gid://shopify/TaxonomyAttribute/12050 : Slide chute length
 gid://shopify/TaxonomyAttribute/6554  : Slide installation type
 gid://shopify/TaxonomyAttribute/10271 : Slide intended finger
+gid://shopify/TaxonomyAttribute/12051 : Slide platform height compatibility
 gid://shopify/TaxonomyAttribute/6555  : Slide safety features
 gid://shopify/TaxonomyAttribute/10272 : Slide type
 gid://shopify/TaxonomyAttribute/6556  : Slide water use capability
+gid://shopify/TaxonomyAttribute/12052 : Slider thickness
 gid://shopify/TaxonomyAttribute/6557  : Slime & putty kit components included
 gid://shopify/TaxonomyAttribute/10995 : Sling material
+gid://shopify/TaxonomyAttribute/12053 : Sling width
 gid://shopify/TaxonomyAttribute/6313  : Slipcover stretch type
 gid://shopify/TaxonomyAttribute/3268  : Slipper style
+gid://shopify/TaxonomyAttribute/12054 : Slot length
 gid://shopify/TaxonomyAttribute/3393  : Slot machine type
+gid://shopify/TaxonomyAttribute/12055 : Slot width
 gid://shopify/TaxonomyAttribute/3241  : Small animal food form
 gid://shopify/TaxonomyAttribute/3242  : Small animal food ingredients
 gid://shopify/TaxonomyAttribute/3243  : Small animal habitat/cage type
@@ -6595,6 +7578,7 @@ gid://shopify/TaxonomyAttribute/5556  : Smart glasses features
 gid://shopify/TaxonomyAttribute/3007  : Smart watch features
 gid://shopify/TaxonomyAttribute/10996 : Smith machine bar path
 gid://shopify/TaxonomyAttribute/8718  : Smoke color
+gid://shopify/TaxonomyAttribute/12056 : Smoke point
 gid://shopify/TaxonomyAttribute/10273 : Smoked malt smoking material
 gid://shopify/TaxonomyAttribute/6161  : Smoker type
 gid://shopify/TaxonomyAttribute/6314  : Smoking chip size
@@ -6603,6 +7587,8 @@ gid://shopify/TaxonomyAttribute/7944  : Snack processing method
 gid://shopify/TaxonomyAttribute/7945  : Snack texture
 gid://shopify/TaxonomyAttribute/10274 : Snap installation method
 gid://shopify/TaxonomyAttribute/10275 : Snare drum bearing edge profile
+gid://shopify/TaxonomyAttribute/12057 : Snare drum depth
+gid://shopify/TaxonomyAttribute/12058 : Snare drum diameter
 gid://shopify/TaxonomyAttribute/10276 : Snare drum finish type
 gid://shopify/TaxonomyAttribute/10277 : Snare drum hoop type
 gid://shopify/TaxonomyAttribute/10278 : Snare drum mounting type
@@ -6622,8 +7608,11 @@ gid://shopify/TaxonomyAttribute/11000 : Snow sports helmet safety certification
 gid://shopify/TaxonomyAttribute/11001 : Snowboard base material
 gid://shopify/TaxonomyAttribute/2894  : Snowboard construction
 gid://shopify/TaxonomyAttribute/1325  : Snowboard design
+gid://shopify/TaxonomyAttribute/12681 : Snowboard size
 gid://shopify/TaxonomyAttribute/11002 : Snowboard width class
 gid://shopify/TaxonomyAttribute/1323  : Snowboarding style
+gid://shopify/TaxonomyAttribute/12059 : Snowmobile track length
+gid://shopify/TaxonomyAttribute/12060 : Snowmobile track lug height
 gid://shopify/TaxonomyAttribute/2753  : Snowmobile type
 gid://shopify/TaxonomyAttribute/6163  : Soap dispenser operation type
 gid://shopify/TaxonomyAttribute/5236  : Soap making method
@@ -6637,6 +7626,7 @@ gid://shopify/TaxonomyAttribute/6810  : Sock cushioning
 gid://shopify/TaxonomyAttribute/6811  : Sock cushioning level
 gid://shopify/TaxonomyAttribute/6812  : Sock grip type
 gid://shopify/TaxonomyAttribute/6813  : Sock toe style
+gid://shopify/TaxonomyAttribute/12682 : Socket diameter
 gid://shopify/TaxonomyAttribute/2214  : Socket driver tip
 gid://shopify/TaxonomyAttribute/2170  : Socket type
 gid://shopify/TaxonomyAttribute/1406  : Soda maker accessories included
@@ -6647,6 +7637,7 @@ gid://shopify/TaxonomyAttribute/8720  : Soft top includes frame/hardware
 gid://shopify/TaxonomyAttribute/8721  : Soft top installation type
 gid://shopify/TaxonomyAttribute/8722  : Soft top window configuration
 gid://shopify/TaxonomyAttribute/11010 : Softball certification
+gid://shopify/TaxonomyAttribute/12064 : Softball circumference
 gid://shopify/TaxonomyAttribute/3169  : Softball discipline
 gid://shopify/TaxonomyAttribute/2052  : Softbox mounting type
 gid://shopify/TaxonomyAttribute/2053  : Softbox shape
@@ -6676,9 +7667,11 @@ gid://shopify/TaxonomyAttribute/10287 : Soprano saxophone mouthpiece baffle type
 gid://shopify/TaxonomyAttribute/10288 : Soprano saxophone mouthpiece chamber size
 gid://shopify/TaxonomyAttribute/10289 : Soprano saxophone mouthpiece finish
 gid://shopify/TaxonomyAttribute/10290 : Soprano saxophone mouthpiece included accessories
+gid://shopify/TaxonomyAttribute/12065 : Soprano saxophone mouthpiece table length
 gid://shopify/TaxonomyAttribute/10291 : Soprano saxophone mouthpiece tonal character
 gid://shopify/TaxonomyAttribute/10292 : Sound character
 gid://shopify/TaxonomyAttribute/2420  : Sound controls
+gid://shopify/TaxonomyAttribute/12683 : Sound detection resolution
 gid://shopify/TaxonomyAttribute/2431  : Sound effects
 gid://shopify/TaxonomyAttribute/10293 : Sound expansion method
 gid://shopify/TaxonomyAttribute/3323  : Sound insulation
@@ -6691,6 +7684,7 @@ gid://shopify/TaxonomyAttribute/6560  : Sound type
 gid://shopify/TaxonomyAttribute/10298 : Soundboard material
 gid://shopify/TaxonomyAttribute/7946  : Soup or broth variety
 gid://shopify/TaxonomyAttribute/7947  : Sour cream variety
+gid://shopify/TaxonomyAttribute/12066 : Sousaphone weight
 gid://shopify/TaxonomyAttribute/7948  : Soy sauce variety
 gid://shopify/TaxonomyAttribute/6165  : Spa installation type
 gid://shopify/TaxonomyAttribute/6166  : Space heater safety features
@@ -6701,17 +7695,23 @@ gid://shopify/TaxonomyAttribute/10299 : Sparkler shape
 gid://shopify/TaxonomyAttribute/8726  : Speaker cone material
 gid://shopify/TaxonomyAttribute/2411  : Speaker configuration
 gid://shopify/TaxonomyAttribute/1819  : Speaker design
+gid://shopify/TaxonomyAttribute/12068 : Speaker driver diameter
 gid://shopify/TaxonomyAttribute/5440  : Speaker enclosure type
 gid://shopify/TaxonomyAttribute/3065  : Speaker features
+gid://shopify/TaxonomyAttribute/12069 : Speaker mounting cutout diameter
 gid://shopify/TaxonomyAttribute/5651  : Speaker position in laptop
 gid://shopify/TaxonomyAttribute/8727  : Speaker size
 gid://shopify/TaxonomyAttribute/1820  : Speaker technology
 gid://shopify/TaxonomyAttribute/2693  : Speakerphone type
+gid://shopify/TaxonomyAttribute/12684 : Spear size
 gid://shopify/TaxonomyAttribute/10300 : Special effects output interface
 gid://shopify/TaxonomyAttribute/10301 : Special effects stand stability features
 gid://shopify/TaxonomyAttribute/10302 : Specialty malt name/type
 gid://shopify/TaxonomyAttribute/10303 : Specimen presentation
+gid://shopify/TaxonomyAttribute/12685 : Speed
 gid://shopify/TaxonomyAttribute/11014 : Speed bag accessories included
+gid://shopify/TaxonomyAttribute/12070 : Speed measurement accuracy
+gid://shopify/TaxonomyAttribute/12071 : Speed range
 gid://shopify/TaxonomyAttribute/11015 : Speed rating
 gid://shopify/TaxonomyAttribute/1273  : Speed settings
 gid://shopify/TaxonomyAttribute/8728  : Speedometer backlight type
@@ -6719,11 +7719,14 @@ gid://shopify/TaxonomyAttribute/8729  : Speedometer display type
 gid://shopify/TaxonomyAttribute/8730  : Speedometer unit of measure
 gid://shopify/TaxonomyAttribute/6167  : Spice organizer features
 gid://shopify/TaxonomyAttribute/2121  : Spike design
+gid://shopify/TaxonomyAttribute/12686 : Spike diameter
+gid://shopify/TaxonomyAttribute/12687 : Spike length
 gid://shopify/TaxonomyAttribute/11016 : Spike replaceability
 gid://shopify/TaxonomyAttribute/11017 : Spike shape
 gid://shopify/TaxonomyAttribute/11018 : Spike thread size
 gid://shopify/TaxonomyAttribute/11019 : Spin classification
 gid://shopify/TaxonomyAttribute/11020 : Spin profile
+gid://shopify/TaxonomyAttribute/12072 : Spin time
 gid://shopify/TaxonomyAttribute/11021 : Spin types supported
 gid://shopify/TaxonomyAttribute/7949  : Spinach preparation style
 gid://shopify/TaxonomyAttribute/7950  : Spinach variety
@@ -6734,6 +7737,7 @@ gid://shopify/TaxonomyAttribute/10307 : Spindle hook type
 gid://shopify/TaxonomyAttribute/10308 : Spindle support method
 gid://shopify/TaxonomyAttribute/10309 : Spindle tip style
 gid://shopify/TaxonomyAttribute/10310 : Spindle whorl position
+gid://shopify/TaxonomyAttribute/12073 : Spindle whorl weight
 gid://shopify/TaxonomyAttribute/11022 : Spinner blade shape
 gid://shopify/TaxonomyAttribute/10311 : Spinner control card design/type
 gid://shopify/TaxonomyAttribute/11023 : Spinner subtype
@@ -6743,9 +7747,12 @@ gid://shopify/TaxonomyAttribute/10313 : Spinning oil application tool
 gid://shopify/TaxonomyAttribute/10314 : Spinning oil features
 gid://shopify/TaxonomyAttribute/6561  : Spinning top features
 gid://shopify/TaxonomyAttribute/6562  : Spinning top launch mechanism
+gid://shopify/TaxonomyAttribute/12074 : Spinning wheel bobbin weight
 gid://shopify/TaxonomyAttribute/10315 : Spinning wheel brake/tension system type
 gid://shopify/TaxonomyAttribute/10316 : Spinning wheel drive system
+gid://shopify/TaxonomyAttribute/12075 : Spinning wheel drive wheel diameter
 gid://shopify/TaxonomyAttribute/10317 : Spinning wheel hook system
+gid://shopify/TaxonomyAttribute/12076 : Spinning wheel orifice height
 gid://shopify/TaxonomyAttribute/10318 : Spinning wheel part application
 gid://shopify/TaxonomyAttribute/10319 : Spinning wheel portability/foldability
 gid://shopify/TaxonomyAttribute/10320 : Spinning wheel tension adjustment type
@@ -6758,6 +7765,7 @@ gid://shopify/TaxonomyAttribute/11026 : Split shot size
 gid://shopify/TaxonomyAttribute/1868  : Splitter use
 gid://shopify/TaxonomyAttribute/3079  : Splitter/Switch features
 gid://shopify/TaxonomyAttribute/8732  : Spoiler adjustability
+gid://shopify/TaxonomyAttribute/12077 : Spoiler width
 gid://shopify/TaxonomyAttribute/11027 : Spoke accessory function
 gid://shopify/TaxonomyAttribute/11028 : Spoke butting profile
 gid://shopify/TaxonomyAttribute/11029 : Spoke gauge
@@ -6798,6 +7806,7 @@ gid://shopify/TaxonomyAttribute/6174  : Sprinkler type
 gid://shopify/TaxonomyAttribute/6175  : Sprinkler valve type
 gid://shopify/TaxonomyAttribute/11036 : Sprint canoe class
 gid://shopify/TaxonomyAttribute/7953  : Sprout presentation
+gid://shopify/TaxonomyAttribute/12078 : Spur shank length
 gid://shopify/TaxonomyAttribute/7954  : Squash and gourd variety
 gid://shopify/TaxonomyAttribute/2349  : Squeegee blade design
 gid://shopify/TaxonomyAttribute/6176  : Squirrel feed type
@@ -6806,6 +7815,7 @@ gid://shopify/TaxonomyAttribute/11037 : Stability class
 gid://shopify/TaxonomyAttribute/11038 : Stabilizer thread size
 gid://shopify/TaxonomyAttribute/11039 : Stabilizer type
 gid://shopify/TaxonomyAttribute/1928  : Stack configuration
+gid://shopify/TaxonomyAttribute/12079 : Stack height
 gid://shopify/TaxonomyAttribute/6178  : Stackability
 gid://shopify/TaxonomyAttribute/6179  : Stackable design
 gid://shopify/TaxonomyAttribute/6180  : Stacking capability
@@ -6816,19 +7826,25 @@ gid://shopify/TaxonomyAttribute/6181  : Stainless steel cleaner features
 gid://shopify/TaxonomyAttribute/1583  : Stair lifts control type
 gid://shopify/TaxonomyAttribute/3113  : Staircase features
 gid://shopify/TaxonomyAttribute/1585  : Staircase type
+gid://shopify/TaxonomyAttribute/12080 : Stake length
 gid://shopify/TaxonomyAttribute/11040 : Stake shape
+gid://shopify/TaxonomyAttribute/12081 : Stalk length
 gid://shopify/TaxonomyAttribute/10330 : Stamp block features
 gid://shopify/TaxonomyAttribute/10331 : Stamp block type
 gid://shopify/TaxonomyAttribute/6564  : Stamp set pieces included
 gid://shopify/TaxonomyAttribute/2373  : Stamp theme
 gid://shopify/TaxonomyAttribute/2251  : Stamp type
+gid://shopify/TaxonomyAttribute/12082 : Stanchion diameter
 gid://shopify/TaxonomyAttribute/10332 : Stand padding material
+gid://shopify/TaxonomyAttribute/12083 : Stand weight
 gid://shopify/TaxonomyAttribute/3282  : Stand/Display type
 gid://shopify/TaxonomyAttribute/6182  : Staple coating
 gid://shopify/TaxonomyAttribute/10333 : Staple fiber animal fiber type
 gid://shopify/TaxonomyAttribute/10334 : Staple fiber crimp level
 gid://shopify/TaxonomyAttribute/10335 : Staple fiber preparation type
 gid://shopify/TaxonomyAttribute/10336 : Staple fiber source type
+gid://shopify/TaxonomyAttribute/12084 : Staple fiber weight
+gid://shopify/TaxonomyAttribute/12085 : Staple length
 gid://shopify/TaxonomyAttribute/2243  : Staple wire gauge
 gid://shopify/TaxonomyAttribute/6183  : Staple/pin shape
 gid://shopify/TaxonomyAttribute/3161  : Stapler features
@@ -6841,19 +7857,26 @@ gid://shopify/TaxonomyAttribute/8734  : Starter drive type
 gid://shopify/TaxonomyAttribute/11041 : Starter pistol action type
 gid://shopify/TaxonomyAttribute/11042 : Starter pistol caliber
 gid://shopify/TaxonomyAttribute/8735  : Starter terminal type
+gid://shopify/TaxonomyAttribute/12087 : Starting bar weight
 gid://shopify/TaxonomyAttribute/11043 : Starting block anchoring method
 gid://shopify/TaxonomyAttribute/2685  : Station type
 gid://shopify/TaxonomyAttribute/1393  : Stationery binding type
 gid://shopify/TaxonomyAttribute/5087  : Steam inhaler design
 gid://shopify/TaxonomyAttribute/6184  : Steam nozzle type
+gid://shopify/TaxonomyAttribute/12689 : Steam pressure
 gid://shopify/TaxonomyAttribute/6315  : Steam table pan cover features
 gid://shopify/TaxonomyAttribute/6185  : Steam table pan size
 gid://shopify/TaxonomyAttribute/6186  : Steam table pan size compatibility
 gid://shopify/TaxonomyAttribute/6187  : Steam table pan type
+gid://shopify/TaxonomyAttribute/12088 : Steeping temperature
 gid://shopify/TaxonomyAttribute/11044 : Steerer tube design
+gid://shopify/TaxonomyAttribute/12690 : Steerer tube diameter
 gid://shopify/TaxonomyAttribute/8736  : Steering cable end fitting type
 gid://shopify/TaxonomyAttribute/8737  : Steering column adjustability features
 gid://shopify/TaxonomyAttribute/8738  : Steering column ignition provision
+gid://shopify/TaxonomyAttribute/12089 : Steering column mounting pattern / bolt spacing
+gid://shopify/TaxonomyAttribute/12090 : Steering column overall length
+gid://shopify/TaxonomyAttribute/12091 : Steering column shaft diameter
 gid://shopify/TaxonomyAttribute/8739  : Steering column shaft end interface type
 gid://shopify/TaxonomyAttribute/8740  : Steering column shift type
 gid://shopify/TaxonomyAttribute/8741  : Steering component drive type
@@ -6862,26 +7885,35 @@ gid://shopify/TaxonomyAttribute/8743  : Steering pump pulley type
 gid://shopify/TaxonomyAttribute/8744  : Steering rack finish/coating
 gid://shopify/TaxonomyAttribute/8745  : Steering rack position
 gid://shopify/TaxonomyAttribute/8746  : Steering wheel cover installation type
+gid://shopify/TaxonomyAttribute/12092 : Steering wheel dish depth
 gid://shopify/TaxonomyAttribute/8747  : Steering wheel grip material
 gid://shopify/TaxonomyAttribute/8748  : Steering wheel mounting pattern
 gid://shopify/TaxonomyAttribute/8749  : Steering wheel rim material (grip surface)
+gid://shopify/TaxonomyAttribute/12691 : Steering wheel size
 gid://shopify/TaxonomyAttribute/2497  : Stem length
 gid://shopify/TaxonomyAttribute/7958  : Stem material
+gid://shopify/TaxonomyAttribute/12094 : Stem rise
 gid://shopify/TaxonomyAttribute/6188  : Stemware design
 gid://shopify/TaxonomyAttribute/10337 : Stencil machine consumable type
+gid://shopify/TaxonomyAttribute/12096 : Step height
 gid://shopify/TaxonomyAttribute/8750  : Step surface texture
 gid://shopify/TaxonomyAttribute/2734  : Step type
+gid://shopify/TaxonomyAttribute/12097 : Step width
 gid://shopify/TaxonomyAttribute/11045 : Stepper motion type
 gid://shopify/TaxonomyAttribute/1775  : Sterilization cycle time
 gid://shopify/TaxonomyAttribute/1777  : Sterilization instructions
 gid://shopify/TaxonomyAttribute/1776  : Sterilization method
 gid://shopify/TaxonomyAttribute/2593  : Stethoscope design
 gid://shopify/TaxonomyAttribute/2594  : Stethoscope technology
+gid://shopify/TaxonomyAttribute/12098 : Stick balance point
+gid://shopify/TaxonomyAttribute/12099 : Stick bow height
+gid://shopify/TaxonomyAttribute/12100 : Stick bow placement
 gid://shopify/TaxonomyAttribute/11046 : Stick bow profile
 gid://shopify/TaxonomyAttribute/11047 : Stick construction
 gid://shopify/TaxonomyAttribute/11048 : Stick curvature type
 gid://shopify/TaxonomyAttribute/11049 : Stick head shape
 gid://shopify/TaxonomyAttribute/2850  : Stick material
+gid://shopify/TaxonomyAttribute/12692 : Stick size
 gid://shopify/TaxonomyAttribute/11050 : Stick size compatibility
 gid://shopify/TaxonomyAttribute/6189  : Stick tip style
 gid://shopify/TaxonomyAttribute/10338 : Sticker finish
@@ -6931,6 +7963,7 @@ gid://shopify/TaxonomyAttribute/10346 : Straight pin application
 gid://shopify/TaxonomyAttribute/10347 : Straight pin finish
 gid://shopify/TaxonomyAttribute/10348 : Straight pin head material
 gid://shopify/TaxonomyAttribute/10349 : Straight pin head shape
+gid://shopify/TaxonomyAttribute/12104 : Straightness tolerance
 gid://shopify/TaxonomyAttribute/6192  : Strainer style
 gid://shopify/TaxonomyAttribute/6193  : Strainer type
 gid://shopify/TaxonomyAttribute/6821  : Strand configuration
@@ -6938,13 +7971,16 @@ gid://shopify/TaxonomyAttribute/11056 : Strand material
 gid://shopify/TaxonomyAttribute/10350 : Strap attachment hardware
 gid://shopify/TaxonomyAttribute/11057 : Strap configuration
 gid://shopify/TaxonomyAttribute/2442  : Strap design
+gid://shopify/TaxonomyAttribute/12105 : Strap drop length
 gid://shopify/TaxonomyAttribute/6194  : Strap end fitting type
 gid://shopify/TaxonomyAttribute/11058 : Strap functionality
+gid://shopify/TaxonomyAttribute/12106 : Strap maximum length
 gid://shopify/TaxonomyAttribute/10351 : Strap padding
 gid://shopify/TaxonomyAttribute/11059 : Strap side
 gid://shopify/TaxonomyAttribute/5527  : Strap wearing style
 gid://shopify/TaxonomyAttribute/6822  : Strap width
 gid://shopify/TaxonomyAttribute/6195  : Straw dispensing mechanism
+gid://shopify/TaxonomyAttribute/12107 : Straw length
 gid://shopify/TaxonomyAttribute/2513  : Straw/Stirrer design
 gid://shopify/TaxonomyAttribute/7963  : Strength classification
 gid://shopify/TaxonomyAttribute/10352 : Strength grade
@@ -6952,22 +7988,30 @@ gid://shopify/TaxonomyAttribute/6823  : Stretch level
 gid://shopify/TaxonomyAttribute/8752  : Stretch type
 gid://shopify/TaxonomyAttribute/10353 : Stretcher bar material
 gid://shopify/TaxonomyAttribute/2591  : Stretcher/Gurney intended use
+gid://shopify/TaxonomyAttribute/12109 : Stride length
 gid://shopify/TaxonomyAttribute/11060 : Strike shield shape
 gid://shopify/TaxonomyAttribute/10354 : String core shape
 gid://shopify/TaxonomyAttribute/10355 : String coverage
 gid://shopify/TaxonomyAttribute/10356 : String end type
 gid://shopify/TaxonomyAttribute/2477  : String instrument size
+gid://shopify/TaxonomyAttribute/12693 : String length
 gid://shopify/TaxonomyAttribute/1306  : String material
 gid://shopify/TaxonomyAttribute/10357 : String set type
 gid://shopify/TaxonomyAttribute/5300  : Strip/Patch technology
+gid://shopify/TaxonomyAttribute/12694 : Stroke
+gid://shopify/TaxonomyAttribute/12695 : Stroke length
 gid://shopify/TaxonomyAttribute/2990  : Stroller features
 gid://shopify/TaxonomyAttribute/1745  : Stroller wheel type
 gid://shopify/TaxonomyAttribute/11061 : Strung status
+gid://shopify/TaxonomyAttribute/12110 : Strut extended length
 gid://shopify/TaxonomyAttribute/8753  : Strut placement
+gid://shopify/TaxonomyAttribute/12111 : Strut travel
 gid://shopify/TaxonomyAttribute/11062 : Stud attachment type
 gid://shopify/TaxonomyAttribute/11063 : Stud configuration
+gid://shopify/TaxonomyAttribute/12112 : Stud length
 gid://shopify/TaxonomyAttribute/11064 : Stud material
 gid://shopify/TaxonomyAttribute/6567  : Stuffed animal features
+gid://shopify/TaxonomyAttribute/12696 : Stuffed animal size
 gid://shopify/TaxonomyAttribute/11065 : Stump base type
 gid://shopify/TaxonomyAttribute/11066 : Stump mechanism
 gid://shopify/TaxonomyAttribute/11067 : Stump size
@@ -6983,12 +8027,16 @@ gid://shopify/TaxonomyAttribute/5460  : Subsonic filter
 gid://shopify/TaxonomyAttribute/2981  : Substrate features
 gid://shopify/TaxonomyAttribute/5466  : Subwoofer configuration
 gid://shopify/TaxonomyAttribute/8754  : Subwoofer installation type
+gid://shopify/TaxonomyAttribute/12113 : Subwoofer mounting depth
+gid://shopify/TaxonomyAttribute/12697 : Suction cup size
 gid://shopify/TaxonomyAttribute/1781  : Suction levels
 gid://shopify/TaxonomyAttribute/7964  : Sugar cane variety
 gid://shopify/TaxonomyAttribute/7965  : Sugar content level
 gid://shopify/TaxonomyAttribute/6316  : Sugar dispenser mechanism
+gid://shopify/TaxonomyAttribute/12114 : Sugar per serving
 gid://shopify/TaxonomyAttribute/7966  : Sugar refinement level
 gid://shopify/TaxonomyAttribute/7967  : Sugar source
+gid://shopify/TaxonomyAttribute/12115 : Sugars per 100 g
 gid://shopify/TaxonomyAttribute/11068 : Suit fit
 gid://shopify/TaxonomyAttribute/6824  : Suit pieces
 gid://shopify/TaxonomyAttribute/8755  : Suitable for anchoring use
@@ -7091,13 +8139,17 @@ gid://shopify/TaxonomyAttribute/2824  : Surface texture
 gid://shopify/TaxonomyAttribute/10366 : Surface types included
 gid://shopify/TaxonomyAttribute/11083 : Surfboard construction
 gid://shopify/TaxonomyAttribute/3178  : Surfboard features
+gid://shopify/TaxonomyAttribute/12698 : Surfboard size
 gid://shopify/TaxonomyAttribute/11084 : Surfboard tail shape
+gid://shopify/TaxonomyAttribute/12118 : Surfboard volume
+gid://shopify/TaxonomyAttribute/12699 : Surge energy rating
 gid://shopify/TaxonomyAttribute/2029  : Surveillance camera design
 gid://shopify/TaxonomyAttribute/2030  : Surveillance camera mounting type
 gid://shopify/TaxonomyAttribute/3299  : Surverying accessories included
 gid://shopify/TaxonomyAttribute/1200  : Suspender style
 gid://shopify/TaxonomyAttribute/8759  : Suspension bushing type
 gid://shopify/TaxonomyAttribute/11085 : Suspension configuration
+gid://shopify/TaxonomyAttribute/12119 : Suspension lift amount
 gid://shopify/TaxonomyAttribute/6963  : Suspension material
 gid://shopify/TaxonomyAttribute/11086 : Suspension trainer accessories included
 gid://shopify/TaxonomyAttribute/11087 : Suspension trainer anchor type
@@ -7106,14 +8158,18 @@ gid://shopify/TaxonomyAttribute/10367 : Sustain pedal form factor
 gid://shopify/TaxonomyAttribute/10368 : Sustain pedal switch type
 gid://shopify/TaxonomyAttribute/1356  : Sustainability
 gid://shopify/TaxonomyAttribute/10369 : Sustainability certification
+gid://shopify/TaxonomyAttribute/12120 : Swab cord length
 gid://shopify/TaxonomyAttribute/5304  : Swab end configuration
+gid://shopify/TaxonomyAttribute/12121 : Swab head diameter
 gid://shopify/TaxonomyAttribute/10370 : Swab intended bassoon section
+gid://shopify/TaxonomyAttribute/12122 : Swab length
 gid://shopify/TaxonomyAttribute/2939  : Swab material
 gid://shopify/TaxonomyAttribute/10371 : Swab style
 gid://shopify/TaxonomyAttribute/10372 : Swab weight material
 gid://shopify/TaxonomyAttribute/10373 : Swab weight style
 gid://shopify/TaxonomyAttribute/8760  : Sway bar adjustability
 gid://shopify/TaxonomyAttribute/8761  : Sway bar coating
+gid://shopify/TaxonomyAttribute/12123 : Sway bar diameter
 gid://shopify/TaxonomyAttribute/8762  : Sway bar fitment (front/rear/kit)
 gid://shopify/TaxonomyAttribute/6826  : Sweatshirt pocket type
 gid://shopify/TaxonomyAttribute/7970  : Sweet potato variety
@@ -7124,6 +8180,7 @@ gid://shopify/TaxonomyAttribute/7972  : Sweetening type
 gid://shopify/TaxonomyAttribute/11090 : Swim armband construction type
 gid://shopify/TaxonomyAttribute/11091 : Swim belt purpose
 gid://shopify/TaxonomyAttribute/11092 : Swim board features
+gid://shopify/TaxonomyAttribute/12700 : Swim board size
 gid://shopify/TaxonomyAttribute/6827  : Swim bottom length
 gid://shopify/TaxonomyAttribute/11093 : Swim buoy features
 gid://shopify/TaxonomyAttribute/11094 : Swim cap style
@@ -7155,6 +8212,7 @@ gid://shopify/TaxonomyAttribute/2469  : Synthesis method
 gid://shopify/TaxonomyAttribute/10375 : Synthesizer form factor
 gid://shopify/TaxonomyAttribute/10376 : Synthetic feather style
 gid://shopify/TaxonomyAttribute/8764  : Synthetic formulation type
+gid://shopify/TaxonomyAttribute/12701 : Syringe size
 gid://shopify/TaxonomyAttribute/7973  : Syrup base ingredient
 gid://shopify/TaxonomyAttribute/7974  : Syrup variety
 gid://shopify/TaxonomyAttribute/5467  : System components included
@@ -7165,6 +8223,7 @@ gid://shopify/TaxonomyAttribute/5615  : System/Power cable connector type (end B
 gid://shopify/TaxonomyAttribute/10377 : T-shirt fit
 gid://shopify/TaxonomyAttribute/8795  : TPMS sensor frequency band
 gid://shopify/TaxonomyAttribute/5626  : TV broadcast standards supported
+gid://shopify/TaxonomyAttribute/12124 : Tab neck height
 gid://shopify/TaxonomyAttribute/2235  : Tab style
 gid://shopify/TaxonomyAttribute/10378 : Tabla included components
 gid://shopify/TaxonomyAttribute/10379 : Tabla set pieces included
@@ -7186,12 +8245,15 @@ gid://shopify/TaxonomyAttribute/2819  : Tableware material
 gid://shopify/TaxonomyAttribute/2245  : Tack/Pushpin head design
 gid://shopify/TaxonomyAttribute/11109 : Tackle components included
 gid://shopify/TaxonomyAttribute/2220  : Tag fastening
+gid://shopify/TaxonomyAttribute/12702 : Tail size
 gid://shopify/TaxonomyAttribute/5295  : Talc content
 gid://shopify/TaxonomyAttribute/10381 : Talking drum accessories included
 gid://shopify/TaxonomyAttribute/10382 : Talking drum cord material
 gid://shopify/TaxonomyAttribute/10383 : Talking drum tuning mechanism
 gid://shopify/TaxonomyAttribute/10384 : Tam-tam construction style
 gid://shopify/TaxonomyAttribute/10385 : Tam-tam items included
+gid://shopify/TaxonomyAttribute/12125 : Tam-tam playing area diameter
+gid://shopify/TaxonomyAttribute/12126 : Tam-tam thickness
 gid://shopify/TaxonomyAttribute/7975  : Tamarillo variety
 gid://shopify/TaxonomyAttribute/7976  : Tamarind variety
 gid://shopify/TaxonomyAttribute/10386 : Tambourine frame style
@@ -7215,14 +8277,18 @@ gid://shopify/TaxonomyAttribute/2203  : Tape material
 gid://shopify/TaxonomyAttribute/11111 : Tape purpose
 gid://shopify/TaxonomyAttribute/5475  : Tape speed supported
 gid://shopify/TaxonomyAttribute/11112 : Tape type
+gid://shopify/TaxonomyAttribute/12127 : Tape width
 gid://shopify/TaxonomyAttribute/7977  : Tapenade main ingredients
 gid://shopify/TaxonomyAttribute/10394 : Tapestry loom loom format
 gid://shopify/TaxonomyAttribute/10395 : Tapestry loom shedding method
 gid://shopify/TaxonomyAttribute/10396 : Tapestry loom tensioning system
 gid://shopify/TaxonomyAttribute/10397 : Tar head material
 gid://shopify/TaxonomyAttribute/10398 : Tar playing style
+gid://shopify/TaxonomyAttribute/12129 : Tar rim depth
 gid://shopify/TaxonomyAttribute/10399 : Tar tuning system
+gid://shopify/TaxonomyAttribute/12703 : Tar yield
 gid://shopify/TaxonomyAttribute/2537  : Target audience
+gid://shopify/TaxonomyAttribute/12131 : Target batch volume
 gid://shopify/TaxonomyAttribute/8765  : Target components
 gid://shopify/TaxonomyAttribute/5301  : Target facial zone
 gid://shopify/TaxonomyAttribute/837   : Target gender
@@ -7235,6 +8301,8 @@ gid://shopify/TaxonomyAttribute/1425  : Targeted pests
 gid://shopify/TaxonomyAttribute/5292  : Targeted skin concern
 gid://shopify/TaxonomyAttribute/1386  : Targeted stains
 gid://shopify/TaxonomyAttribute/7978  : Taro variety
+gid://shopify/TaxonomyAttribute/12132 : Tassel drop length
+gid://shopify/TaxonomyAttribute/12133 : Tassel spacing
 gid://shopify/TaxonomyAttribute/10401 : Tassel trim header type
 gid://shopify/TaxonomyAttribute/10402 : Tassel trim use case
 gid://shopify/TaxonomyAttribute/7979  : Taste profile
@@ -7244,6 +8312,7 @@ gid://shopify/TaxonomyAttribute/6207  : Teapot spout style
 gid://shopify/TaxonomyAttribute/10403 : Teasing tool style
 gid://shopify/TaxonomyAttribute/1572  : Technology level
 gid://shopify/TaxonomyAttribute/11117 : Tee base style
+gid://shopify/TaxonomyAttribute/12704 : Teeth length
 gid://shopify/TaxonomyAttribute/1896  : Telephone cable interface
 gid://shopify/TaxonomyAttribute/5616  : Telephone cable second interface
 gid://shopify/TaxonomyAttribute/5025  : Telephone cord style
@@ -7255,6 +8324,7 @@ gid://shopify/TaxonomyAttribute/5409  : Television speaker position
 gid://shopify/TaxonomyAttribute/3094  : Television specialized features
 gid://shopify/TaxonomyAttribute/10404 : Temper / hardness
 gid://shopify/TaxonomyAttribute/2351  : Temperature
+gid://shopify/TaxonomyAttribute/12705 : Temperature accuracy
 gid://shopify/TaxonomyAttribute/1774  : Temperature control
 gid://shopify/TaxonomyAttribute/10405 : Temperature control type
 gid://shopify/TaxonomyAttribute/1555  : Temperature measurement
@@ -7264,10 +8334,14 @@ gid://shopify/TaxonomyAttribute/11118 : Tenkara action ratio
 gid://shopify/TaxonomyAttribute/11119 : Tennis ball court surface
 gid://shopify/TaxonomyAttribute/11120 : Tennis ball pressure type
 gid://shopify/TaxonomyAttribute/11121 : Tennis racket grip size
+gid://shopify/TaxonomyAttribute/12134 : Tenon diameter
+gid://shopify/TaxonomyAttribute/12135 : Tenor flutophone body length
 gid://shopify/TaxonomyAttribute/10406 : Tenor flutophone fingering system
+gid://shopify/TaxonomyAttribute/12136 : Tenor flutophone weight
 gid://shopify/TaxonomyAttribute/10407 : Tenor recorder joint type
 gid://shopify/TaxonomyAttribute/10408 : Tenor saxophone key system
 gid://shopify/TaxonomyAttribute/10409 : Tenor saxophone pad material
+gid://shopify/TaxonomyAttribute/12137 : Tenor saxophone weight
 gid://shopify/TaxonomyAttribute/10410 : Tenor trombone slide type
 gid://shopify/TaxonomyAttribute/10411 : Tenor trombone valve configuration
 gid://shopify/TaxonomyAttribute/2446  : Tension
@@ -7289,6 +8363,7 @@ gid://shopify/TaxonomyAttribute/1553  : Test format
 gid://shopify/TaxonomyAttribute/1576  : Test method
 gid://shopify/TaxonomyAttribute/8766  : Test result output method
 gid://shopify/TaxonomyAttribute/1556  : Test sample
+gid://shopify/TaxonomyAttribute/12706 : Test time
 gid://shopify/TaxonomyAttribute/8767  : Tether/strap system
 gid://shopify/TaxonomyAttribute/2892  : Tetherball equipment included
 gid://shopify/TaxonomyAttribute/5529  : Tethering policy
@@ -7306,6 +8381,8 @@ gid://shopify/TaxonomyAttribute/5078  : Therapeutic swing accessories included
 gid://shopify/TaxonomyAttribute/11126 : Therapeutic technology
 gid://shopify/TaxonomyAttribute/5085  : Therapy mode supported
 gid://shopify/TaxonomyAttribute/5117  : Therapy temperature type
+gid://shopify/TaxonomyAttribute/12707 : Thermal accuracy
+gid://shopify/TaxonomyAttribute/12708 : Thermal design power
 gid://shopify/TaxonomyAttribute/2204  : Thermal detector type
 gid://shopify/TaxonomyAttribute/5119  : Thermal sensation
 gid://shopify/TaxonomyAttribute/6832  : Thermal set components
@@ -7314,8 +8391,11 @@ gid://shopify/TaxonomyAttribute/6209  : Thermocouple junction type
 gid://shopify/TaxonomyAttribute/2205  : Thermocouple type
 gid://shopify/TaxonomyAttribute/6210  : Thermometer design
 gid://shopify/TaxonomyAttribute/6211  : Thermos handle type
+gid://shopify/TaxonomyAttribute/12140 : Thermostat flange diameter
 gid://shopify/TaxonomyAttribute/8768  : Thermostat type
+gid://shopify/TaxonomyAttribute/12709 : Thickness
 gid://shopify/TaxonomyAttribute/2219  : Thickness type
+gid://shopify/TaxonomyAttribute/12141 : Thigh circumference
 gid://shopify/TaxonomyAttribute/10419 : Thimble guide size
 gid://shopify/TaxonomyAttribute/10434 : Thread & yarn guide mounting/attachment style
 gid://shopify/TaxonomyAttribute/10435 : Thread & yarn guide tension control
@@ -7328,12 +8408,16 @@ gid://shopify/TaxonomyAttribute/10424 : Thread cutter safety features
 gid://shopify/TaxonomyAttribute/10425 : Thread cutter usage/application
 gid://shopify/TaxonomyAttribute/2126  : Thread direction
 gid://shopify/TaxonomyAttribute/10426 : Thread finish / treatment
+gid://shopify/TaxonomyAttribute/12710 : Thread length
 gid://shopify/TaxonomyAttribute/10427 : Thread material
 gid://shopify/TaxonomyAttribute/10428 : Thread material (fiber)
 gid://shopify/TaxonomyAttribute/10429 : Thread package format
+gid://shopify/TaxonomyAttribute/12711 : Thread pitch
 gid://shopify/TaxonomyAttribute/10430 : Thread rack compatible spool type
+gid://shopify/TaxonomyAttribute/12143 : Thread rack peg length
 gid://shopify/TaxonomyAttribute/6212  : Thread standard
 gid://shopify/TaxonomyAttribute/10431 : Thread standard size
+gid://shopify/TaxonomyAttribute/12144 : Thread thickness
 gid://shopify/TaxonomyAttribute/10432 : Thread type
 gid://shopify/TaxonomyAttribute/10433 : Thread weight system
 gid://shopify/TaxonomyAttribute/10421 : Thread/cord type (beading pattern)
@@ -7341,6 +8425,7 @@ gid://shopify/TaxonomyAttribute/2127  : Threaded rod size
 gid://shopify/TaxonomyAttribute/10437 : Threader intended use
 gid://shopify/TaxonomyAttribute/10438 : Threading system
 gid://shopify/TaxonomyAttribute/6834  : Threading type
+gid://shopify/TaxonomyAttribute/12145 : Throat space
 gid://shopify/TaxonomyAttribute/8769  : Throttle type (scooter conversion)
 gid://shopify/TaxonomyAttribute/8770  : Throw rope end attachment
 gid://shopify/TaxonomyAttribute/8771  : Throw rope storage/packaging type
@@ -7370,13 +8455,16 @@ gid://shopify/TaxonomyAttribute/3042  : Timepiece features
 gid://shopify/TaxonomyAttribute/6570  : Timer count mode
 gid://shopify/TaxonomyAttribute/2040  : Timer design
 gid://shopify/TaxonomyAttribute/6571  : Timer display type
+gid://shopify/TaxonomyAttribute/12712 : Timer duration
 gid://shopify/TaxonomyAttribute/6215  : Timer mechanism
 gid://shopify/TaxonomyAttribute/10440 : Timer operating modes
 gid://shopify/TaxonomyAttribute/1439  : Timer type
+gid://shopify/TaxonomyAttribute/12147 : Timing accuracy
 gid://shopify/TaxonomyAttribute/8775  : Timing belt construction material (rubber compound)
 gid://shopify/TaxonomyAttribute/8776  : Timing belt profile
 gid://shopify/TaxonomyAttribute/8777  : Timing belt reinforcement cord material
 gid://shopify/TaxonomyAttribute/8778  : Timing component material
+gid://shopify/TaxonomyAttribute/12148 : Timing precision
 gid://shopify/TaxonomyAttribute/10441 : Tin whistle body material
 gid://shopify/TaxonomyAttribute/10442 : Tin whistle bore type
 gid://shopify/TaxonomyAttribute/10443 : Tin whistle included accessories
@@ -7384,6 +8472,7 @@ gid://shopify/TaxonomyAttribute/6216  : Tine position
 gid://shopify/TaxonomyAttribute/5289  : Tingle intensity
 gid://shopify/TaxonomyAttribute/2603  : Tip design
 gid://shopify/TaxonomyAttribute/8779  : Tip finish/coating
+gid://shopify/TaxonomyAttribute/12149 : Tip length
 gid://shopify/TaxonomyAttribute/1635  : Tip material
 gid://shopify/TaxonomyAttribute/2460  : Tip opening
 gid://shopify/TaxonomyAttribute/10444 : Tip shape
@@ -7397,17 +8486,24 @@ gid://shopify/TaxonomyAttribute/11131 : Tire compound type
 gid://shopify/TaxonomyAttribute/6217  : Tire construction
 gid://shopify/TaxonomyAttribute/6218  : Tire construction type
 gid://shopify/TaxonomyAttribute/8782  : Tire load range
+gid://shopify/TaxonomyAttribute/12151 : Tire outside diameter
 gid://shopify/TaxonomyAttribute/8783  : Tire position
+gid://shopify/TaxonomyAttribute/12713 : Tire profile
 gid://shopify/TaxonomyAttribute/11132 : Tire repair kit components
+gid://shopify/TaxonomyAttribute/12714 : Tire rim
+gid://shopify/TaxonomyAttribute/12152 : Tire section width
 gid://shopify/TaxonomyAttribute/8784  : Tire sidewall type
+gid://shopify/TaxonomyAttribute/12715 : Tire size
 gid://shopify/TaxonomyAttribute/8785  : Tire speed rating
 gid://shopify/TaxonomyAttribute/8786  : Tire spoon type
 gid://shopify/TaxonomyAttribute/11133 : Tire system compatibility
 gid://shopify/TaxonomyAttribute/8787  : Tire temperature rating (UTQG)
 gid://shopify/TaxonomyAttribute/8788  : Tire traction rating (UTQG)
+gid://shopify/TaxonomyAttribute/12153 : Tire tread depth
 gid://shopify/TaxonomyAttribute/6219  : Tire tread pattern
 gid://shopify/TaxonomyAttribute/11134 : Tire tread style
 gid://shopify/TaxonomyAttribute/8789  : Tire tube type
+gid://shopify/TaxonomyAttribute/12716 : Tire width
 gid://shopify/TaxonomyAttribute/6220  : Tissue lotion content
 gid://shopify/TaxonomyAttribute/8790  : Title status
 gid://shopify/TaxonomyAttribute/6221  : Toaster features
@@ -7421,6 +8517,7 @@ gid://shopify/TaxonomyAttribute/11136 : Toe pick style
 gid://shopify/TaxonomyAttribute/6837  : Toe protection type
 gid://shopify/TaxonomyAttribute/6838  : Toe reinforcement type
 gid://shopify/TaxonomyAttribute/1607  : Toe spacer design
+gid://shopify/TaxonomyAttribute/12155 : Toe stop stem length
 gid://shopify/TaxonomyAttribute/11137 : Toe stop stem thread size
 gid://shopify/TaxonomyAttribute/1322  : Toe strap type
 gid://shopify/TaxonomyAttribute/847   : Toe style
@@ -7432,6 +8529,7 @@ gid://shopify/TaxonomyAttribute/2961  : Toilet/Bidet mounting type
 gid://shopify/TaxonomyAttribute/10445 : Tom mount adjustment features
 gid://shopify/TaxonomyAttribute/10446 : Tom mount components included
 gid://shopify/TaxonomyAttribute/10447 : Tom mount mounting position
+gid://shopify/TaxonomyAttribute/12156 : Tom-tom depth
 gid://shopify/TaxonomyAttribute/2472  : Tom-tom design
 gid://shopify/TaxonomyAttribute/5462  : Tonearm type
 gid://shopify/TaxonomyAttribute/6222  : Tong type
@@ -7450,14 +8548,20 @@ gid://shopify/TaxonomyAttribute/1675  : Toothpick design
 gid://shopify/TaxonomyAttribute/6224  : Toothpick dispensing mechanism
 gid://shopify/TaxonomyAttribute/10448 : Top (soundboard) material
 gid://shopify/TaxonomyAttribute/6968  : Top bunk access method
+gid://shopify/TaxonomyAttribute/12157 : Top depth
 gid://shopify/TaxonomyAttribute/6839  : Top fit
 gid://shopify/TaxonomyAttribute/6840  : Top hat style
+gid://shopify/TaxonomyAttribute/12717 : Top length
 gid://shopify/TaxonomyAttribute/1193  : Top length type
 gid://shopify/TaxonomyAttribute/1400  : Top surface material
+gid://shopify/TaxonomyAttribute/12159 : Top tube length
 gid://shopify/TaxonomyAttribute/5026  : Top-up method
 gid://shopify/TaxonomyAttribute/6225  : Topographical relief
 gid://shopify/TaxonomyAttribute/7986  : Topping form
 gid://shopify/TaxonomyAttribute/7987  : Topping type
+gid://shopify/TaxonomyAttribute/12160 : Torso length
+gid://shopify/TaxonomyAttribute/12163 : Total sugars per 100 g
+gid://shopify/TaxonomyAttribute/12164 : Total sugars per serving
 gid://shopify/TaxonomyAttribute/2223  : Tote handle type
 gid://shopify/TaxonomyAttribute/2549  : Totem design
 gid://shopify/TaxonomyAttribute/1881  : Touch capabilities
@@ -7468,12 +8572,14 @@ gid://shopify/TaxonomyAttribute/11139 : Tow hook type
 gid://shopify/TaxonomyAttribute/11140 : Tow point configuration
 gid://shopify/TaxonomyAttribute/8793  : Tow strap protective features
 gid://shopify/TaxonomyAttribute/8794  : Tow strap type
+gid://shopify/TaxonomyAttribute/12165 : Tow strap width
 gid://shopify/TaxonomyAttribute/11141 : Towable tube style
 gid://shopify/TaxonomyAttribute/11142 : Towed water sport discipline
 gid://shopify/TaxonomyAttribute/11143 : Towel features
 gid://shopify/TaxonomyAttribute/6226  : Towel holder design
 gid://shopify/TaxonomyAttribute/11144 : Towel style
 gid://shopify/TaxonomyAttribute/6227  : Towel weave
+gid://shopify/TaxonomyAttribute/12167 : Towing capacity
 gid://shopify/TaxonomyAttribute/6572  : Toy airplane control type
 gid://shopify/TaxonomyAttribute/6573  : Toy airplane features
 gid://shopify/TaxonomyAttribute/6574  : Toy airplane flight capability
@@ -7482,6 +8588,7 @@ gid://shopify/TaxonomyAttribute/6576  : Toy boat play features
 gid://shopify/TaxonomyAttribute/6577  : Toy boat recommended play environment
 gid://shopify/TaxonomyAttribute/6578  : Toy bowling equipment included
 gid://shopify/TaxonomyAttribute/6579  : Toy car features
+gid://shopify/TaxonomyAttribute/12168 : Toy dimensions
 gid://shopify/TaxonomyAttribute/6580  : Toy drawing tablet accessories included
 gid://shopify/TaxonomyAttribute/6581  : Toy drawing tablet erase method
 gid://shopify/TaxonomyAttribute/6582  : Toy drawing tablet screen type
@@ -7492,14 +8599,17 @@ gid://shopify/TaxonomyAttribute/6586  : Toy gift basket items included
 gid://shopify/TaxonomyAttribute/6587  : Toy glider launch method
 gid://shopify/TaxonomyAttribute/6588  : Toy helicopter control type
 gid://shopify/TaxonomyAttribute/6589  : Toy helicopter features
+gid://shopify/TaxonomyAttribute/12170 : Toy jack size
 gid://shopify/TaxonomyAttribute/6590  : Toy jacks set items included
 gid://shopify/TaxonomyAttribute/6591  : Toy keyboard learning mode
 gid://shopify/TaxonomyAttribute/6592  : Toy keyboard sound theme
 gid://shopify/TaxonomyAttribute/6593  : Toy kitchen appliances included
 gid://shopify/TaxonomyAttribute/6594  : Toy kitchen assembly requirement
+gid://shopify/TaxonomyAttribute/12171 : Toy kitchen counter height
 gid://shopify/TaxonomyAttribute/6595  : Toy kitchen interactive features
 gid://shopify/TaxonomyAttribute/6596  : Toy motorcycle feature set
 gid://shopify/TaxonomyAttribute/6597  : Toy motorcycle scale
+gid://shopify/TaxonomyAttribute/12172 : Toy parachute canopy diameter
 gid://shopify/TaxonomyAttribute/6598  : Toy parachute launch method
 gid://shopify/TaxonomyAttribute/6599  : Toy piano and keyboard accessories included
 gid://shopify/TaxonomyAttribute/6600  : Toy playset assembly required
@@ -7526,6 +8636,7 @@ gid://shopify/TaxonomyAttribute/6230  : Track rail circuit configuration
 gid://shopify/TaxonomyAttribute/6611  : Track set special features
 gid://shopify/TaxonomyAttribute/11148 : Track surface compatibility
 gid://shopify/TaxonomyAttribute/6231  : Track system standard
+gid://shopify/TaxonomyAttribute/12173 : Track width
 gid://shopify/TaxonomyAttribute/5344  : Tracker form factor
 gid://shopify/TaxonomyAttribute/11149 : Tracking aid type
 gid://shopify/TaxonomyAttribute/1549  : Tracking metrics
@@ -7542,6 +8653,7 @@ gid://shopify/TaxonomyAttribute/2032  : Trail camera design
 gid://shopify/TaxonomyAttribute/8796  : Trailer construction
 gid://shopify/TaxonomyAttribute/8797  : Trailer coupler size
 gid://shopify/TaxonomyAttribute/8798  : Trailer hitch mounting location/method
+gid://shopify/TaxonomyAttribute/12176 : Trailer interior width
 gid://shopify/TaxonomyAttribute/8799  : Trailer light function
 gid://shopify/TaxonomyAttribute/11151 : Trailer suspension type
 gid://shopify/TaxonomyAttribute/2724  : Trailer type
@@ -7560,7 +8672,9 @@ gid://shopify/TaxonomyAttribute/11158 : Training surface usage
 gid://shopify/TaxonomyAttribute/6841  : Training usage type
 gid://shopify/TaxonomyAttribute/2766  : Trampoline design
 gid://shopify/TaxonomyAttribute/6612  : Trampoline enclosure type
+gid://shopify/TaxonomyAttribute/12177 : Trampoline padding thickness
 gid://shopify/TaxonomyAttribute/6613  : Trampoline safety certifications
+gid://shopify/TaxonomyAttribute/12718 : Trampoline size
 gid://shopify/TaxonomyAttribute/5354  : Transceiver form factor
 gid://shopify/TaxonomyAttribute/5063  : Transfer aid type
 gid://shopify/TaxonomyAttribute/10452 : Transfer application method
@@ -7569,10 +8683,13 @@ gid://shopify/TaxonomyAttribute/1586  : Transfer boards surface type
 gid://shopify/TaxonomyAttribute/10453 : Transfer method
 gid://shopify/TaxonomyAttribute/3272  : Transfer paper technique
 gid://shopify/TaxonomyAttribute/10454 : Transfer peel temperature
+gid://shopify/TaxonomyAttribute/12719 : Transfer time
 gid://shopify/TaxonomyAttribute/8802  : Transmission cooler construction
 gid://shopify/TaxonomyAttribute/8803  : Transmission fluid specification
+gid://shopify/TaxonomyAttribute/12720 : Transmission frequency
 gid://shopify/TaxonomyAttribute/8804  : Transmission mount bushing material
 gid://shopify/TaxonomyAttribute/8805  : Transmission mount type
+gid://shopify/TaxonomyAttribute/12721 : Transmission power
 gid://shopify/TaxonomyAttribute/2699  : Transmission type
 gid://shopify/TaxonomyAttribute/5478  : Transmitter form factor
 gid://shopify/TaxonomyAttribute/6969  : Transparency level
@@ -7604,6 +8721,9 @@ gid://shopify/TaxonomyAttribute/1644  : Treatment type
 gid://shopify/TaxonomyAttribute/6234  : Tree shape
 gid://shopify/TaxonomyAttribute/2805  : Tree stand material
 gid://shopify/TaxonomyAttribute/2108  : Trellis design
+gid://shopify/TaxonomyAttribute/12722 : Trench depth
+gid://shopify/TaxonomyAttribute/12723 : Trench width
+gid://shopify/TaxonomyAttribute/12178 : Triangle striker length
 gid://shopify/TaxonomyAttribute/10458 : Triangle striker material
 gid://shopify/TaxonomyAttribute/2877  : Tricycle design
 gid://shopify/TaxonomyAttribute/2878  : Tricycle propulsion type
@@ -7616,6 +8736,8 @@ gid://shopify/TaxonomyAttribute/10462 : Trim application method
 gid://shopify/TaxonomyAttribute/6842  : Trim detail
 gid://shopify/TaxonomyAttribute/10463 : Trim elasticity
 gid://shopify/TaxonomyAttribute/10464 : Trim finish
+gid://shopify/TaxonomyAttribute/12179 : Trim header width
+gid://shopify/TaxonomyAttribute/12724 : Trim length
 gid://shopify/TaxonomyAttribute/6235  : Trimmer line feed system
 gid://shopify/TaxonomyAttribute/6236  : Trimmer line shape
 gid://shopify/TaxonomyAttribute/2166  : Trip type
@@ -7624,6 +8746,7 @@ gid://shopify/TaxonomyAttribute/3060  : Tripod/Monopod attachment type
 gid://shopify/TaxonomyAttribute/2009  : Tripod/Monopod head type
 gid://shopify/TaxonomyAttribute/8810  : Trolleybus power supply type
 gid://shopify/TaxonomyAttribute/2528  : Trophy design
+gid://shopify/TaxonomyAttribute/12180 : Truck axle width
 gid://shopify/TaxonomyAttribute/8812  : Truck bed length class
 gid://shopify/TaxonomyAttribute/8811  : Truck bed/body type
 gid://shopify/TaxonomyAttribute/11166 : Truck mounting hole pattern
@@ -7638,10 +8761,13 @@ gid://shopify/TaxonomyAttribute/10467 : Tuba leadpipe material
 gid://shopify/TaxonomyAttribute/10468 : Tube base type
 gid://shopify/TaxonomyAttribute/2417  : Tube component
 gid://shopify/TaxonomyAttribute/2418  : Tube configuration
+gid://shopify/TaxonomyAttribute/12181 : Tube diameter
+gid://shopify/TaxonomyAttribute/12726 : Tube length
 gid://shopify/TaxonomyAttribute/10469 : Tube matching grade
 gid://shopify/TaxonomyAttribute/11169 : Tube weight category
 gid://shopify/TaxonomyAttribute/11170 : Tubeless compatible
 gid://shopify/TaxonomyAttribute/10470 : Tubing shape
+gid://shopify/TaxonomyAttribute/12727 : Tubing size (before shrinking)
 gid://shopify/TaxonomyAttribute/11171 : Tubular construction type
 gid://shopify/TaxonomyAttribute/10471 : Tulip type (flower form)
 gid://shopify/TaxonomyAttribute/3286  : Tuner design
@@ -7651,9 +8777,12 @@ gid://shopify/TaxonomyAttribute/2588  : Tuning fork design
 gid://shopify/TaxonomyAttribute/2589  : Tuning fork frequency
 gid://shopify/TaxonomyAttribute/10473 : Tuning mechanism
 gid://shopify/TaxonomyAttribute/2399  : Tuning modes
+gid://shopify/TaxonomyAttribute/12183 : Tuning peg post diameter
 gid://shopify/TaxonomyAttribute/2465  : Tuning pitch
 gid://shopify/TaxonomyAttribute/2400  : Tuning range
 gid://shopify/TaxonomyAttribute/10474 : Tuning system
+gid://shopify/TaxonomyAttribute/12184 : Tunnel diameter
+gid://shopify/TaxonomyAttribute/12185 : Turn radius
 gid://shopify/TaxonomyAttribute/8814  : Turn signal lens color
 gid://shopify/TaxonomyAttribute/8815  : Turn signal lighting style
 gid://shopify/TaxonomyAttribute/7988  : Turnip and rutabaga variety
@@ -7661,7 +8790,9 @@ gid://shopify/TaxonomyAttribute/6237  : Turntable type
 gid://shopify/TaxonomyAttribute/8816  : Tweeter crossover type
 gid://shopify/TaxonomyAttribute/8817  : Tweeter material
 gid://shopify/TaxonomyAttribute/8818  : Tweeter mount type
+gid://shopify/TaxonomyAttribute/12186 : Tweeter sensitivity
 gid://shopify/TaxonomyAttribute/10475 : Twill direction
+gid://shopify/TaxonomyAttribute/12187 : Twine thickness
 gid://shopify/TaxonomyAttribute/10476 : Twist direction
 gid://shopify/TaxonomyAttribute/8819  : U-joint series/size
 gid://shopify/TaxonomyAttribute/5027  : UC platform certification
@@ -7705,6 +8836,8 @@ gid://shopify/TaxonomyAttribute/6239  : Umbrella base type
 gid://shopify/TaxonomyAttribute/6240  : Umbrella opening mechanism
 gid://shopify/TaxonomyAttribute/6241  : Umbrella type
 gid://shopify/TaxonomyAttribute/6972  : Under-bed features
+gid://shopify/TaxonomyAttribute/12188 : Underbed clearance
+gid://shopify/TaxonomyAttribute/12189 : Underbed clearance height
 gid://shopify/TaxonomyAttribute/6843  : Underfoot strap type
 gid://shopify/TaxonomyAttribute/3249  : Undershirt style
 gid://shopify/TaxonomyAttribute/6844  : Underwear fit
@@ -7718,11 +8851,13 @@ gid://shopify/TaxonomyAttribute/8821  : Update method
 gid://shopify/TaxonomyAttribute/8822  : Upholstery fabric backing type
 gid://shopify/TaxonomyAttribute/8823  : Upholstery fabric water resistance
 gid://shopify/TaxonomyAttribute/2797  : Upholstery material
+gid://shopify/TaxonomyAttribute/12728 : Uplink gain
 gid://shopify/TaxonomyAttribute/5357  : Uplink port type
 gid://shopify/TaxonomyAttribute/6848  : Upper material
 gid://shopify/TaxonomyAttribute/10491 : Upright bass pickup system
 gid://shopify/TaxonomyAttribute/10492 : Upright piano power source
 gid://shopify/TaxonomyAttribute/11172 : Urination device features
+gid://shopify/TaxonomyAttribute/12192 : Usable fabric width
 gid://shopify/TaxonomyAttribute/8824  : Usage
 gid://shopify/TaxonomyAttribute/1681  : Usage conditions
 gid://shopify/TaxonomyAttribute/5288  : Usage environment
@@ -7740,6 +8875,7 @@ gid://shopify/TaxonomyAttribute/5390  : VESA mounting pattern
 gid://shopify/TaxonomyAttribute/1512  : VG/PG ratio
 gid://shopify/TaxonomyAttribute/8880  : VOC compliance standard
 gid://shopify/TaxonomyAttribute/8881  : VOC regulatory class
+gid://shopify/TaxonomyAttribute/12731 : VPN throughput
 gid://shopify/TaxonomyAttribute/1382  : Vacuum air filtering technology
 gid://shopify/TaxonomyAttribute/6246  : Vacuum hose connection type
 gid://shopify/TaxonomyAttribute/8825  : Vacuum/boost reference port
@@ -7752,6 +8888,8 @@ gid://shopify/TaxonomyAttribute/8826  : Valve cover gasket material
 gid://shopify/TaxonomyAttribute/8827  : Valve cover material
 gid://shopify/TaxonomyAttribute/8828  : Valve design
 gid://shopify/TaxonomyAttribute/10493 : Valve guard coverage area
+gid://shopify/TaxonomyAttribute/12194 : Valve length
+gid://shopify/TaxonomyAttribute/12195 : Valve lift
 gid://shopify/TaxonomyAttribute/6249  : Valve stem angle
 gid://shopify/TaxonomyAttribute/1280  : Valve type
 gid://shopify/TaxonomyAttribute/8829  : Valvetrain configuration
@@ -7774,6 +8912,7 @@ gid://shopify/TaxonomyAttribute/3201  : Vehicle braking features
 gid://shopify/TaxonomyAttribute/3211  : Vehicle cleaning item features
 gid://shopify/TaxonomyAttribute/8833  : Vehicle coaxial speaker nominal size
 gid://shopify/TaxonomyAttribute/8834  : Vehicle cover size class
+gid://shopify/TaxonomyAttribute/12196 : Vehicle curb weight
 gid://shopify/TaxonomyAttribute/3212  : Vehicle decor features
 gid://shopify/TaxonomyAttribute/8835  : Vehicle decor set items included
 gid://shopify/TaxonomyAttribute/8836  : Vehicle door lock actuation method
@@ -7793,6 +8932,7 @@ gid://shopify/TaxonomyAttribute/3206  : Vehicle frame/body features
 gid://shopify/TaxonomyAttribute/8842  : Vehicle glass cleaner form
 gid://shopify/TaxonomyAttribute/8843  : Vehicle hitch cover illumination type
 gid://shopify/TaxonomyAttribute/8844  : Vehicle hitch cover mounting type
+gid://shopify/TaxonomyAttribute/12197 : Vehicle length
 gid://shopify/TaxonomyAttribute/8845  : Vehicle license plate finish
 gid://shopify/TaxonomyAttribute/8846  : Vehicle license plate frame anti-theft design
 gid://shopify/TaxonomyAttribute/8847  : Vehicle license plate frame plate standard
@@ -7808,6 +8948,7 @@ gid://shopify/TaxonomyAttribute/8856  : Vehicle lift mounting type
 gid://shopify/TaxonomyAttribute/8857  : Vehicle lift type
 gid://shopify/TaxonomyAttribute/8858  : Vehicle magnet attachment type
 gid://shopify/TaxonomyAttribute/8859  : Vehicle magnet intended use
+gid://shopify/TaxonomyAttribute/12198 : Vehicle mileage
 gid://shopify/TaxonomyAttribute/8860  : Vehicle mirror adjustment type
 gid://shopify/TaxonomyAttribute/3408  : Vehicle mirror design
 gid://shopify/TaxonomyAttribute/3207  : Vehicle mirror features
@@ -7831,6 +8972,9 @@ gid://shopify/TaxonomyAttribute/3209  : Vehicle suspension features
 gid://shopify/TaxonomyAttribute/2701  : Vehicle tire type
 gid://shopify/TaxonomyAttribute/2705  : Vehicle type
 gid://shopify/TaxonomyAttribute/8871  : Vehicle wax/polish product form
+gid://shopify/TaxonomyAttribute/12199 : Vehicle wheel backspacing
+gid://shopify/TaxonomyAttribute/12200 : Vehicle wheel load rating
+gid://shopify/TaxonomyAttribute/12201 : Vehicle wheel offset
 gid://shopify/TaxonomyAttribute/8872  : Vehicle wheel valve stem type
 gid://shopify/TaxonomyAttribute/8873  : Vehicle windshield fluid formula
 gid://shopify/TaxonomyAttribute/6849  : Veil length type
@@ -7843,12 +8987,15 @@ gid://shopify/TaxonomyAttribute/8875  : Ventilation level
 gid://shopify/TaxonomyAttribute/5582  : Ventilation type
 gid://shopify/TaxonomyAttribute/8876  : Venting design
 gid://shopify/TaxonomyAttribute/2607  : Verification technology
+gid://shopify/TaxonomyAttribute/12202 : Vertical drop distance
+gid://shopify/TaxonomyAttribute/12203 : Vestibule floor area
 gid://shopify/TaxonomyAttribute/11177 : Vestibule type
 gid://shopify/TaxonomyAttribute/10498 : Vibraphone bar material
 gid://shopify/TaxonomyAttribute/10499 : Vibraphone motor type
 gid://shopify/TaxonomyAttribute/10500 : Vibraphone range (octaves)
 gid://shopify/TaxonomyAttribute/10501 : Vibraphone resonator tube material
 gid://shopify/TaxonomyAttribute/10502 : Vibraphone tuning standard
+gid://shopify/TaxonomyAttribute/12204 : Vibration amplitude
 gid://shopify/TaxonomyAttribute/1963  : Video codecs/formats supported
 gid://shopify/TaxonomyAttribute/3168  : Video game content features
 gid://shopify/TaxonomyAttribute/4678  : Video game format
@@ -7869,6 +9016,7 @@ gid://shopify/TaxonomyAttribute/8877  : Vintage & classic truck cab type
 gid://shopify/TaxonomyAttribute/10503 : Vintage advertisement decade
 gid://shopify/TaxonomyAttribute/10504 : Vintage advertisement format
 gid://shopify/TaxonomyAttribute/10505 : Vintage advertisement subject category
+gid://shopify/TaxonomyAttribute/12205 : Viola body length
 gid://shopify/TaxonomyAttribute/11179 : Virginia Tech helmet star rating
 gid://shopify/TaxonomyAttribute/10506 : Virtual analog synthesizer form factor
 gid://shopify/TaxonomyAttribute/2711  : Viscosity
@@ -7884,19 +9032,26 @@ gid://shopify/TaxonomyAttribute/2303  : Visual effect
 gid://shopify/TaxonomyAttribute/1942  : VoIP protocol support
 gid://shopify/TaxonomyAttribute/7991  : Vodka base ingredient
 gid://shopify/TaxonomyAttribute/8882  : Voice coil configuration
+gid://shopify/TaxonomyAttribute/12207 : Voice coil diameter
 gid://shopify/TaxonomyAttribute/6614  : Voice effects
 gid://shopify/TaxonomyAttribute/5464  : Voice recorder form factor
+gid://shopify/TaxonomyAttribute/12729 : Voltage
 gid://shopify/TaxonomyAttribute/8883  : Voltage rating type
 gid://shopify/TaxonomyAttribute/8884  : Voltage regulator connector type
+gid://shopify/TaxonomyAttribute/12730 : Volume
 gid://shopify/TaxonomyAttribute/5353  : WAN interface type
 gid://shopify/TaxonomyAttribute/11184 : Wader foot type
 gid://shopify/TaxonomyAttribute/11185 : Wader sole type
+gid://shopify/TaxonomyAttribute/12208 : Wader thickness
 gid://shopify/TaxonomyAttribute/3185  : Wader type
 gid://shopify/TaxonomyAttribute/6253  : Waffle style
+gid://shopify/TaxonomyAttribute/12209 : Waist reduction potential
 gid://shopify/TaxonomyAttribute/37    : Waist rise
+gid://shopify/TaxonomyAttribute/12732 : Waist size
 gid://shopify/TaxonomyAttribute/6850  : Waistband style
 gid://shopify/TaxonomyAttribute/11186 : Wakeboard binding mounting pattern
 gid://shopify/TaxonomyAttribute/11187 : Wakeboard riding style
+gid://shopify/TaxonomyAttribute/12733 : Wakeboard size
 gid://shopify/TaxonomyAttribute/5074  : Walker brake type
 gid://shopify/TaxonomyAttribute/5075  : Walker seat type
 gid://shopify/TaxonomyAttribute/5073  : Walker type
@@ -7923,6 +9078,7 @@ gid://shopify/TaxonomyAttribute/1389  : Washing method
 gid://shopify/TaxonomyAttribute/1377  : Washing programs
 gid://shopify/TaxonomyAttribute/6259  : Waste container lid features
 gid://shopify/TaxonomyAttribute/6260  : Waste container sign message
+gid://shopify/TaxonomyAttribute/12210 : Waste tank capacity
 gid://shopify/TaxonomyAttribute/1202  : Watch accessory style
 gid://shopify/TaxonomyAttribute/6851  : Watch band design
 gid://shopify/TaxonomyAttribute/1201  : Watch display
@@ -7930,7 +9086,9 @@ gid://shopify/TaxonomyAttribute/3008  : Watch features
 gid://shopify/TaxonomyAttribute/6852  : Watch movement
 gid://shopify/TaxonomyAttribute/2951  : Watch/Band material
 gid://shopify/TaxonomyAttribute/8885  : Water activation
+gid://shopify/TaxonomyAttribute/12211 : Water capacity
 gid://shopify/TaxonomyAttribute/6973  : Water chamber configuration
+gid://shopify/TaxonomyAttribute/12734 : Water consumption per cycle
 gid://shopify/TaxonomyAttribute/11189 : Water dispensing mechanism
 gid://shopify/TaxonomyAttribute/6615  : Water exposure protection level
 gid://shopify/TaxonomyAttribute/1407  : Water filter application
@@ -7949,6 +9107,7 @@ gid://shopify/TaxonomyAttribute/8887  : Water pump drive type
 gid://shopify/TaxonomyAttribute/8888  : Water pump housing material
 gid://shopify/TaxonomyAttribute/8889  : Water pump impeller material
 gid://shopify/TaxonomyAttribute/8890  : Water pump mounting type
+gid://shopify/TaxonomyAttribute/12212 : Water pump outlet port diameter
 gid://shopify/TaxonomyAttribute/7992  : Water purification method
 gid://shopify/TaxonomyAttribute/11193 : Water resistance
 gid://shopify/TaxonomyAttribute/10511 : Water resistance level
@@ -7959,6 +9118,7 @@ gid://shopify/TaxonomyAttribute/10515 : Water rocket recovery system
 gid://shopify/TaxonomyAttribute/6263  : Water sensor design
 gid://shopify/TaxonomyAttribute/11194 : Water ski base design
 gid://shopify/TaxonomyAttribute/11195 : Water ski fin type
+gid://shopify/TaxonomyAttribute/12735 : Water ski size
 gid://shopify/TaxonomyAttribute/7993  : Water source
 gid://shopify/TaxonomyAttribute/1249  : Water sport
 gid://shopify/TaxonomyAttribute/11196 : Water sports safety standard
@@ -7966,23 +9126,36 @@ gid://shopify/TaxonomyAttribute/6264  : Water supply type
 gid://shopify/TaxonomyAttribute/6620  : Water table feature set
 gid://shopify/TaxonomyAttribute/6621  : Water table items included
 gid://shopify/TaxonomyAttribute/6622  : Water table water source type
+gid://shopify/TaxonomyAttribute/12736 : Water tank capacity
+gid://shopify/TaxonomyAttribute/12214 : Water treatment capacity
+gid://shopify/TaxonomyAttribute/12215 : Water volume treated per tablet
 gid://shopify/TaxonomyAttribute/8886  : Water-fed design
 gid://shopify/TaxonomyAttribute/6975  : Waterbed stabilization level
 gid://shopify/TaxonomyAttribute/10516 : Watercolor ink water resistance (after drying)
+gid://shopify/TaxonomyAttribute/12216 : Watercraft beam
 gid://shopify/TaxonomyAttribute/8891  : Watercraft care application area
+gid://shopify/TaxonomyAttribute/12217 : Watercraft care coverage area
 gid://shopify/TaxonomyAttribute/11197 : Watercraft drive mechanism
 gid://shopify/TaxonomyAttribute/2737  : Watercraft engine control type
 gid://shopify/TaxonomyAttribute/3216  : Watercraft features
+gid://shopify/TaxonomyAttribute/12218 : Watercraft fuel tank feed connection diameter
+gid://shopify/TaxonomyAttribute/12219 : Watercraft fuel tank fill neck diameter
 gid://shopify/TaxonomyAttribute/8892  : Watercraft fuel tank sending unit pattern
 gid://shopify/TaxonomyAttribute/8893  : Watercraft fuel tank shape
+gid://shopify/TaxonomyAttribute/12220 : Watercraft fuel tank vent connection diameter
 gid://shopify/TaxonomyAttribute/8894  : Watercraft hull material
 gid://shopify/TaxonomyAttribute/8895  : Watercraft ignition part voltage
 gid://shopify/TaxonomyAttribute/8896  : Watercraft impeller material grade
+gid://shopify/TaxonomyAttribute/12221 : Watercraft impeller outer diameter
+gid://shopify/TaxonomyAttribute/12222 : Watercraft impeller thickness (overall width)
 gid://shopify/TaxonomyAttribute/8897  : Watercraft lighting certification / compliance
+gid://shopify/TaxonomyAttribute/12223 : Watercraft motor lock shackle/bolt diameter
 gid://shopify/TaxonomyAttribute/8898  : Watercraft motor mount adjustment features
 gid://shopify/TaxonomyAttribute/2739  : Watercraft motor mounting type
 gid://shopify/TaxonomyAttribute/8899  : Watercraft piston part type
 gid://shopify/TaxonomyAttribute/8900  : Watercraft propeller blade rake
+gid://shopify/TaxonomyAttribute/12224 : Watercraft propeller diameter
+gid://shopify/TaxonomyAttribute/12225 : Watercraft propeller pitch
 gid://shopify/TaxonomyAttribute/8901  : Watercraft propeller rotation direction
 gid://shopify/TaxonomyAttribute/2863  : Watercraft propulsion type
 gid://shopify/TaxonomyAttribute/8902  : Watercraft pump stage / impeller role
@@ -7990,6 +9163,7 @@ gid://shopify/TaxonomyAttribute/8903  : Watercraft registration status
 gid://shopify/TaxonomyAttribute/8904  : Watercraft safety equipment activation type
 gid://shopify/TaxonomyAttribute/8905  : Watercraft steering cable core material
 gid://shopify/TaxonomyAttribute/8906  : Watercraft steering cable hardware included
+gid://shopify/TaxonomyAttribute/12226 : Watercraft steering cable stroke
 gid://shopify/TaxonomyAttribute/8907  : Watercraft steering cable system type
 gid://shopify/TaxonomyAttribute/8908  : Watercraft steering wheel hub/bore type
 gid://shopify/TaxonomyAttribute/2743  : Watercraft steering wheel type
@@ -7997,10 +9171,14 @@ gid://shopify/TaxonomyAttribute/2755  : Watercraft type
 gid://shopify/TaxonomyAttribute/7994  : Watercress variety
 gid://shopify/TaxonomyAttribute/6265  : Watering needs
 gid://shopify/TaxonomyAttribute/11198 : Waterproof level
+gid://shopify/TaxonomyAttribute/12737 : Waterproof rating (hydrostatic head)
+gid://shopify/TaxonomyAttribute/12738 : Waveski size
 gid://shopify/TaxonomyAttribute/2893  : Wax application method
 gid://shopify/TaxonomyAttribute/10517 : Wax blend composition
 gid://shopify/TaxonomyAttribute/11199 : Wax coat type
 gid://shopify/TaxonomyAttribute/11200 : Wax hardness
+gid://shopify/TaxonomyAttribute/12227 : Wax included weight
+gid://shopify/TaxonomyAttribute/12228 : Wax melt point temperature
 gid://shopify/TaxonomyAttribute/6266  : Wax paper form
 gid://shopify/TaxonomyAttribute/10518 : Wax physical form
 gid://shopify/TaxonomyAttribute/10519 : Wax recommended candle application
@@ -8018,29 +9196,38 @@ gid://shopify/TaxonomyAttribute/6854  : Weave style
 gid://shopify/TaxonomyAttribute/10520 : Weave type
 gid://shopify/TaxonomyAttribute/6853  : Weave/finish
 gid://shopify/TaxonomyAttribute/10521 : Weaving beater edge type
+gid://shopify/TaxonomyAttribute/12229 : Weaving beater edge width
 gid://shopify/TaxonomyAttribute/10522 : Weaving beater style
 gid://shopify/TaxonomyAttribute/10523 : Weaving shuttle tip style
 gid://shopify/TaxonomyAttribute/10524 : Weaving shuttle use case
+gid://shopify/TaxonomyAttribute/12230 : Weaving width
 gid://shopify/TaxonomyAttribute/11203 : Webbing construction type
 gid://shopify/TaxonomyAttribute/11204 : Webbing design
 gid://shopify/TaxonomyAttribute/2033  : Webcam design
+gid://shopify/TaxonomyAttribute/12739 : Weight
+gid://shopify/TaxonomyAttribute/12232 : Weight (packed)
 gid://shopify/TaxonomyAttribute/11205 : Weight adjustability
 gid://shopify/TaxonomyAttribute/1233  : Weight bar activity
 gid://shopify/TaxonomyAttribute/1234  : Weight bar type
 gid://shopify/TaxonomyAttribute/11206 : Weight integration system
 gid://shopify/TaxonomyAttribute/5139  : Weight loss mechanism
+gid://shopify/TaxonomyAttribute/12740 : Weight measurement accuracy
 gid://shopify/TaxonomyAttribute/11207 : Weight plate compatibility
 gid://shopify/TaxonomyAttribute/11208 : Weight plate style
+gid://shopify/TaxonomyAttribute/12234 : Weight stack
 gid://shopify/TaxonomyAttribute/2392  : Weight type
 gid://shopify/TaxonomyAttribute/1552  : Weight unit supported
 gid://shopify/TaxonomyAttribute/11209 : Weightlifting belt style
 gid://shopify/TaxonomyAttribute/11210 : Weightlifting federation certification
 gid://shopify/TaxonomyAttribute/3059  : Welding helmet features
+gid://shopify/TaxonomyAttribute/12235 : Wet boiling point
 gid://shopify/TaxonomyAttribute/11211 : Wetsuit boot height
 gid://shopify/TaxonomyAttribute/11212 : Wetsuit entry system
 gid://shopify/TaxonomyAttribute/11213 : Wetsuit seam construction
+gid://shopify/TaxonomyAttribute/12741 : Wetsuit thickness
 gid://shopify/TaxonomyAttribute/7995  : Wheat product form
 gid://shopify/TaxonomyAttribute/10525 : Wheel arrangement
+gid://shopify/TaxonomyAttribute/12742 : Wheel base
 gid://shopify/TaxonomyAttribute/6268  : Wheel bearing type
 gid://shopify/TaxonomyAttribute/11214 : Wheel brake type
 gid://shopify/TaxonomyAttribute/8910  : Wheel chock grip features
@@ -8055,14 +9242,19 @@ gid://shopify/TaxonomyAttribute/1314  : Wheel hardness
 gid://shopify/TaxonomyAttribute/1315  : Wheel hub placement
 gid://shopify/TaxonomyAttribute/11216 : Wheel illumination
 gid://shopify/TaxonomyAttribute/11217 : Wheel material
+gid://shopify/TaxonomyAttribute/12237 : Wheel offset
 gid://shopify/TaxonomyAttribute/2704  : Wheel part type
 gid://shopify/TaxonomyAttribute/11218 : Wheel profile
 gid://shopify/TaxonomyAttribute/11219 : Wheel setup type
+gid://shopify/TaxonomyAttribute/12743 : Wheel size
+gid://shopify/TaxonomyAttribute/12238 : Wheel spacer thickness
 gid://shopify/TaxonomyAttribute/5641  : Wheel style
 gid://shopify/TaxonomyAttribute/8917  : Wheel system finish
 gid://shopify/TaxonomyAttribute/6269  : Wheel tread style
 gid://shopify/TaxonomyAttribute/1283  : Wheel type
+gid://shopify/TaxonomyAttribute/12239 : Wheel width
 gid://shopify/TaxonomyAttribute/1587  : Wheelchair type
+gid://shopify/TaxonomyAttribute/12240 : Whip diameter
 gid://shopify/TaxonomyAttribute/11220 : Whip style
 gid://shopify/TaxonomyAttribute/7996  : Whipped cream base
 gid://shopify/TaxonomyAttribute/7997  : Whipped cream form
@@ -8077,21 +9269,33 @@ gid://shopify/TaxonomyAttribute/10529 : White glue finish/appearance when dry
 gid://shopify/TaxonomyAttribute/10530 : White glue washability
 gid://shopify/TaxonomyAttribute/11222 : Whitewater kayak style
 gid://shopify/TaxonomyAttribute/11223 : Whitewater rating (class)
+gid://shopify/TaxonomyAttribute/12241 : Whorl diameter
 gid://shopify/TaxonomyAttribute/10531 : Whorl mounting interface
 gid://shopify/TaxonomyAttribute/1940  : Wi-Fi band
 gid://shopify/TaxonomyAttribute/1847  : Wi-Fi standard
 gid://shopify/TaxonomyAttribute/10532 : Wick construction type
 gid://shopify/TaxonomyAttribute/10533 : Wick core type
+gid://shopify/TaxonomyAttribute/12242 : Wick diameter
+gid://shopify/TaxonomyAttribute/12243 : Wick hole diameter
+gid://shopify/TaxonomyAttribute/12244 : Wick length
 gid://shopify/TaxonomyAttribute/6271  : Wick material
 gid://shopify/TaxonomyAttribute/10534 : Wick tab crimp type
 gid://shopify/TaxonomyAttribute/10535 : Wick tab material
+gid://shopify/TaxonomyAttribute/12245 : Wick tab neck height
+gid://shopify/TaxonomyAttribute/12246 : Wick tab neck inner diameter
 gid://shopify/TaxonomyAttribute/10536 : Wick tab shape
+gid://shopify/TaxonomyAttribute/12247 : Wick tab size
 gid://shopify/TaxonomyAttribute/10537 : Wick type included
+gid://shopify/TaxonomyAttribute/12744 : Width
+gid://shopify/TaxonomyAttribute/12745 : Width (folded)
+gid://shopify/TaxonomyAttribute/12746 : Width (packed)
+gid://shopify/TaxonomyAttribute/12747 : Width (pitched)
 gid://shopify/TaxonomyAttribute/5061  : Width adjustment
 gid://shopify/TaxonomyAttribute/6855  : Wig fiber material
 gid://shopify/TaxonomyAttribute/11224 : Wildlife attractant scent
 gid://shopify/TaxonomyAttribute/11225 : Willow grade
 gid://shopify/TaxonomyAttribute/11226 : Willow type
+gid://shopify/TaxonomyAttribute/12748 : Wind speed accuracy
 gid://shopify/TaxonomyAttribute/6623  : Wind-up mechanism type
 gid://shopify/TaxonomyAttribute/6624  : Wind-up toy movement pattern
 gid://shopify/TaxonomyAttribute/11227 : Windbreak purpose
@@ -8117,6 +9321,7 @@ gid://shopify/TaxonomyAttribute/8925  : Window glass tint level
 gid://shopify/TaxonomyAttribute/8926  : Window net latch mechanism
 gid://shopify/TaxonomyAttribute/8927  : Window net mounting hardware
 gid://shopify/TaxonomyAttribute/8928  : Window net opening direction
+gid://shopify/TaxonomyAttribute/12249 : Window net strap width
 gid://shopify/TaxonomyAttribute/8929  : Window regulator operation
 gid://shopify/TaxonomyAttribute/6274  : Window rod type
 gid://shopify/TaxonomyAttribute/6275  : Window screen type
@@ -8124,8 +9329,11 @@ gid://shopify/TaxonomyAttribute/6276  : Window treatment lining type
 gid://shopify/TaxonomyAttribute/2807  : Window treatment material
 gid://shopify/TaxonomyAttribute/8930  : Windshield coverage area
 gid://shopify/TaxonomyAttribute/8931  : Windshield mount attachment method
+gid://shopify/TaxonomyAttribute/12250 : Windshield repair kit maximum crack length
+gid://shopify/TaxonomyAttribute/12251 : Windshield repair kit maximum repair diameter
 gid://shopify/TaxonomyAttribute/8932  : Windshield washer fluid seasonality
 gid://shopify/TaxonomyAttribute/11231 : Windsurf fin style
+gid://shopify/TaxonomyAttribute/12749 : Windsurfing board size
 gid://shopify/TaxonomyAttribute/2869  : Windsurfing board style
 gid://shopify/TaxonomyAttribute/11232 : Windsurfing connection standard
 gid://shopify/TaxonomyAttribute/11233 : Windsurfing sail style
@@ -8141,18 +9349,23 @@ gid://shopify/TaxonomyAttribute/8000  : Wine style
 gid://shopify/TaxonomyAttribute/1475  : Wine sweetness
 gid://shopify/TaxonomyAttribute/1476  : Wine variety
 gid://shopify/TaxonomyAttribute/10544 : Winemaking process stage
+gid://shopify/TaxonomyAttribute/12253 : Wing area
 gid://shopify/TaxonomyAttribute/6625  : Wing count
 gid://shopify/TaxonomyAttribute/11234 : Wing handle type
 gid://shopify/TaxonomyAttribute/11235 : Wing part type
 gid://shopify/TaxonomyAttribute/5319  : Wing style
+gid://shopify/TaxonomyAttribute/12255 : Wingfoil board length
 gid://shopify/TaxonomyAttribute/11236 : Wingfoiling style
+gid://shopify/TaxonomyAttribute/12256 : Wingspan
 gid://shopify/TaxonomyAttribute/3032  : Wipe dispenser/warmer features
 gid://shopify/TaxonomyAttribute/1722  : Wipe fragrance
 gid://shopify/TaxonomyAttribute/1753  : Wipe packaging
 gid://shopify/TaxonomyAttribute/5240  : Wipe purpose
 gid://shopify/TaxonomyAttribute/8933  : Wiper arm finish
+gid://shopify/TaxonomyAttribute/12257 : Wiper arm length
 gid://shopify/TaxonomyAttribute/8934  : Wiper arm pivot mount type
 gid://shopify/TaxonomyAttribute/8935  : Wiper blade attachment type
+gid://shopify/TaxonomyAttribute/12258 : Wiper blade length
 gid://shopify/TaxonomyAttribute/8936  : Wiper blade rubber material
 gid://shopify/TaxonomyAttribute/8937  : Wiper system position
 gid://shopify/TaxonomyAttribute/10545 : Wire coating material
@@ -8161,8 +9374,10 @@ gid://shopify/TaxonomyAttribute/10547 : Wire construction type
 gid://shopify/TaxonomyAttribute/10548 : Wire finish
 gid://shopify/TaxonomyAttribute/8938  : Wire gauge (AWG)
 gid://shopify/TaxonomyAttribute/8939  : Wire insulation material
+gid://shopify/TaxonomyAttribute/12750 : Wire length
 gid://shopify/TaxonomyAttribute/10549 : Wire packaging type
 gid://shopify/TaxonomyAttribute/10550 : Wire shape/profile
+gid://shopify/TaxonomyAttribute/12259 : Wire spool length
 gid://shopify/TaxonomyAttribute/2341  : Wire thickness
 gid://shopify/TaxonomyAttribute/2903  : Wire/Rope material
 gid://shopify/TaxonomyAttribute/5029  : Wireless charging standard
@@ -8176,23 +9391,36 @@ gid://shopify/TaxonomyAttribute/5685  : Wood finish
 gid://shopify/TaxonomyAttribute/10552 : Wood grain direction
 gid://shopify/TaxonomyAttribute/6280  : Wood grain orientation
 gid://shopify/TaxonomyAttribute/6281  : Wood seasoning method
+gid://shopify/TaxonomyAttribute/12260 : Wood slice diameter
 gid://shopify/TaxonomyAttribute/10553 : Wood slice edge style
 gid://shopify/TaxonomyAttribute/6626  : Wooden block special features
 gid://shopify/TaxonomyAttribute/10554 : Woodwind body construction
 gid://shopify/TaxonomyAttribute/2451  : Woodwind care items included
 gid://shopify/TaxonomyAttribute/10555 : Woodwind polishing cloth intended use
 gid://shopify/TaxonomyAttribute/10556 : Woodwind small part type
+gid://shopify/TaxonomyAttribute/12261 : Woofer diameter
+gid://shopify/TaxonomyAttribute/12262 : Woofer mounting cutout diameter
+gid://shopify/TaxonomyAttribute/12263 : Woofer mounting depth
 gid://shopify/TaxonomyAttribute/8940  : Woofer mounting type
+gid://shopify/TaxonomyAttribute/12264 : Woofer sensitivity
 gid://shopify/TaxonomyAttribute/8941  : Woofer surround material
 gid://shopify/TaxonomyAttribute/3389  : Work capacity
+gid://shopify/TaxonomyAttribute/12751 : Working area height
+gid://shopify/TaxonomyAttribute/12265 : Working area length
+gid://shopify/TaxonomyAttribute/12752 : Working area width
+gid://shopify/TaxonomyAttribute/12753 : Working distance
 gid://shopify/TaxonomyAttribute/10557 : Worn-on finger
+gid://shopify/TaxonomyAttribute/12267 : Wrap coverage area
 gid://shopify/TaxonomyAttribute/6282  : Wrap format
 gid://shopify/TaxonomyAttribute/11239 : Wrap style
 gid://shopify/TaxonomyAttribute/10558 : Wrapping occasion
 gid://shopify/TaxonomyAttribute/10559 : Wrapping paper features
 gid://shopify/TaxonomyAttribute/2309  : Wreath design
+gid://shopify/TaxonomyAttribute/12270 : Wrench flat size
 gid://shopify/TaxonomyAttribute/11240 : Wrestling dummy design
 gid://shopify/TaxonomyAttribute/11241 : Wrestling mat safety certifications
+gid://shopify/TaxonomyAttribute/12271 : Wrist pin diameter
+gid://shopify/TaxonomyAttribute/12272 : Wrist pin length
 gid://shopify/TaxonomyAttribute/5622  : Wrist rest features
 gid://shopify/TaxonomyAttribute/5621  : Wrist rest type
 gid://shopify/TaxonomyAttribute/11242 : Wrist strap style
@@ -8205,11 +9433,14 @@ gid://shopify/TaxonomyAttribute/8001  : Yam variety
 gid://shopify/TaxonomyAttribute/10562 : Yarn cutter physical style
 gid://shopify/TaxonomyAttribute/11244 : Yarn finish or effect
 gid://shopify/TaxonomyAttribute/10563 : Yarn guide style
+gid://shopify/TaxonomyAttribute/12754 : Yarn length
 gid://shopify/TaxonomyAttribute/10564 : Yarn swift adjustability
 gid://shopify/TaxonomyAttribute/10565 : Yarn swift bearing type
+gid://shopify/TaxonomyAttribute/12273 : Yarn swift maximum skein circumference
 gid://shopify/TaxonomyAttribute/2312  : Yarn weight category
 gid://shopify/TaxonomyAttribute/8002  : Yeast application
 gid://shopify/TaxonomyAttribute/6627  : Yo-yo accessory/part type
+gid://shopify/TaxonomyAttribute/12275 : Yo-yo axle length
 gid://shopify/TaxonomyAttribute/6628  : Yo-yo axle system type
 gid://shopify/TaxonomyAttribute/6629  : Yo-yo bearing size class
 gid://shopify/TaxonomyAttribute/6630  : Yo-yo bearing type
@@ -8222,8 +9453,10 @@ gid://shopify/TaxonomyAttribute/11245 : Yoke type
 gid://shopify/TaxonomyAttribute/10566 : Zill playing style
 gid://shopify/TaxonomyAttribute/10567 : Zill strap material
 gid://shopify/TaxonomyAttribute/10568 : Zills strap adjustability
+gid://shopify/TaxonomyAttribute/12276 : Zills weight
 gid://shopify/TaxonomyAttribute/10569 : Zipper application
 gid://shopify/TaxonomyAttribute/10570 : Zipper chain type
+gid://shopify/TaxonomyAttribute/12277 : Zipper chain width
 gid://shopify/TaxonomyAttribute/10571 : Zipper end type
 gid://shopify/TaxonomyAttribute/10572 : Zipper gauge
 gid://shopify/TaxonomyAttribute/6857  : Zipper opening length
@@ -8238,6 +9471,7 @@ gid://shopify/TaxonomyAttribute/10578 : Zipper slider material
 gid://shopify/TaxonomyAttribute/10579 : Zipper slider/pull configuration
 gid://shopify/TaxonomyAttribute/6858  : Zipper style
 gid://shopify/TaxonomyAttribute/10580 : Zipper tape material
+gid://shopify/TaxonomyAttribute/12278 : Zipper tape width
 gid://shopify/TaxonomyAttribute/10581 : Zipper teeth type
 gid://shopify/TaxonomyAttribute/2268  : Zoom type
 gid://shopify/TaxonomyAttribute/6060  : pH adjustment direction


### PR DESCRIPTION
## What this PR does

This PR imports the Core/Admin-compatible V0 set of measurement attributes into the public taxonomy package.

## ⚠️ Reviewer note: `taxonomy.json` formatting

This PR also changes `dist/en/taxonomy.json` to be generated in compact JSON form. This is intentional, but it is not a trivial formatting change: after adding the measurement vocabulary, the pretty-printed generated `taxonomy.json` is ~106 MB, which exceeds GitHub's hard 100 MB per-file limit and cannot be pushed.

The compact file preserves the same JSON data contract for consumers that parse `taxonomy.json`, but it does make the file much less human-readable and creates a large formatting-only diff for that generated file. This PR still contains real taxonomy data additions; the formatting-only note applies specifically to the large line churn in `dist/en/taxonomy.json`. Reviewers should treat the large deletion count in `dist/en/taxonomy.json` as a consequence of compacting that generated file, not as deleted taxonomy content.

This is acceptable for prototype purposes, but we should still explore the right long-term distribution contract for large generated taxonomy artifacts.

## What is included

This PR imports:

- `1,235` public measurement attributes total
- `33,219` category/measurement assignments
- English names and descriptions for newly imported measurement attributes
- regenerated `dist/en` files

## Files changed

- `data/attributes.yml`
  - adds the measurement attributes
  - each measurement attribute includes `type: measurement`, `measurement_type`, and `supported_units`
- `data/categories/*.yml`
  - assigns the new measurement attributes to their relevant categories
- `data/localizations/attributes/en.yml`
  - adds English names and descriptions for the new attributes so the English distribution can be generated
- `dist/en/attributes.json` and `dist/en/attributes.txt`
  - regenerate the public English attribute distribution with measurement metadata
- `dist/en/categories.json` and `dist/en/taxonomy.json`
  - regenerate category/taxonomy output so category attribute references include the new measurement attributes
- `dev/lib/product_taxonomy/commands/generate_dist_command.rb`
  - writes `taxonomy.json` in compact JSON form so the generated taxonomy distribution stays below GitHub's file size limit as measurement coverage grows
- `dev/test/integration/all_data_files_import_test.rb`
  - updates the expected Snowboards category attribute list now that measurement attributes are available there

## Unit representation

For V0, `supported_units` contains canonical taxonomy unit symbols such as `cm`, `in`, `ml`, and `fl oz`.

Using symbols keeps the taxonomy data intentionally compact and compatible with other locales. The taxonomy should define the measurement vocabulary: which attributes exist, which categories they apply to, which measurement type they use, and which unit symbols are supported for each attribute.

This keeps the public taxonomy contract simple for V0. The remaining integration details—mapping taxonomy unit symbols to Core-supported units, validating supported units for each measurement type, and normalizing inferred or predicted measurement values before persistence—will be addressed next in Core as part of its own technical design.


## Validation

- `bundle exec rake test:unit`
- `bundle exec rake test:integration`
- `bundle exec rake schema:vet`
