### PR TITLE
[UoM prototype] Render measurement attributes in docs (3/4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   - [🕹️ Interactive explorer](#️-interactive-explorer)
 - [🧭 Getting started](#-getting-started)
   - [🧩 1. Integrators: How to integrate with the taxonomy](#-1-integrators-how-to-integrate-with-the-taxonomy)
+    - [Attribute types](#attribute-types)
     - [🗺️ Mapping to other taxonomies](#️-mapping-to-other-taxonomies)
   - [🧑🏼‍🏫 2. Taxonomists: How to make changes to the taxonomy](#-2-taxonomists-how-to-make-changes-to-the-taxonomy)
   - [👩🏼‍💻 3. Developers: How to evolve the system](#-3-developers-how-to-evolve-the-system)
@@ -51,6 +52,10 @@ You can think of this repository serving 3 primary users:
 Dive straight into [`dist`](./dist/) to find the files you need and integrate this taxonomy into your system.
 
 We offer `txt` and `json` formats to make it easy to integrate with your systems. If you have a specific format you'd like to see, please open an issue and let us know!
+
+#### Attribute types
+
+Attributes include an explicit `type`. Closed-list attributes define a set of taxonomy values. Measurement attributes define a `measurement_type` and `supported_units` instead of values.
 
 #### 🗺️ Mapping to other taxonomies
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,41 @@ We offer `txt` and `json` formats to make it easy to integrate with your systems
 
 #### Attribute types
 
-Attributes include an explicit `type`. Closed-list attributes define a set of taxonomy values. Measurement attributes define a `measurement_type` and `supported_units` instead of values.
+Attributes include an explicit `type`:
+
+- `closed_list`: an attribute whose value is selected from a predefined set of taxonomy values, used when consistent value standardization is needed across products.
+- `measurement`: an attribute whose value is a number paired with a supported unit, used when products need precise measurements such as dimensions, weight, volume, or power.
+
+Closed-list attributes include `values`:
+
+```json
+{
+  "id": "gid://shopify/TaxonomyAttribute/1",
+  "name": "Color",
+  "handle": "color",
+  "type": "closed_list",
+  "values": [
+    {
+      "id": "gid://shopify/TaxonomyValue/1",
+      "name": "Black",
+      "handle": "color__black"
+    }
+  ]
+}
+```
+
+Measurement attributes include `measurement_type` and `supported_units` instead of `values`:
+
+```json
+{
+  "id": "gid://shopify/TaxonomyAttribute/12429",
+  "name": "Height",
+  "handle": "height",
+  "type": "measurement",
+  "measurement_type": "dimension",
+  "supported_units": ["cm", "in"]
+}
+```
 
 #### 🗺️ Mapping to other taxonomies
 

--- a/dev/lib/product_taxonomy/models/serializers/attribute/docs/base_and_extended_serializer.rb
+++ b/dev/lib/product_taxonomy/models/serializers/attribute/docs/base_and_extended_serializer.rb
@@ -23,13 +23,19 @@ module ProductTaxonomy
                 "name" => attribute.extended? ? attribute.base_attribute.name : attribute.name,
                 "handle" => attribute.handle,
                 "extended_name" => attribute.extended? ? attribute.name : nil,
-                "values" => attribute.values.map do |value|
+                "type" => attribute.type,
+              }
+              if attribute.measurement?
+                result["measurement_type"] = attribute.measurement_type
+                result["supported_units"] = attribute.supported_units
+              else
+                result["values"] = attribute.values.map do |value|
                   {
                     "id" => value.gid,
                     "name" => value.name,
                   }
-                end,
-              }
+                end
+              end
               result.delete("extended_name") unless attribute.extended?
               result
             end

--- a/dev/lib/product_taxonomy/models/serializers/attribute/docs/reversed_serializer.rb
+++ b/dev/lib/product_taxonomy/models/serializers/attribute/docs/reversed_serializer.rb
@@ -28,24 +28,31 @@ module ProductTaxonomy
             # @return [Hash] The serialized attribute.
             def serialize(attribute, attribute_categories)
               attribute_categories ||= []
-              {
+              result = {
                 "id" => attribute.gid,
                 "handle" => attribute.handle,
                 "name" => attribute.name,
                 "base_name" => attribute.extended? ? attribute.base_attribute.name : nil,
+                "type" => attribute.type,
                 "categories" => attribute_categories.sort_by(&:full_name).map do |category|
                   {
                     "id" => category.gid,
                     "full_name" => category.full_name,
                   }
                 end,
-                "values" => attribute.sorted_values.map do |value|
+              }
+              if attribute.measurement?
+                result["measurement_type"] = attribute.measurement_type
+                result["supported_units"] = attribute.supported_units
+              else
+                result["values"] = attribute.sorted_values.map do |value|
                   {
                     "id" => value.gid,
                     "name" => value.name,
                   }
-                end,
-              }
+                end
+              end
+              result
             end
           end
         end

--- a/dev/test/models/serializers/attribute/docs/base_and_extended_serializer_test.rb
+++ b/dev/test/models/serializers/attribute/docs/base_and_extended_serializer_test.rb
@@ -38,6 +38,7 @@ module ProductTaxonomy
               "id" => "gid://shopify/TaxonomyAttribute/1",
               "name" => "Base Attribute",
               "handle" => "base_handle",
+              "type" => "closed_list",
               "values" => [
                 {
                   "id" => "gid://shopify/TaxonomyValue/1",
@@ -49,12 +50,37 @@ module ProductTaxonomy
             assert_equal expected, BaseAndExtendedSerializer.serialize(@base_attribute)
           end
 
+          test "serialize measurement attribute returns the expected structure" do
+            measurement_attribute = ProductTaxonomy::Attribute.new(
+              id: 2,
+              name: "Height",
+              description: "Height Description",
+              friendly_id: "height",
+              handle: "height",
+              type: "measurement",
+              measurement_type: "dimension",
+              supported_units: ["cm", "in"],
+            )
+
+            expected = {
+              "id" => "gid://shopify/TaxonomyAttribute/2",
+              "name" => "Height",
+              "handle" => "height",
+              "type" => "measurement",
+              "measurement_type" => "dimension",
+              "supported_units" => ["cm", "in"],
+            }
+
+            assert_equal expected, BaseAndExtendedSerializer.serialize(measurement_attribute)
+          end
+
           test "serialize extended attribute returns the expected structure" do
             expected = {
               "id" => "gid://shopify/TaxonomyAttribute/1",
               "name" => "Base Attribute",
               "handle" => "extended_handle",
               "extended_name" => "Extended Attribute",
+              "type" => "closed_list",
               "values" => [
                 {
                   "id" => "gid://shopify/TaxonomyValue/1",
@@ -76,6 +102,7 @@ module ProductTaxonomy
                 "name" => "Base Attribute",
                 "handle" => "extended_handle",
                 "extended_name" => "Extended Attribute",
+                "type" => "closed_list",
                 "values" => [
                   {
                     "id" => "gid://shopify/TaxonomyValue/1",
@@ -87,6 +114,7 @@ module ProductTaxonomy
                 "id" => "gid://shopify/TaxonomyAttribute/1",
                 "name" => "Base Attribute",
                 "handle" => "base_handle",
+                "type" => "closed_list",
                 "values" => [
                   {
                     "id" => "gid://shopify/TaxonomyValue/1",

--- a/dev/test/models/serializers/attribute/docs/reversed_serializer_test.rb
+++ b/dev/test/models/serializers/attribute/docs/reversed_serializer_test.rb
@@ -37,6 +37,7 @@ module ProductTaxonomy
               "handle" => "test_handle",
               "name" => "Test Attribute",
               "base_name" => nil,
+              "type" => "closed_list",
               "categories" => [
                 {
                   "id" => "gid://shopify/TaxonomyCategory/1",
@@ -52,6 +53,37 @@ module ProductTaxonomy
             }
 
             assert_equal expected, ReversedSerializer.serialize(@attribute, [@category])
+          end
+
+          test "serialize measurement attribute returns the expected JSON structure" do
+            measurement_attribute = ProductTaxonomy::Attribute.new(
+              id: 2,
+              name: "Height",
+              description: "Height Description",
+              friendly_id: "height",
+              handle: "height",
+              type: "measurement",
+              measurement_type: "dimension",
+              supported_units: ["cm", "in"],
+            )
+
+            expected = {
+              "id" => "gid://shopify/TaxonomyAttribute/2",
+              "handle" => "height",
+              "name" => "Height",
+              "base_name" => nil,
+              "type" => "measurement",
+              "categories" => [
+                {
+                  "id" => "gid://shopify/TaxonomyCategory/1",
+                  "full_name" => "Test Category",
+                },
+              ],
+              "measurement_type" => "dimension",
+              "supported_units" => ["cm", "in"],
+            }
+
+            assert_equal expected, ReversedSerializer.serialize(measurement_attribute, [@category])
           end
 
           test "serialize with extended attribute returns the expected JSON structure" do
@@ -76,6 +108,7 @@ module ProductTaxonomy
               "handle" => "extended_handle",
               "name" => "Extended Attribute",
               "base_name" => "Base Attribute",
+              "type" => "closed_list",
               "categories" => [],
               "values" => [
                 {
@@ -99,6 +132,7 @@ module ProductTaxonomy
                   "handle" => "test_handle",
                   "name" => "Test Attribute",
                   "base_name" => nil,
+                  "type" => "closed_list",
                   "categories" => [
                     {
                       "id" => "gid://shopify/TaxonomyCategory/1",

--- a/docs/_layouts/attributes.html
+++ b/docs/_layouts/attributes.html
@@ -26,16 +26,41 @@ layout: default
           <span class="id">{{ attribute.id }}</span>
         </div>
         <div>
-          <ul class="values-container__list">
-            {% for value in attribute.values %}
-            <li class="values-container__list-item">
-              <div class="values-container__list-item-content">
-                {{ value.name }}
-                <div class="id">{{ value.id }}</div>
+          <div class="attribute-metadata">
+            <div class="attribute-metadata__row">
+              <span class="attribute-metadata__label">Type</span>
+              <span class="id">{{ attribute.type }}</span>
+            </div>
+            {% if attribute.type == "measurement" %}
+              <div class="attribute-metadata__row">
+                <span class="attribute-metadata__label">Measurement type</span>
+                <span class="id">{{ attribute.measurement_type }}</span>
               </div>
-            </li>
-            {% endfor %}
-          </ul>
+              <div class="attribute-metadata__row">
+                <span class="attribute-metadata__label">Supported units</span>
+                <div class="attribute-metadata__units">
+                  {% for unit in attribute.supported_units %}
+                    <span class="id">{{ unit }}</span>
+                  {% endfor %}
+                </div>
+              </div>
+            {% endif %}
+          </div>
+          {% unless attribute.type == "measurement" %}
+            <div class="attribute-metadata__row">
+              <span class="attribute-metadata__label">Values</span>
+            </div>
+            <ul class="values-container__list">
+              {% for value in attribute.values %}
+              <li class="values-container__list-item">
+                <div class="values-container__list-item-content">
+                  {{ value.name }}
+                  <div class="id">{{ value.id }}</div>
+                </div>
+              </li>
+              {% endfor %}
+            </ul>
+          {% endunless %}
         </div>
       </div>
     </div>

--- a/docs/_layouts/attributes.html
+++ b/docs/_layouts/attributes.html
@@ -11,6 +11,7 @@ layout: default
   </div>
 </div>
 {% for attribute in site.data[page.target].reversed_attributes.attributes %}
+{% assign attribute_type = attribute.type | default: "closed_list" %}
 <div class="attribute-container hidden" data-handle="{{ attribute.handle }}" >
   <div class="column">
     <div class="attributes-wrapper box">
@@ -29,9 +30,9 @@ layout: default
           <div class="attribute-metadata">
             <div class="attribute-metadata__row">
               <span class="attribute-metadata__label">Type</span>
-              <span class="id">{{ attribute.type }}</span>
+              <span class="id">{{ attribute_type }}</span>
             </div>
-            {% if attribute.type == "measurement" %}
+            {% if attribute_type == "measurement" %}
               <div class="attribute-metadata__row">
                 <span class="attribute-metadata__label">Measurement type</span>
                 <span class="id">{{ attribute.measurement_type }}</span>
@@ -46,7 +47,7 @@ layout: default
               </div>
             {% endif %}
           </div>
-          {% unless attribute.type == "measurement" %}
+          {% unless attribute_type == "measurement" %}
             <div class="attribute-metadata__row">
               <span class="attribute-metadata__label">Values</span>
             </div>

--- a/docs/_layouts/categories.html
+++ b/docs/_layouts/categories.html
@@ -73,16 +73,41 @@ layout: default
             </div>
           </h4>
           <div class="values-container">
-            <ul class="values-container__list">
-              {% for value in attribute.values %}
-                <li class="values-container__list-item">
-                  <div class="values-container__list-item-content">
-                    {{ value.name }}
-                    <div class="id">{{ value.id }}</div>
+            <div class="attribute-metadata">
+              <div class="attribute-metadata__row">
+                <span class="attribute-metadata__label">Type</span>
+                <span class="id">{{ attribute.type }}</span>
+              </div>
+              {% if attribute.type == "measurement" %}
+                <div class="attribute-metadata__row">
+                  <span class="attribute-metadata__label">Measurement type</span>
+                  <span class="id">{{ attribute.measurement_type }}</span>
+                </div>
+                <div class="attribute-metadata__row">
+                  <span class="attribute-metadata__label">Supported units</span>
+                  <div class="attribute-metadata__units">
+                    {% for unit in attribute.supported_units %}
+                      <span class="id">{{ unit }}</span>
+                    {% endfor %}
                   </div>
-                </li>
-              {% endfor %}
-            </ul>
+                </div>
+              {% endif %}
+            </div>
+            {% unless attribute.type == "measurement" %}
+              <div class="attribute-metadata__row">
+                <span class="attribute-metadata__label">Values</span>
+              </div>
+              <ul class="values-container__list">
+                {% for value in attribute.values %}
+                  <li class="values-container__list-item">
+                    <div class="values-container__list-item-content">
+                      {{ value.name }}
+                      <div class="id">{{ value.id }}</div>
+                    </div>
+                  </li>
+                {% endfor %}
+              </ul>
+            {% endunless %}
           </div>
         </div>
       {% endfor %}

--- a/docs/_layouts/categories.html
+++ b/docs/_layouts/categories.html
@@ -58,6 +58,7 @@ layout: default
     <div class="values-wrapper box">
       <h3 id="category-attributes-title">Category Attributes</h3>
       {% for attribute in site.data[page.target].attributes %}
+        {% assign attribute_type = attribute.type | default: "closed_list" %}
         <div class="value-container attribute-values hidden" data-handle="{{ attribute.handle }}">
           <h4 class="value-title attribute-title" tabindex="0">
             <div class="value-title__text">
@@ -76,9 +77,9 @@ layout: default
             <div class="attribute-metadata">
               <div class="attribute-metadata__row">
                 <span class="attribute-metadata__label">Type</span>
-                <span class="id">{{ attribute.type }}</span>
+                <span class="id">{{ attribute_type }}</span>
               </div>
-              {% if attribute.type == "measurement" %}
+              {% if attribute_type == "measurement" %}
                 <div class="attribute-metadata__row">
                   <span class="attribute-metadata__label">Measurement type</span>
                   <span class="id">{{ attribute.measurement_type }}</span>
@@ -93,7 +94,7 @@ layout: default
                 </div>
               {% endif %}
             </div>
-            {% unless attribute.type == "measurement" %}
+            {% unless attribute_type == "measurement" %}
               <div class="attribute-metadata__row">
                 <span class="attribute-metadata__label">Values</span>
               </div>

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -185,6 +185,28 @@ a:active {
   gap: 0.25rem;
 }
 
+.attribute-metadata {
+  margin-top: 0.75rem;
+}
+
+.attribute-metadata__row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+
+.attribute-metadata__label {
+  font-weight: 600;
+}
+
+.attribute-metadata__units {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
 .value-title {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## What this PR does

This PR updates the public docs/visualizer path to understand measurement attributes introduced in #950 and bulk-imported in #951.

It is stacked on #951 so the visualizer can be reviewed with the V0 measurement vocabulary.

## What changed

- Docs attribute serializers now emit `type` for attributes.
- Measurement attributes emit `measurement_type` and `supported_units` instead of a values list.
- Category and attribute visualizer pages render each attribute's type and measurement metadata instead of assuming every attribute has closed-list values.
- The root README documents the V0 attribute-type shape.

## UX changes

The visualizer now makes the attribute type explicit when an attribute is expanded:

- Closed-list attributes show `Type: closed_list`, followed by a `Values` label and their allowed taxonomy values.
- Measurement attributes show `Type: measurement`, `Measurement type`, and `Supported units` instead of a values list.
- The dedicated attribute search/details page uses the same measurement metadata treatment, so measurement attributes can be understood outside of a category context as well.

Image 1 — closed-list attribute expanded in a category:

<img width="896" height="950" alt="image" src="https://github.com/user-attachments/assets/2ea4d170-1e7a-4635-a934-cd60f8a48177" />

Image 2 — measurement attribute expanded in a category:

<img width="936" height="971" alt="image" src="https://github.com/user-attachments/assets/ee7fc7de-833c-436c-9711-726857f58a55" />

Image 3 — measurement attribute on the attribute details page:

<img width="1050" height="556" alt="image" src="https://github.com/user-attachments/assets/f120c009-5edd-46d2-89d5-232f86121454" />

## Validation

- `ruby -c` passed for the changed Ruby serializers/tests.
- Focused docs serializer tests passed.
- `bundle exec rake test:unit` passed.
- `bundle exec bin/product_taxonomy docs` passed.
- `bundle exec jekyll build --source ../docs --destination /tmp/product-taxonomy-docs-site` passed.
- Verified generated unstable docs data and rendered HTML include measurement attributes with `measurement_type` and `supported_units`, and closed-list attributes with a `Values` label.
- `git diff --check` passed.
