### PR TITLE
Fix Shopify mapping release finalization

### DIFF
--- a/dev/lib/product_taxonomy/commands/generate_release_command.rb
+++ b/dev/lib/product_taxonomy/commands/generate_release_command.rb
@@ -132,12 +132,17 @@ module ProductTaxonomy
 
     def update_mapping_files(filename, field_name, new_value)
       files = Dir.glob(File.expand_path("integrations/**/mappings/#{filename}", ProductTaxonomy.data_path))
+      escaped_field_name = Regexp.escape(field_name)
 
-      files = [files.sort.last] if filename == "to_shopify.yml"
+      if filename == "to_shopify.yml"
+        files = files.select do |file|
+          File.read(file).match?(%r{#{escaped_field_name}: shopify/\d{4}-\d{2}-unstable})
+        end
+      end
 
       files.each do |file|
         content = File.read(file)
-        content.gsub!(%r{#{field_name}: shopify/\d{4}-\d{2}(-unstable)?}, "#{field_name}: #{new_value}")
+        content.gsub!(%r{#{escaped_field_name}: shopify/\d{4}-\d{2}(-unstable)?}, "#{field_name}: #{new_value}")
         File.write(file, content)
       end
     end

--- a/dev/test/commands/generate_release_command_test.rb
+++ b/dev/test/commands/generate_release_command_test.rb
@@ -158,6 +158,21 @@ module ProductTaxonomy
       assert_equal "input_taxonomy: shopify/#{@next_version}", from_shopify_content
     end
 
+    test "execute preserves finalized to_shopify mapping when release has no pending mapping" do
+      latest_shopify_file = File.expand_path("data/integrations/shopify/2023-12/mappings/to_shopify.yml", @tmp_base_path)
+      finalized_shopify_file = File.expand_path("data/integrations/shopify/2022-10/mappings/to_shopify.yml", @tmp_base_path)
+
+      FileUtils.rm_f(latest_shopify_file)
+      File.write(finalized_shopify_file, "output_taxonomy: shopify/2023-12")
+
+      assert_equal "output_taxonomy: shopify/2023-12", File.read(finalized_shopify_file)
+
+      command = GenerateReleaseCommand.new(current_version: @version, next_version: @next_version)
+      command.execute
+
+      assert_equal "output_taxonomy: shopify/2023-12", File.read(finalized_shopify_file)
+    end
+
     test "execute updates taxonomy fields in mapping files" do
       command = GenerateReleaseCommand.new(current_version: @version, next_version: @next_version)
       command.execute
@@ -346,7 +361,7 @@ module ProductTaxonomy
       assert_equal "/repo/path", command.send(:git_repo_root) # Should use memoized value
     end
 
-    test "update_mapping_files handles to_shopify.yml files specially" do
+    test "update_mapping_files updates only pending to_shopify.yml files" do
       older_shopify_version = "2022-10"
       latest_shopify_version = "2023-12"
 
@@ -359,14 +374,37 @@ module ProductTaxonomy
       older_shopify_file = File.join(older_shopify_dir, "to_shopify.yml")
       latest_shopify_file = File.join(latest_shopify_dir, "to_shopify.yml")
 
-      File.write(older_shopify_file, "output_taxonomy: shopify/#{older_shopify_version}-unstable")
+      File.write(older_shopify_file, "output_taxonomy: shopify/#{latest_shopify_version}")
       File.write(latest_shopify_file, "output_taxonomy: shopify/#{latest_shopify_version}-unstable")
 
       command = GenerateReleaseCommand.new(current_version: @version, next_version: @next_version)
       command.send(:update_mapping_files, "to_shopify.yml", "output_taxonomy", "shopify/#{@version}")
 
-      assert_equal "output_taxonomy: shopify/#{older_shopify_version}-unstable", File.read(older_shopify_file)
+      assert_equal "output_taxonomy: shopify/#{latest_shopify_version}", File.read(older_shopify_file)
       assert_equal "output_taxonomy: shopify/#{@version}", File.read(latest_shopify_file)
+    end
+
+    test "update_mapping_files updates every pending to_shopify.yml file" do
+      shopify_mapping_file = File.expand_path("data/integrations/shopify/2023-12/mappings/to_shopify.yml", @tmp_base_path)
+      other_integration_dir = File.expand_path("data/integrations/other/2023-12/mappings", @tmp_base_path)
+      finalized_integration_dir = File.expand_path("data/integrations/finalized/2022-10/mappings", @tmp_base_path)
+
+      FileUtils.mkdir_p(other_integration_dir)
+      FileUtils.mkdir_p(finalized_integration_dir)
+
+      other_pending_file = File.join(other_integration_dir, "to_shopify.yml")
+      finalized_file = File.join(finalized_integration_dir, "to_shopify.yml")
+
+      File.write(shopify_mapping_file, "output_taxonomy: shopify/2023-12-unstable")
+      File.write(other_pending_file, "output_taxonomy: shopify/2023-12-unstable")
+      File.write(finalized_file, "output_taxonomy: shopify/2023-12")
+
+      command = GenerateReleaseCommand.new(current_version: @version, next_version: @next_version)
+      command.send(:update_mapping_files, "to_shopify.yml", "output_taxonomy", "shopify/#{@version}")
+
+      assert_equal "output_taxonomy: shopify/#{@version}", File.read(shopify_mapping_file)
+      assert_equal "output_taxonomy: shopify/#{@version}", File.read(other_pending_file)
+      assert_equal "output_taxonomy: shopify/2023-12", File.read(finalized_file)
     end
 
     test "update_mapping_files updates all from_shopify.yml files in non-shopify integrations" do


### PR DESCRIPTION
## Summary

This PR fixes release mapping finalization so stable releases only rewrite Shopify `to_shopify.yml` mappings that are still pending finalization.

Related issue: shop/issues-taxonomy#474

## Context

The release command previously selected the `to_shopify.yml` file to finalize with `files.sort.last`. That assumes the newest Shopify version directory always has its own `to_shopify.yml`, but releases only produce one when that cycle has remappings.

When an intermediate release has no mapping file, the path-order heuristic can select an older, already-finalized mapping and rewrite its `output_taxonomy` to the new release. That skips the intermediate version in the mapping chain and breaks the mapping validation test.

## Changes

- Replaced `files.sort.last` selection with state-based filtering: only `to_shopify.yml` files whose `output_taxonomy` still points at `shopify/YYYY-MM-unstable` are finalized.
- Updated the existing `to_shopify.yml` special-case test so finalized mappings stay untouched.
- Added a regression test through `execute` for the no-pending-mapping case, preserving already-finalized Shopify links.

## Testing

- `bundle exec ruby -Itest test/commands/generate_release_command_test.rb`
- `bundle exec rubocop lib/product_taxonomy/commands/generate_release_command.rb test/commands/generate_release_command_test.rb`

I also ran `bundle exec rake test` locally with an isolated Ruby 4 bundle workaround. Unit and integration tests passed; the existing benchmark task failed on a performance threshold in this local Ruby 4/Nix environment. Full CI will be triggered with `devx ci --full`.
