### PR TITLE
[UoM prototype] Support measurement attributes in CLI commands (4/4)

### DIFF
--- a/dev/lib/product_taxonomy/cli.rb
+++ b/dev/lib/product_taxonomy/cli.rb
@@ -97,7 +97,10 @@ module ProductTaxonomy
     end
 
     desc "add_attribute NAME DESCRIPTION", "Add a new attribute to the taxonomy with NAME and DESCRIPTION"
-    option :values, type: :string, desc: "A comma separated list of values to add to the attribute"
+    option :type, type: :string, desc: "Attribute type: closed_list or measurement"
+    option :values, type: :string, desc: "A comma separated list of values to add to a closed-list attribute"
+    option :measurement_type, type: :string, desc: "Measurement type for a measurement attribute"
+    option :supported_units, type: :string, desc: "A comma separated list of supported units for a measurement attribute"
     option :base_attribute_friendly_id, type: :string, desc: "Create an extended attribute by extending the attribute with this friendly ID"
     def add_attribute(name, description)
       AddAttributeCommand.new(options.merge(name:, description:)).run

--- a/dev/lib/product_taxonomy/commands/add_attribute_command.rb
+++ b/dev/lib/product_taxonomy/commands/add_attribute_command.rb
@@ -8,6 +8,9 @@ module ProductTaxonomy
       @name = options[:name]
       @description = options[:description]
       @values = options[:values]
+      @type = options[:type].presence || "closed_list"
+      @measurement_type = options[:measurement_type]
+      @supported_units = options[:supported_units]
       @base_attribute_friendly_id = options[:base_attribute_friendly_id]
     end
 
@@ -15,15 +18,28 @@ module ProductTaxonomy
       if @base_attribute_friendly_id
         create_extended_attribute!
       else
-        create_base_attribute_with_values!
+        create_base_attribute!
       end
       update_data_files!
     end
 
     private
 
-    def create_base_attribute_with_values!
-      raise "Values must be provided when creating a base attribute" if value_names.empty?
+    def create_base_attribute!
+      case @type
+      when "closed_list"
+        create_closed_list_attribute!
+      when "measurement"
+        create_measurement_attribute!
+      else
+        raise "Unsupported attribute type `#{@type}`. Supported types are: closed_list, measurement"
+      end
+    end
+
+    def create_closed_list_attribute!
+      raise "Values must be provided when creating a closed-list attribute" if value_names.empty?
+      raise "Measurement type should not be provided when creating a closed-list attribute" if @measurement_type.present?
+      raise "Supported units should not be provided when creating a closed-list attribute" if supported_unit_names.any?
 
       @attribute = Attribute.create_validate_and_add!(
         id: Attribute.next_id,
@@ -31,13 +47,35 @@ module ProductTaxonomy
         description: @description,
         friendly_id:,
         handle:,
+        type: "closed_list",
         values: find_or_create_values,
       )
-      logger.info("Created base attribute `#{@attribute.name}` with friendly_id=`#{@attribute.friendly_id}`")
+      logger.info("Created closed-list attribute `#{@attribute.name}` with friendly_id=`#{@attribute.friendly_id}`")
+    end
+
+    def create_measurement_attribute!
+      raise "Values should not be provided when creating a measurement attribute" if value_names.any?
+      raise "Measurement type must be provided when creating a measurement attribute" if @measurement_type.blank?
+      raise "Supported units must be provided when creating a measurement attribute" if supported_unit_names.empty?
+
+      @attribute = Attribute.create_validate_and_add!(
+        id: Attribute.next_id,
+        name: @name,
+        description: @description,
+        friendly_id:,
+        handle:,
+        type: "measurement",
+        measurement_type: @measurement_type,
+        supported_units: supported_unit_names,
+      )
+      logger.info("Created measurement attribute `#{@attribute.name}` with friendly_id=`#{@attribute.friendly_id}`")
     end
 
     def create_extended_attribute!
       raise "Values should not be provided when creating an extended attribute" if value_names.any?
+      raise "Type should not be provided when creating an extended attribute" if @type != "closed_list"
+      raise "Measurement type should not be provided when creating an extended attribute" if @measurement_type.present?
+      raise "Supported units should not be provided when creating an extended attribute" if supported_unit_names.any?
 
       @attribute = ExtendedAttribute.create_validate_and_add!(
         name: @name,
@@ -65,7 +103,11 @@ module ProductTaxonomy
     end
 
     def value_names
-      @values&.split(",")&.map(&:strip) || []
+      @values&.split(",")&.map(&:strip)&.reject(&:blank?) || []
+    end
+
+    def supported_unit_names
+      @supported_unit_names ||= @supported_units&.split(",")&.map(&:strip)&.reject(&:blank?) || []
     end
 
     def find_or_create_values

--- a/dev/lib/product_taxonomy/commands/add_value_command.rb
+++ b/dev/lib/product_taxonomy/commands/add_value_command.rb
@@ -21,6 +21,9 @@ module ProductTaxonomy
       if @attribute.extended?
         raise "Attribute `#{@attribute.name}` is an extended attribute, please use a primary attribute instead"
       end
+      if @attribute.measurement?
+        raise "Attribute `#{@attribute.name}` is a measurement attribute and cannot have values"
+      end
 
       friendly_id = IdentifierFormatter.format_friendly_id("#{@attribute.friendly_id}__#{@name}")
       value = Value.create_validate_and_add!(

--- a/dev/test/commands/add_attribute_command_test.rb
+++ b/dev/test/commands/add_attribute_command_test.rb
@@ -63,6 +63,30 @@ module ProductTaxonomy
       assert_includes value_friendly_ids, "size__large"
     end
 
+    test "execute successfully adds a new measurement attribute" do
+      stub_commands
+
+      AddAttributeCommand.new(
+        name: "Height",
+        description: "Specifies the vertical measurement from bottom to top",
+        type: "measurement",
+        measurement_type: "dimension",
+        supported_units: "cm, in",
+      ).execute
+
+      new_attribute = Attribute.find_by(friendly_id: "height")
+      assert_not_nil new_attribute
+      assert_equal 2, new_attribute.id
+      assert_equal "Height", new_attribute.name
+      assert_equal "Specifies the vertical measurement from bottom to top", new_attribute.description
+      assert_equal "height", new_attribute.friendly_id
+      assert_equal "height", new_attribute.handle
+      assert_equal "measurement", new_attribute.type
+      assert_equal "dimension", new_attribute.measurement_type
+      assert_equal ["cm", "in"], new_attribute.supported_units
+      assert_empty new_attribute.values
+    end
+
     test "execute successfully adds an extended attribute" do
       DumpAttributesCommand.any_instance.expects(:execute).once
       DumpValuesCommand.any_instance.expects(:execute).once
@@ -89,6 +113,37 @@ module ProductTaxonomy
       assert_equal @base_attribute.values.first.name, new_attribute.values.first.name
     end
 
+    test "execute successfully adds a measurement-backed extended attribute" do
+      measurement_attribute = Attribute.new(
+        id: 2,
+        name: "Height",
+        description: "Specifies the vertical measurement from bottom to top",
+        friendly_id: "height",
+        handle: "height",
+        type: "measurement",
+        measurement_type: "dimension",
+        supported_units: ["cm", "in"],
+      )
+      Attribute.add(measurement_attribute)
+
+      stub_commands
+
+      AddAttributeCommand.new(
+        name: "Interior Height",
+        description: "Specifies the interior vertical measurement from bottom to top",
+        base_attribute_friendly_id: "height",
+      ).execute
+
+      new_attribute = Attribute.find_by(friendly_id: "interior_height")
+      assert_not_nil new_attribute
+      assert_instance_of ExtendedAttribute, new_attribute
+      assert_equal measurement_attribute, new_attribute.base_attribute
+      assert_equal "measurement", new_attribute.type
+      assert_equal "dimension", new_attribute.measurement_type
+      assert_equal ["cm", "in"], new_attribute.supported_units
+      assert_empty new_attribute.values
+    end
+
     test "execute raises error when creating base attribute without values" do
       stub_commands
 
@@ -97,6 +152,61 @@ module ProductTaxonomy
           name: "Material",
           description: "Product material information",
           values: "",
+        ).execute
+      end
+    end
+
+    test "execute raises error when creating measurement attribute without measurement_type" do
+      stub_commands
+
+      assert_raises(RuntimeError) do
+        AddAttributeCommand.new(
+          name: "Height",
+          description: "Specifies the vertical measurement from bottom to top",
+          type: "measurement",
+          supported_units: "cm, in",
+        ).execute
+      end
+    end
+
+    test "execute raises error when creating measurement attribute without supported_units" do
+      stub_commands
+
+      assert_raises(RuntimeError) do
+        AddAttributeCommand.new(
+          name: "Height",
+          description: "Specifies the vertical measurement from bottom to top",
+          type: "measurement",
+          measurement_type: "dimension",
+        ).execute
+      end
+    end
+
+    test "execute raises error when creating measurement attribute with values" do
+      stub_commands
+
+      assert_raises(RuntimeError) do
+        AddAttributeCommand.new(
+          name: "Height",
+          description: "Specifies the vertical measurement from bottom to top",
+          type: "measurement",
+          measurement_type: "dimension",
+          supported_units: "cm, in",
+          values: "Short, Tall",
+        ).execute
+      end
+    end
+
+    test "execute raises error when creating closed-list attribute with measurement metadata" do
+      stub_commands
+
+      assert_raises(RuntimeError) do
+        AddAttributeCommand.new(
+          name: "Size",
+          description: "Product size information",
+          values: "Small, Medium, Large",
+          measurement_type: "dimension",
+          supported_units: "cm, in",
         ).execute
       end
     end
@@ -110,6 +220,21 @@ module ProductTaxonomy
           description: "Color of clothing items",
           base_attribute_friendly_id: "color",
           values: "Red, Blue",
+        ).execute
+      end
+    end
+
+    test "execute raises error when creating extended attribute with measurement options" do
+      stub_commands
+
+      assert_raises(RuntimeError) do
+        AddAttributeCommand.new(
+          name: "Clothing Color",
+          description: "Color of clothing items",
+          base_attribute_friendly_id: "color",
+          type: "measurement",
+          measurement_type: "dimension",
+          supported_units: "cm, in",
         ).execute
       end
     end

--- a/dev/test/commands/add_value_command_test.rb
+++ b/dev/test/commands/add_value_command_test.rb
@@ -72,6 +72,26 @@ module ProductTaxonomy
       end
     end
 
+    test "execute raises error when trying to add value to measurement attribute" do
+      measurement_attribute = Attribute.new(
+        id: 2,
+        name: "Height",
+        description: "Specifies the vertical measurement from bottom to top",
+        friendly_id: "height",
+        handle: "height",
+        type: "measurement",
+        measurement_type: "dimension",
+        supported_units: ["cm", "in"],
+      )
+      Attribute.add(measurement_attribute)
+
+      stub_commands
+
+      assert_raises(RuntimeError) do
+        AddValueCommand.new(name: "Tall", attribute_friendly_id: "height").execute
+      end
+    end
+
     test "execute raises error when value already exists" do
       stub_commands
 


### PR DESCRIPTION
## Summary

Follow-up to the UoM stack to make the maintainer CLI understand measurement attributes.

- adds `add_attribute` options for measurement attributes:
  - `--type measurement`
  - `--measurement_type ...`
  - `--supported_units "cm, in"`
- keeps closed-list attributes as the default `add_attribute` behavior
- validates invalid option combinations in the command layer:
  - closed-list attributes require `values` and reject measurement metadata
  - measurement attributes require `measurement_type` / `supported_units` and reject `values`
  - extended attributes inherit from their base and reject explicit value/type/measurement options
- prevents `add_value` from adding values to measurement attributes
- adds focused command test coverage

## Stack

Stacked on PR3 / `rt/uom-visualizer-docs`.

## Validation

- `ruby -c dev/lib/product_taxonomy/commands/add_attribute_command.rb`
- `ruby -c dev/lib/product_taxonomy/commands/add_value_command.rb`
- `ruby -c dev/test/commands/add_attribute_command_test.rb`
- `ruby -c dev/test/commands/add_value_command_test.rb`
- `git diff --check`
- `cd dev && bundle exec ruby -Itest test/commands/add_attribute_command_test.rb`
- `cd dev && bundle exec ruby -Itest test/commands/add_value_command_test.rb`
- `cd dev && bundle exec rake test:unit`
- `cd dev && bundle exec rake schema:vet`
- `cd dev && bundle exec rake test:integration`