### PR TITLE
Add size type taxonomy attribute

### DIFF
--- a/data/categories/aa_apparel_accessories.yml
+++ b/data/categories/aa_apparel_accessories.yml
@@ -57,6 +57,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -88,6 +89,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -123,6 +125,7 @@
   - pattern
   - pocket_type
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -152,6 +155,7 @@
   - pattern
   - pocket_type
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -180,6 +184,7 @@
   - pattern
   - pocket_type
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -209,6 +214,7 @@
   - pattern
   - pocket_type
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -236,6 +242,7 @@
   - pattern
   - pocket_type
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -261,6 +268,7 @@
   - pattern
   - pocket_type
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -288,6 +296,7 @@
   - pattern
   - pocket_type
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -316,6 +325,7 @@
   - pocket_closure_type
   - pocket_type
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -343,6 +353,7 @@
   - pattern
   - pocket_type
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -375,6 +386,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -403,6 +415,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -429,6 +442,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -455,6 +469,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -482,6 +497,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -503,6 +519,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -532,6 +549,7 @@
   - integrated_bottom_type
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -561,6 +579,7 @@
   - integrated_bottom_type
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -585,6 +604,7 @@
   - integrated_bottom_type
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -614,6 +634,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sports_bra_padding_type
   - target_gender
   return_reasons:
@@ -644,6 +665,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -672,6 +694,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -699,6 +722,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -725,6 +749,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -753,6 +778,7 @@
   - insulation_fill_material
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -783,6 +809,7 @@
   - packability
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -810,6 +837,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -840,6 +868,7 @@
   - garment_back_style
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -866,6 +895,7 @@
   - garment_back_style
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -887,6 +917,7 @@
   - garment_back_style
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -908,6 +939,7 @@
   - garment_back_style
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -933,6 +965,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -975,6 +1008,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -998,6 +1032,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -1024,6 +1059,7 @@
   - fabric
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -1045,6 +1081,7 @@
   - fabric
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -1067,6 +1104,7 @@
   - fabric
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -1087,6 +1125,7 @@
   - fabric
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -1102,6 +1141,7 @@
   - fabric
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -1118,6 +1158,7 @@
   - fabric
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -1138,6 +1179,7 @@
   - fabric
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -1157,6 +1199,7 @@
   - fabric
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -1172,6 +1215,7 @@
   - fabric
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -1194,6 +1238,7 @@
   - fabric
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - band_too_big
   - band_too_small
@@ -1220,6 +1265,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -1244,6 +1290,7 @@
   - pattern
   - seam_design
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -1267,6 +1314,7 @@
   - jockstrap_design_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -1292,6 +1340,7 @@
   - fabric
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -1313,6 +1362,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -1338,6 +1388,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -1361,6 +1412,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -1380,6 +1432,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -1400,6 +1453,7 @@
   - pantyhose_style
   - pattern
   - size
+  - size_type
   - target_gender
   - toe_reinforcement_type
   return_reasons:
@@ -1424,6 +1478,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -1442,6 +1497,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -1462,6 +1518,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -1484,6 +1541,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -1502,6 +1560,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -1529,6 +1588,7 @@
   - pattern
   - shapewear_support_level
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -1555,6 +1615,7 @@
   - post_surgery_stage_suitability
   - shapewear_support_level
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -1579,6 +1640,7 @@
   - pattern
   - shapewear_support_level
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -1604,6 +1666,7 @@
   - shapewear_enhancement_feature
   - shapewear_support_level
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -1629,6 +1692,7 @@
   - pattern
   - shapewear_support_level
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -1655,6 +1719,7 @@
   - pattern
   - shapewear_support_level
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -1679,6 +1744,7 @@
   - pattern
   - shapewear_support_level
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -1698,6 +1764,7 @@
   - pattern
   - shapewear_support_level
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -1717,6 +1784,7 @@
   - pattern
   - shapewear_support_level
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -1745,6 +1813,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -1769,6 +1838,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -1793,6 +1863,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -1817,6 +1888,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -1841,6 +1913,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -1866,6 +1939,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - underwear_style
   - waist_rise
@@ -1892,6 +1966,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -1916,6 +1991,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -1936,6 +2012,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -1956,6 +2033,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -1975,6 +2053,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -1997,6 +2076,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -2021,6 +2101,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -2041,6 +2122,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -2061,6 +2143,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -2091,6 +2174,7 @@
   - pattern
   - pregnancy_stage_suitability
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -2121,6 +2205,7 @@
   - pregnancy_stage_suitability
   - pumping_compatibility
   - target_gender
+  - size_type
   return_reasons:
   - band_too_big
   - band_too_small
@@ -2151,6 +2236,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -2183,6 +2269,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -2223,6 +2310,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -2252,6 +2340,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -2280,6 +2369,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - target_gender
   return_reasons:
   - waist_too_big
@@ -2310,6 +2400,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - target_gender
   return_reasons:
   - waist_too_big
@@ -2340,6 +2431,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -2368,6 +2460,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -2396,6 +2489,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -2424,6 +2518,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -2452,6 +2547,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - target_gender
   return_reasons:
   - waist_too_big
@@ -2482,6 +2578,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -2506,6 +2603,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -2530,6 +2628,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -2551,6 +2650,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - skirt/dress_length_type
   - target_gender
   return_reasons:
@@ -2578,6 +2678,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -2610,6 +2711,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -2636,6 +2738,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -2663,6 +2766,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -2690,6 +2794,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -2717,6 +2822,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - trim_detail
@@ -2746,6 +2852,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -2773,6 +2880,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -2800,6 +2908,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -2836,6 +2945,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -2864,6 +2974,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -2893,6 +3004,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -2921,6 +3033,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -2954,6 +3067,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -2983,6 +3097,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -3008,6 +3123,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -3033,6 +3149,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -3058,6 +3175,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -3082,6 +3200,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -3110,6 +3229,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -3138,6 +3258,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -3166,6 +3287,7 @@
   - pattern
   - pregnancy_stage_suitability
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -3192,6 +3314,7 @@
   - pattern
   - pregnancy_stage_suitability
   - target_gender
+  - size_type
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -3211,6 +3334,7 @@
   - pattern
   - pregnancy_stage_suitability
   - target_gender
+  - size_type
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -3230,6 +3354,7 @@
   - pattern
   - pregnancy_stage_suitability
   - target_gender
+  - size_type
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -3250,6 +3375,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -3273,6 +3399,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -3296,6 +3423,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - undershirt_style
   return_reasons:
@@ -3329,6 +3457,7 @@
   - pattern
   - pouch_style
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -3352,6 +3481,7 @@
   - pattern
   - pouch_style
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -3375,6 +3505,7 @@
   - pattern
   - pouch_style
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -3398,6 +3529,7 @@
   - pattern
   - pouch_style
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -3423,6 +3555,7 @@
   - protective_cup_configuration
   - rear_coverage
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -3446,6 +3579,7 @@
   - pattern
   - pouch_style
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -3470,6 +3604,7 @@
   - pouch_design
   - pouch_style
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -3494,6 +3629,7 @@
   - pattern
   - pouch_style
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -3517,6 +3653,7 @@
   - pattern
   - pouch_style
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -3540,6 +3677,7 @@
   - pattern
   - pouch_style
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -3561,6 +3699,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -3596,6 +3735,7 @@
   - outerwear_pieces_included
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -3621,6 +3761,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -3664,6 +3805,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -3690,6 +3832,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -3716,6 +3859,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -3741,6 +3885,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -3767,6 +3912,7 @@
   - outerwear_length_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -3792,6 +3938,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -3818,6 +3965,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -3846,6 +3994,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -3871,6 +4020,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -3892,6 +4042,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -3913,6 +4064,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -3940,6 +4092,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -3966,6 +4119,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -3991,6 +4145,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -4017,6 +4172,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -4042,6 +4198,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -4067,6 +4224,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -4093,6 +4251,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -4119,6 +4278,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -4145,6 +4305,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -4166,6 +4327,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -4193,6 +4355,7 @@
   - rain_suit_configuration
   - seam_sealing_type
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -4221,6 +4384,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -4246,6 +4410,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -4266,6 +4431,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -4286,6 +4452,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -4307,6 +4474,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - target_gender
   - top_length_type
   return_reasons:
@@ -4333,6 +4501,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -4359,6 +4528,7 @@
   - outerwear_pieces_included
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -4390,6 +4560,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - skirt_style
   - sleeve_length_type
@@ -4431,6 +4602,7 @@
   - pattern
   - pocket_style
   - size
+  - size_type
   - target_gender
   - waist_rise
   - waistband_style
@@ -4459,6 +4631,7 @@
   - pattern
   - pocket_style
   - size
+  - size_type
   - target_gender
   - waist_rise
   - waistband_style
@@ -4487,6 +4660,7 @@
   - pattern
   - pocket_style
   - size
+  - size_type
   - target_gender
   - waist_rise
   - waistband_style
@@ -4518,6 +4692,7 @@
   - pattern
   - pocket_style
   - size
+  - size_type
   - target_gender
   - waist_rise
   - waistband_style
@@ -4548,6 +4723,7 @@
   - pattern
   - pocket_style
   - size
+  - size_type
   - target_gender
   - waist_rise
   - waistband_style
@@ -4576,6 +4752,7 @@
   - pattern
   - pocket_style
   - size
+  - size_type
   - target_gender
   - waist_rise
   - waistband_style
@@ -4603,6 +4780,7 @@
   - pattern
   - pocket_style
   - size
+  - size_type
   - target_gender
   - waist_rise
   - waistband_style
@@ -4632,6 +4810,7 @@
   - pattern
   - pocket_style
   - size
+  - size_type
   - target_gender
   - waist_rise
   - waistband_style
@@ -4662,6 +4841,7 @@
   - pattern
   - pocket_style
   - size
+  - size_type
   - target_gender
   - waist_rise
   - waistband_style
@@ -4686,6 +4866,7 @@
   - pattern
   - pocket_style
   - size
+  - size_type
   - target_gender
   - waist_rise
   - waistband_style
@@ -4721,6 +4902,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - sleeve_style
   - stretch_level
@@ -4750,6 +4932,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - sleeve_style
   - stretch_level
@@ -4778,6 +4961,7 @@
   - one_piece_style
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - sleeve_style
   - stretch_level
@@ -4807,6 +4991,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - sleeve_style
   - stretch_level
@@ -4835,6 +5020,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - sleeve_style
   - stretch_level
@@ -4864,6 +5050,7 @@
   - pattern
   - placket_type
   - size
+  - size_type
   - sleeve_length_type
   - sleeve_style
   - stretch_level
@@ -4897,6 +5084,7 @@
   - pattern
   - shirt_cuff_style
   - size
+  - size_type
   - sleeve_length_type
   - sleeve_style
   - stretch_level
@@ -4927,6 +5115,7 @@
   - pattern
   - shirt_cuff_style
   - size
+  - size_type
   - sleeve_length_type
   - sleeve_style
   - stretch_level
@@ -4953,6 +5142,7 @@
   - pattern
   - shirt_cuff_style
   - size
+  - size_type
   - sleeve_length_type
   - sleeve_style
   - stretch_level
@@ -4978,6 +5168,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - sleeve_style
   - stretch_level
@@ -5006,6 +5197,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - sleeve_style
   - strap_width
@@ -5035,6 +5227,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - sleeve_style
   - stretch_level
@@ -5063,6 +5256,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - sleeve_style
   - stretch_level
@@ -5092,6 +5286,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - sleeve_style
   - stretch_level
@@ -5121,6 +5316,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - sleeve_style
   - stretch_level
@@ -5150,6 +5346,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - sleeve_style
   - stretch_level
@@ -5183,6 +5380,7 @@
   - fit
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -5207,6 +5405,7 @@
   - fit
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -5232,6 +5431,7 @@
   - fit
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -5256,6 +5456,7 @@
   - fit
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -5280,6 +5481,7 @@
   - fit
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -5307,6 +5509,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -5331,6 +5534,7 @@
   - fit
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -5355,6 +5559,7 @@
   - fit
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -5379,6 +5584,7 @@
   - fit
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -5405,6 +5611,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - skirt_style
   - target_gender
@@ -5430,6 +5637,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -5459,6 +5667,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleepwear_set_pieces_included
   - target_gender
   return_reasons:
@@ -5482,6 +5691,7 @@
   - fly_style
   - pattern
   - size
+  - size_type
   - sleepwear_set_pieces_included
   - target_gender
   - thermal_set_components
@@ -5509,6 +5719,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleepwear_set_pieces_included
   - target_gender
   return_reasons:
@@ -5540,6 +5751,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - sleepwear_set_pieces_included
   - target_gender
   - waist_rise
@@ -5565,6 +5777,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - sleepwear_set_pieces_included
   - target_gender
   - waist_rise
@@ -5591,6 +5804,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - sleepwear_set_pieces_included
   - target_gender
   - waist_rise
@@ -5616,6 +5830,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - sleepwear_set_pieces_included
   - target_gender
   - waist_rise
@@ -5643,6 +5858,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - sleepwear_set_pieces_included
   - target_gender
   - waist_rise
@@ -5668,6 +5884,7 @@
   - fit
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleepwear_set_pieces_included
   - target_gender
@@ -5695,6 +5912,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - sleepwear_set_pieces_included
   - target_gender
   - waist_rise
@@ -5716,6 +5934,7 @@
   - fabric_texture
   - pattern
   - size
+  - size_type
   - sleepwear_set_pieces_included
   - target_gender
   - top_length_type
@@ -5740,6 +5959,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleepwear_set_pieces_included
   - target_gender
   return_reasons:
@@ -5760,6 +5980,7 @@
   - nightgown_style
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleepwear_set_pieces_included
   - sleeve_length_type
@@ -5786,6 +6007,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleepwear_set_pieces_included
   - sleeve_length_type
   - target_gender
@@ -5812,6 +6034,7 @@
   - pattern
   - robe_style
   - size
+  - size_type
   - sleepwear_set_pieces_included
   - target_gender
   return_reasons:
@@ -5837,6 +6060,7 @@
   - pattern
   - rear_opening_type
   - size
+  - size_type
   - sleepwear_set_pieces_included
   - sleeve_length_type
   - target_gender
@@ -5861,6 +6085,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleepwear_set_pieces_included
   - target_gender
   return_reasons:
@@ -5898,6 +6123,7 @@
   - sock_cushioning_level
   - sock_toe_style
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -5922,6 +6148,7 @@
   - sock_cushioning_level
   - sock_toe_style
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -5947,6 +6174,7 @@
   - sock_cushioning_level
   - sock_toe_style
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -5971,6 +6199,7 @@
   - sock_cushioning_level
   - sock_toe_style
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -5996,6 +6225,7 @@
   - sock_grip_type
   - sock_toe_style
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -6022,6 +6252,7 @@
   - sock_toe_style
   - target_gender
   - toe_coverage
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -6046,6 +6277,7 @@
   - sock_cushioning_level
   - sock_toe_style
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -6070,6 +6302,7 @@
   - sock_cushioning_level
   - sock_toe_style
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -6095,6 +6328,7 @@
   - sock_cushioning_level
   - sock_toe_style
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -6119,6 +6353,7 @@
   - sock_cushioning_level
   - sock_toe_style
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -6143,6 +6378,7 @@
   - sock_cushioning_level
   - sock_toe_style
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -6168,6 +6404,7 @@
   - sock_cushioning_level
   - sock_toe_style
   - target_gender
+  - size_type
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -6189,6 +6426,7 @@
   - sock_cushioning_level
   - sock_toe_style
   - target_gender
+  - size_type
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -6210,6 +6448,7 @@
   - sock_cushioning_level
   - sock_toe_style
   - target_gender
+  - size_type
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -6231,6 +6470,7 @@
   - sock_cushioning_level
   - sock_toe_style
   - target_gender
+  - size_type
   return_reasons:
   - changed_my_mind
   - item_not_as_described
@@ -6257,6 +6497,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - suit_pieces
   - target_gender
@@ -6286,6 +6527,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - suit_pieces
   - target_gender
   - waist_rise
@@ -6312,6 +6554,7 @@
   - lapel_style
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - suit_pieces
   - target_gender
@@ -6340,6 +6583,7 @@
   - lapel_style
   - pattern
   - size
+  - size_type
   - suit_pieces
   - target_gender
   - vent_style
@@ -6366,6 +6610,7 @@
   - lapel_style
   - pattern
   - size
+  - size_type
   - suit_pieces
   - target_gender
   - vent_style
@@ -6388,6 +6633,7 @@
   - lapel_style
   - pattern
   - size
+  - size_type
   - suit_pieces
   - target_gender
   - vent_style
@@ -6413,6 +6659,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - suit_pieces
   - target_gender
@@ -6451,6 +6698,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -6478,6 +6726,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - swimwear_features
   - target_gender
   return_reasons:
@@ -6502,6 +6751,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - swimwear_features
   - target_gender
   return_reasons:
@@ -6529,6 +6779,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - swimwear_features
   - target_gender
   return_reasons:
@@ -6554,6 +6805,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - swimwear_set_pieces_included
@@ -6583,6 +6835,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -6610,6 +6863,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -6636,6 +6890,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - swimwear_features
   - target_gender
   return_reasons:
@@ -6661,6 +6916,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -6687,6 +6943,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -6713,6 +6970,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -6738,6 +6996,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -6766,6 +7025,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -6793,6 +7053,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -6814,6 +7075,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -6835,6 +7097,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -6856,6 +7119,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -6877,6 +7141,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -6898,6 +7163,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -6919,6 +7185,7 @@
   - lining_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -6943,6 +7210,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -6976,6 +7244,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -7005,6 +7274,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -7030,6 +7300,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -7055,6 +7326,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -7080,6 +7352,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -7103,6 +7376,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -7139,6 +7413,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -7164,6 +7439,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -7186,6 +7462,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -7204,6 +7481,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -7222,6 +7500,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -7244,6 +7523,7 @@
   - pattern
   - set_items_included
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -7267,6 +7547,7 @@
   - pattern
   - set_items_included
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7286,6 +7567,7 @@
   - pattern
   - set_items_included
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7304,6 +7586,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -7323,6 +7606,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -7342,6 +7626,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -7361,6 +7646,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -7380,6 +7666,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -7399,6 +7686,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -7418,6 +7706,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -7437,6 +7726,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -7456,6 +7746,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -7475,6 +7766,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -7508,6 +7800,7 @@
   - pattern
   - reflective_tape_pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -7537,6 +7830,7 @@
   - pattern
   - reinforced_areas
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -7563,6 +7857,7 @@
   - pattern
   - reinforced_areas
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7585,6 +7880,7 @@
   - pattern
   - reinforced_areas
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7607,6 +7903,7 @@
   - pattern
   - reinforced_areas
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7627,6 +7924,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -7658,6 +7956,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -7683,6 +7982,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7703,6 +8003,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7723,6 +8024,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7743,6 +8045,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7763,6 +8066,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7783,6 +8087,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7811,6 +8116,7 @@
   - military_branch
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -7837,6 +8143,7 @@
   - military_branch
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7858,6 +8165,7 @@
   - military_branch
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7879,6 +8187,7 @@
   - military_branch
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7900,6 +8209,7 @@
   - military_branch
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7921,6 +8231,7 @@
   - military_branch
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7942,6 +8253,7 @@
   - military_branch
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7963,6 +8275,7 @@
   - military_branch
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -7992,6 +8305,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -8021,6 +8335,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -8045,6 +8360,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -8069,6 +8385,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -8093,6 +8410,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -8117,6 +8435,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -8141,6 +8460,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -8165,6 +8485,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -8189,6 +8510,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - target_gender
   - uniform_pieces_included
   - uniform_role
@@ -8216,6 +8538,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - target_gender
   - uniform_pieces_included
   - uniform_role
@@ -8238,6 +8561,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - target_gender
   - uniform_pieces_included
   - uniform_role
@@ -8262,6 +8586,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -8290,6 +8615,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -8321,6 +8647,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -8346,6 +8673,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -8366,6 +8694,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -8386,6 +8715,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -8406,6 +8736,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -8426,6 +8757,7 @@
   - high_visibility_class
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -8447,6 +8779,7 @@
   - pattern
   - reflective_tape_pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -8468,6 +8801,7 @@
   - pattern
   - reflective_tape_pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -8489,6 +8823,7 @@
   - pattern
   - reflective_tape_pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -8516,6 +8851,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -8548,6 +8884,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -8571,6 +8908,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -8593,6 +8931,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -8615,6 +8954,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -8637,6 +8977,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -8659,6 +9000,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -8681,6 +9023,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -8702,6 +9045,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - target_gender
   return_reasons:
@@ -8724,6 +9068,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - target_gender
   return_reasons:
@@ -8747,6 +9092,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -8769,6 +9115,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -8790,6 +9137,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -8814,6 +9162,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
@@ -8841,6 +9190,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -8880,6 +9230,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -8904,6 +9255,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -8927,6 +9279,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -8950,6 +9303,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -8973,6 +9327,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -8996,6 +9351,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -9020,6 +9376,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -9044,6 +9401,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -9067,6 +9425,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -9091,6 +9450,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -9115,6 +9475,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -9139,6 +9500,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -9162,6 +9524,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -9185,6 +9548,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -9208,6 +9572,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -9231,6 +9596,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -9255,6 +9621,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -9278,6 +9645,7 @@
   - outerwear_clothing_features
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -9308,6 +9676,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - skirt/dress_length_type
   - skirt_style
   - sleeve_length_type
@@ -9333,6 +9702,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   return_reasons:
@@ -9357,6 +9727,7 @@
   - pattern
   - shoe_size
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -9390,6 +9761,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -9412,6 +9784,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -9435,6 +9808,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -9458,6 +9832,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -9481,6 +9856,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - swimwear_features
   - target_gender
   return_reasons:
@@ -9503,6 +9879,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -9526,6 +9903,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - swimwear_features
   - target_gender
   return_reasons:
@@ -9547,6 +9925,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - swimwear_features
   - target_gender
   return_reasons:
@@ -9568,6 +9947,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -9591,6 +9971,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - swimwear_features
   - target_gender
   return_reasons:
@@ -9612,6 +9993,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - swimwear_features
   - target_gender
   return_reasons:
@@ -9633,6 +10015,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -9656,6 +10039,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -9678,6 +10062,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - swimwear_features
   - target_gender
@@ -9712,6 +10097,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -9736,6 +10122,7 @@
   - one_piece_style
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -9759,6 +10146,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -9782,6 +10170,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -9805,6 +10194,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -9829,6 +10219,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -9853,6 +10244,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -9877,6 +10269,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -9900,6 +10293,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -9923,6 +10317,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -9947,6 +10342,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -9973,6 +10369,7 @@
   - pants_length_type
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - target_gender
   - top_length_type
@@ -9993,7 +10390,8 @@
   - aa-1-25-11-1
   - aa-1-25-11-2
   - aa-1-25-11-3
-  attributes: []
+  attributes:
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -10019,6 +10417,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10040,6 +10439,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10061,6 +10461,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10082,6 +10483,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10103,6 +10505,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10124,6 +10527,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10151,6 +10555,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10174,6 +10579,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10206,6 +10612,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -10230,6 +10637,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -10254,6 +10662,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -10278,6 +10687,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -10302,6 +10712,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -10326,6 +10737,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -10350,6 +10762,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -10373,6 +10786,7 @@
   - fabric
   - intimate_apparel_features
   - size
+  - size_type
   - target_gender
   - underwear_style
   - waist_rise
@@ -10396,6 +10810,7 @@
   - fabric
   - intimate_apparel_features
   - size
+  - size_type
   - target_gender
   - waist_rise
   return_reasons:
@@ -10421,6 +10836,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10445,6 +10861,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10471,6 +10888,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10494,6 +10912,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10523,6 +10942,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10546,6 +10966,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10569,6 +10990,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10592,6 +11014,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10615,6 +11038,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10638,6 +11062,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -10661,6 +11086,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   - undershirt_style
   return_reasons:
@@ -11715,6 +12141,7 @@
   - headwear_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -11741,6 +12168,7 @@
   - headwear_features
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -11765,6 +12193,7 @@
   - headwear_features
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -11789,6 +12218,7 @@
   - headwear_features
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -11813,6 +12243,7 @@
   - headwear_features
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -11836,6 +12267,7 @@
   - headwear_features
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -11859,6 +12291,7 @@
   - headwear_features
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -11882,6 +12315,7 @@
   - headwear_features
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -11906,6 +12340,7 @@
   - headwear_features
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -11930,6 +12365,7 @@
   - pattern
   - target_gender
   - weave_style
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -11953,6 +12389,7 @@
   - headwear_features
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -11977,6 +12414,7 @@
   - headwear_features
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -12001,6 +12439,7 @@
   - pattern
   - target_gender
   - top_hat_style
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -12024,6 +12463,7 @@
   - headwear_features
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -12048,6 +12488,7 @@
   - headwear_features
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -12071,6 +12512,7 @@
   - headwear_features
   - pattern
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -12096,6 +12538,7 @@
   - pattern
   - pom_pom_type
   - target_gender
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -12119,6 +12562,7 @@
   - headwear_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -12139,6 +12583,7 @@
   - headwear_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -12159,6 +12604,7 @@
   - headwear_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -12179,6 +12625,7 @@
   - headwear_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -12199,6 +12646,7 @@
   - headwear_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -12219,6 +12667,7 @@
   - headwear_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -12239,6 +12688,7 @@
   - headwear_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -12259,6 +12709,7 @@
   - headwear_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -12279,6 +12730,7 @@
   - headwear_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -12432,6 +12884,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -12701,6 +13154,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - suspender_style
   - target_gender
   return_reasons:
@@ -13020,6 +13474,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -13041,6 +13496,7 @@
   - color
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -13062,6 +13518,7 @@
   - handwear_material
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -13085,6 +13542,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -13106,6 +13564,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -13256,6 +13715,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -13279,6 +13739,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -13302,6 +13763,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big
@@ -13325,6 +13787,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -13344,6 +13807,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind
@@ -13363,6 +13827,7 @@
   - fabric
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - changed_my_mind

--- a/data/categories/ae_arts_entertainment.yml
+++ b/data/categories/ae_arts_entertainment.yml
@@ -11509,6 +11509,7 @@
   - handwear_material
   - pattern
   - size
+  - size_type
   - sport
   - sports_logo
   - target_gender
@@ -11558,6 +11559,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - sport
   - sports_logo
@@ -11586,6 +11588,7 @@
   - neckline
   - pattern
   - size
+  - size_type
   - sleeve_length_type
   - sport
   - sports_logo
@@ -11725,6 +11728,7 @@
   - print_placement
   - print_technique
   - size
+  - size_type
   - sleeve_length_type
   - sleeve_style
   - sport

--- a/data/categories/ae_arts_entertainment.yml
+++ b/data/categories/ae_arts_entertainment.yml
@@ -11509,7 +11509,6 @@
   - handwear_material
   - pattern
   - size
-  - size_type
   - sport
   - sports_logo
   - target_gender
@@ -11559,7 +11558,6 @@
   - neckline
   - pattern
   - size
-  - size_type
   - sleeve_length_type
   - sport
   - sports_logo
@@ -11588,7 +11586,6 @@
   - neckline
   - pattern
   - size
-  - size_type
   - sleeve_length_type
   - sport
   - sports_logo
@@ -11728,7 +11725,6 @@
   - print_placement
   - print_technique
   - size
-  - size_type
   - sleeve_length_type
   - sleeve_style
   - sport

--- a/data/categories/el_electronics.yml
+++ b/data/categories/el_electronics.yml
@@ -1409,6 +1409,7 @@
   - material
   - pattern
   - size
+  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -15624,6 +15625,7 @@
   - power_source
   - shape
   - size
+  - size_type
   - surface_texture
   - theme
   - wrist_rest_type

--- a/data/categories/el_electronics.yml
+++ b/data/categories/el_electronics.yml
@@ -1409,7 +1409,6 @@
   - material
   - pattern
   - size
-  - size_type
   return_reasons:
   - too_big
   - too_small
@@ -15625,7 +15624,6 @@
   - power_source
   - shape
   - size
-  - size_type
   - surface_texture
   - theme
   - wrist_rest_type

--- a/data/categories/hb_health_beauty.yml
+++ b/data/categories/hb_health_beauty.yml
@@ -1757,6 +1757,7 @@
   - material
   - product_certifications_standards
   - size
+  - size_type
   - usage_type
   return_reasons:
   - size
@@ -4155,6 +4156,7 @@
   - closure_type
   - material
   - size
+  - size_type
   - target_gender
   - usage_type
   return_reasons:
@@ -6372,6 +6374,7 @@
   - mask_type
   - material
   - size
+  - size_type
   - target_gender
   return_reasons:
   - fit
@@ -6537,6 +6540,7 @@
   - compression_level
   - material
   - size
+  - size_type
   return_reasons:
   - size
   - compression
@@ -6569,6 +6573,7 @@
   - material_firmness
   - pattern
   - size
+  - size_type
   - support/brace_material
   return_reasons:
   - too_tight
@@ -6595,6 +6600,7 @@
   - material_firmness
   - pattern
   - size
+  - size_type
   - support/brace_material
   return_reasons:
   - too_tight
@@ -6620,6 +6626,7 @@
   - material_firmness
   - pattern
   - size
+  - size_type
   - support/brace_material
   return_reasons:
   - size
@@ -6644,6 +6651,7 @@
   - material_firmness
   - pattern
   - size
+  - size_type
   - support/brace_material
   return_reasons:
   - too_tight
@@ -6671,6 +6679,7 @@
   - material_firmness
   - pattern
   - size
+  - size_type
   - support/brace_material
   return_reasons:
   - size
@@ -6694,6 +6703,7 @@
   - material_firmness
   - pattern
   - size
+  - size_type
   - support/brace_material
   return_reasons:
   - size
@@ -6717,6 +6727,7 @@
   - material_firmness
   - pattern
   - size
+  - size_type
   - support/brace_material
   return_reasons:
   - too_big
@@ -6741,6 +6752,7 @@
   - material_firmness
   - pattern
   - size
+  - size_type
   - support/brace_material
   return_reasons:
   - too_tight
@@ -6766,6 +6778,7 @@
   - patella_opening_design
   - pattern
   - size
+  - size_type
   - support/brace_material
   - support_level
   return_reasons:
@@ -6792,6 +6805,7 @@
   - pattern
   - radiology_compatibility
   - size
+  - size_type
   - support/brace_material
   - therapeutic_features
   return_reasons:
@@ -6817,6 +6831,7 @@
   - material_firmness
   - pattern
   - size
+  - size_type
   - splint/stay_configuration
   - support/brace_material
   return_reasons:
@@ -6841,6 +6856,7 @@
   - material_firmness
   - pattern
   - size
+  - size_type
   - support/brace_material
   return_reasons:
   - changed_my_mind
@@ -6861,6 +6877,7 @@
   - material_firmness
   - pattern
   - size
+  - size_type
   - support/brace_material
   return_reasons:
   - changed_my_mind
@@ -6881,6 +6898,7 @@
   - material_firmness
   - pattern
   - size
+  - size_type
   - support/brace_material
   return_reasons:
   - changed_my_mind
@@ -6901,6 +6919,7 @@
   - material_firmness
   - pattern
   - size
+  - size_type
   - support/brace_material
   return_reasons:
   - changed_my_mind
@@ -6921,6 +6940,7 @@
   - material_firmness
   - pattern
   - size
+  - size_type
   - support/brace_material
   return_reasons:
   - changed_my_mind
@@ -7803,6 +7823,7 @@
   - pillow_shape
   - product_form
   - size
+  - size_type
   - treatment_objective
   return_reasons:
   - size
@@ -7833,6 +7854,7 @@
   - pillow_shape
   - product_form
   - size
+  - size_type
   - support_cushion_features
   - treatment_objective
   return_reasons:
@@ -7861,6 +7883,7 @@
   - pillow_shape
   - product_form
   - size
+  - size_type
   - support_cushion_features
   - treatment_objective
   return_reasons:
@@ -7889,6 +7912,7 @@
   - pillow_shape
   - product_form
   - size
+  - size_type
   - support_cushion_features
   - treatment_objective
   return_reasons:
@@ -7910,6 +7934,7 @@
   - pillow_shape
   - product_form
   - size
+  - size_type
   - treatment_objective
   return_reasons:
   - changed_my_mind
@@ -7927,6 +7952,7 @@
   - pillow_shape
   - product_form
   - size
+  - size_type
   - treatment_objective
   return_reasons:
   - changed_my_mind
@@ -8542,6 +8568,7 @@
   - scent
   - shower_cap_lining_material
   - size
+  - size_type
   - skin_care_effect
   - suitable_for_skin_type
   - usage_type
@@ -15437,6 +15464,7 @@
   - material
   - product_form
   - size
+  - size_type
   - skin_care_effect
   - support_rigidity_level
   - target_gender
@@ -20912,6 +20940,7 @@
   - material
   - product_form
   - size
+  - size_type
   - treatment_objective
   return_reasons:
   - material
@@ -20935,6 +20964,7 @@
   - material
   - product_form
   - size
+  - size_type
   - treatment_objective
   return_reasons:
   - size
@@ -20958,6 +20988,7 @@
   - material
   - product_form
   - size
+  - size_type
   - treatment_objective
   return_reasons:
   - too_tight
@@ -20984,6 +21015,7 @@
   - product_certifications_standards
   - product_form
   - size
+  - size_type
   - treatment_objective
   return_reasons:
   - too_bulky
@@ -21006,6 +21038,7 @@
   - material
   - product_form
   - size
+  - size_type
   - treatment_objective
   - usage_type
   return_reasons:
@@ -21028,6 +21061,7 @@
   - material
   - product_form
   - size
+  - size_type
   - treatment_objective
   - usage_type
   return_reasons:
@@ -21053,6 +21087,7 @@
   - product_certifications_standards
   - product_form
   - size
+  - size_type
   - treatment_objective
   - usage_type
   return_reasons:
@@ -21075,6 +21110,7 @@
   - material
   - product_form
   - size
+  - size_type
   - treatment_objective
   return_reasons:
   - taste
@@ -21098,6 +21134,7 @@
   - material
   - product_form
   - size
+  - size_type
   - treatment_objective
   return_reasons:
   - material
@@ -21121,6 +21158,7 @@
   - material
   - product_form
   - size
+  - size_type
   - treatment_objective
   return_reasons:
   - size

--- a/data/categories/hb_health_beauty.yml
+++ b/data/categories/hb_health_beauty.yml
@@ -1757,7 +1757,6 @@
   - material
   - product_certifications_standards
   - size
-  - size_type
   - usage_type
   return_reasons:
   - size
@@ -4156,7 +4155,6 @@
   - closure_type
   - material
   - size
-  - size_type
   - target_gender
   - usage_type
   return_reasons:
@@ -6374,7 +6372,6 @@
   - mask_type
   - material
   - size
-  - size_type
   - target_gender
   return_reasons:
   - fit
@@ -6540,7 +6537,6 @@
   - compression_level
   - material
   - size
-  - size_type
   return_reasons:
   - size
   - compression
@@ -6573,7 +6569,6 @@
   - material_firmness
   - pattern
   - size
-  - size_type
   - support/brace_material
   return_reasons:
   - too_tight
@@ -6600,7 +6595,6 @@
   - material_firmness
   - pattern
   - size
-  - size_type
   - support/brace_material
   return_reasons:
   - too_tight
@@ -6626,7 +6620,6 @@
   - material_firmness
   - pattern
   - size
-  - size_type
   - support/brace_material
   return_reasons:
   - size
@@ -6651,7 +6644,6 @@
   - material_firmness
   - pattern
   - size
-  - size_type
   - support/brace_material
   return_reasons:
   - too_tight
@@ -6679,7 +6671,6 @@
   - material_firmness
   - pattern
   - size
-  - size_type
   - support/brace_material
   return_reasons:
   - size
@@ -6703,7 +6694,6 @@
   - material_firmness
   - pattern
   - size
-  - size_type
   - support/brace_material
   return_reasons:
   - size
@@ -6727,7 +6717,6 @@
   - material_firmness
   - pattern
   - size
-  - size_type
   - support/brace_material
   return_reasons:
   - too_big
@@ -6752,7 +6741,6 @@
   - material_firmness
   - pattern
   - size
-  - size_type
   - support/brace_material
   return_reasons:
   - too_tight
@@ -6778,7 +6766,6 @@
   - patella_opening_design
   - pattern
   - size
-  - size_type
   - support/brace_material
   - support_level
   return_reasons:
@@ -6805,7 +6792,6 @@
   - pattern
   - radiology_compatibility
   - size
-  - size_type
   - support/brace_material
   - therapeutic_features
   return_reasons:
@@ -6831,7 +6817,6 @@
   - material_firmness
   - pattern
   - size
-  - size_type
   - splint/stay_configuration
   - support/brace_material
   return_reasons:
@@ -6856,7 +6841,6 @@
   - material_firmness
   - pattern
   - size
-  - size_type
   - support/brace_material
   return_reasons:
   - changed_my_mind
@@ -6877,7 +6861,6 @@
   - material_firmness
   - pattern
   - size
-  - size_type
   - support/brace_material
   return_reasons:
   - changed_my_mind
@@ -6898,7 +6881,6 @@
   - material_firmness
   - pattern
   - size
-  - size_type
   - support/brace_material
   return_reasons:
   - changed_my_mind
@@ -6919,7 +6901,6 @@
   - material_firmness
   - pattern
   - size
-  - size_type
   - support/brace_material
   return_reasons:
   - changed_my_mind
@@ -6940,7 +6921,6 @@
   - material_firmness
   - pattern
   - size
-  - size_type
   - support/brace_material
   return_reasons:
   - changed_my_mind
@@ -7823,7 +7803,6 @@
   - pillow_shape
   - product_form
   - size
-  - size_type
   - treatment_objective
   return_reasons:
   - size
@@ -7854,7 +7833,6 @@
   - pillow_shape
   - product_form
   - size
-  - size_type
   - support_cushion_features
   - treatment_objective
   return_reasons:
@@ -7883,7 +7861,6 @@
   - pillow_shape
   - product_form
   - size
-  - size_type
   - support_cushion_features
   - treatment_objective
   return_reasons:
@@ -7912,7 +7889,6 @@
   - pillow_shape
   - product_form
   - size
-  - size_type
   - support_cushion_features
   - treatment_objective
   return_reasons:
@@ -7934,7 +7910,6 @@
   - pillow_shape
   - product_form
   - size
-  - size_type
   - treatment_objective
   return_reasons:
   - changed_my_mind
@@ -7952,7 +7927,6 @@
   - pillow_shape
   - product_form
   - size
-  - size_type
   - treatment_objective
   return_reasons:
   - changed_my_mind
@@ -8568,7 +8542,6 @@
   - scent
   - shower_cap_lining_material
   - size
-  - size_type
   - skin_care_effect
   - suitable_for_skin_type
   - usage_type
@@ -15464,7 +15437,6 @@
   - material
   - product_form
   - size
-  - size_type
   - skin_care_effect
   - support_rigidity_level
   - target_gender
@@ -20940,7 +20912,6 @@
   - material
   - product_form
   - size
-  - size_type
   - treatment_objective
   return_reasons:
   - material
@@ -20964,7 +20935,6 @@
   - material
   - product_form
   - size
-  - size_type
   - treatment_objective
   return_reasons:
   - size
@@ -20988,7 +20958,6 @@
   - material
   - product_form
   - size
-  - size_type
   - treatment_objective
   return_reasons:
   - too_tight
@@ -21015,7 +20984,6 @@
   - product_certifications_standards
   - product_form
   - size
-  - size_type
   - treatment_objective
   return_reasons:
   - too_bulky
@@ -21038,7 +21006,6 @@
   - material
   - product_form
   - size
-  - size_type
   - treatment_objective
   - usage_type
   return_reasons:
@@ -21061,7 +21028,6 @@
   - material
   - product_form
   - size
-  - size_type
   - treatment_objective
   - usage_type
   return_reasons:
@@ -21087,7 +21053,6 @@
   - product_certifications_standards
   - product_form
   - size
-  - size_type
   - treatment_objective
   - usage_type
   return_reasons:
@@ -21110,7 +21075,6 @@
   - material
   - product_form
   - size
-  - size_type
   - treatment_objective
   return_reasons:
   - taste
@@ -21134,7 +21098,6 @@
   - material
   - product_form
   - size
-  - size_type
   - treatment_objective
   return_reasons:
   - material
@@ -21158,7 +21121,6 @@
   - material
   - product_form
   - size
-  - size_type
   - treatment_objective
   return_reasons:
   - size

--- a/data/categories/hg_home_garden.yml
+++ b/data/categories/hg_home_garden.yml
@@ -21824,6 +21824,7 @@
   - pattern
   - shape
   - size
+  - size_type
   return_reasons:
   - size
   - color
@@ -28646,6 +28647,7 @@
   - handle_material
   - pattern
   - size
+  - size_type
   - target_gender
   - tool/utensil_material
   return_reasons:

--- a/data/categories/hg_home_garden.yml
+++ b/data/categories/hg_home_garden.yml
@@ -21824,7 +21824,6 @@
   - pattern
   - shape
   - size
-  - size_type
   return_reasons:
   - size
   - color
@@ -28647,7 +28646,6 @@
   - handle_material
   - pattern
   - size
-  - size_type
   - target_gender
   - tool/utensil_material
   return_reasons:

--- a/data/categories/ma_mature.yml
+++ b/data/categories/ma_mature.yml
@@ -41,6 +41,7 @@
   - intimate_apparel_features
   - pattern
   - size
+  - size_type
   - target_gender
   return_reasons:
   - too_big

--- a/data/categories/ma_mature.yml
+++ b/data/categories/ma_mature.yml
@@ -41,7 +41,6 @@
   - intimate_apparel_features
   - pattern
   - size
-  - size_type
   - target_gender
   return_reasons:
   - too_big

--- a/data/localizations/attributes/en.yml
+++ b/data/localizations/attributes/en.yml
@@ -20372,6 +20372,9 @@ en:
     size_system:
       name: Size system
       description: Specifies the sizing system or regional standard the size label corresponds to (e.g., US, UK, EU, International letter).
+    size_type:
+      name: Size type
+      description: Describes the cut of a product, such as regular, petite, plus, big, tall, or maternity.
     sizzle_mechanism:
       name: Sizzle mechanism
       description: Specifies how the cymbal produces the sizzle effect (e.g., rivets installed in the cymbal, attachable chain/sizzler, or no hardware included).

--- a/dist/en/attributes.txt
+++ b/dist/en/attributes.txt
@@ -6533,6 +6533,7 @@ gid://shopify/TaxonomyAttribute/2778  : Size
 gid://shopify/TaxonomyAttribute/6156  : Size adjustability
 gid://shopify/TaxonomyAttribute/10264 : Size designation
 gid://shopify/TaxonomyAttribute/10265 : Size system
+gid://shopify/TaxonomyAttribute/12821 : Size type
 gid://shopify/TaxonomyAttribute/10266 : Sizzle mechanism
 gid://shopify/TaxonomyAttribute/10981 : Skate blade discipline
 gid://shopify/TaxonomyAttribute/10982 : Skate brake type


### PR DESCRIPTION
## Summary

Adds the Size type closed-list attribute to 465 relevant categories under Apparel & Accessories.

Values:
- Big
- Maternity
- Petite
- Plus
- Regular
- Tall
- Other

## IDs

- Attribute: 12821
- Values: 82505–82511

## Validation

- Unit: 426 runs, 287,433 assertions, 0 failures
- Integration: 12 runs, 527,797 assertions, 0 failures
- Source and distribution schema validation: passed
- Orphan detection: passed
- 465 expected category assignments; 0 missing; 0 extra
- Source, English localization, and distribution parity: passed
- `git diff --check`: passed