### PR TITLE
Point distribution docs at gzip release assets

### DIFF
--- a/.github/workflows/publish_unstable_dist.yml
+++ b/.github/workflows/publish_unstable_dist.yml
@@ -89,11 +89,17 @@ jobs:
       - name: Create unstable prerelease if needed
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
 
+          notes="Rolling distribution assets generated from main. Version: \`$VERSION\` (built from $GITHUB_SHA)."
+
           if gh release view unstable --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "The unstable prerelease already exists; leaving its tag unchanged."
+            echo "The unstable prerelease already exists; updating its notes and leaving its tag unchanged."
+            gh release edit unstable \
+              --repo "$GITHUB_REPOSITORY" \
+              --notes "$notes"
           else
             gh release create unstable \
               --repo "$GITHUB_REPOSITORY" \
@@ -101,7 +107,7 @@ jobs:
               --prerelease \
               --latest=false \
               --title "Unstable" \
-              --notes "Rolling distribution assets generated from main."
+              --notes "$notes"
           fi
 
       - name: Publish unstable assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### 📦 Distribution
+
+- Distribution files are now published as gzip-compressed GitHub release assets. Download stable files from `https://github.com/Shopify/product-taxonomy/releases/latest/download/<asset>` (or pin a version with `releases/download/v<version>/<asset>`) and main-tracking files from `releases/download/unstable/<asset>`, then decompress (for example `curl -L <url> | gunzip`). Assets are named `<basename>.<locale>.<format>.gz`, with nested paths flattened using dots (for example `categories.en.json.gz`, `integrations.all_mappings.en.json.gz`). The committed `dist/` directory is deprecated and will be removed from `main` on October 31, 2026.
+
 ## 2026-05
 
 #### 📚 Taxonomy Tree

--- a/README.md
+++ b/README.md
@@ -48,7 +48,19 @@ You can think of this repository serving 3 primary users:
 
 ### 🧩 1. Integrators: How to integrate with the taxonomy
 
-Dive straight into [`dist`](./dist/) to find the files you need and integrate this taxonomy into your system.
+Distribution files are published as gzip-compressed assets on [GitHub releases](https://github.com/Shopify/product-taxonomy/releases):
+
+- **Stable** (recommended): `https://github.com/Shopify/product-taxonomy/releases/latest/download/<asset>`, or pin a version with `releases/download/v<version>/<asset>`.
+- **Unstable** (tracks `main`): `https://github.com/Shopify/product-taxonomy/releases/download/unstable/<asset>`.
+
+Assets are named `<basename>.<locale>.<format>.gz`, with nested paths flattened using dots (`categories.en.json.gz`, `integrations.all_mappings.en.json.gz`). Decompress after downloading:
+
+```sh
+curl -L https://github.com/Shopify/product-taxonomy/releases/latest/download/categories.en.json.gz | gunzip > categories.json
+```
+
+> [!IMPORTANT]
+> The committed [`dist/`](./dist/) directory is deprecated and will be removed on **October 31, 2026**. Migrate to the release-asset URLs above before then.
 
 We offer `txt` and `json` formats to make it easy to integrate with your systems. If you have a specific format you'd like to see, please open an issue and let us know!
 

--- a/data/integrations/README.md
+++ b/data/integrations/README.md
@@ -24,7 +24,7 @@ data/integrations/
 └── <integration 2> #...
 ```
 
-Generated distribution files for mappings can be found in `dist/{locale}/integrations`.
+Mapping distribution files are published as gzip-compressed [GitHub release assets](https://github.com/Shopify/product-taxonomy/releases) (for example `integrations.all_mappings.en.json.gz` — see the [main README](../../README.md#-1-integrators-how-to-integrate-with-the-taxonomy) for download instructions). Running `bin/product_taxonomy dist` generates them locally under `dist/{locale}/integrations`. The committed `dist/` directory is deprecated and will be removed on October 31, 2026.
 
 ```
 dist/{locale}/integrations/

--- a/docs/_releases/unstable/index.html
+++ b/docs/_releases/unstable/index.html
@@ -4,6 +4,6 @@ layout: categories
 title: unstable
 target: unstable
 permalink: /releases/unstable/
-github_url: https://github.com/Shopify/product-taxonomy/tree/main/dist
+github_url: https://github.com/Shopify/product-taxonomy/releases/tag/unstable
 include_in_release_list: true
 ---

--- a/docs/_releases/unstable/values.html
+++ b/docs/_releases/unstable/values.html
@@ -4,5 +4,5 @@ layout: values
 title: unstable
 target: unstable
 permalink: /releases/unstable/values/
-github_url: https://github.com/Shopify/product-taxonomy/tree/main/dist
+github_url: https://github.com/Shopify/product-taxonomy/releases/tag/unstable
 ---


### PR DESCRIPTION
Summary

Distribution files are now published as gzip-compressed GitHub release assets (#957), and `dist/` will be removed from `main` at cutover. This migrates this repo's docs to the new download location before that happens. October 31st is the tentative cutover deadline.

### What changed

- **`README.md`**: Integrators section points at release assets instead of `dist/` — stable (`releases/latest/download/<asset>`), pinned (`releases/download/v<version>/<asset>`), and main-tracking (`releases/download/unstable/<asset>`). Documents the flattened asset naming (`categories.en.json.gz`, `integrations.all_mappings.en.json.gz`) and the `curl -L <url> | gunzip` decompression step.
- **`CHANGELOG.md`**: adds an Unreleased entry calling out the new download location, the gzip format, and the upcoming `dist/` removal.
- **`data/integrations/README.md`**: mapping-files pointer now references release assets; clarifies `dist/{locale}/integrations` is local generator output.
- **`docs/_releases/unstable/{index,values}.html`**: `github_url` front matter `tree/main/dist` → `releases/tag/unstable`. This is the "(sourced from GitHub)" link next to the Unstable release on the [taxonomy explorer homepage](https://shopify.github.io/product-taxonomy/).