### PR TITLE
Maintain `return_reason` sorting when serializing categories

### DIFF
--- a/dev/lib/product_taxonomy/models/serializers/category/data/data_serializer.rb
+++ b/dev/lib/product_taxonomy/models/serializers/category/data/data_serializer.rb
@@ -16,11 +16,11 @@ module ProductTaxonomy
             def serialize(category)
               return_reason_ids = category.return_reasons.map(&:friendly_id)
               has_unknown = return_reason_ids.delete('unknown')
-              has_other = return_reason_ids.delete('other')
+              has_other = return_reason_ids.delete('other_reason')
 
               sorted_return_reasons = AlphanumericSorter.sort(return_reason_ids)
               sorted_return_reasons += ['unknown'] if has_unknown
-              sorted_return_reasons += ['other'] if has_other
+              sorted_return_reasons += ['other_reason'] if has_other
               
               {
                 "id" => category.id,

--- a/dev/lib/product_taxonomy/models/serializers/category/data/data_serializer.rb
+++ b/dev/lib/product_taxonomy/models/serializers/category/data/data_serializer.rb
@@ -14,20 +14,20 @@ module ProductTaxonomy
             # @param [Category] category
             # @return [Hash]
             def serialize(category)
+              # The curated order in `data/categories/*.yml` is meaningful, so it is preserved as-is; only the
+              # catch-all reasons are pulled out and appended.
               return_reason_ids = category.return_reasons.map(&:friendly_id)
-              has_unknown = return_reason_ids.delete('unknown')
-              has_other = return_reason_ids.delete('other_reason')
+              has_unknown = return_reason_ids.delete("unknown")
+              has_other = return_reason_ids.delete("other_reason")
+              return_reason_ids << "unknown" if has_unknown
+              return_reason_ids << "other_reason" if has_other
 
-              sorted_return_reasons = AlphanumericSorter.sort(return_reason_ids)
-              sorted_return_reasons += ['unknown'] if has_unknown
-              sorted_return_reasons += ['other_reason'] if has_other
-              
               {
                 "id" => category.id,
                 "name" => category.name,
                 "children" => category.children.sort_by(&:id_parts).map(&:id),
                 "attributes" => AlphanumericSorter.sort(category.attributes.map(&:friendly_id), other_last: true),
-                "return_reasons" => sorted_return_reasons,
+                "return_reasons" => return_reason_ids,
               }
             end
           end

--- a/dev/test/models/serializers/category/data/data_serializer_test.rb
+++ b/dev/test/models/serializers/category/data/data_serializer_test.rb
@@ -50,6 +50,24 @@ module ProductTaxonomy
             assert_equal expected, DataSerializer.serialize(@root)
           end
 
+          test "serialize sorts return reasons alphanumerically with unknown and other_reason last" do
+            category = ProductTaxonomy::Category.new(
+              id: "cc",
+              name: "Sorted Root",
+              return_reasons: [
+                return_reason(1, "too_big"),
+                return_reason(2, "other_reason"),
+                return_reason(3, "changed_my_mind"),
+                return_reason(4, "unknown"),
+                return_reason(5, "color"),
+              ],
+            )
+
+            expected = ["changed_my_mind", "color", "too_big", "unknown", "other_reason"]
+
+            assert_equal expected, DataSerializer.serialize(category)["return_reasons"]
+          end
+
           test "serialize_all returns all categories in data format" do
             expected = [
               {
@@ -90,6 +108,18 @@ module ProductTaxonomy
             ]
 
             assert_equal expected, DataSerializer.serialize_all(@root)
+          end
+
+          private
+
+          def return_reason(id, friendly_id)
+            ProductTaxonomy::ReturnReason.new(
+              id:,
+              name: friendly_id.tr("_", " ").capitalize,
+              description: "Description for #{friendly_id}",
+              friendly_id:,
+              handle: friendly_id.tr("_", "-"),
+            )
           end
         end
       end

--- a/dev/test/models/serializers/category/data/data_serializer_test.rb
+++ b/dev/test/models/serializers/category/data/data_serializer_test.rb
@@ -50,7 +50,7 @@ module ProductTaxonomy
             assert_equal expected, DataSerializer.serialize(@root)
           end
 
-          test "serialize sorts return reasons alphanumerically with unknown and other_reason last" do
+          test "serialize preserves the return reason order, moving unknown and other_reason to the end" do
             category = ProductTaxonomy::Category.new(
               id: "cc",
               name: "Sorted Root",
@@ -63,7 +63,7 @@ module ProductTaxonomy
               ],
             )
 
-            expected = ["changed_my_mind", "color", "too_big", "unknown", "other_reason"]
+            expected = ["too_big", "changed_my_mind", "color", "unknown", "other_reason"]
 
             assert_equal expected, DataSerializer.serialize(category)["return_reasons"]
           end


### PR DESCRIPTION
The sorting of the return reasons is meaningful so we need to maintain them, apart from `unknown` and `other_reason` which needs to stay at the end.

This removes the call to alphabetize them from the Category serialization class.

It also fixes the special treatment of `other_reason` which is using the incorrect `other` friendly id.