### PR TITLE
Reflect inherited return reasons in the category YML

### DIFF
--- a/data/categories/aa_apparel_accessories.yml
+++ b/data/categories/aa_apparel_accessories.yml
@@ -502,13 +502,7 @@
   - target_gender
   - top_length_type
   - zipper_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-1-4
   name: Boxing Shorts
   children: []
@@ -583,13 +577,7 @@
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-1-5-2
   name: Dance Dresses
   children: []
@@ -608,13 +596,7 @@
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-1-6
   name: Sports Bras
   children: []
@@ -898,13 +880,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-1-9-2
   name: Unitards
   children: []
@@ -920,13 +896,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-1-9-3
   name: Triathlon Suits
   children: []
@@ -942,13 +912,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-4
   name: Dresses
   children: []
@@ -1126,13 +1090,7 @@
   - pattern
   - target_gender
   - size_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-2-2-2
   name: Bra Straps
   children: []
@@ -1142,13 +1100,7 @@
   - pattern
   - target_gender
   - size_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-2-3
   name: Breast Enhancing Inserts
   children: []
@@ -1200,13 +1152,7 @@
   - pattern
   - target_gender
   - size_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-2-6
   name: Breast Lift Tape
   children: []
@@ -1216,13 +1162,7 @@
   - pattern
   - target_gender
   - size_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-3
   name: Bras
   children: []
@@ -1414,13 +1354,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-8-2-2
   name: Shirttail Garters
   children: []
@@ -1434,13 +1368,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-8-3
   name: Pantyhose
   children: []
@@ -1480,13 +1408,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-8-5
   name: Fashion & Body Tape
   children: []
@@ -1499,13 +1421,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-9
   name: Petticoats & Pettipants
   children:
@@ -1543,13 +1459,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-9-2
   name: Pettipants
   children: []
@@ -1562,13 +1472,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-10
   name: Shapewear
   children:
@@ -1746,13 +1650,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-10-7
   name: Arm & Upper Body Shapers
   children: []
@@ -1766,13 +1664,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-10-8
   name: Shaping Slips
   children: []
@@ -1786,13 +1678,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-11
   name: Women's Underpants
   children:
@@ -1994,13 +1880,7 @@
   - size_type
   - target_gender
   - waist_rise
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-11-8
   name: Hipsters
   children: []
@@ -2015,13 +1895,7 @@
   - size_type
   - target_gender
   - waist_rise
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-11-9
   name: Cheeky Panties
   children: []
@@ -2036,13 +1910,7 @@
   - size_type
   - target_gender
   - waist_rise
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-12
   name: Women's Undershirts
   children: []
@@ -2103,13 +1971,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-15
   name: Corsets & Bustiers
   children: []
@@ -2124,13 +1986,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-6-16
   name: Lingerie Sets
   children: []
@@ -2145,13 +2001,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-7
   name: Maternity Clothing
   children:
@@ -2580,13 +2430,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-7-4-14
   name: Tights
   children: []
@@ -2605,13 +2449,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-7-4-15
   name: Capris
   children: []
@@ -2630,13 +2468,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-7-5
   name: Maternity Skirts
   children: []
@@ -3101,13 +2933,7 @@
   - sleeve_length_type
   - target_gender
   - top_length_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-7-8-4-2
   name: Nursing Hoodies
   children: []
@@ -3127,13 +2953,7 @@
   - sleeve_length_type
   - target_gender
   - top_length_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-7-8-4-3
   name: Nursing Tank Tops
   children: []
@@ -3153,13 +2973,7 @@
   - sleeve_length_type
   - target_gender
   - top_length_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-7-8-4-4
   name: Nursing Sweatshirts
   children: []
@@ -3179,13 +2993,7 @@
   - sleeve_length_type
   - target_gender
   - top_length_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-7-8-5
   name: Overshirts
   children: []
@@ -3315,13 +3123,7 @@
   - pregnancy_stage_suitability
   - target_gender
   - size_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-7-10
   name: Maternity Shapewear & Support Garments
   children: []
@@ -3335,13 +3137,7 @@
   - pregnancy_stage_suitability
   - target_gender
   - size_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-7-11
   name: Maternity Underwear
   children: []
@@ -3355,13 +3151,7 @@
   - pregnancy_stage_suitability
   - target_gender
   - size_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-8
   name: Men's Undergarments
   children:
@@ -3679,13 +3469,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-9
   name: One-Pieces
   children: []
@@ -4023,13 +3807,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-10-2-8-2
   name: Changing & Surf Ponchos
   children: []
@@ -4045,13 +3823,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-10-2-9
   name: Puffer Jackets
   children: []
@@ -4309,13 +4081,7 @@
   - sleeve_length_type
   - target_gender
   - top_length_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-10-3
   name: Rain Pants
   children: []
@@ -4413,13 +4179,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-10-5-2
   name: Snow Bibs
   children: []
@@ -4434,13 +4194,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-10-5-3
   name: Snow Pants
   children: []
@@ -4455,13 +4209,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-10-6
   name: Vests
   children: []
@@ -4531,13 +4279,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-11
   name: Outfit Sets
   children: []
@@ -4845,13 +4587,7 @@
   - target_gender
   - waist_rise
   - waistband_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-12-13
   name: Palazzo Pants
   children: []
@@ -4870,13 +4606,7 @@
   - target_gender
   - waist_rise
   - waistband_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-13
   name: Clothing Tops
   children:
@@ -5121,13 +4851,7 @@
   - stretch_level
   - target_gender
   - top_length_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-13-7-2
   name: Dress Shirts
   children: []
@@ -5148,13 +4872,7 @@
   - stretch_level
   - target_gender
   - top_length_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-13-8
   name: T-Shirts
   children: []
@@ -5353,13 +5071,7 @@
   - target_gender
   - top_fit
   - top_length_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-14
   name: Shorts
   children:
@@ -5916,13 +5628,7 @@
   - sleepwear_set_pieces_included
   - target_gender
   - waist_rise
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-17-2-2
   name: Loungewear Tops
   children: []
@@ -5962,13 +5668,7 @@
   - size_type
   - sleepwear_set_pieces_included
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-17-3
   name: Nightgowns
   children: []
@@ -6088,13 +5788,7 @@
   - size_type
   - sleepwear_set_pieces_included
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-18
   name: Socks
   children:
@@ -6405,13 +6099,7 @@
   - sock_toe_style
   - target_gender
   - size_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-18-12
   name: Compression Socks
   children: []
@@ -6427,13 +6115,7 @@
   - sock_toe_style
   - target_gender
   - size_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-18-13
   name: Dress Socks
   children: []
@@ -6449,13 +6131,7 @@
   - sock_toe_style
   - target_gender
   - size_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-18-14
   name: Thermal Socks
   children: []
@@ -6471,13 +6147,7 @@
   - sock_toe_style
   - target_gender
   - size_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-19
   name: Suits
   children:
@@ -6614,13 +6284,7 @@
   - suit_pieces
   - target_gender
   - vent_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-19-3-2
   name: Tuxedo Jackets
   children: []
@@ -6637,13 +6301,7 @@
   - suit_pieces
   - target_gender
   - vent_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-19-4
   name: Unstitched Suit Sets
   children: []
@@ -6663,13 +6321,7 @@
   - sleeve_length_type
   - suit_pieces
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-20
   name: Swimwear
   children:
@@ -7057,13 +6709,7 @@
   - sleeve_length_type
   - swimwear_features
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-20-25-2
   name: Period One-Piece Swimsuits
   children: []
@@ -7079,13 +6725,7 @@
   - sleeve_length_type
   - swimwear_features
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-20-26
   name: Swim Jammers
   children: []
@@ -7101,13 +6741,7 @@
   - sleeve_length_type
   - swimwear_features
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-20-27
   name: Swim Skirts
   children: []
@@ -7123,13 +6757,7 @@
   - sleeve_length_type
   - swimwear_features
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-20-28
   name: Tankinis
   children: []
@@ -7145,13 +6773,7 @@
   - sleeve_length_type
   - swimwear_features
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-20-29
   name: Swim Leggings
   children: []
@@ -7167,13 +6789,7 @@
   - sleeve_length_type
   - swimwear_features
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-20-30
   name: Swim Shorts
   children: []
@@ -7189,13 +6805,7 @@
   - sleeve_length_type
   - swimwear_features
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-22
   name: Wedding & Bridal Party Dresses
   children:
@@ -7278,13 +6888,7 @@
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-22-1-2
   name: Junior Bridesmaid Dresses
   children: []
@@ -7304,13 +6908,7 @@
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-22-1-3
   name: Mother of the Bride Dresses
   children: []
@@ -7330,13 +6928,7 @@
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-22-1-4
   name: Flower Girl Dresses
   children: []
@@ -7356,13 +6948,7 @@
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-22-2
   name: Wedding Dresses
   children: []
@@ -7465,13 +7051,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-23-1-2
   name: Kimono Jackets & Cardigans
   children: []
@@ -7484,13 +7064,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-23-1-3
   name: Haori Jackets
   children: []
@@ -7503,13 +7077,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-23-2
   name: Saris & Lehengas
   children:
@@ -7549,13 +7117,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-23-2-2
   name: Lehengas
   children: []
@@ -7569,13 +7131,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-23-3
   name: Kilts
   children: []
@@ -7589,13 +7145,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-23-4
   name: Hanboks
   children: []
@@ -7609,13 +7159,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-23-5
   name: Dirndls
   children: []
@@ -7629,13 +7173,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-23-6
   name: Cheongsams
   children: []
@@ -7649,13 +7187,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-23-7
   name: Kurtas & Kurta Sets
   children: []
@@ -7669,13 +7201,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-23-8
   name: Baju Melayu
   children: []
@@ -7689,13 +7215,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-23-9
   name: Abayas & Jilbabs
   children: []
@@ -7709,13 +7229,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-23-10
   name: Salwar Kameez & Suit Sets
   children: []
@@ -7729,13 +7243,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-23-11
   name: Dashikis
   children: []
@@ -7749,13 +7257,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-23-12
   name: Kaftans
   children: []
@@ -7769,13 +7271,7 @@
   - size_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24
   name: Uniforms & Workwear
   children:
@@ -7859,13 +7355,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-1-2
   name: Coveralls
   children: []
@@ -7882,13 +7372,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-1-3
   name: Bib Overalls
   children: []
@@ -7905,13 +7389,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-2
   name: Flight Suits
   children: []
@@ -7984,13 +7462,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-3-2
   name: Food Service Aprons
   children: []
@@ -8005,13 +7477,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-3-3
   name: Chef Pants & Trousers
   children: []
@@ -8026,13 +7492,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-3-4
   name: Food Service Hair Nets
   children: []
@@ -8047,13 +7507,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-3-5
   name: Food Service Shirts & Blouses
   children: []
@@ -8068,13 +7522,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-3-6
   name: Chef Coats & Jackets
   children: []
@@ -8089,13 +7537,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-4
   name: Military Uniforms
   children:
@@ -8145,13 +7587,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-4-2
   name: Combat Uniforms
   children: []
@@ -8167,13 +7603,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-4-3
   name: Military Insignia & Badges
   children: []
@@ -8189,13 +7619,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-4-4
   name: Dress Uniforms
   children: []
@@ -8211,13 +7635,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-4-5
   name: Military Patches
   children: []
@@ -8233,13 +7651,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-4-6
   name: Military Coats & Jackets
   children: []
@@ -8255,13 +7667,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-4-7
   name: Military Uniform Pants
   children: []
@@ -8277,13 +7683,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-5
   name: School Uniforms
   children:
@@ -8339,13 +7739,7 @@
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-5-2
   name: School Uniform Sweaters & Knitwear
   children: []
@@ -8364,13 +7758,7 @@
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-5-3
   name: School Uniform Pants & Shorts
   children: []
@@ -8389,13 +7777,7 @@
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-5-4
   name: School Uniform Tops
   children: []
@@ -8414,13 +7796,7 @@
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-5-5
   name: School Uniform Blazers & Outerwear
   children: []
@@ -8439,13 +7815,7 @@
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-5-6
   name: School Uniform Skirts
   children: []
@@ -8464,13 +7834,7 @@
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-5-7
   name: School Uniform Dresses & Jumpers
   children: []
@@ -8489,13 +7853,7 @@
   - skirt/dress_length_type
   - sleeve_length_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-6
   name: Security Uniforms
   children:
@@ -8542,13 +7900,7 @@
   - target_gender
   - uniform_pieces_included
   - uniform_role
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-6-3
   name: Security Uniform Pants
   children: []
@@ -8565,13 +7917,7 @@
   - target_gender
   - uniform_pieces_included
   - uniform_role
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-7
   name: Sports Uniforms
   children: []
@@ -8675,13 +8021,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-9-2
   name: Scrub Tops
   children: []
@@ -8696,13 +8036,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-9-3
   name: Scrub Jackets
   children: []
@@ -8717,13 +8051,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-9-4
   name: Scrub Pants
   children: []
@@ -8738,13 +8066,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-9-5
   name: Scrub Sets
   children: []
@@ -8759,13 +8081,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-11
   name: Clergy Uniforms
   children: []
@@ -8781,13 +8097,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-12
   name: Housekeeping Uniforms
   children: []
@@ -8803,13 +8113,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-24-13
   name: Security Uniform Accessories
   children: []
@@ -8825,13 +8129,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-1-25
   name: Baby & Children's Clothing
   children:
@@ -11312,13 +10610,7 @@
   - pattern
   - target_gender
   - veil_length_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-7-2
   name: Bridal Sashes & Belts
   children: []
@@ -11330,13 +10622,7 @@
   - pattern
   - target_gender
   - veil_length_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-7-3
   name: Bridal Gloves
   children: []
@@ -11348,13 +10634,7 @@
   - pattern
   - target_gender
   - veil_length_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-7-4
   name: Bridal Veils
   children: []
@@ -11366,13 +10646,7 @@
   - pattern
   - target_gender
   - veil_length_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-7-5
   name: Bridal Tiaras & Headpieces
   children: []
@@ -11384,13 +10658,7 @@
   - pattern
   - target_gender
   - veil_length_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-7-6
   name: Bridal Dupattas & Shawls
   children: []
@@ -11402,13 +10670,7 @@
   - pattern
   - target_gender
   - veil_length_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-8
   name: Button Studs
   children: []
@@ -11613,13 +10875,7 @@
   - fabric
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-14-1-2
   name: Hair Donuts & Bun Makers
   children: []
@@ -11630,13 +10886,7 @@
   - fabric
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-14-2
   name: Hair Combs
   children: []
@@ -11776,13 +11026,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-14-6-3
   name: Hair Barrettes & Slides
   children: []
@@ -11797,13 +11041,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-14-6-4
   name: Hair Bows & Bow Clips
   children: []
@@ -11818,13 +11056,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-14-7
   name: Hair Wreaths
   children: []
@@ -11907,13 +11139,7 @@
   - pattern
   - ponytail_holder_style
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-14-9-2
   name: Spiral Hair Ties
   children: []
@@ -11925,13 +11151,7 @@
   - pattern
   - ponytail_holder_style
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-14-10
   name: Tiaras
   children: []
@@ -12037,13 +11257,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-14-15
   name: Durags & Hair Wraps
   children: []
@@ -12053,13 +11267,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-15
   name: Hand Muffs
   children: []
@@ -12564,13 +11772,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-17-18
   name: Pillbox Hats
   children: []
@@ -12585,13 +11787,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-17-19
   name: Kufis & Topis
   children: []
@@ -12606,13 +11802,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-17-20
   name: Fezzes
   children: []
@@ -12627,13 +11817,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-17-21
   name: Pork Pie Hats
   children: []
@@ -12648,13 +11832,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-17-22
   name: Newsboy Caps
   children: []
@@ -12669,13 +11847,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-17-23
   name: Sombreros
   children: []
@@ -12690,13 +11862,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-17-24
   name: Cloche Hats
   children: []
@@ -12711,13 +11877,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-17-25
   name: Graduation Caps
   children: []
@@ -12732,13 +11892,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-18
   name: Headwear
   children:
@@ -12847,13 +12001,7 @@
   - fabric
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-18-5
   name: Bonnets & Sleep Caps
   children: []
@@ -12866,13 +12014,7 @@
   - fabric
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-19
   name: Leg Warmers
   children: []
@@ -12998,13 +12140,7 @@
   - pattern
   - target_gender
   - weave_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-23-2
   name: Ascots & Cravats
   children: []
@@ -13017,13 +12153,7 @@
   - pattern
   - target_gender
   - weave_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-23-3
   name: Tie Sets
   children: []
@@ -13036,13 +12166,7 @@
   - pattern
   - target_gender
   - weave_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-24
   name: Pinback Buttons
   children: []
@@ -13226,13 +12350,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-30-2
   name: Survival & Paracord Wristbands
   children: []
@@ -13243,13 +12361,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-30-3
   name: Insect Repellent Wristbands
   children: []
@@ -13260,13 +12372,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-30-4
   name: Sweat Wristbands
   children: []
@@ -13277,13 +12383,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-30-5
   name: Awareness Wristbands
   children: []
@@ -13294,13 +12394,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-31
   name: Traditional Clothing Accessories
   children:
@@ -13340,13 +12434,7 @@
   - fabric
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-31-2
   name: Kilt & Highland Wear Accessories
   children: []
@@ -13358,13 +12446,7 @@
   - fabric
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-31-3
   name: Cummerbunds
   children: []
@@ -13376,13 +12458,7 @@
   - fabric
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-31-4
   name: Dupattas
   children: []
@@ -13394,13 +12470,7 @@
   - fabric
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-31-5
   name: Bindis & Forehead Adornments
   children: []
@@ -13412,13 +12482,7 @@
   - fabric
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-31-6
   name: Graduation Regalia Accessories
   children: []
@@ -13430,13 +12494,7 @@
   - fabric
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-32
   name: Fashion Face Masks
   children: []
@@ -13587,13 +12645,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-35
   name: Clothing Patches
   children: []
@@ -13604,13 +12656,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-2-36
   name: Detachable Collars
   children: []
@@ -13621,13 +12667,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-3
   name: Costumes & Accessories
   children:
@@ -13789,13 +12829,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-3-3-4
   name: Costume Tops
   children: []
@@ -13809,13 +12843,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-3-3-5
   name: Costume Onesies & Jumpsuits
   children: []
@@ -13829,13 +12857,7 @@
   - size
   - size_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-3-4
   name: Masks
   children: []
@@ -13865,13 +12887,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-4
   name: Handbag & Wallet Accessories
   children:
@@ -13968,13 +12984,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-4-5
   name: Bag Bases & Protectors
   children: []
@@ -13984,13 +12994,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-4-6
   name: Purse Hooks & Hangers
   children: []
@@ -14000,13 +13004,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-4-7
   name: Bag Inserts & Organizers
   children: []
@@ -14016,13 +13014,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-4-8
   name: Bag Charms
   children: []
@@ -14032,13 +13024,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-5
   name: Handbags, Wallets & Cases
   children:
@@ -14100,13 +13086,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-5-1-2
   name: Badge Reels
   children: []
@@ -14117,13 +13097,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-5-1-3
   name: ID Card Holders
   children: []
@@ -14134,13 +13108,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-5-2
   name: Business Card Cases
   children: []
@@ -14773,13 +13741,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-5-4-22
   name: Belt Bags
   children: []
@@ -14796,13 +13758,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-5-4-23
   name: Backpack Handbags
   children: []
@@ -14819,13 +13775,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-5-5
   name: Wallets & Money Clips
   children:
@@ -15014,13 +13964,7 @@
   - pattern
   - target_gender
   - wallet_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-6
   name: Jewelry
   children:
@@ -15165,13 +14109,7 @@
   - pattern
   - pin_backing_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-6-4-2
   name: Lapel Pins
   children: []
@@ -15183,13 +14121,7 @@
   - pattern
   - pin_backing_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-6-5
   name: Charms & Pendants
   children:
@@ -15225,13 +14157,7 @@
   - pattern
   - stone_setting_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-6-5-2
   name: Charms
   children: []
@@ -15243,13 +14169,7 @@
   - pattern
   - stone_setting_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-6-6
   name: Earrings
   children: []
@@ -15364,13 +14284,7 @@
   - ring_size
   - stone_shape
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-6-9-2
   name: Engagement Rings
   children: []
@@ -15386,13 +14300,7 @@
   - ring_size
   - stone_shape
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-6-10
   name: Watch Accessories
   children:
@@ -15506,13 +14414,7 @@
   - protection_coverage_area
   - target_gender
   - watch_accessory_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-6-10-5
   name: Watch Parts & Components
   children: []
@@ -15524,13 +14426,7 @@
   - protection_coverage_area
   - target_gender
   - watch_accessory_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-6-10-6
   name: Watch Tools
   children: []
@@ -15542,13 +14438,7 @@
   - protection_coverage_area
   - target_gender
   - watch_accessory_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-6-10-7
   name: Watch Display Stands
   children: []
@@ -15560,13 +14450,7 @@
   - protection_coverage_area
   - target_gender
   - watch_accessory_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-6-10-8
   name: Watch Protective Cases & Covers
   children: []
@@ -15578,13 +14462,7 @@
   - protection_coverage_area
   - target_gender
   - watch_accessory_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-6-11
   name: Watches
   children: []
@@ -15658,13 +14536,7 @@
   - stone_creation_method
   - stone_cut_grade
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-7
   name: Shoe Accessories
   children:
@@ -15773,13 +14645,7 @@
   - pattern
   - shoe_size
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-7-3-2
   name: Heel Protectors
   children: []
@@ -15790,13 +14656,7 @@
   - pattern
   - shoe_size
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-7-3-3
   name: Toe Covers
   children: []
@@ -15807,13 +14667,7 @@
   - pattern
   - shoe_size
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-7-4
   name: Shoe Grips
   children:
@@ -15852,13 +14706,7 @@
   - shoe_size
   - suitable_surface_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-7-4-2
   name: Traction Sprays & Rosin
   children: []
@@ -15870,13 +14718,7 @@
   - shoe_size
   - suitable_surface_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-7-4-3
   name: Replacement Studs & Spikes
   children: []
@@ -15888,13 +14730,7 @@
   - shoe_size
   - suitable_surface_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-7-4-4
   name: Adhesive Grip Pads & Treads
   children: []
@@ -15906,13 +14742,7 @@
   - shoe_size
   - suitable_surface_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-7-5
   name: Shoe Inserts
   children:
@@ -16052,13 +14882,7 @@
   - pattern
   - shoe_size
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-7-5-4-2
   name: Heel Grips & Liners
   children: []
@@ -16071,13 +14895,7 @@
   - pattern
   - shoe_size
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-7-5-5
   name: Toe Pads
   children: []
@@ -16091,13 +14909,7 @@
   - pattern
   - shoe_size
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: aa-7-6
   name: Shoelaces
   children: []

--- a/data/categories/ae_arts_entertainment.yml
+++ b/data/categories/ae_arts_entertainment.yml
@@ -7,6 +7,9 @@
   - ae-3
   attributes: []
   return_reasons:
+  - too_big
+  - too_small
+  - style
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -1511,6 +1514,7 @@
   - fusible_application_method
   - pattern
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -1533,6 +1537,7 @@
   - suitable_for_crafting_material
   - washability
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -1594,6 +1599,7 @@
   - suitable_for_crafting_material
   - washability
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -1629,6 +1635,7 @@
   - suitable_for_crafting_material
   - washability
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item

--- a/data/categories/ae_arts_entertainment.yml
+++ b/data/categories/ae_arts_entertainment.yml
@@ -986,13 +986,7 @@
   - color
   - fastener_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-1-2-3
   name: Craft Paint, Ink & Glaze
   children:
@@ -4611,13 +4605,7 @@
   - stretch_level
   - textile_finish_treatment
   - water_resistance_level
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-1-2-14-1-2
   name: Painting Canvas
   children:
@@ -5497,13 +5485,7 @@
   - wax_blend_composition
   - wax_physical_form
   - wax_recommended_candle_application
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-1-2-17-1-1-7
   name: Coconut Wax
   children: []
@@ -5516,13 +5498,7 @@
   - wax_blend_composition
   - wax_physical_form
   - wax_recommended_candle_application
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-1-2-17-1-2
   name: Wick Tabs
   children:
@@ -5647,13 +5623,7 @@
   - material
   - olfactory_arts_material_form
   - wick_construction_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-1-2-17-1-3-4
   name: Cored Wicks
   children: []
@@ -5662,13 +5632,7 @@
   - material
   - olfactory_arts_material_form
   - wick_construction_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-1-2-17-1-4
   name: Candle Fragrance Additives
   children: []
@@ -5678,13 +5642,7 @@
   - color
   - olfactory_arts_material_form
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-1-2-17-1-5
   name: Candle Dyes & Colorants
   children: []
@@ -5694,13 +5652,7 @@
   - color
   - olfactory_arts_material_form
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-1-2-17-1-6
   name: Candle Making Additives
   children: []
@@ -5710,13 +5662,7 @@
   - color
   - olfactory_arts_material_form
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-1-2-17-2
   name: Perfumery Ingredients
   children:
@@ -5784,13 +5730,7 @@
   children: []
   attributes:
   - olfactory_arts_material_form
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-1-3
   name: Art & Crafting Tool Accessories
   children:
@@ -7421,13 +7361,7 @@
   - color
   - construction
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-1-4-6-13
   name: Protractors
   children: []
@@ -7435,13 +7369,7 @@
   - color
   - construction
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-1-4-7
   name: Cutting Mats
   children: []
@@ -9504,13 +9432,7 @@
   - material
   - number_of_compartments
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-1-5-5
   name: Craft Storage Boxes & Cases
   children: []
@@ -9521,13 +9443,7 @@
   - material
   - number_of_compartments
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-1-6
   name: Crafting Patterns & Molds
   children:
@@ -9951,13 +9867,7 @@
   - fabric
   - fastener_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-1-7-2
   name: Garment Fabric
   children: []
@@ -9966,13 +9876,7 @@
   - fabric
   - fastener_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-1-7-3
   name: Sewing Notions & Fasteners
   children: []
@@ -9981,13 +9885,7 @@
   - fabric
   - fastener_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-2
   name: Collectibles
   children:
@@ -12168,37 +12066,19 @@
   children: []
   attributes:
   - equipment_contact_material_brew_wine
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-3-6
   name: Brewing & Winemaking Cleaning & Sanitizing
   children: []
   attributes:
   - equipment_contact_material_brew_wine
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-3-7
   name: Bottling & Packaging Supplies
   children: []
   attributes:
   - equipment_contact_material_brew_wine
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-4
   name: Juggling
   children:
@@ -13243,26 +13123,14 @@
   attributes:
   - instrument_accessory_material
   - instrument_support_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-7-1-6-2
   name: Brass Instrument Stands
   children: []
   attributes:
   - instrument_accessory_material
   - instrument_support_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-7-2
   name: Conductor Batons
   children: []
@@ -14596,13 +14464,7 @@
   - drum_pedal_cam_type
   - drum_pedal_clamp_type
   - footboard_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-7-12-5-3-7
   name: Electronic Kick Drum Trigger Pedals
   children: []
@@ -14615,13 +14477,7 @@
   - drum_pedal_cam_type
   - drum_pedal_clamp_type
   - footboard_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-7-12-6
   name: Drum Stick & Brush Accessories
   children:
@@ -14674,13 +14530,7 @@
   - closure_type
   - mounting_attachment_method
   - mounting_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-7-12-7
   name: Drum Sticks & Brushes
   children:
@@ -15408,13 +15258,7 @@
   - pick_design
   - pick_grip_aid
   - thickness_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-7-13-1-8
   name: Guitar Slides
   children: []
@@ -17413,13 +17257,7 @@
   - instrument_accessory_material
   - saxophone_mouthpiece_baffle_type
   - tip_opening
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-7-14-7-4-2
   name: Saxophone Necks
   children: []
@@ -18629,39 +18467,21 @@
   attributes:
   - cymbal_weight_class
   - instrument_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-8-5-2-9
   name: Stack Cymbals
   children: []
   attributes:
   - cymbal_weight_class
   - instrument_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-8-5-2-10
   name: Hi-Hat Cymbals
   children: []
   attributes:
   - cymbal_weight_class
   - instrument_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-8-5-3
   name: Drum Kits
   children:
@@ -18882,13 +18702,7 @@
   - instrument_material
   - lumber/wood_type
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-8-5-3-11
   name: Shell Packs
   children: []
@@ -18900,13 +18714,7 @@
   - instrument_material
   - lumber/wood_type
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-8-5-4
   name: Electronic Drums
   children:
@@ -20632,13 +20440,7 @@
   - snare_drum_mounting_type
   - snare_drum_strainer_type
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-8-5-10-5
   name: Marching Snare Drums
   children: []
@@ -20651,13 +20453,7 @@
   - snare_drum_mounting_type
   - snare_drum_strainer_type
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-8-5-11
   name: Tom-Toms
   children:
@@ -21982,13 +21778,7 @@
   - instrument_material
   - lumber/wood_type
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-8-8-3-6
   name: Contrabass Flutes
   children: []
@@ -22004,13 +21794,7 @@
   - instrument_material
   - lumber/wood_type
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: ae-2-8-8-4
   name: Flutophones
   children:

--- a/data/categories/ap_animals_pet_supplies.yml
+++ b/data/categories/ap_animals_pet_supplies.yml
@@ -19,6 +19,8 @@
   children: []
   attributes: []
   return_reasons:
+  - size
+  - color
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -4967,6 +4969,7 @@
   - animal_type
   - pet_supply_product_form
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -5050,6 +5053,7 @@
   - animal_type
   - pet_supply_product_form
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -5063,6 +5067,7 @@
   - animal_type
   - pet_supply_product_form
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item

--- a/data/categories/bi_business_industrial.yml
+++ b/data/categories/bi_business_industrial.yml
@@ -10563,10 +10563,4 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit

--- a/data/categories/bi_business_industrial.yml
+++ b/data/categories/bi_business_industrial.yml
@@ -68,6 +68,8 @@
   - paper_size
   - pattern
   return_reasons:
+  - size
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -1752,6 +1754,7 @@
   - color
   - pattern
   return_reasons:
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -6842,57 +6845,6 @@
   - damaged_or_defective
   - unknown
   - other_reason
-- id: bi-19-8-3
-  name: Procedure Training Simulators & Task Trainers
-  children: []
-  attributes:
-  - material
-  - medical_specialty
-  - procedure
-  - skin_tone
-  return_reasons:
-  - size
-  - incompatible
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
-- id: bi-19-8-4
-  name: Simulator Kits & Training Bundles
-  children: []
-  attributes:
-  - material
-  - medical_specialty
-  - procedure
-  - skin_tone
-  return_reasons:
-  - size
-  - assortment
-  - incompatible
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
-- id: bi-19-8-5
-  name: Synthetic Tissue Models & Training Pads
-  children: []
-  attributes:
-  - material
-  - medical_specialty
-  - procedure
-  - skin_tone
-  return_reasons:
-  - incompatible
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
 - id: bi-19-8-2-1
   name: Trainer Replacement Parts & Consumables
   children: []
@@ -6955,6 +6907,57 @@
   - size
   - shade
   - material
+  - incompatible
+  - changed_my_mind
+  - item_not_as_described
+  - received_the_wrong_item
+  - damaged_or_defective
+  - unknown
+  - other_reason
+- id: bi-19-8-3
+  name: Procedure Training Simulators & Task Trainers
+  children: []
+  attributes:
+  - material
+  - medical_specialty
+  - procedure
+  - skin_tone
+  return_reasons:
+  - size
+  - incompatible
+  - changed_my_mind
+  - item_not_as_described
+  - received_the_wrong_item
+  - damaged_or_defective
+  - unknown
+  - other_reason
+- id: bi-19-8-4
+  name: Simulator Kits & Training Bundles
+  children: []
+  attributes:
+  - material
+  - medical_specialty
+  - procedure
+  - skin_tone
+  return_reasons:
+  - size
+  - assortment
+  - incompatible
+  - changed_my_mind
+  - item_not_as_described
+  - received_the_wrong_item
+  - damaged_or_defective
+  - unknown
+  - other_reason
+- id: bi-19-8-5
+  name: Synthetic Tissue Models & Training Pads
+  children: []
+  attributes:
+  - material
+  - medical_specialty
+  - procedure
+  - skin_tone
+  return_reasons:
   - incompatible
   - changed_my_mind
   - item_not_as_described
@@ -8191,6 +8194,7 @@
   - color
   - pattern
   return_reasons:
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -8221,6 +8225,7 @@
   - color
   - pattern
   return_reasons:
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -8299,6 +8304,7 @@
   - color
   - pattern
   return_reasons:
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -8314,6 +8320,7 @@
   - color
   - pattern
   return_reasons:
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -9214,6 +9221,7 @@
   - pattern
   - preservation_type
   return_reasons:
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item

--- a/data/categories/bt_baby_toddler.yml
+++ b/data/categories/bt_baby_toddler.yml
@@ -207,6 +207,8 @@
   - personalization_options
   - target_gender
   return_reasons:
+  - too_big
+  - too_small
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -224,6 +226,7 @@
   attributes:
   - infant_age_group
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -241,6 +244,7 @@
   - material
   - pattern
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -925,6 +929,8 @@
   - pattern
   - toy/game_material
   return_reasons:
+  - size
+  - color
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -1041,6 +1047,8 @@
   - pattern
   - toy/game_material
   return_reasons:
+  - size
+  - color
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -1686,6 +1694,8 @@
   - product_certifications_standards
   - toy/game_material
   return_reasons:
+  - size
+  - color
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -2624,6 +2634,8 @@
   - ingredients
   - material
   return_reasons:
+  - size
+  - absorbency
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item

--- a/data/categories/bu_bundles.yml
+++ b/data/categories/bu_bundles.yml
@@ -4,6 +4,9 @@
   children: []
   attributes: []
   return_reasons:
+  - too_big
+  - too_small
+  - style
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item

--- a/data/categories/el_electronics.yml
+++ b/data/categories/el_electronics.yml
@@ -4882,13 +4882,7 @@
   - power_source
   - radio_features
   - tuner_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: el-2-3-8
   name: Reel-to-Reel Tape Players & Recorders
   children: []

--- a/data/categories/fb_food_beverages_tobacco.yml
+++ b/data/categories/fb_food_beverages_tobacco.yml
@@ -435,13 +435,7 @@
   - dietary_preferences
   - dietary_supplements
   - distillation_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-1-5-11
   name: Baijiu
   children: []
@@ -452,13 +446,7 @@
   - dietary_preferences
   - dietary_supplements
   - distillation_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-1-5-12
   name: Aquavit
   children: []
@@ -469,13 +457,7 @@
   - dietary_preferences
   - dietary_supplements
   - distillation_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-1-5-13
   name: Mezcal
   children: []
@@ -486,13 +468,7 @@
   - dietary_preferences
   - dietary_supplements
   - distillation_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-1-5-14
   name: Bacanora & Sotol
   children: []
@@ -503,13 +479,7 @@
   - dietary_preferences
   - dietary_supplements
   - distillation_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-1-6
   name: Premixed Spirits & Cocktail Mixes
   children:
@@ -661,13 +631,7 @@
   - country
   - dietary_preferences
   - dietary_supplements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-1-6-6-2
   name: Wine Slush Mixes
   children: []
@@ -677,13 +641,7 @@
   - country
   - dietary_preferences
   - dietary_supplements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-1-6-6-3
   name: Wine Spritzes & Mimosa Cocktails
   children: []
@@ -693,13 +651,7 @@
   - country
   - dietary_preferences
   - dietary_supplements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-1-7
   name: Wine
   children: []
@@ -731,13 +683,7 @@
   - country
   - dietary_preferences
   - dietary_supplements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-1-9
   name: Mead
   children: []
@@ -746,13 +692,7 @@
   - country
   - dietary_preferences
   - dietary_supplements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-2
   name: Buttermilk
   children:
@@ -782,13 +722,7 @@
   - buttermilk_variety
   - dietary_preferences
   - flavor
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-2-2
   name: Laban
   children: []
@@ -797,13 +731,7 @@
   - buttermilk_variety
   - dietary_preferences
   - flavor
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-2-3
   name: Ayran & Doogh
   children: []
@@ -812,13 +740,7 @@
   - buttermilk_variety
   - dietary_preferences
   - flavor
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-3
   name: Coffee
   children:
@@ -960,13 +882,7 @@
   - dietary_preferences
   - dietary_supplements
   - flavor
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-4
   name: Cordials, Syrups & Squash
   children:
@@ -999,13 +915,7 @@
   - flavor
   - package_type
   - sugar_content_level
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-4-2
   name: Beverage Syrups
   children: []
@@ -1016,13 +926,7 @@
   - flavor
   - package_type
   - sugar_content_level
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-4-3
   name: Cordials
   children: []
@@ -1033,13 +937,7 @@
   - flavor
   - package_type
   - sugar_content_level
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-5
   name: Fruit Flavored Drinks
   children:
@@ -1071,13 +969,7 @@
   - flavor
   - package_type
   - texture_inclusions
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-5-2
   name: Lemonade
   children: []
@@ -1088,13 +980,7 @@
   - flavor
   - package_type
   - texture_inclusions
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-6
   name: Hot Chocolate
   children:
@@ -1193,13 +1079,7 @@
   - allergen_information
   - dietary_preferences
   - dietary_supplements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-7
   name: Juices, Milkshakes & Smoothies
   children:
@@ -1411,13 +1291,7 @@
   - carbonation
   - dietary_preferences
   - dietary_supplements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-8-5-2
   name: Low Alcohol & Alcohol-Free Vodka
   children: []
@@ -1426,13 +1300,7 @@
   - carbonation
   - dietary_preferences
   - dietary_supplements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-8-5-3
   name: Low Alcohol & Alcohol-Free Rum
   children: []
@@ -1441,13 +1309,7 @@
   - carbonation
   - dietary_preferences
   - dietary_supplements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-8-5-4
   name: Non-Alcoholic Whiskey & Bourbon
   children: []
@@ -1456,13 +1318,7 @@
   - carbonation
   - dietary_preferences
   - dietary_supplements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-8-5-5
   name: Aperitifs & Amari
   children: []
@@ -1471,13 +1327,7 @@
   - carbonation
   - dietary_preferences
   - dietary_supplements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-8-5-6
   name: Low Alcohol & Alcohol-Free Tequila & Mezcal
   children: []
@@ -1486,13 +1336,7 @@
   - carbonation
   - dietary_preferences
   - dietary_supplements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-8-5-7
   name: Low Alcohol & Alcohol-Free Liqueurs
   children: []
@@ -1501,13 +1345,7 @@
   - carbonation
   - dietary_preferences
   - dietary_supplements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-8-6
   name: Low Alcohol & Alcohol-Free Wine
   children: []
@@ -1534,13 +1372,7 @@
   - carbonation
   - dietary_preferences
   - dietary_supplements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-8-8
   name: Low Alcohol & Alcohol-Free Kombucha
   children: []
@@ -1549,13 +1381,7 @@
   - carbonation
   - dietary_preferences
   - dietary_supplements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-9
   name: Milk
   children: []
@@ -1641,13 +1467,7 @@
   - allergen_information
   - barista_suitability
   - dietary_preferences
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-10-2-2
   name: Mixed Nut Drinks
   children: []
@@ -1655,13 +1475,7 @@
   - allergen_information
   - barista_suitability
   - dietary_preferences
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-10-2-3
   name: Almond Drinks
   children: []
@@ -1669,13 +1483,7 @@
   - allergen_information
   - barista_suitability
   - dietary_preferences
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-10-2-4
   name: Macadamia Drinks
   children: []
@@ -1683,13 +1491,7 @@
   - allergen_information
   - barista_suitability
   - dietary_preferences
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-10-3
   name: Oat Drinks
   children: []
@@ -1751,13 +1553,7 @@
   - allergen_information
   - barista_suitability
   - dietary_preferences
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-10-7
   name: Hemp Drinks
   children: []
@@ -1765,13 +1561,7 @@
   - allergen_information
   - barista_suitability
   - dietary_preferences
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-11
   name: Powdered Beverage Mixes
   children:
@@ -1800,13 +1590,7 @@
   - dietary_preferences
   - flavor
   - powdered_beverage_variety
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-11-2
   name: Sports Drink Mixes
   children: []
@@ -1815,13 +1599,7 @@
   - dietary_preferences
   - flavor
   - powdered_beverage_variety
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-11-3
   name: Iced Tea Mixes
   children: []
@@ -1830,13 +1608,7 @@
   - dietary_preferences
   - flavor
   - powdered_beverage_variety
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-12
   name: Soda
   children: []
@@ -1999,13 +1771,7 @@
   - flavor
   - tea_input_type
   - tea_variety
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-14-2-2
   name: Herbal & Fruit Tea
   children: []
@@ -2017,13 +1783,7 @@
   - flavor
   - tea_input_type
   - tea_variety
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-14-2-3
   name: Oolong Tea
   children: []
@@ -2035,13 +1795,7 @@
   - flavor
   - tea_input_type
   - tea_variety
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-14-2-4
   name: White Tea
   children: []
@@ -2053,13 +1807,7 @@
   - flavor
   - tea_input_type
   - tea_variety
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-14-2-5
   name: Rooibos Tea
   children: []
@@ -2071,13 +1819,7 @@
   - flavor
   - tea_input_type
   - tea_variety
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-14-2-6
   name: Pu-erh Tea
   children: []
@@ -2089,13 +1831,7 @@
   - flavor
   - tea_input_type
   - tea_variety
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-14-2-7
   name: Black Tea
   children: []
@@ -2107,13 +1843,7 @@
   - flavor
   - tea_input_type
   - tea_variety
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-14-2-8
   name: Green Tea
   children: []
@@ -2125,13 +1855,7 @@
   - flavor
   - tea_input_type
   - tea_variety
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-14-3
   name: Ready-To-Drink Herbal Infusions & Tea
   children: []
@@ -2164,13 +1888,7 @@
   - flavor
   - tea_input_type
   - tea_variety
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-15
   name: Vinegar Drinks
   children: []
@@ -2309,13 +2027,7 @@
   - dietary_supplements
   - flavor
   - package_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-16-6
   name: Functional & Enhanced Water
   children: []
@@ -2326,13 +2038,7 @@
   - dietary_supplements
   - flavor
   - package_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-16-7
   name: Flavored Water
   children: []
@@ -2343,13 +2049,7 @@
   - dietary_supplements
   - flavor
   - package_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-16-8
   name: Purified Water
   children: []
@@ -2360,13 +2060,7 @@
   - dietary_supplements
   - flavor
   - package_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-1-16-9
   name: Coconut Water
   children: []
@@ -2377,13 +2071,7 @@
   - dietary_supplements
   - flavor
   - package_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2
   name: Food Items
   children:
@@ -2580,13 +2268,7 @@
   - flour/grain_type
   - frosting_or_icing_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-4-1-2
   name: Panettones
   children: []
@@ -2598,13 +2280,7 @@
   - flour/grain_type
   - frosting_or_icing_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-4-1-3
   name: Roll Cakes & Swiss Rolls
   children: []
@@ -2616,13 +2292,7 @@
   - flour/grain_type
   - frosting_or_icing_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-4-1-4
   name: Pound Cakes & Bundt Cakes
   children: []
@@ -2634,13 +2304,7 @@
   - flour/grain_type
   - frosting_or_icing_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-4-1-5
   name: Fruit Cakes
   children: []
@@ -2652,13 +2316,7 @@
   - flour/grain_type
   - frosting_or_icing_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-4-1-6
   name: Cheesecakes
   children: []
@@ -2670,13 +2328,7 @@
   - flour/grain_type
   - frosting_or_icing_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-4-2
   name: Dessert Bars
   children:
@@ -2709,13 +2361,7 @@
   - flour/grain_type
   - frosting_or_icing_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-4-2-2
   name: Blondies
   children: []
@@ -2726,13 +2372,7 @@
   - flour/grain_type
   - frosting_or_icing_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-5
   name: Coffee Cakes
   children: []
@@ -2791,13 +2431,7 @@
   - flavor
   - flour/grain_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-6-2
   name: Wafer Cookies
   children: []
@@ -2809,13 +2443,7 @@
   - flavor
   - flour/grain_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-6-3
   name: Sandwich Cookies
   children: []
@@ -2827,13 +2455,7 @@
   - flavor
   - flour/grain_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-6-4
   name: Gingerbread & Holiday Cookies
   children: []
@@ -2845,13 +2467,7 @@
   - flavor
   - flour/grain_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-6-5
   name: Biscotti & Cantuccini
   children: []
@@ -2863,13 +2479,7 @@
   - flavor
   - flour/grain_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-7
   name: Cupcakes
   children: []
@@ -2961,13 +2571,7 @@
   - flavor
   - flour/grain_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-10-2
   name: Wafer Cups & Bowls
   children: []
@@ -2977,13 +2581,7 @@
   - flavor
   - flour/grain_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-10-3
   name: Sugar Cones
   children: []
@@ -2993,13 +2591,7 @@
   - flavor
   - flour/grain_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-10-4
   name: Waffle Cones
   children: []
@@ -3009,13 +2601,7 @@
   - flavor
   - flour/grain_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-11
   name: Muffins
   children: []
@@ -3075,13 +2661,7 @@
   - flour/grain_type
   - pastry_filling_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-12-2
   name: Scones
   children: []
@@ -3092,13 +2672,7 @@
   - flour/grain_type
   - pastry_filling_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-12-3
   name: Baklava
   children: []
@@ -3109,13 +2683,7 @@
   - flour/grain_type
   - pastry_filling_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-12-4
   name: Puff Pastries
   children: []
@@ -3126,13 +2694,7 @@
   - flour/grain_type
   - pastry_filling_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-12-5
   name: Strudels & Turnovers
   children: []
@@ -3143,13 +2705,7 @@
   - flour/grain_type
   - pastry_filling_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-12-6
   name: Cannoli
   children: []
@@ -3160,13 +2716,7 @@
   - flour/grain_type
   - pastry_filling_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-12-7
   name: Éclairs
   children: []
@@ -3177,13 +2727,7 @@
   - flour/grain_type
   - pastry_filling_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-12-8
   name: Croissants
   children: []
@@ -3194,13 +2738,7 @@
   - flour/grain_type
   - pastry_filling_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-12-9
   name: Danish Pastries
   children: []
@@ -3211,13 +2749,7 @@
   - flour/grain_type
   - pastry_filling_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-13
   name: Pies & Tarts
   children:
@@ -3253,13 +2785,7 @@
   - pie_crust_type
   - product_format
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-13-2
   name: Pies
   children: []
@@ -3271,13 +2797,7 @@
   - pie_crust_type
   - product_format
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-13-3
   name: Quiches
   children: []
@@ -3289,13 +2809,7 @@
   - pie_crust_type
   - product_format
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-14
   name: Taco Shells & Tostadas
   children: []
@@ -3342,13 +2856,7 @@
   - dietary_preferences
   - flour/grain_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-15-2
   name: Rice Paper & Spring Roll Wrappers
   children: []
@@ -3357,13 +2865,7 @@
   - dietary_preferences
   - flour/grain_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-16
   name: Mooncakes
   children: []
@@ -3373,13 +2875,7 @@
   - flavor
   - flour/grain_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-17
   name: Crêpes
   children: []
@@ -3389,13 +2885,7 @@
   - flavor
   - flour/grain_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-1-18
   name: Waffles
   children: []
@@ -3405,13 +2895,7 @@
   - flavor
   - flour/grain_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-2
   name: Candied & Chocolate Covered Fruit
   children:
@@ -3477,13 +2961,7 @@
   - dietary_preferences
   - fruit_variety
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-3
   name: Candy & Chocolate
   children:
@@ -3539,13 +3017,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-3-1-2
   name: Gummy Candy
   children: []
@@ -3555,13 +3027,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-3-1-3
   name: Chewing Gum
   children: []
@@ -3571,13 +3037,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-3-1-4
   name: Caramel & Toffee
   children: []
@@ -3587,13 +3047,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-3-1-5
   name: Cotton Candy
   children: []
@@ -3603,13 +3057,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-3-1-6
   name: Licorice Candy
   children: []
@@ -3619,13 +3067,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-3-1-7
   name: Lollipops
   children: []
@@ -3635,13 +3077,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-3-2
   name: Chocolate
   children:
@@ -3678,13 +3114,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-3-2-2
   name: Chocolate Truffles & Bonbons
   children: []
@@ -3695,13 +3125,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-3-2-3
   name: Novelty & Shaped Chocolates
   children: []
@@ -3712,13 +3136,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-3-2-4
   name: Chocolate Bars & Tablets
   children: []
@@ -3729,13 +3147,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-3-2-5
   name: Seasonal & Holiday Chocolates
   children: []
@@ -3746,13 +3158,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-3-2-6
   name: Chocolate Gift Boxes
   children: []
@@ -3763,13 +3169,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-4
   name: Condiments & Sauces
   children:
@@ -3924,13 +3324,7 @@
   - flavor
   - storage_requirements
   - topping_form
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-4-3-4
   name: Dessert Sauces
   children: []
@@ -3940,13 +3334,7 @@
   - flavor
   - storage_requirements
   - topping_form
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-4-4
   name: Fish Sauce
   children: []
@@ -4218,13 +3606,7 @@
   - dietary_preferences
   - pickling_method
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-4-15-2
   name: Kimchi
   children: []
@@ -4233,13 +3615,7 @@
   - dietary_preferences
   - pickling_method
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-4-16
   name: Pizza Sauce
   children: []
@@ -4289,13 +3665,7 @@
   - dietary_preferences
   - heat_level
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-4-17-2
   name: Chutney
   children: []
@@ -4305,13 +3675,7 @@
   - dietary_preferences
   - heat_level
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-4-18
   name: Salad Dressing
   children: []
@@ -4468,13 +3832,7 @@
   - dietary_preferences
   - sauce_variety
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-4-25-2
   name: Béchamel Sauces
   children: []
@@ -4483,13 +3841,7 @@
   - dietary_preferences
   - sauce_variety
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-4-25-3
   name: Hollandaise & Béarnaise Sauces
   children: []
@@ -4498,13 +3850,7 @@
   - dietary_preferences
   - sauce_variety
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-4-26
   name: Worcestershire Sauce
   children: []
@@ -4530,13 +3876,7 @@
   - dietary_preferences
   - heat_level
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-4-28
   name: Barbecue Sauces
   children: []
@@ -4545,13 +3885,7 @@
   - dietary_preferences
   - heat_level
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-4-29
   name: Cooking Pastes & Purees
   children: []
@@ -4560,13 +3894,7 @@
   - dietary_preferences
   - heat_level
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5
   name: Cooking & Baking Ingredients
   children:
@@ -4777,13 +4105,7 @@
   - bean_paste_variety
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-8-2
   name: Fermented Bean Curd
   children: []
@@ -4792,13 +4114,7 @@
   - bean_paste_variety
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-8-3
   name: Almond & Marzipan Paste
   children: []
@@ -4807,13 +4123,7 @@
   - bean_paste_variety
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-8-4
   name: Fermented Black Beans
   children: []
@@ -4822,13 +4132,7 @@
   - bean_paste_variety
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-8-5
   name: Bean Paste Making Kits
   children: []
@@ -4837,13 +4141,7 @@
   - bean_paste_variety
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-9
   name: Bread Crumbs
   children: []
@@ -4941,13 +4239,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-11
   name: Cookie Decorating Kits
   children: []
@@ -5357,13 +4649,7 @@
   - leavening_agent
   - primary_dish_application
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-16-5
   name: Dumpling & Wonton Wrappers
   children: []
@@ -5374,13 +4660,7 @@
   - leavening_agent
   - primary_dish_application
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-16-6
   name: Biscuit Dough
   children: []
@@ -5391,13 +4671,7 @@
   - leavening_agent
   - primary_dish_application
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-16-7
   name: Pasta Dough
   children: []
@@ -5408,13 +4682,7 @@
   - leavening_agent
   - primary_dish_application
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-16-8
   name: Phyllo Dough
   children: []
@@ -5425,13 +4693,7 @@
   - leavening_agent
   - primary_dish_application
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-16-9
   name: Masa & Tortilla Dough
   children: []
@@ -5442,13 +4704,7 @@
   - leavening_agent
   - primary_dish_application
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-17
   name: Edible Baking Decorations
   children:
@@ -5482,13 +4738,7 @@
   - dietary_preferences
   - pattern
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-17-2
   name: Edible Glitter & Dust
   children: []
@@ -5498,13 +4748,7 @@
   - dietary_preferences
   - pattern
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-17-3
   name: Edible Images & Cake Toppers
   children: []
@@ -5514,13 +4758,7 @@
   - dietary_preferences
   - pattern
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-17-4
   name: Fondant & Sugar Paste
   children: []
@@ -5530,13 +4768,7 @@
   - dietary_preferences
   - pattern
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-18
   name: Egg Replacers
   children: []
@@ -5649,13 +4881,7 @@
   - dietary_preferences
   - pattern
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-22-2
   name: Glazes & Drips
   children: []
@@ -5665,13 +4891,7 @@
   - dietary_preferences
   - pattern
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-22-3
   name: Royal Icing & Meringue Mixes
   children: []
@@ -5681,13 +4901,7 @@
   - dietary_preferences
   - pattern
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-23
   name: Lemon & Lime Juice
   children: []
@@ -5794,13 +5008,7 @@
   - dietary_preferences
   - filling_consistency
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-27-2
   name: Caramel & Dulce de Leche Fillings
   children: []
@@ -5809,13 +5017,7 @@
   - dietary_preferences
   - filling_consistency
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-27-3
   name: Fruit Fillings
   children: []
@@ -5824,13 +5026,7 @@
   - dietary_preferences
   - filling_consistency
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-27-4
   name: Cream & Custard Fillings
   children: []
@@ -5839,13 +5035,7 @@
   - dietary_preferences
   - filling_consistency
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-28
   name: Shortening & Lard
   children:
@@ -5876,13 +5066,7 @@
   - fat_rendering_state
   - hydrogenation_level
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-28-2
   name: Vegetable Shortening
   children: []
@@ -5892,13 +5076,7 @@
   - fat_rendering_state
   - hydrogenation_level
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-29
   name: Starter Cultures
   children:
@@ -5928,13 +5106,7 @@
   - dietary_preferences
   - fermentation_application
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-29-2
   name: Cheese Starter Cultures
   children: []
@@ -5943,13 +5115,7 @@
   - dietary_preferences
   - fermentation_application
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-29-3
   name: Yogurt Starter Cultures
   children: []
@@ -5958,13 +5124,7 @@
   - dietary_preferences
   - fermentation_application
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-29-4
   name: Kefir Starter Cultures
   children: []
@@ -5973,13 +5133,7 @@
   - dietary_preferences
   - fermentation_application
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-29-5
   name: Kombucha & Jun Cultures
   children: []
@@ -5988,13 +5142,7 @@
   - dietary_preferences
   - fermentation_application
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-30
   name: Sugar & Sweeteners
   children:
@@ -6079,13 +5227,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-30-3-2
   name: Sugar Alcohol Sweeteners
   children: []
@@ -6093,13 +5235,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-30-3-3
   name: Monk Fruit Sweeteners
   children: []
@@ -6107,13 +5243,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-30-4
   name: Syrups & Nectars
   children:
@@ -6143,13 +5273,7 @@
   - dietary_preferences
   - storage_requirements
   - syrup_base_ingredient
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-30-4-2
   name: Agave Syrup
   children: []
@@ -6158,13 +5282,7 @@
   - dietary_preferences
   - storage_requirements
   - syrup_base_ingredient
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-30-4-3
   name: Date Syrup
   children: []
@@ -6173,13 +5291,7 @@
   - dietary_preferences
   - storage_requirements
   - syrup_base_ingredient
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-30-5
   name: Cotton Candy Sugar
   children: []
@@ -6205,13 +5317,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-31
   name: Tapioca Pearls
   children: []
@@ -6332,13 +5438,7 @@
   - food_product_form
   - storage_requirements
   - yeast_application
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-36-2
   name: Brewing & Fermentation Yeast
   children: []
@@ -6348,13 +5448,7 @@
   - food_product_form
   - storage_requirements
   - yeast_application
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-36-3
   name: Nutritional Yeast
   children: []
@@ -6364,13 +5458,7 @@
   - food_product_form
   - storage_requirements
   - yeast_application
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-37
   name: Food Acids & pH Regulators
   children: []
@@ -6379,13 +5467,7 @@
   - dietary_preferences
   - ingredient_processing_method
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-38
   name: Gums & Pectins
   children: []
@@ -6394,13 +5476,7 @@
   - dietary_preferences
   - ingredient_processing_method
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-39
   name: Marshmallow Creme
   children: []
@@ -6409,13 +5485,7 @@
   - dietary_preferences
   - ingredient_processing_method
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-5-40
   name: Pie Crust Mixes
   children: []
@@ -6424,13 +5494,7 @@
   - dietary_preferences
   - ingredient_processing_method
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-6
   name: Dairy Products
   children:
@@ -6579,13 +5643,7 @@
   - dietary_preferences
   - fat_source
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-6-1-6
   name: Ghee & Clarified Butter
   children: []
@@ -6595,13 +5653,7 @@
   - dietary_preferences
   - fat_source
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-6-1-7
   name: Flavored & Compound Butter
   children: []
@@ -6611,13 +5663,7 @@
   - dietary_preferences
   - fat_source
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-6-2
   name: Cheese
   children: []
@@ -6766,13 +5812,7 @@
   - dietary_preferences
   - fat_content
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-6-5-4
   name: Double Cream
   children: []
@@ -6784,13 +5824,7 @@
   - dietary_preferences
   - fat_content
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-6-5-5
   name: Cooking Cream
   children: []
@@ -6802,13 +5836,7 @@
   - dietary_preferences
   - fat_content
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-6-5-6
   name: Clotted Cream
   children: []
@@ -6820,13 +5848,7 @@
   - dietary_preferences
   - fat_content
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-6-5-7
   name: Half & Half
   children: []
@@ -6838,13 +5860,7 @@
   - dietary_preferences
   - fat_content
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-6-5-8
   name: Heavy Cream
   children: []
@@ -6856,13 +5872,7 @@
   - dietary_preferences
   - fat_content
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-6-5-9
   name: Light Cream
   children: []
@@ -6874,13 +5884,7 @@
   - dietary_preferences
   - fat_content
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-6-6
   name: Sour Cream
   children: []
@@ -6952,13 +5956,7 @@
   - dietary_preferences
   - milk_source_animal
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-6-10
   name: Kefir
   children: []
@@ -6968,13 +5966,7 @@
   - dietary_preferences
   - milk_source_animal
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-7
   name: Dips & Spreads
   children:
@@ -7206,13 +6198,7 @@
   - dietary_preferences
   - spread_consistency
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-7-12
   name: Fruit & Vegetable Butters
   children: []
@@ -7221,13 +6207,7 @@
   - dietary_preferences
   - spread_consistency
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-7-13
   name: Pâté
   children: []
@@ -7236,13 +6216,7 @@
   - dietary_preferences
   - spread_consistency
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-8
   name: Food Gift Baskets
   children:
@@ -7276,13 +6250,7 @@
   - food_basket_items_included
   - pattern
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-8-2
   name: Tobacco Gift Baskets
   children: []
@@ -7293,13 +6261,7 @@
   - food_basket_items_included
   - pattern
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-9
   name: Frozen Desserts & Novelties
   children:
@@ -7440,13 +6402,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-9-1-7
   name: Ice Cream Mixes & Bases
   children: []
@@ -7454,13 +6410,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-9-2
   name: Ice Cream Novelties
   children:
@@ -7491,13 +6441,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-9-2-2
   name: Ice Cream Cakes & Pies
   children: []
@@ -7505,13 +6449,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-9-2-3
   name: Ice Cream Sandwiches
   children: []
@@ -7519,13 +6457,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-9-2-4
   name: Mochi Ice Cream
   children: []
@@ -7533,13 +6465,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-9-2-5
   name: Freeze-Dried Ice Cream
   children: []
@@ -7547,13 +6473,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-9-2-6
   name: Ice Cream Bites
   children: []
@@ -7561,13 +6481,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-9-3
   name: Ice Pops
   children: []
@@ -7594,13 +6508,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-9-5
   name: Frozen Cakes & Pies
   children: []
@@ -7609,13 +6517,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10
   name: Fruits & Vegetables
   children:
@@ -7673,13 +6575,7 @@
   - dietary_preferences
   - packing_medium
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-1-2
   name: Fruit Pulps & Purées
   children: []
@@ -7688,13 +6584,7 @@
   - dietary_preferences
   - packing_medium
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-2
   name: Canned & Jarred Vegetables
   children:
@@ -7727,13 +6617,7 @@
   - cut_or_preparation_style
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-2-2
   name: Canned Artichokes
   children: []
@@ -7742,13 +6626,7 @@
   - cut_or_preparation_style
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-2-3
   name: Canned Mushrooms
   children: []
@@ -7757,13 +6635,7 @@
   - cut_or_preparation_style
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-2-4
   name: Canned Hearts of Palm
   children: []
@@ -7772,13 +6644,7 @@
   - cut_or_preparation_style
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-2-5
   name: Canned & Jarred Peppers
   children: []
@@ -7787,13 +6653,7 @@
   - cut_or_preparation_style
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-2-6
   name: Canned Corn
   children: []
@@ -7802,13 +6662,7 @@
   - cut_or_preparation_style
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-3
   name: Canned & Prepared Beans
   children: []
@@ -7856,13 +6710,7 @@
   - drying_method
   - fruit_piece_form
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-4-2
   name: Dried Tropical Fruits
   children: []
@@ -7872,13 +6720,7 @@
   - drying_method
   - fruit_piece_form
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-5
   name: Dried Vegetables
   children: []
@@ -8118,13 +6960,7 @@
   - food_product_form
   - fruit_cut_style
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-7-6-2
   name: Raspberries
   children: []
@@ -8135,13 +6971,7 @@
   - food_product_form
   - fruit_cut_style
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-7-6-3
   name: Mixed Berries
   children: []
@@ -8152,13 +6982,7 @@
   - food_product_form
   - fruit_cut_style
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-7-6-4
   name: Blackberries
   children: []
@@ -8169,13 +6993,7 @@
   - food_product_form
   - fruit_cut_style
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-7-6-5
   name: Cranberries
   children: []
@@ -8186,13 +7004,7 @@
   - food_product_form
   - fruit_cut_style
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-7-6-6
   name: Blueberries
   children: []
@@ -8203,13 +7015,7 @@
   - food_product_form
   - fruit_cut_style
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-7-6-7
   name: Strawberries
   children: []
@@ -8220,13 +7026,7 @@
   - food_product_form
   - fruit_cut_style
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-7-7
   name: Breadfruit
   children: []
@@ -8469,13 +7269,7 @@
   - fruit_cut_style
   - seed_content
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-7-10-9
   name: Citrons
   children: []
@@ -8486,13 +7280,7 @@
   - fruit_cut_style
   - seed_content
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-7-10-10
   name: Yuzu
   children: []
@@ -8503,13 +7291,7 @@
   - fruit_cut_style
   - seed_content
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-7-10-11
   name: Pomelos
   children: []
@@ -8520,13 +7302,7 @@
   - fruit_cut_style
   - seed_content
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-7-11
   name: Coconuts
   children: []
@@ -9322,13 +8098,7 @@
   - fruit_cut_style
   - ripeness_stage
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-7-45
   name: Plantains
   children: []
@@ -9340,13 +8110,7 @@
   - fruit_cut_style
   - ripeness_stage
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-7-46
   name: Durians
   children: []
@@ -9358,13 +8122,7 @@
   - fruit_cut_style
   - ripeness_stage
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-8
   name: Fresh & Frozen Vegetables
   children:
@@ -10314,13 +9072,7 @@
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-8-26-14
   name: Microgreens
   children: []
@@ -10334,13 +9086,7 @@
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-8-26-15
   name: Mustard Greens
   children: []
@@ -10354,13 +9100,7 @@
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-8-26-16
   name: Edible Flowers
   children: []
@@ -10374,13 +9114,7 @@
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-8-26-17
   name: Broccoli Rabe
   children: []
@@ -10394,13 +9128,7 @@
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-8-26-18
   name: Collard Greens
   children: []
@@ -10414,13 +9142,7 @@
   - produce_washing_state
   - storage_requirements
   - vegetable_preparation_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-8-27
   name: Horseradish Root
   children: []
@@ -10978,13 +9700,7 @@
   - storage_requirements
   - turnip_and_rutabaga_variety
   - vegetable_preparation_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-8-52-2
   name: Turnips
   children: []
@@ -10996,13 +9712,7 @@
   - storage_requirements
   - turnip_and_rutabaga_variety
   - vegetable_preparation_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-8-53
   name: Vegetable Mixes
   children: []
@@ -11138,13 +9848,7 @@
   - food_product_form
   - storage_requirements
   - vegetable_preparation_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-10-9
   name: Fruit Sauces
   children: []
@@ -11171,13 +9875,7 @@
   - food_packing_medium
   - food_product_form
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-11
   name: Grains, Rice & Cereal
   children:
@@ -11299,13 +9997,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-11-4-2
   name: Granola
   children: []
@@ -11315,13 +10007,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-11-4-3
   name: Muesli
   children: []
@@ -11331,13 +10017,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-11-5
   name: Couscous
   children: []
@@ -11443,13 +10123,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-11-7-4
   name: Oat Flour & Powder
   children: []
@@ -11458,13 +10132,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-11-7-5
   name: Steel Cut Oats
   children: []
@@ -11473,13 +10141,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-11-7-6
   name: Instant & Quick Oats
   children: []
@@ -11488,13 +10150,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-11-7-7
   name: Cornmeal & Polenta
   children: []
@@ -11503,13 +10159,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-11-8
   name: Quinoa
   children: []
@@ -11609,13 +10259,7 @@
   - grain_processing_method
   - rice_grain_length
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-11-14
   name: Bulgur
   children: []
@@ -11625,13 +10269,7 @@
   - grain_processing_method
   - rice_grain_length
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-11-15
   name: Cornmeal & Hominy
   children: []
@@ -11641,13 +10279,7 @@
   - grain_processing_method
   - rice_grain_length
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-11-16
   name: Sorghum
   children: []
@@ -11657,13 +10289,7 @@
   - grain_processing_method
   - rice_grain_length
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-11-17
   name: Freekeh
   children: []
@@ -11673,13 +10299,7 @@
   - grain_processing_method
   - rice_grain_length
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-11-18
   name: Teff
   children: []
@@ -11689,13 +10309,7 @@
   - grain_processing_method
   - rice_grain_length
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-12
   name: Meat, Seafood & Eggs
   children:
@@ -11831,13 +10445,7 @@
   - egg_size
   - egg_source_animal
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-12-1-6
   name: Powdered Eggs
   children: []
@@ -11849,13 +10457,7 @@
   - egg_size
   - egg_source_animal
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-12-2
   name: Meat
   children:
@@ -12130,13 +10732,7 @@
   - meat_processing_state
   - meat_raising_claim
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-12-2-2-7
   name: Veal
   children: []
@@ -12152,13 +10748,7 @@
   - meat_processing_state
   - meat_raising_claim
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-12-2-2-8
   name: Bison
   children: []
@@ -12174,13 +10764,7 @@
   - meat_processing_state
   - meat_raising_claim
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-12-2-3
   name: Lunch & Deli Meats
   children:
@@ -12216,13 +10800,7 @@
   - food_product_form
   - meat_processing_state
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-12-2-3-2
   name: Ham
   children: []
@@ -12234,13 +10812,7 @@
   - food_product_form
   - meat_processing_state
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-12-2-3-3
   name: Salami
   children: []
@@ -12252,13 +10824,7 @@
   - food_product_form
   - meat_processing_state
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-12-3
   name: Seafood
   children:
@@ -12336,13 +10902,7 @@
   - seafood_source
   - seafood_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-12-3-4
   name: Smoked Seafood
   children: []
@@ -12354,13 +10914,7 @@
   - seafood_source
   - seafood_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-13
   name: Nuts & Seeds
   children: []
@@ -12459,13 +11013,7 @@
   - meal_course
   - serving_temperature
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-15-1-2
   name: Prepared Salads
   children: []
@@ -12477,13 +11025,7 @@
   - meal_course
   - serving_temperature
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-15-1-3
   name: Prepared Fries & Potato Sides
   children: []
@@ -12495,13 +11037,7 @@
   - meal_course
   - serving_temperature
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-15-2
   name: Prepared Meals & Entrées
   children: []
@@ -12533,13 +11069,7 @@
   - heating_instructions
   - meal_course
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-16
   name: Seasonings & Spices
   children:
@@ -12664,13 +11194,7 @@
   - food_product_form
   - seasoning_variety
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-16-7
   name: Rice Seasonings & Furikake
   children: []
@@ -12680,13 +11204,7 @@
   - food_product_form
   - seasoning_variety
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-16-8
   name: Barbecue Rubs & Dry Rubs
   children: []
@@ -12696,13 +11214,7 @@
   - food_product_form
   - seasoning_variety
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-16-9
   name: Brining & Curing Mixes
   children: []
@@ -12712,13 +11224,7 @@
   - food_product_form
   - seasoning_variety
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17
   name: Snack Foods
   children:
@@ -12855,13 +11361,7 @@
   - dietary_preferences
   - protein_source
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-2-4
   name: Protein Bars
   children: []
@@ -12872,13 +11372,7 @@
   - dietary_preferences
   - protein_source
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-3
   name: Cheese Puffs
   children: []
@@ -12983,13 +11477,7 @@
   - fruit_snack_form
   - snack_processing_method
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-7-2
   name: Fruit Leather & Rolls
   children: []
@@ -12999,13 +11487,7 @@
   - fruit_snack_form
   - snack_processing_method
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-7-3
   name: Freeze-Dried Fruit Snacks
   children: []
@@ -13015,13 +11497,7 @@
   - fruit_snack_form
   - snack_processing_method
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-8
   name: Jerky
   children:
@@ -13052,13 +11528,7 @@
   - jerky_form
   - meat_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-8-2
   name: Meat Sticks
   children: []
@@ -13068,13 +11538,7 @@
   - jerky_form
   - meat_type
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-9
   name: Popcorn
   children:
@@ -13107,13 +11571,7 @@
   - popcorn_form
   - popcorn_kernel_variety
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-9-2
   name: Ready-to-Eat Popcorn
   children: []
@@ -13123,13 +11581,7 @@
   - popcorn_form
   - popcorn_kernel_variety
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-9-3
   name: Popcorn Kernels
   children: []
@@ -13139,13 +11591,7 @@
   - popcorn_form
   - popcorn_kernel_variety
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-9-4
   name: Popcorn Seasonings & Mixes
   children: []
@@ -13155,13 +11601,7 @@
   - popcorn_form
   - popcorn_kernel_variety
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-10
   name: Pork Rinds
   children: []
@@ -13230,13 +11670,7 @@
   - flavor
   - gelling_agent
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-12-2
   name: Gelatin & Jelly Desserts
   children: []
@@ -13246,13 +11680,7 @@
   - flavor
   - gelling_agent
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-13
   name: Puffed Rice Cakes
   children: []
@@ -13355,13 +11783,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-17-2
   name: Korean Tteok & Tteokbokki Rice Cakes
   children: []
@@ -13370,13 +11792,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-17-3
   name: Mochi Blocks
   children: []
@@ -13385,13 +11801,7 @@
   - dietary_preferences
   - flavor
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-18
   name: Trail & Snack Mixes
   children:
@@ -13422,13 +11832,7 @@
   - dietary_preferences
   - snack_mix_variety
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-18-2
   name: Trail Mixes
   children: []
@@ -13437,13 +11841,7 @@
   - dietary_preferences
   - snack_mix_variety
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-18-3
   name: Party Snack Mixes
   children: []
@@ -13452,13 +11850,7 @@
   - dietary_preferences
   - snack_mix_variety
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-18-4
   name: Namkeen & Sev Mixes
   children: []
@@ -13467,13 +11859,7 @@
   - dietary_preferences
   - snack_mix_variety
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-19
   name: Puffed & Extruded Snacks
   children: []
@@ -13483,13 +11869,7 @@
   - flavor
   - food_product_form
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-20
   name: Rice Crackers
   children: []
@@ -13499,13 +11879,7 @@
   - flavor
   - food_product_form
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-21
   name: Seaweed Snacks
   children: []
@@ -13515,13 +11889,7 @@
   - flavor
   - food_product_form
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-17-22
   name: Nut & Seed Snacks
   children: []
@@ -13531,13 +11899,7 @@
   - flavor
   - food_product_form
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-18
   name: Soups & Broths
   children: []
@@ -13635,13 +11997,7 @@
   - preparation_state
   - primary_plant_protein_source
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-19-2-2
   name: Plant-Based Burgers
   children: []
@@ -13651,13 +12007,7 @@
   - preparation_state
   - primary_plant_protein_source
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-19-2-3
   name: Plant-Based Deli & Bacon Slices
   children: []
@@ -13667,13 +12017,7 @@
   - preparation_state
   - primary_plant_protein_source
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-19-2-4
   name: Plant-Based Sausages
   children: []
@@ -13683,13 +12027,7 @@
   - preparation_state
   - primary_plant_protein_source
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-19-2-5
   name: Plant-Based Ground Meat Alternatives
   children: []
@@ -13699,13 +12037,7 @@
   - preparation_state
   - primary_plant_protein_source
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-19-3
   name: Seitan
   children: []
@@ -13770,13 +12102,7 @@
   - dietary_preferences
   - storage_requirements
   - tofu_preparation_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-19-5-2
   name: Fried & Puffed Tofu
   children: []
@@ -13785,13 +12111,7 @@
   - dietary_preferences
   - storage_requirements
   - tofu_preparation_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-19-5-3
   name: Silken Tofu
   children: []
@@ -13800,13 +12120,7 @@
   - dietary_preferences
   - storage_requirements
   - tofu_preparation_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-19-5-4
   name: Dried Tofu
   children: []
@@ -13815,13 +12129,7 @@
   - dietary_preferences
   - storage_requirements
   - tofu_preparation_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-19-6
   name: Textured Vegetable Protein
   children: []
@@ -13829,13 +12137,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-19-7
   name: Soy-Based Desserts & Yogurts
   children: []
@@ -13843,13 +12145,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-19-8
   name: Egg Alternatives
   children: []
@@ -13857,13 +12153,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-19-9
   name: Natto
   children: []
@@ -13871,13 +12161,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-2-19-10
   name: Yuba & Dried Bean Curd
   children: []
@@ -13885,13 +12169,7 @@
   - allergen_information
   - dietary_preferences
   - storage_requirements
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3
   name: Tobacco Products
   children:
@@ -13995,13 +12273,7 @@
   - tobacco_cut_type
   - tobacco_strength
   - tobacco_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-5-2
   name: Whole Leaf Tobacco
   children: []
@@ -14010,13 +12282,7 @@
   - tobacco_cut_type
   - tobacco_strength
   - tobacco_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-5-3
   name: Hookah & Shisha Tobacco
   children: []
@@ -14025,13 +12291,7 @@
   - tobacco_cut_type
   - tobacco_strength
   - tobacco_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-5-4
   name: Rolling Tobacco
   children: []
@@ -14040,13 +12300,7 @@
   - tobacco_cut_type
   - tobacco_strength
   - tobacco_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-5-5
   name: Pipe Tobacco
   children: []
@@ -14055,13 +12309,7 @@
   - tobacco_cut_type
   - tobacco_strength
   - tobacco_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-6
   name: Smoking Pipes
   children:
@@ -14097,13 +12345,7 @@
   - pipe_shape
   - stem_material
   - tobacco_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-6-2
   name: Water Pipes & Bongs
   children: []
@@ -14114,13 +12356,7 @@
   - pipe_shape
   - stem_material
   - tobacco_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-6-3
   name: Traditional Smoking Pipes
   children: []
@@ -14131,13 +12367,7 @@
   - pipe_shape
   - stem_material
   - tobacco_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-6-4
   name: Hand Pipes
   children: []
@@ -14148,13 +12378,7 @@
   - pipe_shape
   - stem_material
   - tobacco_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-7
   name: Vaporizers & Electronic Cigarettes
   children:
@@ -14265,13 +12489,7 @@
   - heating_technology
   - pattern
   - vaping_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-7-3-3
   name: Portable Vaporizers
   children: []
@@ -14287,13 +12505,7 @@
   - heating_technology
   - pattern
   - vaping_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-7-4
   name: Vape Cartridges
   children: []
@@ -14326,13 +12538,7 @@
   - e_liquid_flavor
   - pattern
   - vaping_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-7-6
   name: Replacement Coils
   children: []
@@ -14345,13 +12551,7 @@
   - e_liquid_flavor
   - pattern
   - vaping_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-7-7
   name: Vaporizer Parts & Accessories
   children: []
@@ -14364,13 +12564,7 @@
   - e_liquid_flavor
   - pattern
   - vaping_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-8
   name: Rolling Papers
   children:
@@ -14404,13 +12598,7 @@
   - rolling_paper_format
   - rolling_paper_gum_type
   - rolling_paper_size
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-8-3
   name: Pre-Rolled Cones
   children: []
@@ -14421,13 +12609,7 @@
   - rolling_paper_format
   - rolling_paper_gum_type
   - rolling_paper_size
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-9
   name: Snuff & Snus
   children: []
@@ -14435,25 +12617,13 @@
   - strength_classification
   - tobacco_cut_type
   - tobacco_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-10
   name: Nicotine Pouches
   children: []
   attributes:
   - strength_classification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-3-11
   name: Rolling Tips & Filters
   children: []
@@ -14461,13 +12631,7 @@
   - cigarette_filter_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fb-4
   name: Cannabis Products
   children:

--- a/data/categories/fr_furniture.yml
+++ b/data/categories/fr_furniture.yml
@@ -128,13 +128,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-1-2-2
   name: Bassinet & Cradle Liners & Covers
   children: []
@@ -143,13 +137,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-1-2-3
   name: Canopies & Mosquito Nets
   children: []
@@ -158,13 +146,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-1-2-4
   name: Bassinet & Cradle Mattresses
   children: []
@@ -173,13 +155,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-1-2-5
   name: Bassinet Sheets & Mattress Protectors
   children: []
@@ -188,13 +164,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-1-2-6
   name: Bassinet Support Pillows & Wedges
   children: []
@@ -203,13 +173,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-1-3
   name: Bassinets & Cradles
   children:
@@ -423,13 +387,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-1-4
   name: Changing Tables
   children: []
@@ -638,13 +596,7 @@
   - crib_accessory_features
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-1-5-4
   name: Crib Mattress Protectors & Pads
   children: []
@@ -654,13 +606,7 @@
   - crib_accessory_features
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-1-6
   name: Cribs & Toddler Beds
   children:
@@ -869,13 +815,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-1-7-2
   name: High Chair Harnesses & Safety Straps
   children: []
@@ -883,13 +823,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-1-7-3
   name: High Chair Trays
   children: []
@@ -897,13 +831,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-1-7-4
   name: High Chair Footrests & Leg Wraps
   children: []
@@ -911,13 +839,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-1-8
   name: High Chairs & Booster Seats
   children:
@@ -1029,13 +951,7 @@
   - furniture/fixture_material
   - pattern
   - upholstery_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-1-9
   name: Play Sofas
   children: []
@@ -1061,13 +977,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-1-11
   name: Learning Towers & Kitchen Helper Stools
   children: []
@@ -1075,13 +985,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-1-12
   name: Step Stools & Booster Stools
   children: []
@@ -1089,13 +993,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-1-13
   name: Toddler Chairs & Armchairs
   children: []
@@ -1103,13 +1001,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-2
   name: Beds & Accessories
   children:
@@ -1170,13 +1062,7 @@
   - compatible_bed_frame_style
   - compatible_mattress_size
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-2-1-2
   name: Bed Rails
   children: []
@@ -1186,13 +1072,7 @@
   - compatible_bed_frame_style
   - compatible_mattress_size
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-2-1-3
   name: Bed Slats
   children: []
@@ -1202,13 +1082,7 @@
   - compatible_bed_frame_style
   - compatible_mattress_size
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-2-1-4
   name: Water Bed Bladders & Tubes
   children: []
@@ -1218,13 +1092,7 @@
   - compatible_bed_frame_style
   - compatible_mattress_size
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-2-1-5
   name: Water Bed Heaters
   children: []
@@ -1234,13 +1102,7 @@
   - compatible_bed_frame_style
   - compatible_mattress_size
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-2-2
   name: Beds & Bed Frames
   children:
@@ -1933,13 +1795,7 @@
   - slat_color
   - slat_material
   - slat_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-2-6
   name: Mattresses
   children:
@@ -2125,13 +1981,7 @@
   - mattress_features
   - mattress_top_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-2-6-9
   name: Hybrid Mattresses
   children: []
@@ -2143,13 +1993,7 @@
   - mattress_features
   - mattress_top_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-3
   name: Benches
   children:
@@ -2829,13 +2673,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-4
   name: Cabinets & Storage
   children:
@@ -3225,13 +3063,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-4-2
   name: Buffets
   children: []
@@ -4027,13 +3859,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-4-10-2
   name: Record Storage Crates
   children: []
@@ -4041,13 +3867,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-4-11
   name: Sideboards
   children: []
@@ -4105,13 +3925,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-4-12-2
   name: Lockers
   children: []
@@ -4119,13 +3933,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-4-12-3
   name: Shoe Cabinets
   children: []
@@ -4133,13 +3941,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-4-12-4
   name: Garage Storage Cabinets
   children: []
@@ -4147,13 +3949,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-4-13
   name: Storage Chests
   children:
@@ -4221,13 +4017,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-4-13-4
   name: Blanket Chests
   children: []
@@ -4235,13 +4025,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-4-14
   name: Vanities
   children:
@@ -4320,13 +4104,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-4-14-1-1-2
   name: Mirrored Bathroom Cabinets
   children: []
@@ -4334,13 +4112,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-4-14-1-2
   name: Bathroom Vanity Sets
   children: []
@@ -4872,13 +4644,7 @@
   - furniture/fixture_features
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-5
   name: Carts & Islands
   children:
@@ -4930,13 +4696,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-5-1-2
   name: Kitchen Carts
   children: []
@@ -4945,13 +4705,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-5-1-3
   name: Utility & Storage Carts
   children: []
@@ -4960,13 +4714,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-5-2
   name: Islands
   children: []
@@ -5037,13 +4785,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-6-1-2
   name: Hanging Chair Mounting Hardware
   children: []
@@ -5051,13 +4793,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-6-1-3
   name: Hanging Chair Cushions & Pads
   children: []
@@ -5065,13 +4801,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-6-2
   name: Chair Replacement Parts
   children: []
@@ -5079,13 +4809,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-6-3
   name: Chair Armrest Pads
   children: []
@@ -5093,13 +4817,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-6-4
   name: Chair Feet & Glides
   children: []
@@ -5107,13 +4825,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-6-5
   name: Chair Cushions & Pads
   children: []
@@ -5121,13 +4833,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-6-6
   name: Chair Casters & Wheels
   children: []
@@ -5135,13 +4841,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-7
   name: Chairs
   children:
@@ -5305,13 +5005,7 @@
   - filler_material
   - pattern
   - upholstery_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-7-2-2
   name: Outdoor Bean Bag Chairs
   children: []
@@ -5321,13 +5015,7 @@
   - filler_material
   - pattern
   - upholstery_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-7-2-3
   name: Kids' Bean Bag Chairs
   children: []
@@ -5337,13 +5025,7 @@
   - filler_material
   - pattern
   - upholstery_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-7-3
   name: Chaises
   children:
@@ -5510,13 +5192,7 @@
   - pattern
   - seat_type
   - upholstery_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-7-5-2
   name: Balance Ball Chairs
   children: []
@@ -5527,13 +5203,7 @@
   - pattern
   - seat_type
   - upholstery_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-7-5-3
   name: Kneeling Chairs
   children: []
@@ -5544,13 +5214,7 @@
   - pattern
   - seat_type
   - upholstery_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-7-5-4
   name: Floor Sofas & Loungers
   children: []
@@ -5561,13 +5225,7 @@
   - pattern
   - seat_type
   - upholstery_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-7-6
   name: Folding Chairs & Stools
   children:
@@ -5712,13 +5370,7 @@
   - pattern
   - seat_type
   - upholstery_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-7-10
   name: Rocking Chairs
   children:
@@ -5922,13 +5574,7 @@
   - seat_height_category
   - seat_type
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-7-13
   name: Kids' Chairs
   children: []
@@ -5940,13 +5586,7 @@
   - pattern
   - seat_type
   - upholstery_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-8
   name: Daybeds
   children: []
@@ -6087,13 +5727,7 @@
   - kitchen/dining_furniture_items_included
   - pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-10-3-2
   name: Bar & Pub Table Sets
   children: []
@@ -6103,13 +5737,7 @@
   - kitchen/dining_furniture_items_included
   - pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-10-4
   name: Living Room Furniture Sets
   children: []
@@ -6206,13 +5834,7 @@
   - color
   - pattern
   - suitable_space
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-12
   name: Office Furniture
   children:
@@ -6288,13 +5910,7 @@
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-12-1-2
   name: Standing Desks
   children: []
@@ -6311,13 +5927,7 @@
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-12-1-3
   name: Writing Desks
   children: []
@@ -6334,13 +5944,7 @@
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-12-1-4
   name: Kids' Desks
   children: []
@@ -6357,13 +5961,7 @@
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-12-1-5
   name: Secretary Desks
   children: []
@@ -6380,13 +5978,7 @@
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-12-1-6
   name: Computer Desks
   children: []
@@ -6403,13 +5995,7 @@
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-12-1-7
   name: Reception Desks
   children: []
@@ -6426,13 +6012,7 @@
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-12-1-8
   name: Gaming Desks
   children: []
@@ -6449,13 +6029,7 @@
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-12-2
   name: Office Chairs
   children: []
@@ -6583,13 +6157,7 @@
   - furniture/fixture_material
   - pattern
   - privacy_or_acoustic_feature
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-12-5-2
   name: Office Pods & Acoustic Booths
   children: []
@@ -6598,13 +6166,7 @@
   - furniture/fixture_material
   - pattern
   - privacy_or_acoustic_feature
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-12-5-3
   name: Study Carrels
   children: []
@@ -6613,13 +6175,7 @@
   - furniture/fixture_material
   - pattern
   - privacy_or_acoustic_feature
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-13
   name: Office Furniture Accessories
   children:
@@ -6703,65 +6259,35 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-13-3-2
   name: Desk Privacy & Acoustic Screens
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-13-3-3
   name: Cubicle Panels
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-13-3-4
   name: Cubicle Shelves
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-13-3-5
   name: Cubicle Hooks & Hangers
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-14
   name: Ottomans
   children: []
@@ -7470,13 +6996,7 @@
   - pattern
   - seat_structure
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-15-4-2
   name: Outdoor Chairs
   children:
@@ -7574,13 +7094,7 @@
   - seat_structure
   - seat_type
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-15-4-2-9-2
   name: Folding Loveseat Chairs
   children: []
@@ -7596,13 +7110,7 @@
   - seat_structure
   - seat_type
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-15-4-2-15
   name: Rocking Chairs
   children: []
@@ -7685,13 +7193,7 @@
   - seat_structure
   - seat_type
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-15-4-2-20
   name: Adirondack Chairs
   children: []
@@ -7705,13 +7207,7 @@
   - seat_structure
   - seat_type
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-15-4-2-21
   name: Outdoor Dining Chairs
   children: []
@@ -7725,13 +7221,7 @@
   - seat_structure
   - seat_type
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-15-4-3
   name: Outdoor Sectional Sofa Units
   children: []
@@ -7828,13 +7318,7 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-15-5
   name: Outdoor Storage Boxes
   children: []
@@ -8008,13 +7492,7 @@
   - furniture/fixture_material
   - pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-15-6-7-2
   name: Fire Pit Tables
   children: []
@@ -8024,13 +7502,7 @@
   - furniture/fixture_material
   - pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-15-6-7-3
   name: Fire Bowls
   children: []
@@ -8040,13 +7512,7 @@
   - furniture/fixture_material
   - pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-15-6-9
   name: Game Tables
   children:
@@ -8077,13 +7543,7 @@
   - furniture/fixture_material
   - pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-15-6-9-2
   name: Chess Tables
   children: []
@@ -8092,13 +7552,7 @@
   - furniture/fixture_material
   - pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-15-6-9-3
   name: Outdoor Foosball Tables
   children: []
@@ -8107,13 +7561,7 @@
   - furniture/fixture_material
   - pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-15-6-9-4
   name: Outdoor Billiard Tables
   children: []
@@ -8122,13 +7570,7 @@
   - furniture/fixture_material
   - pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-15-6-11
   name: Poolside Tables
   children: []
@@ -8156,13 +7598,7 @@
   - furniture/fixture_material
   - pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-15-6-13
   name: Picnic Tables
   children: []
@@ -8171,13 +7607,7 @@
   - furniture/fixture_material
   - pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-16
   name: Outdoor Furniture Accessories
   children:
@@ -8223,13 +7653,7 @@
   - color
   - cover_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-16-3
   name: Outdoor Furniture Cushions
   children: []
@@ -8237,13 +7661,7 @@
   - color
   - cover_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-16-4
   name: Outdoor Furniture Replacement Parts
   children: []
@@ -8251,13 +7669,7 @@
   - color
   - cover_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-17
   name: Room Divider Accessories
   children: []
@@ -8458,13 +7870,7 @@
   - mounting_type
   - pattern
   - suitable_location
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-19-1-7
   name: Cube Bookcases & Shelves
   children: []
@@ -8474,13 +7880,7 @@
   - mounting_type
   - pattern
   - suitable_location
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-19-2
   name: Wall Shelves & Ledges
   children:
@@ -8622,13 +8022,7 @@
   - mounting_type
   - pattern
   - suitable_location
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-19-3
   name: Heavy Duty & Utility Shelving
   children: []
@@ -8638,13 +8032,7 @@
   - mounting_type
   - pattern
   - suitable_location
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-20
   name: Shelving Accessories
   children:
@@ -8692,78 +8080,42 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-20-3
   name: Shelf Dividers & Organizers
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-20-4
   name: Shelf Rails & Guards
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-20-5
   name: Shelf Posts & Uprights
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-20-6
   name: Shelf Liners & Covers
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-20-7
   name: Shelf Brackets
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-21
   name: Sofa Accessories
   children:
@@ -8832,13 +8184,7 @@
   - compatible_seating_capacity
   - pattern
   - section_orientation_compatibility
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-22
   name: Sofas
   children:
@@ -9015,13 +8361,7 @@
   - seat_upholstery_material
   - seat_upholstery_pattern
   - sofa_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-23
   name: Table Accessories
   children:
@@ -9090,13 +8430,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-23-4
   name: Table Leaves
   children: []
@@ -9104,13 +8438,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-23-5
   name: Table Casters
   children: []
@@ -9118,13 +8446,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-23-6
   name: Table Bases
   children: []
@@ -9132,13 +8454,7 @@
   - color
   - furniture/fixture_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-24
   name: Tables
   children:
@@ -9278,13 +8594,7 @@
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-24-1-5
   name: Nesting Tables
   children: []
@@ -9297,13 +8607,7 @@
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-24-2
   name: Activity Tables
   children: []
@@ -9412,13 +8716,7 @@
   - tabletop_material
   - tabletop_pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-24-5
   name: Kotatsu
   children: []
@@ -9479,23 +8777,11 @@
   - tabletop_material
   - tabletop_pattern
   - tabletop_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: fr-25
   name: Pedestals & Plinths
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit

--- a/data/categories/hb_health_beauty.yml
+++ b/data/categories/hb_health_beauty.yml
@@ -2631,13 +2631,7 @@
   - package_type
   - product_form
   - protein_source
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hb-1-9-2-2-2
   name: Protein Shakes
   children: []
@@ -2653,13 +2647,7 @@
   - package_type
   - product_form
   - protein_source
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hb-1-9-2-3
   name: Weight Gainer Shakes
   children: []
@@ -7323,13 +7311,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hb-1-31-1
   name: Hearing Aid Batteries
   children: []
@@ -7346,13 +7328,7 @@
   - pattern
   - plug_type
   - product_certifications_standards
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hb-1-31-2
   name: Hearing Aid Cleaning & Maintenance
   children: []
@@ -7360,13 +7336,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hb-1-31-3
   name: Hearing Aid Cases & Storage
   children: []
@@ -7374,13 +7344,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hb-1-31-4
   name: Hearing Aid Domes, Tips & Wax Guards
   children: []
@@ -7388,13 +7352,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hb-1-31-5
   name: Hearing Aid Charging Accessories
   children: []
@@ -7403,13 +7361,7 @@
   - connector_gender
   - connector_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hb-2
   name: Jewelry Cleaning & Care
   children:
@@ -22657,13 +22609,7 @@
   - hb-3-21-2
   - hb-3-21-3
   attributes: []
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hb-3-21-1
   name: Essential Oil Singles
   children: []
@@ -22673,13 +22619,7 @@
   - material
   - pattern
   - product_form
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hb-3-21-2
   name: Essential Oil Blends
   children: []
@@ -22689,13 +22629,7 @@
   - material
   - pattern
   - product_form
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hb-3-21-3
   name: Essential Oil Diffusers
   children: []
@@ -22705,13 +22639,7 @@
   - material
   - pattern
   - product_form
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hb-3-22
   name: Essential Oil Accessories
   children: []
@@ -22721,10 +22649,4 @@
   - material
   - pattern
   - product_form
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit

--- a/data/categories/hb_health_beauty.yml
+++ b/data/categories/hb_health_beauty.yml
@@ -7979,6 +7979,8 @@
   - safety_certifications
   - target_gender
   return_reasons:
+  - size
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -17640,6 +17642,8 @@
   - product_form
   - treatment_objective
   return_reasons:
+  - size
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -18325,6 +18329,8 @@
   - oral_care_function
   - product_form
   return_reasons:
+  - size
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -19834,6 +19840,8 @@
   - product_form
   - target_gender
   return_reasons:
+  - size
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -21182,6 +21190,8 @@
   - pattern
   - product_form
   return_reasons:
+  - size
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -22028,6 +22038,7 @@
   - product_form
   - product_sterility
   return_reasons:
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item

--- a/data/categories/hg_home_garden.yml
+++ b/data/categories/hg_home_garden.yml
@@ -23559,13 +23559,7 @@
   attributes:
   - cleaning_instructions
   - material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hg-11-6-16-6
   name: Ice Maker Water Filters
   children: []
@@ -24008,13 +24002,7 @@
   - lumber/wood_type
   - material
   - shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hg-11-6-19-2
   name: Charcoal Chimneys
   children: []
@@ -24479,13 +24467,7 @@
   - lumber/wood_type
   - material
   - package_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hg-11-6-19-10
   name: Grill Lights
   children: []
@@ -25551,13 +25533,7 @@
   - cleaning_instructions
   - compatible_water_cooler_type
   - material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hg-11-6-30-4
   name: Water Cooler Drip Trays
   children: []
@@ -29368,13 +29344,7 @@
   - ingress_protection_ip_rating
   - power_source
   - tool/utensil_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hg-11-8-18
   name: Cooking Timers
   children: []
@@ -31780,13 +31750,7 @@
   - power_source
   - slice_style
   - tool/utensil_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hg-11-8-44-2
   name: Cheese Slicers
   children: []
@@ -31797,13 +31761,7 @@
   - power_source
   - slice_style
   - tool/utensil_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hg-11-8-44-3
   name: Egg Slicers
   children: []
@@ -31814,13 +31772,7 @@
   - power_source
   - slice_style
   - tool/utensil_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hg-11-8-44-4
   name: Mandoline Slicers
   children: []
@@ -31831,13 +31783,7 @@
   - power_source
   - slice_style
   - tool/utensil_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hg-11-8-45
   name: Kitchen Utensil Sets
   children: []
@@ -35360,13 +35306,7 @@
   attributes:
   - material
   - suitable_space
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hg-12-1-2
   name: Disease Control
   children: []
@@ -41677,13 +41617,7 @@
   - connecting_thread
   - manufacturer_type
   - material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: hg-12-4-9
   name: Snow Blower Accessories
   children:

--- a/data/categories/hg_home_garden.yml
+++ b/data/categories/hg_home_garden.yml
@@ -14152,6 +14152,7 @@
   - suitable_space
   - thermometer_design
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -15730,6 +15731,7 @@
   - suitable_for_material_type
   - wax_type
   return_reasons:
+  - color
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -15812,6 +15814,8 @@
   - shoe_treatment_purpose
   - suitable_for_material_type
   return_reasons:
+  - color
+  - scent
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -20535,6 +20539,7 @@
   - usage_type
   - wrap_format
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -20577,6 +20582,7 @@
   - usage_type
   - wrap_format
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -20598,6 +20604,7 @@
   - usage_type
   - wrap_format
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -20619,6 +20626,7 @@
   - wax_type
   - wrap_format
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -20746,6 +20754,7 @@
   - pattern
   - usage_type
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -22507,6 +22516,8 @@
   - material
   - pattern
   return_reasons:
+  - size
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -22561,6 +22572,7 @@
   - material
   - pattern
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -24707,6 +24719,7 @@
   - material
   - pattern
   return_reasons:
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -28835,9 +28848,9 @@
   attributes:
   - cleaning_instructions
   - handle_material
+  - piping_tip_shape
   - tool/utensil_material
   - usage_type
-  - piping_tip_shape
   return_reasons:
   - size
   - color
@@ -29277,6 +29290,7 @@
   - tool/utensil_material
   - units_of_measurement
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -31734,6 +31748,7 @@
   - slice_style
   - tool/utensil_material
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -35256,6 +35271,7 @@
   - ph_level
   - suitable_space
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -37076,6 +37092,7 @@
   - product_certifications_standards
   - suitable_space
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -37098,6 +37115,7 @@
   - sand_type
   - suitable_space
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -37120,6 +37138,7 @@
   - soil_texture
   - suitable_space
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -37373,6 +37392,7 @@
   - product_sterility
   - suitable_space
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -37560,6 +37580,8 @@
   - suitable_space
   - supplement_function
   return_reasons:
+  - size
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -37619,6 +37641,8 @@
   - suitable_space
   - supplement_function
   return_reasons:
+  - size
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -46727,11 +46751,11 @@
   - inflation_method
   - material
   - pattern
+  - pool_lounge_style
   - pool_lounger_features
   - shape
   - suitable_for_pool_type
   - suitable_for_water_type
-  - pool_lounge_style
   return_reasons:
   - size
   - color

--- a/data/categories/lb_luggage_bags.yml
+++ b/data/categories/lb_luggage_bags.yml
@@ -855,10 +855,4 @@
   - carry_options
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit

--- a/data/categories/ma_mature.yml
+++ b/data/categories/ma_mature.yml
@@ -25,6 +25,7 @@
   - ma-1-6
   attributes: []
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item

--- a/data/categories/pa_product_add_ons.yml
+++ b/data/categories/pa_product_add_ons.yml
@@ -11,6 +11,7 @@
   - pa-7
   attributes: []
   return_reasons:
+  - incompatible
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -60,6 +61,8 @@
   children: []
   attributes: []
   return_reasons:
+  - size
+  - style
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item

--- a/data/categories/se_services.yml
+++ b/data/categories/se_services.yml
@@ -849,10 +849,4 @@
   name: Food & Beverage Services
   children: []
   attributes: []
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit

--- a/data/categories/sg_sporting_goods.yml
+++ b/data/categories/sg_sporting_goods.yml
@@ -340,13 +340,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-1-4-2-6
   name: American Football Helmet Covers
   children: []
@@ -357,13 +351,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-1-4-2-7
   name: American Football Helmet Decals
   children: []
@@ -374,13 +362,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-1-4-2-8
   name: American Football Chin Strap Hardware & Parts
   children: []
@@ -391,13 +373,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-1-4-2-9
   name: American Football Helmet Visor Hardware
   children: []
@@ -408,13 +384,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-1-4-3
   name: American Football Helmets
   children:
@@ -454,13 +424,7 @@
   - pattern
   - sports_governing_body_certification
   - virginia_tech_helmet_star_rating
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-1-4-3-2
   name: Replica & Collectible American Football Helmets
   children: []
@@ -474,13 +438,7 @@
   - pattern
   - sports_governing_body_certification
   - virginia_tech_helmet_star_rating
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-1-4-4
   name: American Football Neck Rolls
   children: []
@@ -558,13 +516,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-1-4-8
   name: American Football Arm & Elbow Pads
   children: []
@@ -575,13 +527,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-1-4-9
   name: American Football Mouthguards
   children: []
@@ -592,13 +538,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-1-4-10
   name: American Football Protective Sleeves
   children: []
@@ -609,13 +549,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-1-4-11
   name: American Football Back Plates
   children: []
@@ -626,13 +560,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-1-5
   name: American Football Training Equipment
   children:
@@ -725,13 +653,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-1-5-3
   name: American Football Tackle Rings
   children: []
@@ -740,13 +662,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-1-5-4
   name: Flag Football Belts & Sets
   children: []
@@ -755,13 +671,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-1-5-5
   name: American Football Blocking Pads
   children: []
@@ -770,13 +680,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-1-6
   name: American Footballs
   children: []
@@ -1030,13 +934,7 @@
   - pattern
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-3-4
   name: Catchers Mitts
   children: []
@@ -1054,13 +952,7 @@
   - pattern
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-4
   name: Baseball & Softball Pitching Grips
   children: []
@@ -1230,13 +1122,7 @@
   - pattern
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-8-2-2
   name: Umpire Chest Protectors
   children: []
@@ -1248,13 +1134,7 @@
   - pattern
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-8-3
   name: Baseball & Softball Leg Guards
   children:
@@ -1294,13 +1174,7 @@
   - knee_protection_design
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-8-3-3
   name: Batters Leg Guards
   children: []
@@ -1314,13 +1188,7 @@
   - knee_protection_design
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-8-3-4
   name: Umpire Leg Guards
   children: []
@@ -1334,13 +1202,7 @@
   - knee_protection_design
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-8-4
   name: Catchers Equipment Sets
   children: []
@@ -1404,13 +1266,7 @@
   - mask_cage_material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-8-5-2
   name: Umpire Masks
   children: []
@@ -1424,13 +1280,7 @@
   - mask_cage_material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-8-5-4
   name: Catchers Face Masks
   children: []
@@ -1444,13 +1294,7 @@
   - mask_cage_material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-8-6
   name: Baseball & Softball Hand & Wrist Guards
   children: []
@@ -1461,13 +1305,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-8-7
   name: Baseball & Softball Sliding Mitts
   children: []
@@ -1478,13 +1316,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-8-8
   name: Baseball & Softball Elbow Guards
   children: []
@@ -1495,13 +1327,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-8-9
   name: Baseball & Softball Fielder Masks
   children: []
@@ -1512,13 +1338,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-8-10
   name: Leg Guard Accessories
   children: []
@@ -1529,13 +1349,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-8-11
   name: Catchers Helmet & Mask Accessories
   children: []
@@ -1546,13 +1360,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-9
   name: Baseball & Softball Training Aids
   children:
@@ -1628,13 +1436,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-9-1-3
   name: Batting Cage Packages
   children: []
@@ -1648,13 +1450,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-9-1-4
   name: Baseball & Softball Batting Cage Nets
   children: []
@@ -1668,13 +1464,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-9-2
   name: Baseball & Softball Batting Tees
   children: []
@@ -1810,13 +1600,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-9-9
   name: Baseball & Softball Training Bats
   children: []
@@ -1829,13 +1613,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-9-10
   name: Batting Cage Accessories
   children: []
@@ -1848,13 +1626,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-9-11
   name: Baseball & Softball Batting Tee Parts
   children: []
@@ -1867,13 +1639,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-9-12
   name: Baseball & Softball Hitting Net Replacement Parts
   children: []
@@ -1886,13 +1652,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-9-13
   name: Baseball & Softball Pitching Screen Replacement Parts
   children: []
@@ -1905,13 +1665,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-10
   name: Baseball Bats
   children: []
@@ -1974,13 +1728,7 @@
   - pattern
   - seam_type
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-11-2
   name: Tee Balls & Reduced-Injury Baseballs
   children: []
@@ -1993,13 +1741,7 @@
   - pattern
   - seam_type
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-12
   name: Pitching Machines
   children: []
@@ -2081,13 +1823,7 @@
   - pattern
   - softball_certification
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-14-2
   name: Fastpitch Softballs
   children: []
@@ -2099,13 +1835,7 @@
   - pattern
   - softball_certification
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-15
   name: Baseball & Softball Equipment Bags
   children: []
@@ -2114,13 +1844,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-16
   name: Baseball & Softball Bat Grips
   children: []
@@ -2129,13 +1853,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-17
   name: Baseball & Softball Base Accessories
   children: []
@@ -2144,13 +1862,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-18
   name: Baseball & Softball Glove Care & Accessories
   children: []
@@ -2159,13 +1871,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-19
   name: Pitching Machine Accessories
   children: []
@@ -2174,13 +1880,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-2-20
   name: Baseball & Softball Field Marking Tools
   children: []
@@ -2189,13 +1889,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3
   name: Basketball
   children:
@@ -2310,13 +2004,7 @@
   - material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-1-2-2
   name: Basketball Pole Pads
   children: []
@@ -2331,13 +2019,7 @@
   - material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-1-3
   name: Basketball Hoop Posts
   children: []
@@ -2414,13 +2096,7 @@
   - compatible_pole_dimensions
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-1-7
   name: Basketball Return Systems
   children: []
@@ -2430,13 +2106,7 @@
   - compatible_pole_dimensions
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-1-8
   name: Basketball Hoop Lights
   children: []
@@ -2446,13 +2116,7 @@
   - compatible_pole_dimensions
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-1-9
   name: Basketball Hoop Bases
   children: []
@@ -2462,13 +2126,7 @@
   - compatible_pole_dimensions
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-2
   name: Basketball Hoops
   children:
@@ -2507,13 +2165,7 @@
   - pattern
   - sports_governing_body_certification
   - suitable_space
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-2-2
   name: Portable Basketball Hoops
   children: []
@@ -2526,13 +2178,7 @@
   - pattern
   - sports_governing_body_certification
   - suitable_space
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-2-3
   name: Wall-Mounted Basketball Hoops
   children: []
@@ -2545,13 +2191,7 @@
   - pattern
   - sports_governing_body_certification
   - suitable_space
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-2-4
   name: Door-Mounted Mini Basketball Hoops
   children: []
@@ -2564,13 +2204,7 @@
   - pattern
   - sports_governing_body_certification
   - suitable_space
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-3
   name: Basketball Training Aids
   children:
@@ -2691,13 +2325,7 @@
   - pattern
   - skill_focus
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-3-4-2
   name: Basketball Shot Tracking Sensors
   children: []
@@ -2707,13 +2335,7 @@
   - pattern
   - skill_focus
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-3-4-3
   name: Basketball Shooting Machines
   children: []
@@ -2723,13 +2345,7 @@
   - pattern
   - skill_focus
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-3-4-4
   name: Basketball Rim Targets & Reducers
   children: []
@@ -2739,13 +2355,7 @@
   - pattern
   - skill_focus
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-3-5
   name: Basketball Training Mats & Floor Markers
   children: []
@@ -2755,13 +2365,7 @@
   - pattern
   - skill_focus
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-3-6
   name: Basketball Court Marking Stencils
   children: []
@@ -2771,13 +2375,7 @@
   - pattern
   - skill_focus
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-3-7
   name: Basketball Passing Targets
   children: []
@@ -2787,13 +2385,7 @@
   - pattern
   - skill_focus
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-3-8
   name: Basketball Coaching Boards
   children: []
@@ -2803,13 +2395,7 @@
   - pattern
   - skill_focus
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-3-9
   name: Basketball Rebounders
   children: []
@@ -2819,13 +2405,7 @@
   - pattern
   - skill_focus
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-4
   name: Basketballs
   children: []
@@ -2885,13 +2465,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-7
   name: Basketball Protective Gear
   children: []
@@ -2899,13 +2473,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-3-8
   name: Basketball Apparel
   children: []
@@ -2913,13 +2481,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4
   name: Boxing & Martial Arts
   children:
@@ -3003,13 +2565,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-1-1-2
   name: Boxing & Martial Arts Forearm Guards
   children: []
@@ -3019,13 +2575,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-1-1-3
   name: Boxing & Martial Arts Wrist Guards
   children: []
@@ -3035,13 +2585,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-1-2
   name: Boxing & Martial Arts Body Protectors
   children:
@@ -3075,13 +2619,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-1-2-2
   name: Chest & Rib Guards
   children: []
@@ -3091,13 +2629,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-1-2-3
   name: Coach Body Protectors
   children: []
@@ -3107,13 +2639,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-1-2-4
   name: Thigh Pads
   children: []
@@ -3123,13 +2649,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-1-3
   name: Boxing & Martial Arts Headgear
   children: []
@@ -3322,13 +2842,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-1-8
   name: Boxing & Martial Arts Foot Guards
   children: []
@@ -3338,13 +2852,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-2
   name: Boxing & Martial Arts Training Equipment
   children:
@@ -3518,13 +3026,7 @@
   - padding_material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-2-3-5
   name: Punching & Training Stands
   children: []
@@ -3535,13 +3037,7 @@
   - padding_material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-2-3-6
   name: Punching & Training Chains
   children: []
@@ -3552,13 +3048,7 @@
   - padding_material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-2-3-7
   name: Punching & Training Mounts & Brackets
   children: []
@@ -3569,13 +3059,7 @@
   - padding_material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-2-4
   name: Punching & Training Bags
   children:
@@ -3833,13 +3317,7 @@
   - padding_material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-2-7
   name: Training Weapons
   children: []
@@ -3849,13 +3327,7 @@
   - padding_material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-2-8
   name: Coaching Sticks
   children: []
@@ -3865,13 +3337,7 @@
   - padding_material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-2-9
   name: Thai Pads
   children: []
@@ -3881,13 +3347,7 @@
   - padding_material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-3
   name: Boxing Ring Parts
   children:
@@ -3987,13 +3447,7 @@
   - material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-3-5
   name: Boxing Ring Turnbuckle Covers
   children: []
@@ -4003,13 +3457,7 @@
   - material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-3-6
   name: Boxing Ring Rope Spacers
   children: []
@@ -4019,13 +3467,7 @@
   - material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-3-7
   name: Boxing Ring Canvases
   children: []
@@ -4035,13 +3477,7 @@
   - material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-3-8
   name: Boxing Ring Ropes & Rope Covers
   children: []
@@ -4051,13 +3487,7 @@
   - material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-3-9
   name: Boxing Ring Corner Pads & Cushions
   children: []
@@ -4067,13 +3497,7 @@
   - material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-3-10
   name: Boxing Ring Steps
   children: []
@@ -4083,13 +3507,7 @@
   - material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-4
   name: Boxing Rings
   children: []
@@ -4256,13 +3674,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-6-6
   name: Kamas
   children: []
@@ -4272,13 +3684,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-6-7
   name: Shinai
   children: []
@@ -4288,13 +3694,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-6-8
   name: Training Swords
   children: []
@@ -4304,13 +3704,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-4-6-9
   name: Chain Whips & Rope Darts
   children: []
@@ -4320,13 +3714,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-5
   name: Broomball Equipment
   children:
@@ -4416,13 +3804,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-5-5
   name: Broomball Shoes
   children: []
@@ -4431,13 +3813,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-5-6
   name: Broomball Protective Gear
   children: []
@@ -4446,13 +3822,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-6
   name: Cheerleading
   children:
@@ -4505,13 +3875,7 @@
   - pom_pom_handle_style
   - sports_governing_body_certification
   - strand_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-6-4
   name: Cheerleading Shoes
   children: []
@@ -4521,13 +3885,7 @@
   - pom_pom_handle_style
   - sports_governing_body_certification
   - strand_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-6-5
   name: Cheerleading Uniforms
   children: []
@@ -4537,13 +3895,7 @@
   - pom_pom_handle_style
   - sports_governing_body_certification
   - strand_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-6-6
   name: Cheerleading Hair Bows
   children: []
@@ -4553,13 +3905,7 @@
   - pom_pom_handle_style
   - sports_governing_body_certification
   - strand_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-6-7
   name: Cheerleading Training Aids
   children: []
@@ -4569,13 +3915,7 @@
   - pom_pom_handle_style
   - sports_governing_body_certification
   - strand_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-7
   name: Coaching & Officiating
   children:
@@ -4714,13 +4054,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-7-2-5
   name: Field Marking Machines
   children: []
@@ -4729,13 +4063,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-7-2-6
   name: Field Marking Webbing
   children: []
@@ -4744,13 +4072,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-7-2-7
   name: Field Marking Stencils
   children: []
@@ -4759,13 +4081,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-7-3
   name: Flip Coins & Discs
   children:
@@ -4909,13 +4225,7 @@
   - pattern
   - sport
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-7-4-5
   name: Linesman Flag Accessories & Replacement Parts
   children: []
@@ -4924,13 +4234,7 @@
   - pattern
   - sport
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-7-4-6
   name: Referee Chair Accessories
   children: []
@@ -4939,13 +4243,7 @@
   - pattern
   - sport
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-7-5
   name: Penalty Cards & Flags
   children:
@@ -5015,13 +4313,7 @@
   - pattern
   - sport
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-7-6
   name: Pitch Counters
   children: []
@@ -5281,13 +4573,7 @@
   - pattern
   - sport
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-7-10-6
   name: Electronic Whistles
   children: []
@@ -5298,13 +4584,7 @@
   - pattern
   - sport
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-7-11
   name: Umpire Indicators
   children: []
@@ -5332,13 +4612,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8
   name: Cricket
   children:
@@ -5445,13 +4719,7 @@
   - material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-2-3
   name: Cricket Bat Oils & Waxes
   children: []
@@ -5463,13 +4731,7 @@
   - material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-2-4
   name: Cricket Bat Tapes & Face Sheets
   children: []
@@ -5481,13 +4743,7 @@
   - material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-2-6
   name: Cricket Bat Covers
   children: []
@@ -5499,13 +4755,7 @@
   - material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-2-7
   name: Cricket Bat Toe Guards
   children: []
@@ -5517,13 +4767,7 @@
   - material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-2-8
   name: Cricket Bat Stickers & Decals
   children: []
@@ -5535,13 +4779,7 @@
   - material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-3
   name: Cricket Bats
   children: []
@@ -5654,13 +4892,7 @@
   - pattern
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-5-1-2
   name: Cricket Batting Inner Gloves
   children: []
@@ -5672,13 +4904,7 @@
   - pattern
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-5-1-3
   name: Cricket Batting Gloves
   children: []
@@ -5690,13 +4916,7 @@
   - pattern
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-5-1-4
   name: Cricket Wicketkeeping Inner Gloves
   children: []
@@ -5708,13 +4928,7 @@
   - pattern
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-5-2
   name: Cricket Helmets
   children: []
@@ -5772,13 +4986,7 @@
   - cricket_protection_grade
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-5-3-2
   name: Cricket Wicket-Keeping Pads
   children: []
@@ -5790,13 +4998,7 @@
   - cricket_protection_grade
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-5-4
   name: Cricket Abdominal Guards
   children: []
@@ -5806,13 +5008,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-5-5
   name: Cricket Chest Guards
   children: []
@@ -5822,13 +5018,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-5-6
   name: Cricket Arm & Wrist Guards
   children: []
@@ -5838,13 +5028,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-5-7
   name: Cricket Thigh Guards
   children: []
@@ -5854,13 +5038,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-5-8
   name: Cricket Helmet Accessories
   children: []
@@ -5870,13 +5048,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-6
   name: Cricket Stumps
   children: []
@@ -6042,13 +5214,7 @@
   - fielding_training_focus
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-7-5-2
   name: Cricket Fielding Gloves & Mitts
   children: []
@@ -6059,13 +5225,7 @@
   - fielding_training_focus
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-7-5-3
   name: Cricket Fielding Bats
   children: []
@@ -6076,13 +5236,7 @@
   - fielding_training_focus
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-7-6
   name: Cricket Nets
   children:
@@ -6114,13 +5268,7 @@
   - cricket_training_focus
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-7-6-2
   name: Cricket Batting Cages
   children: []
@@ -6130,13 +5278,7 @@
   - cricket_training_focus
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-7-6-3
   name: Barrier & Backstop Nets
   children: []
@@ -6146,13 +5288,7 @@
   - cricket_training_focus
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-7-7
   name: Cricket Pitch Mats
   children: []
@@ -6224,13 +5360,7 @@
   - cricket_training_focus
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-7-11
   name: Cricket Training Balls
   children: []
@@ -6240,13 +5370,7 @@
   - cricket_training_focus
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-8
   name: Cricket Shoes
   children: []
@@ -6286,13 +5410,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-10
   name: Cricket Clothing & Uniforms
   children: []
@@ -6300,13 +5418,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-11
   name: Cricket Shoe Accessories
   children: []
@@ -6314,13 +5426,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-8-12
   name: Mini Cricket Bats
   children: []
@@ -6328,13 +5434,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-9
   name: Dancing
   children:
@@ -6434,13 +5534,7 @@
   - sports_governing_body_certification
   - target_gender
   - toe_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-9-2-2
   name: Character Shoes
   children: []
@@ -6462,13 +5556,7 @@
   - sports_governing_body_certification
   - target_gender
   - toe_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-9-2-3
   name: Dance Sneakers
   children: []
@@ -6490,13 +5578,7 @@
   - sports_governing_body_certification
   - target_gender
   - toe_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-9-3
   name: Dance Protective Gear
   children: []
@@ -6504,13 +5586,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-9-4
   name: Dance Training Equipment
   children: []
@@ -6518,13 +5594,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-9-5
   name: Dance Poles
   children: []
@@ -6532,13 +5602,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-9-6
   name: Twirling Batons
   children: []
@@ -6546,13 +5610,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-9-7
   name: Dancing Grip Enhancers
   children: []
@@ -6560,13 +5618,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10
   name: Fencing
   children:
@@ -6674,13 +5726,7 @@
   - pattern
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10-1-2-2
   name: Fencing Gloves
   children: []
@@ -6694,13 +5740,7 @@
   - pattern
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10-1-3
   name: Fencing Jackets & Lamés
   children:
@@ -6739,13 +5779,7 @@
   - pattern
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10-1-3-2
   name: Fencing Jackets
   children: []
@@ -6759,13 +5793,7 @@
   - pattern
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10-1-4
   name: Fencing Masks
   children: []
@@ -6818,13 +5846,7 @@
   - fencing_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10-1-7
   name: Fencing Pants & Breeches
   children: []
@@ -6835,13 +5857,7 @@
   - fencing_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10-2
   name: Fencing Scoring Equipment
   children:
@@ -6876,13 +5892,7 @@
   - fencing_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10-2-2
   name: Fencing Reels
   children: []
@@ -6893,13 +5903,7 @@
   - fencing_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10-2-3
   name: Fencing Sockets & Plugs
   children: []
@@ -6910,13 +5914,7 @@
   - fencing_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10-2-4
   name: Fencing Scoring Machines
   children: []
@@ -6927,13 +5925,7 @@
   - fencing_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10-2-5
   name: Fencing Remote Displays
   children: []
@@ -6944,13 +5936,7 @@
   - fencing_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10-2-6
   name: Fencing Floor Cords
   children: []
@@ -6961,13 +5947,7 @@
   - fencing_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10-3
   name: Fencing Training Aids
   children:
@@ -7171,13 +6151,7 @@
   - fencing_weapon_type
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10-3-10
   name: Fencing Body Cord Accessories
   children: []
@@ -7188,13 +6162,7 @@
   - fencing_weapon_type
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10-4
   name: Fencing Weapons
   children:
@@ -7332,13 +6300,7 @@
   - hand_side
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10-4-4-2
   name: Fencing Sabre Blades
   children: []
@@ -7352,13 +6314,7 @@
   - hand_side
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10-4-5
   name: Fencing Foils
   children: []
@@ -7371,13 +6327,7 @@
   - hand_side
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-10-5
   name: Fencing Shoes
   children: []
@@ -7386,13 +6336,7 @@
   - fencing_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11
   name: Field Hockey & Lacrosse
   children:
@@ -7495,13 +6439,7 @@
   - protective_gear_safety_certifications
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-1-1-2
   name: Field Hockey Goalkeeper Gloves
   children: []
@@ -7515,13 +6453,7 @@
   - protective_gear_safety_certifications
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-1-1-3
   name: Lacrosse Gloves
   children: []
@@ -7535,13 +6467,7 @@
   - protective_gear_safety_certifications
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-1-2
   name: Field Hockey & Lacrosse Helmets
   children: []
@@ -7598,13 +6524,7 @@
   - pattern
   - protective_gear_safety_certifications
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-1-3-2
   name: Field Hockey & Lacrosse Goggles
   children: []
@@ -7616,13 +6536,7 @@
   - pattern
   - protective_gear_safety_certifications
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-1-4
   name: Field Hockey & Lacrosse Pads
   children:
@@ -7659,13 +6573,7 @@
   - pattern
   - protective_gear_safety_certifications
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-1-4-2
   name: Arm & Elbow Pads
   children: []
@@ -7676,13 +6584,7 @@
   - pattern
   - protective_gear_safety_certifications
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-1-4-3
   name: Goalie Leg Guards & Kickers
   children: []
@@ -7693,13 +6595,7 @@
   - pattern
   - protective_gear_safety_certifications
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-1-4-4
   name: Field Hockey & Lacrosse Shin Guards
   children: []
@@ -7710,13 +6606,7 @@
   - pattern
   - protective_gear_safety_certifications
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-1-4-5
   name: Field Hockey & Lacrosse Shoulder Pads & Chest Protectors
   children: []
@@ -7727,13 +6617,7 @@
   - pattern
   - protective_gear_safety_certifications
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-1-5
   name: Field Hockey & Lacrosse Mouthguards
   children: []
@@ -7744,13 +6628,7 @@
   - pattern
   - protective_gear_safety_certifications
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-1-6
   name: Field Hockey & Lacrosse Groin & Abdominal Protectors
   children: []
@@ -7761,13 +6639,7 @@
   - pattern
   - protective_gear_safety_certifications
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-1-7
   name: Field Hockey & Lacrosse Throat Guards
   children: []
@@ -7778,13 +6650,7 @@
   - pattern
   - protective_gear_safety_certifications
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-1-8
   name: Field Hockey & Lacrosse Goalie Pants & Shorts
   children: []
@@ -7795,13 +6661,7 @@
   - pattern
   - protective_gear_safety_certifications
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-1-9
   name: Field Hockey & Lacrosse Helmet Accessories
   children: []
@@ -7812,13 +6672,7 @@
   - pattern
   - protective_gear_safety_certifications
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-2
   name: Field Hockey Balls
   children: []
@@ -7896,13 +6750,7 @@
   - stick_bow_profile
   - stick_head_shape
   - stick_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-4-2
   name: Indoor Field Hockey Sticks
   children: []
@@ -7914,13 +6762,7 @@
   - stick_bow_profile
   - stick_head_shape
   - stick_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-5
   name: Field Hockey Training Aids
   children:
@@ -8060,13 +6902,7 @@
   - field_hockey_training_objective
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-5-5-2
   name: Field Hockey Stick Bags
   children: []
@@ -8076,13 +6912,7 @@
   - field_hockey_training_objective
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-5-5-3
   name: Field Hockey Ball Bags
   children: []
@@ -8092,13 +6922,7 @@
   - field_hockey_training_objective
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-5-6
   name: Field Hockey Training Balls
   children: []
@@ -8108,13 +6932,7 @@
   - field_hockey_training_objective
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-5-7
   name: Field Hockey Training Mats
   children: []
@@ -8124,13 +6942,7 @@
   - field_hockey_training_objective
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-6
   name: Lacrosse Balls
   children: []
@@ -8284,13 +7096,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-9-5
   name: Lacrosse Grip Tape
   children: []
@@ -8298,13 +7104,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-9-6
   name: Lacrosse Stick End Caps
   children: []
@@ -8312,13 +7112,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-9-7
   name: Lacrosse Stick Bags
   children: []
@@ -8326,13 +7120,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-10
   name: Lacrosse Sticks
   children:
@@ -8368,13 +7156,7 @@
   - sports_governing_body_certification
   - stick_material
   - strung_status
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-10-2
   name: Mini Lacrosse Sticks
   children: []
@@ -8386,13 +7168,7 @@
   - sports_governing_body_certification
   - stick_material
   - strung_status
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-11
   name: Lacrosse Training Aids
   children:
@@ -8464,13 +7240,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus_area
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-11-4
   name: Lacrosse Backstop Systems
   children: []
@@ -8480,13 +7250,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus_area
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-11-5
   name: Lacrosse Training Dummies
   children: []
@@ -8496,13 +7260,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus_area
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-12
   name: Field Hockey & Lacrosse Shoes
   children:
@@ -8557,13 +7315,7 @@
   - sports_governing_body_certification
   - target_gender
   - toe_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-12-2
   name: Lacrosse Cleats
   children: []
@@ -8583,13 +7335,7 @@
   - sports_governing_body_certification
   - target_gender
   - toe_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-13
   name: Field Hockey & Lacrosse Bags
   children: []
@@ -8597,13 +7343,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-11-14
   name: Field Hockey Equipment Sets
   children: []
@@ -8611,13 +7351,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12
   name: Figure Skating & Hockey
   children:
@@ -8828,13 +7562,7 @@
   - pattern
   - sports_governing_body_certification
   - training_surface_usage
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-1-7-2
   name: Dryland & Multi-Sport Training Tiles
   children: []
@@ -8844,13 +7572,7 @@
   - pattern
   - sports_governing_body_certification
   - training_surface_usage
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-1-8
   name: Figure Skating Jump Trainers
   children: []
@@ -8955,13 +7677,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-1-14
   name: Hockey Passing Trainer Accessories
   children: []
@@ -8970,13 +7686,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-2
   name: Hockey Balls & Pucks
   children:
@@ -9036,13 +7746,7 @@
   - pattern
   - playing_environment
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-2-1-2
   name: Street Hockey Balls
   children: []
@@ -9055,13 +7759,7 @@
   - pattern
   - playing_environment
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-2-2
   name: Hockey Pucks
   children: []
@@ -9093,13 +7791,7 @@
   - intended_playing_surface
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-3
   name: Hockey Goals
   children:
@@ -9133,13 +7825,7 @@
   - mounting_type
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-3-2
   name: Mini Hockey Goals
   children: []
@@ -9150,13 +7836,7 @@
   - mounting_type
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-3-3
   name: Hockey Goal Backstops
   children: []
@@ -9167,13 +7847,7 @@
   - mounting_type
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-4
   name: Hockey Protective Gear
   children:
@@ -9340,13 +8014,7 @@
   - pattern
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-4-5-2
   name: Hockey Goalie Pants
   children: []
@@ -9359,13 +8027,7 @@
   - pattern
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-4-6
   name: Hockey Shin Guards & Leg Pads
   children:
@@ -9402,13 +8064,7 @@
   - cut_resistance_rating
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-4-6-3
   name: Hockey Player Shin Guards
   children: []
@@ -9419,13 +8075,7 @@
   - cut_resistance_rating
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-4-6-4
   name: Hockey Goalie Leg Pads
   children: []
@@ -9436,13 +8086,7 @@
   - cut_resistance_rating
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-4-6-5
   name: Hockey Goalie Knee Guards
   children: []
@@ -9453,13 +8097,7 @@
   - cut_resistance_rating
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-4-7
   name: Hockey Shoulder Pads & Chest Protectors
   children:
@@ -9496,13 +8134,7 @@
   - hockey_size_segment
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-4-7-2
   name: Hockey Chest Protectors
   children: []
@@ -9514,13 +8146,7 @@
   - hockey_size_segment
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-4-8
   name: Hockey Suspenders & Belts
   children: []
@@ -9551,13 +8177,7 @@
   - cut_resistance_rating
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-4-10
   name: Hockey Jocks & Pelvic Protectors
   children: []
@@ -9566,13 +8186,7 @@
   - cut_resistance_rating
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-4-11
   name: Hockey Girdles
   children: []
@@ -9581,13 +8195,7 @@
   - cut_resistance_rating
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-4-12
   name: Hockey Neck Guards
   children: []
@@ -9596,13 +8204,7 @@
   - cut_resistance_rating
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-4-13
   name: Shin Guard Straps & Accessories
   children: []
@@ -9611,13 +8213,7 @@
   - cut_resistance_rating
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-5
   name: Hockey Sledges
   children: []
@@ -9747,13 +8343,7 @@
   - pattern
   - sports_governing_body_certification
   - stick_size_compatibility
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-6-6
   name: Hockey Stick Racks
   children: []
@@ -9762,13 +8352,7 @@
   - pattern
   - sports_governing_body_certification
   - stick_size_compatibility
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-7
   name: Hockey Stick Parts
   children:
@@ -9855,13 +8439,7 @@
   - kick_point
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-7-4
   name: Hockey Stick End Plugs & Extensions
   children: []
@@ -9873,13 +8451,7 @@
   - kick_point
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-8
   name: Hockey Sticks
   children: []
@@ -9987,13 +8559,7 @@
   - pattern
   - skate_blade_discipline
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-9-2-2
   name: Figure Skate Blades
   children: []
@@ -10003,13 +8569,7 @@
   - pattern
   - skate_blade_discipline
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-9-2-3
   name: Goalie Skate Blades
   children: []
@@ -10019,13 +8579,7 @@
   - pattern
   - skate_blade_discipline
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-9-2-4
   name: Speed Skate Blades
   children: []
@@ -10035,13 +8589,7 @@
   - pattern
   - skate_blade_discipline
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-9-3
   name: Ice Skate Sharpeners
   children:
@@ -10078,13 +8626,7 @@
   - pattern
   - radius_of_hollow
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-9-3-4
   name: Ice Skate Sharpening Wheels & Rings
   children: []
@@ -10096,13 +8638,7 @@
   - pattern
   - radius_of_hollow
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-9-3-5
   name: Skate Honing Stones & Deburring Tools
   children: []
@@ -10114,13 +8650,7 @@
   - pattern
   - radius_of_hollow
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-9-4
   name: Skate Blade Guards
   children: []
@@ -10168,13 +8698,7 @@
   - compatible_skating_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-9-7
   name: Skate Laces
   children: []
@@ -10183,13 +8707,7 @@
   - compatible_skating_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-9-8
   name: Skate Boot Covers
   children: []
@@ -10198,13 +8716,7 @@
   - compatible_skating_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-9-9
   name: Skate Blade Soakers
   children: []
@@ -10213,13 +8725,7 @@
   - compatible_skating_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-9-10
   name: Ice Skate Sharpener Parts & Accessories
   children: []
@@ -10228,13 +8734,7 @@
   - compatible_skating_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-10
   name: Ice Skates
   children:
@@ -10406,13 +8906,7 @@
   - shoe_size
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-10-6-2
   name: Long Track Speed Ice Skates
   children: []
@@ -10424,13 +8918,7 @@
   - shoe_size
   - sports_governing_body_certification
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-11
   name: Figure Skating & Hockey Equipment Bags
   children: []
@@ -10438,13 +8926,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-12-12
   name: Hockey Equipment Cleaners & Deodorizers
   children: []
@@ -10452,13 +8934,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13
   name: General Purpose Athletic Equipment
   children:
@@ -10626,13 +9102,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-3-5
   name: Ball Display Stands
   children: []
@@ -10641,13 +9111,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-4
   name: Ball Pump Accessories
   children:
@@ -10696,13 +9160,7 @@
   - hardware_material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-4-3
   name: Ball Pressure Gauges
   children: []
@@ -10712,13 +9170,7 @@
   - hardware_material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-4-4
   name: Ball Pump Hoses
   children: []
@@ -10728,13 +9180,7 @@
   - hardware_material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-5
   name: Ball Pumps
   children: []
@@ -10906,13 +9352,7 @@
   - mat_style
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-9-2
   name: Interlocking Gym Floor Tiles
   children: []
@@ -10923,13 +9363,7 @@
   - mat_style
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-9-3
   name: Wall Pads
   children: []
@@ -10940,13 +9374,7 @@
   - mat_style
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-10
   name: Practice Nets & Screens
   children:
@@ -10976,13 +9404,7 @@
   - net_material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-10-2
   name: Rebounder Nets
   children: []
@@ -10992,13 +9414,7 @@
   - net_material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-10-3
   name: Replacement & Bulk Netting
   children: []
@@ -11008,13 +9424,7 @@
   - net_material
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-11
   name: Speed & Agility Ladders & Hurdles
   children:
@@ -11042,13 +9452,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-11-2
   name: Agility Training Poles & Gates
   children: []
@@ -11056,13 +9460,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-11-3
   name: Agility Ladders
   children: []
@@ -11070,13 +9468,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-12
   name: Sports & Agility Cones
   children: []
@@ -11202,13 +9594,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-16
   name: Training Bibs
   children: []
@@ -11235,13 +9621,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-18
   name: Athletic Tape & Wraps
   children: []
@@ -11249,13 +9629,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-19
   name: Athletic Supporters
   children: []
@@ -11263,13 +9637,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-20
   name: Sports Water Bottles
   children: []
@@ -11277,13 +9645,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-21
   name: Column Pads
   children: []
@@ -11291,13 +9653,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-22
   name: Altitude Training Mask Accessories
   children: []
@@ -11305,13 +9661,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-13-23
   name: Athletic Cup Accessories
   children: []
@@ -11319,13 +9669,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14
   name: Gymnastics
   children:
@@ -11382,13 +9726,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-1-2
   name: Gymnastics Equipment Packages
   children: []
@@ -11397,13 +9735,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-1-3
   name: Parallel Bars
   children: []
@@ -11412,13 +9744,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-2
   name: Gymnastics Protective Gear
   children:
@@ -11476,13 +9802,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-2-3
   name: Gymnastics Wrist Supports
   children: []
@@ -11494,13 +9814,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-2-4
   name: Gymnastics Wristbands
   children: []
@@ -11512,13 +9826,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-2-5
   name: Gymnastics Ankle & Heel Protectors
   children: []
@@ -11530,13 +9838,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-2-6
   name: Gymnastics Knee Pads
   children: []
@@ -11548,13 +9850,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-3
   name: Gymnastics Rings
   children: []
@@ -11672,13 +9968,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-5-2-2
   name: Gymnastics Air Tracks
   children: []
@@ -11688,13 +9978,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-5-2-3
   name: Gymnastics Incline Mats
   children: []
@@ -11704,13 +9988,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-5-3
   name: Gymnastics Foam Pits
   children: []
@@ -11761,13 +10039,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-5-4-2
   name: Pommel Bucks
   children: []
@@ -11777,13 +10049,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-5-5
   name: Gymnastics Spotting Blocks
   children: []
@@ -11851,13 +10117,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-5-8
   name: Gymnastics Vault Safety Mats
   children: []
@@ -11867,13 +10127,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-6
   name: Pommel Horses
   children: []
@@ -11902,13 +10156,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-8
   name: Gymnastics Shoes
   children: []
@@ -11917,13 +10165,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-9
   name: Gymnastics Vaulting Tables
   children: []
@@ -11932,13 +10174,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-10
   name: Gymnastics Accessories & Gifts
   children: []
@@ -11947,13 +10183,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-14-11
   name: Gymnastics Springboard Accessories
   children: []
@@ -11962,13 +10192,7 @@
   - gymnastics_discipline
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-15
   name: Racquetball & Squash
   children:
@@ -12031,13 +10255,7 @@
   - pattern
   - sport
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-15-1-2
   name: Squash Balls
   children: []
@@ -12050,13 +10268,7 @@
   - pattern
   - sport
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-15-2
   name: Racquetball & Squash Eyewear
   children: []
@@ -12279,13 +10491,7 @@
   - pattern
   - racquetball_squash_training_aid_type
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-15-4-7-2
   name: Racquetball & Squash Racket Bags
   children: []
@@ -12295,13 +10501,7 @@
   - pattern
   - racquetball_squash_training_aid_type
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-15-4-8
   name: Racquetball & Squash Training Goggles
   children: []
@@ -12330,13 +10530,7 @@
   - pattern
   - racquetball_squash_training_aid_type
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-15-4-11
   name: Racquetball & Squash Ball Machines
   children: []
@@ -12346,13 +10540,7 @@
   - pattern
   - racquetball_squash_training_aid_type
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-15-4-12
   name: Racquetball & Squash Protective Tape & Guards
   children: []
@@ -12362,13 +10550,7 @@
   - pattern
   - racquetball_squash_training_aid_type
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-15-4-13
   name: Racquetball & Squash Swing Trainers
   children: []
@@ -12378,13 +10560,7 @@
   - pattern
   - racquetball_squash_training_aid_type
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-15-5
   name: Racquetball Rackets
   children: []
@@ -12471,13 +10647,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-15-9
   name: Racquetball & Squash Cleaning Accessories
   children: []
@@ -12485,13 +10655,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-16
   name: Rounders
   children:
@@ -12659,13 +10823,7 @@
   - rounders_equipment_included
   - rounders_governing_body_approval
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-16-3-5
   name: Rounders Pitching Machines
   children: []
@@ -12676,13 +10834,7 @@
   - rounders_equipment_included
   - rounders_governing_body_approval
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-16-4
   name: Rounders Balls
   children: []
@@ -12692,13 +10844,7 @@
   - pattern
   - rounders_governing_body_approval
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-16-5
   name: Rounders Protective Gear
   children: []
@@ -12708,13 +10854,7 @@
   - pattern
   - rounders_governing_body_approval
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-16-6
   name: Rounders Sets
   children: []
@@ -12724,13 +10864,7 @@
   - pattern
   - rounders_governing_body_approval
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-16-7
   name: Rounders Bases
   children: []
@@ -12740,13 +10874,7 @@
   - pattern
   - rounders_governing_body_approval
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-17
   name: Rugby
   children:
@@ -12905,13 +11033,7 @@
   - rugby_headgear_safety_certification
   - rugby_variant
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-17-4-3
   name: Rugby Mouthguards
   children: []
@@ -12925,13 +11047,7 @@
   - rugby_headgear_safety_certification
   - rugby_variant
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-17-4-4
   name: Rugby Protective Shorts & Thigh Guards
   children: []
@@ -12945,13 +11061,7 @@
   - rugby_headgear_safety_certification
   - rugby_variant
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-17-4-5
   name: Rugby Body Armor & Shoulder Pads
   children: []
@@ -12965,13 +11075,7 @@
   - rugby_headgear_safety_certification
   - rugby_variant
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-17-4-6
   name: Rugby Arm Guards
   children: []
@@ -12985,13 +11089,7 @@
   - rugby_headgear_safety_certification
   - rugby_variant
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-17-5
   name: Rugby Training Aids
   children:
@@ -13075,13 +11173,7 @@
   - rugby_size
   - rugby_variant
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-17-5-4
   name: Rugby Tag Belts
   children: []
@@ -13092,13 +11184,7 @@
   - rugby_size
   - rugby_variant
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-17-5-5
   name: Rugby Lineout Lifting Blocks
   children: []
@@ -13109,13 +11195,7 @@
   - rugby_size
   - rugby_variant
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-17-5-6
   name: Rugby Tackle Shields
   children: []
@@ -13126,13 +11206,7 @@
   - rugby_size
   - rugby_variant
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-17-5-7
   name: Rugby Grip Enhancers
   children: []
@@ -13143,13 +11217,7 @@
   - rugby_size
   - rugby_variant
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-17-5-8
   name: Rugby Scrum Machines
   children: []
@@ -13160,13 +11228,7 @@
   - rugby_size
   - rugby_variant
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-17-5-9
   name: Rugby Rebounders
   children: []
@@ -13177,13 +11239,7 @@
   - rugby_size
   - rugby_variant
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-17-6
   name: Rugby Shoes
   children: []
@@ -13225,13 +11281,7 @@
   - pattern
   - rugby_variant
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-17-8
   name: Rugby Bags
   children: []
@@ -13240,13 +11290,7 @@
   - pattern
   - rugby_variant
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-17-9
   name: Rugby Post Accessories
   children: []
@@ -13255,13 +11299,7 @@
   - pattern
   - rugby_variant
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18
   name: Soccer
   children:
@@ -13342,13 +11380,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18-2-2
   name: Soccer Corner Flag Bases
   children: []
@@ -13356,13 +11388,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18-3
   name: Soccer Gloves
   children:
@@ -13405,13 +11431,7 @@
   - sports_governing_body_certification
   - target_gender
   - wrist_strap_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18-3-2
   name: Soccer Field Player Gloves
   children: []
@@ -13426,13 +11446,7 @@
   - sports_governing_body_certification
   - target_gender
   - wrist_strap_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18-4
   name: Soccer Goal Accessories
   children:
@@ -13586,13 +11600,7 @@
   - pattern
   - soccer_goal_target_style
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18-4-6-2
   name: Soccer Goal Corner Targets
   children: []
@@ -13601,13 +11609,7 @@
   - pattern
   - soccer_goal_target_style
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18-4-7
   name: Soccer Goal Bags & Covers
   children: []
@@ -13615,13 +11617,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18-4-8
   name: Soccer Goal Wheel Kits
   children: []
@@ -13629,13 +11625,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18-4-9
   name: Soccer Goal Post Pads
   children: []
@@ -13643,13 +11633,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18-4-10
   name: Soccer Goal Lighting
   children: []
@@ -13657,13 +11641,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18-4-11
   name: Soccer Goal Replacement Parts
   children: []
@@ -13671,13 +11649,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18-5
   name: Soccer Goals
   children: []
@@ -13796,13 +11768,7 @@
   - pattern
   - shin_guard_attachment_method
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18-6-2
   name: Soccer Goalkeeper Protective Tops
   children: []
@@ -13812,13 +11778,7 @@
   - pattern
   - shin_guard_attachment_method
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18-6-3
   name: Soccer Knee & Elbow Pads
   children: []
@@ -13828,13 +11788,7 @@
   - pattern
   - shin_guard_attachment_method
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18-6-4
   name: Soccer Head & Face Guards
   children: []
@@ -13844,13 +11798,7 @@
   - pattern
   - shin_guard_attachment_method
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18-6-5
   name: Soccer Goalkeeper Protective Bottoms
   children: []
@@ -13860,13 +11808,7 @@
   - pattern
   - shin_guard_attachment_method
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18-7
   name: Soccer Training Aids
   children:
@@ -14020,13 +11962,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-18-8
   name: Soccer Shoes
   children: []
@@ -14066,13 +12002,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-19
   name: Team Handball
   children:
@@ -14288,13 +12218,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-19-2-9
   name: Team Handball Grip Resins
   children: []
@@ -14304,13 +12228,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-19-2-10
   name: Team Handball Agility Ladders & Hurdles
   children: []
@@ -14320,13 +12238,7 @@
   - pattern
   - sports_governing_body_certification
   - training_focus
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-19-3
   name: Team Handball Protective Gear
   children: []
@@ -14334,13 +12246,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-20
   name: Tennis
   children:
@@ -14398,13 +12304,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-20-1-2
   name: Tennis Ball Carts & Trolleys
   children: []
@@ -14413,13 +12313,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-20-1-3
   name: Tennis Ball Baskets & Hoppers
   children: []
@@ -14428,13 +12322,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-20-2
   name: Tennis Ball Machines
   children: []
@@ -14682,13 +12570,7 @@
   - sports_governing_body_certification
   - tape_material
   - tape_purpose
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-20-6-3-3-2
   name: Tennis Racket Lead & Tuning Tape
   children: []
@@ -14700,13 +12582,7 @@
   - sports_governing_body_certification
   - tape_material
   - tape_purpose
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-20-6-4
   name: Tennis Racket Grommets
   children: []
@@ -14755,13 +12631,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-20-6-7
   name: Tennis Racket Covers
   children: []
@@ -14771,13 +12641,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-20-6-8
   name: String Stencil Ink & Cards
   children: []
@@ -14787,13 +12651,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-20-7
   name: Tennis Rackets
   children: []
@@ -14938,13 +12796,7 @@
   - rebounder_design_type
   - sports_governing_body_certification
   - training_objective
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-20-8-4-2
   name: Tennis Rebound Nets
   children: []
@@ -14956,13 +12808,7 @@
   - rebounder_design_type
   - sports_governing_body_certification
   - training_objective
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-20-8-5
   name: Tennis Target Trainers
   children: []
@@ -15010,13 +12856,7 @@
   - pattern
   - sports_governing_body_certification
   - training_objective
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-20-8-8
   name: Tennis Net Height Gauges
   children: []
@@ -15026,13 +12866,7 @@
   - pattern
   - sports_governing_body_certification
   - training_objective
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-20-8-9
   name: Tennis Serve Trainers
   children: []
@@ -15042,13 +12876,7 @@
   - pattern
   - sports_governing_body_certification
   - training_objective
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-20-9
   name: Tennis Shoes
   children: []
@@ -15087,13 +12915,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-21
   name: Track & Field
   children:
@@ -15241,13 +13063,7 @@
   - pattern
   - sports_governing_body_certification
   - track_and_field_discipline
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-21-5-2
   name: Pole Vault Pit Safety Inserts
   children: []
@@ -15256,13 +13072,7 @@
   - pattern
   - sports_governing_body_certification
   - track_and_field_discipline
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-21-6
   name: Relay Batons
   children: []
@@ -15465,13 +13275,7 @@
   - sports_governing_body_certification
   - track_and_field_discipline
   - track_field_event_suitability
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-21-10-6
   name: Track & Field Training Plans
   children: []
@@ -15482,13 +13286,7 @@
   - sports_governing_body_certification
   - track_and_field_discipline
   - track_field_event_suitability
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-21-10-7
   name: Track & Field Run-Up Markers
   children: []
@@ -15499,13 +13297,7 @@
   - sports_governing_body_certification
   - track_and_field_discipline
   - track_field_event_suitability
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-21-10-8
   name: Track & Field Tape Measures
   children: []
@@ -15516,13 +13308,7 @@
   - sports_governing_body_certification
   - track_and_field_discipline
   - track_field_event_suitability
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-21-11
   name: Track Hurdles
   children: []
@@ -15612,13 +13398,7 @@
   - pattern
   - sports_governing_body_certification
   - track_and_field_discipline
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-21-16
   name: Shot Put Accessories
   children: []
@@ -15627,13 +13407,7 @@
   - pattern
   - sports_governing_body_certification
   - track_and_field_discipline
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-21-17
   name: Track Hurdle Replacement Parts
   children: []
@@ -15642,13 +13416,7 @@
   - pattern
   - sports_governing_body_certification
   - track_and_field_discipline
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-21-18
   name: Track Starting Block Accessories
   children: []
@@ -15657,13 +13425,7 @@
   - pattern
   - sports_governing_body_certification
   - track_and_field_discipline
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-22
   name: Volleyball
   children:
@@ -15763,13 +13525,7 @@
   - pattern
   - protective_gear_padding_type
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-22-2-3
   name: Volleyball Ankle Braces
   children: []
@@ -15780,13 +13536,7 @@
   - pattern
   - protective_gear_padding_type
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-22-2-4
   name: Volleyball Arm & Forearm Sleeves
   children: []
@@ -15797,13 +13547,7 @@
   - pattern
   - protective_gear_padding_type
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-22-2-5
   name: Volleyball Elbow Pads
   children: []
@@ -15814,13 +13558,7 @@
   - pattern
   - protective_gear_padding_type
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-22-2-6
   name: Volleyball Protective Shorts
   children: []
@@ -15831,13 +13569,7 @@
   - pattern
   - protective_gear_padding_type
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-22-3
   name: Volleyball Training Aids
   children:
@@ -15908,13 +13640,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-22-3-4
   name: Volleyball Footwork Trainers
   children: []
@@ -15923,13 +13649,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-22-3-5
   name: Volleyball Rebounders
   children: []
@@ -15938,13 +13658,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-22-3-6
   name: Volleyball Passing Trainers
   children: []
@@ -15953,13 +13667,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-22-3-7
   name: Volleyball Spike Trainers
   children: []
@@ -15968,13 +13676,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-22-4
   name: Volleyballs
   children: []
@@ -16005,13 +13707,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-22-6
   name: Volleyball Posts
   children: []
@@ -16019,13 +13715,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-22-7
   name: Volleyball Net Accessories
   children: []
@@ -16033,13 +13723,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-23
   name: Wallyball Equipment
   children:
@@ -16394,13 +14078,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-24-6
   name: Water Polo Swimwear
   children: []
@@ -16408,13 +14086,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-25
   name: Wrestling
   children:
@@ -16509,13 +14181,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-25-1-4
   name: Wrestling Groin Guards
   children: []
@@ -16524,13 +14190,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-25-1-5
   name: Wrestling Shin Guards
   children: []
@@ -16539,13 +14199,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-25-1-6
   name: Wrestling Elbow Pads
   children: []
@@ -16554,13 +14208,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-25-1-7
   name: Wrestling Ankle Guards
   children: []
@@ -16569,13 +14217,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-25-1-8
   name: Wrestling Headgear Accessories
   children: []
@@ -16584,13 +14226,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-25-2
   name: Wrestling Training Aids
   children:
@@ -16796,13 +14432,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-25-2-12
   name: Wrestling Leg Sleeves
   children: []
@@ -16811,13 +14441,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-26
   name: Curling
   children:
@@ -16927,13 +14551,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-27
   name: Gaelic Games (GAA)
   children:
@@ -17162,13 +14780,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-29
   name: Ultimate Frisbee
   children: []
@@ -17176,13 +14788,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-30
   name: Triathlon
   children: []
@@ -17190,13 +14796,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-31
   name: Netball
   children: []
@@ -17204,13 +14804,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-1-32
   name: Beach Tennis
   children: []
@@ -17218,13 +14812,7 @@
   - color
   - pattern
   - sports_governing_body_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2
   name: Fitness & General Exercise Equipment
   children:
@@ -17449,13 +15037,7 @@
   - color
   - floor_surface_compatibility
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-3-6
   name: Balance Pods
   children: []
@@ -17463,13 +15045,7 @@
   - color
   - floor_surface_compatibility
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-3-7
   name: Sliding Discs
   children: []
@@ -17477,13 +15053,7 @@
   - color
   - floor_surface_compatibility
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4
   name: Cardio
   children:
@@ -17591,13 +15161,7 @@
   - color
   - elliptical_trainer_part_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-1-4
   name: Elliptical Trainer Bottle Holders
   children: []
@@ -17605,13 +15169,7 @@
   - color
   - elliptical_trainer_part_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-1-5
   name: Elliptical Trainer Covers
   children: []
@@ -17619,13 +15177,7 @@
   - color
   - elliptical_trainer_part_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-1-6
   name: Elliptical Trainer Heart Rate Monitors
   children: []
@@ -17633,13 +15185,7 @@
   - color
   - elliptical_trainer_part_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-1-7
   name: Elliptical Trainer Drive Belts
   children: []
@@ -17647,13 +15193,7 @@
   - color
   - elliptical_trainer_part_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-2
   name: Exercise Bike Accessories & Parts
   children:
@@ -17808,13 +15348,7 @@
   - compatible_exercise_bike_style
   - exercise_bike_accessory_part_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-2-8
   name: Exercise Bike Seats
   children: []
@@ -17825,13 +15359,7 @@
   - compatible_exercise_bike_style
   - exercise_bike_accessory_part_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-2-9
   name: Exercise Bike Tablet Holders
   children: []
@@ -17842,13 +15370,7 @@
   - compatible_exercise_bike_style
   - exercise_bike_accessory_part_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-2-10
   name: Exercise Bike Pedals
   children: []
@@ -17859,13 +15381,7 @@
   - compatible_exercise_bike_style
   - exercise_bike_accessory_part_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-3
   name: Rowing Machine Accessories & Parts
   children:
@@ -17928,65 +15444,35 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-3-4
   name: Rowing Machine Stands & Elevation Kits
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-3-5
   name: Rowing Machine Covers
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-3-6
   name: Rowing Machine Storage Racks & Hangers
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-3-7
   name: Rowing Machine Cleaners & Water Treatments
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-4
   name: Stair Climber & Stepper Accessories & Parts
   children:
@@ -18046,39 +15532,21 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-4-4
   name: Stair Climber & Stepper Covers
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-4-5
   name: Stair Climber & Stepper Laptop Stands
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-5
   name: Treadmill Accessories & Parts
   children:
@@ -18310,13 +15778,7 @@
   - pattern
   - treadmill_part_type
   - treadmill_position
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-5-11-2
   name: Treadmill Incline Motors
   children: []
@@ -18326,13 +15788,7 @@
   - pattern
   - treadmill_part_type
   - treadmill_position
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-5-12
   name: Treadmill Speed Sensors
   children: []
@@ -18388,13 +15844,7 @@
   - color
   - compatible_treadmill_design
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-5-16
   name: Treadmill Remote Controls
   children: []
@@ -18402,13 +15852,7 @@
   - color
   - compatible_treadmill_design
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-5-17
   name: Treadmill Lubricants
   children: []
@@ -18416,13 +15860,7 @@
   - color
   - compatible_treadmill_design
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-5-18
   name: Treadmill Covers
   children: []
@@ -18430,13 +15868,7 @@
   - color
   - compatible_treadmill_design
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-1-6
   name: Rebounder & Mini Trampoline Accessories & Parts
   children: []
@@ -18444,13 +15876,7 @@
   - color
   - compatible_cardio_machine_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-2
   name: Cardio Machines
   children:
@@ -18538,13 +15964,7 @@
   - drive_location
   - incline_adjustment_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-2-1-2-2
   name: Under-Desk Magnetic Elliptical Trainers
   children: []
@@ -18553,13 +15973,7 @@
   - drive_location
   - incline_adjustment_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-2-2
   name: Exercise Bikes
   children:
@@ -18771,13 +16185,7 @@
   - exercise_machine_features
   - motor_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-2-5-2
   name: Commercial Treadmills
   children: []
@@ -18788,13 +16196,7 @@
   - exercise_machine_features
   - motor_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-2-5-3
   name: Under-Desk Treadmills
   children: []
@@ -18805,52 +16207,28 @@
   - exercise_machine_features
   - motor_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-2-6
   name: Ski Trainers
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-2-7
   name: Vertical Climbers
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-2-8
   name: Rope Trainers
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-4-3
   name: Jump Ropes
   children: []
@@ -18880,13 +16258,7 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-5
   name: Exercise Balls
   children: []
@@ -18932,13 +16304,7 @@
   - color
   - pattern
   - resistance_level
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-6-2
   name: Hip Circle Resistance Bands
   children: []
@@ -18946,13 +16312,7 @@
   - color
   - pattern
   - resistance_level
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-6-3
   name: Resistance Tubes
   children: []
@@ -18960,13 +16320,7 @@
   - color
   - pattern
   - resistance_level
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-6-4
   name: Flat Resistance Bands
   children: []
@@ -18974,13 +16328,7 @@
   - color
   - pattern
   - resistance_level
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-7
   name: Exercise Benches
   children:
@@ -19010,13 +16358,7 @@
   - color
   - compatible_bench_positions
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-7-2
   name: Adjustable Exercise Benches
   children: []
@@ -19024,13 +16366,7 @@
   - color
   - compatible_bench_positions
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-7-3
   name: Hyperextension Benches & Roman Chairs
   children: []
@@ -19038,13 +16374,7 @@
   - color
   - compatible_bench_positions
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-7-4
   name: Abdominal & Sit Up Benches
   children: []
@@ -19052,13 +16382,7 @@
   - color
   - compatible_bench_positions
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-7-5
   name: Flat Weight Benches
   children: []
@@ -19066,13 +16390,7 @@
   - color
   - compatible_bench_positions
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-8
   name: Exercise Equipment Mats
   children:
@@ -19326,52 +16644,28 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-11-7
   name: Foam Roller End Caps
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-11-8
   name: Foam Roller Storage Carts
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-11-9
   name: Foam Roller Storage Racks
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-12
   name: Foam Rollers
   children: []
@@ -19423,13 +16717,7 @@
   - counter_type
   - hand_exerciser_style
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-13-2
   name: Finger Extensor Exercisers & Stretchers
   children: []
@@ -19438,13 +16726,7 @@
   - counter_type
   - hand_exerciser_style
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-13-3
   name: Hand Grippers
   children: []
@@ -19453,13 +16735,7 @@
   - counter_type
   - hand_exerciser_style
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-13-4
   name: Power Twister Bars
   children: []
@@ -19468,13 +16744,7 @@
   - counter_type
   - hand_exerciser_style
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-13-5
   name: Grip Rings & Stress Balls
   children: []
@@ -19483,13 +16753,7 @@
   - counter_type
   - hand_exerciser_style
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-14
   name: Inversion Tables & Systems
   children:
@@ -19518,13 +16782,7 @@
   - color
   - pattern
   - therapeutic_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-14-2
   name: Inversion Tables & Benches
   children: []
@@ -19532,13 +16790,7 @@
   - color
   - pattern
   - therapeutic_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-14-4
   name: Inversion Racks & Bars
   children: []
@@ -19546,13 +16798,7 @@
   - color
   - pattern
   - therapeutic_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-14-5
   name: Inversion Boots
   children: []
@@ -19560,13 +16806,7 @@
   - color
   - pattern
   - therapeutic_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-15
   name: Medicine Balls
   children:
@@ -19756,13 +16996,7 @@
   - material
   - pattern
   - push_up_bar_design
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-17-2
   name: Dip & Parallette Bars
   children: []
@@ -19772,13 +17006,7 @@
   - material
   - pattern
   - push_up_bar_design
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-17-3
   name: Pull Up Bars
   children: []
@@ -19788,13 +17016,7 @@
   - material
   - pattern
   - push_up_bar_design
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-18
   name: Reaction Balls
   children: []
@@ -19912,13 +17134,7 @@
   - material
   - mounting_location
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-20-2-2
   name: Reflective Sprays & Paints
   children: []
@@ -19931,13 +17147,7 @@
   - material
   - mounting_location
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-20-2-3
   name: Reflective Stickers & Decals
   children: []
@@ -19950,13 +17160,7 @@
   - material
   - mounting_location
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-20-2-4
   name: Reflective Belts & Harnesses
   children: []
@@ -19969,13 +17173,7 @@
   - material
   - mounting_location
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-21
   name: Stopwatches
   children: []
@@ -20414,13 +17612,7 @@
   - material
   - pattern
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-1-2-2
   name: Multi-Purpose Storage Racks
   children: []
@@ -20430,13 +17622,7 @@
   - material
   - pattern
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-1-2-3
   name: Kettlebell Racks
   children: []
@@ -20446,13 +17632,7 @@
   - material
   - pattern
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-1-2-4
   name: Weight Plate Trees
   children: []
@@ -20462,13 +17642,7 @@
   - material
   - pattern
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-1-2-5
   name: Dumbbell Racks
   children: []
@@ -20478,13 +17652,7 @@
   - material
   - pattern
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-1-3
   name: Weight Bar Collars
   children: []
@@ -20514,13 +17682,7 @@
   - material
   - pattern
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-1-5
   name: Barbell Pads
   children: []
@@ -20529,13 +17691,7 @@
   - material
   - pattern
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-1-6
   name: Weight Lifting Chains
   children: []
@@ -20544,13 +17700,7 @@
   - material
   - pattern
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-1-7
   name: Barbell Jacks
   children: []
@@ -20559,13 +17709,7 @@
   - material
   - pattern
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-2
   name: Free Weights, Dumbbells & Kettlebells
   children:
@@ -20665,13 +17809,7 @@
   - sandbag_style
   - weight_adjustability
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-2-3-2
   name: Strongman Sandbags
   children: []
@@ -20682,13 +17820,7 @@
   - sandbag_style
   - weight_adjustability
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-2-3-3
   name: Power Bags
   children: []
@@ -20699,13 +17831,7 @@
   - sandbag_style
   - weight_adjustability
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-2-4
   name: Weight Plates
   children: []
@@ -20737,13 +17863,7 @@
   - pattern
   - weight_adjustability
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-2-6
   name: Weighted Clubs & Maces
   children: []
@@ -20753,13 +17873,7 @@
   - pattern
   - weight_adjustability
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-3
   name: Weight Lifting Belts
   children: []
@@ -20827,13 +17941,7 @@
   - pattern
   - target_gender
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-4-2
   name: Weight Lifting Wrist Wraps
   children: []
@@ -20849,13 +17957,7 @@
   - pattern
   - target_gender
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-4-3
   name: Weight Lifting Gloves
   children: []
@@ -20871,13 +17973,7 @@
   - pattern
   - target_gender
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-4-4
   name: Weight Lifting Straps
   children: []
@@ -20893,13 +17989,7 @@
   - pattern
   - target_gender
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-5
   name: Weight Lifting Machine & Exercise Bench Accessories
   children:
@@ -20978,13 +18068,7 @@
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-5-2-2
   name: Tricep Ropes
   children: []
@@ -20994,13 +18078,7 @@
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-5-2-3
   name: Single Grip & Stirrup Handles
   children: []
@@ -21010,13 +18088,7 @@
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-5-3
   name: Weights
   children:
@@ -21048,13 +18120,7 @@
   - targeted_muscle_group
   - weight_plate_style
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-5-3-2
   name: Weight Stack Adapter Plates
   children: []
@@ -21064,13 +18130,7 @@
   - targeted_muscle_group
   - weight_plate_style
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-5-4
   name: Replacement Parts & Hardware
   children: []
@@ -21079,13 +18139,7 @@
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-5-5
   name: Weight Lifting Machine Pulleys
   children: []
@@ -21094,13 +18148,7 @@
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-5-6
   name: Pads & Cushions
   children: []
@@ -21109,13 +18157,7 @@
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-5-7
   name: Weight Stack Selector Pins
   children: []
@@ -21124,13 +18166,7 @@
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-5-8
   name: Machine & Bench Attachments
   children: []
@@ -21139,13 +18175,7 @@
   - pattern
   - targeted_muscle_group
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-6
   name: Weight Lifting Machines & Racks
   children:
@@ -21205,13 +18235,7 @@
   - pull_up_bar
   - safety_mechanism_type
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-6-1-2
   name: Power Rack Attachments
   children: []
@@ -21225,13 +18249,7 @@
   - pull_up_bar
   - safety_mechanism_type
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-6-2
   name: Smith Machines
   children: []
@@ -21291,13 +18309,7 @@
   - pattern
   - pull_up_bar
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-6-3-2
   name: Functional Trainers
   children: []
@@ -21309,13 +18321,7 @@
   - pattern
   - pull_up_bar
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-6-3-3
   name: Multi-Station Home Gyms
   children: []
@@ -21327,13 +18333,7 @@
   - pattern
   - pull_up_bar
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-6-3-4
   name: Lat Pulldown Machines
   children: []
@@ -21345,13 +18345,7 @@
   - pattern
   - pull_up_bar
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-6-4
   name: Weight Lifting Racks
   children: []
@@ -21379,13 +18373,7 @@
   - color
   - pattern
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-8
   name: Weight Lifting Support Sleeves
   children: []
@@ -21393,13 +18381,7 @@
   - color
   - pattern
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-9
   name: Weight Lifting Singlets
   children: []
@@ -21407,13 +18389,7 @@
   - color
   - pattern
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-10
   name: Weight Lifting Belt Accessories
   children: []
@@ -21421,13 +18397,7 @@
   - color
   - pattern
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-24-11
   name: Ankle & Wrist Straps
   children: []
@@ -21435,13 +18405,7 @@
   - color
   - pattern
   - weightlifting_federation_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-25
   name: Weighted Clothing
   children:
@@ -21582,13 +18546,7 @@
   - color
   - pattern
   - pedal_configuration
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-26-1-2
   name: Pilates Reformers
   children:
@@ -21612,13 +18570,7 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-26-1-3
   name: Pilates Towers
   children:
@@ -21646,13 +18598,7 @@
   - color
   - included_components
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-26-1-3-2
   name: Pilates Tower Accessories
   children: []
@@ -21660,13 +18606,7 @@
   - color
   - included_components
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-26-1-3-3
   name: Pilates Tower Conversion Kits
   children: []
@@ -21674,39 +18614,21 @@
   - color
   - included_components
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-26-1-4
   name: Pilates Barrels
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-26-1-5
   name: Pilates Cadillacs
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-26-2
   name: Yoga & Pilates Blocks
   children: []
@@ -21823,143 +18745,77 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-26-7
   name: Yoga Wheels
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-26-8
   name: Yoga & Pilates Blankets
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-26-9
   name: Yoga & Pilates Bolsters & Cushions
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-26-10
   name: Yoga & Pilates Balls
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-26-11
   name: Yoga & Pilates Stretch Straps & Bands
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-27
   name: Ice Baths & Cold Plunge Tubs
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-28
   name: Battle Ropes
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-29
   name: Shaker Bottles
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-30
   name: Ab Mats
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-2-31
   name: Plyometric Boxes
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3
   name: Indoor Games
   children:
@@ -22201,13 +19057,7 @@
   - material
   - pattern
   - table_hockey_part_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-1-2-7
   name: Air Hockey Table Blowers
   children: []
@@ -22217,13 +19067,7 @@
   - material
   - pattern
   - table_hockey_part_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-1-2-8
   name: Air Hockey Table Electronics & Sensors
   children: []
@@ -22233,13 +19077,7 @@
   - material
   - pattern
   - table_hockey_part_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-1-3
   name: Air Hockey Tables
   children: []
@@ -22419,13 +19257,7 @@
   - color
   - cue_thread_size
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-2-3-5
   name: Billiard Cue Tip Tools
   children: []
@@ -22434,13 +19266,7 @@
   - color
   - cue_thread_size
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-2-3-6
   name: Billiard Cue Extensions
   children: []
@@ -22449,13 +19275,7 @@
   - color
   - cue_thread_size
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-2-4
   name: Billiard Cues & Bridges
   children:
@@ -22517,13 +19337,7 @@
   - material
   - pattern
   - piece_configuration
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-2-4-1-2
   name: Billiard Bridge Sticks
   children: []
@@ -22536,13 +19350,7 @@
   - material
   - pattern
   - piece_configuration
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-2-4-2
   name: Billiard Cues
   children: []
@@ -22770,13 +19578,7 @@
   - cue_sport_compatibility
   - cushion_rubber_profile
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-2-7-6
   name: Billiard Table Rail Sets
   children: []
@@ -22786,13 +19588,7 @@
   - cue_sport_compatibility
   - cushion_rubber_profile
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-2-7-7
   name: Billiard Table Conversion Tops
   children: []
@@ -22802,13 +19598,7 @@
   - cue_sport_compatibility
   - cushion_rubber_profile
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-2-7-8
   name: Billiard Table Hardware & Fasteners
   children: []
@@ -22818,13 +19608,7 @@
   - cue_sport_compatibility
   - cushion_rubber_profile
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-2-7-9
   name: Billiard Table Cushion Rubber
   children: []
@@ -22834,13 +19618,7 @@
   - cue_sport_compatibility
   - cushion_rubber_profile
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-2-8
   name: Billiard Tables
   children: []
@@ -22868,13 +19646,7 @@
   - billiards_discipline
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-2-10
   name: Billiard Training & Instruction
   children: []
@@ -22882,13 +19654,7 @@
   - billiards_discipline
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-3
   name: Bowling
   children:
@@ -22944,52 +19710,28 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-3-1-2
   name: Bowling Ball Backpacks
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-3-1-3
   name: Bowling Ball Roller Bags
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-3-1-4
   name: Bowling Ball Add-On Bags
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-3-2
   name: Bowling Balls
   children: []
@@ -23098,78 +19840,42 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-3-8
   name: Bowling Shoe Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-3-9
   name: Bowling Training & Assistive Equipment
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-3-10
   name: Bowling Shoes
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-3-11
   name: Bowling Towels & Shammies
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-3-12
   name: Bowling Ball Racks & Holders
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-4
   name: Foosball
   children:
@@ -23288,39 +19994,21 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-4-2-5
   name: Foosball Table Bearings & Bushings
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-4-2-6
   name: Foosball Table Bumpers
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-4-3
   name: Foosball Tables
   children:
@@ -23355,13 +20043,7 @@
   - pattern
   - scoring_method
   - table_size_category
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-4-3-2
   name: Tabletop Foosball Tables
   children: []
@@ -23373,13 +20055,7 @@
   - pattern
   - scoring_method
   - table_size_category
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-5
   name: Multi-Game Tables
   children:
@@ -23631,13 +20307,7 @@
   - ping_pong_certification
   - ping_pong_rubber_type
   - recommended_skill_level
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-6-3-3
   name: Ping Pong Paddle Cleaners
   children: []
@@ -23650,13 +20320,7 @@
   - ping_pong_certification
   - ping_pong_rubber_type
   - recommended_skill_level
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-6-3-4
   name: Ping Pong Paddle Edge Tape
   children: []
@@ -23669,13 +20333,7 @@
   - ping_pong_certification
   - ping_pong_rubber_type
   - recommended_skill_level
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-6-3-5
   name: Ping Pong Paddle Blades
   children: []
@@ -23688,13 +20346,7 @@
   - ping_pong_certification
   - ping_pong_rubber_type
   - recommended_skill_level
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-6-3-6
   name: Ping Pong Paddle Grip Tape
   children: []
@@ -23707,13 +20359,7 @@
   - ping_pong_certification
   - ping_pong_rubber_type
   - recommended_skill_level
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-6-3-7
   name: Ping Pong Paddle Rubber Sheets
   children: []
@@ -23726,13 +20372,7 @@
   - ping_pong_certification
   - ping_pong_rubber_type
   - recommended_skill_level
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-6-4
   name: Ping Pong Paddles & Sets
   children:
@@ -23766,13 +20406,7 @@
   - ping_pong_equipment_included
   - ping_pong_paddle_handle_style
   - ping_pong_rubber_surface_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-6-4-2
   name: Ping Pong Paddle Sets
   children: []
@@ -23783,13 +20417,7 @@
   - ping_pong_equipment_included
   - ping_pong_paddle_handle_style
   - ping_pong_rubber_surface_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-6-5
   name: Ping Pong Robot Accessories
   children:
@@ -23818,13 +20446,7 @@
   - pattern
   - ping_pong_certification
   - ping_pong_robot_accessory_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-6-5-2
   name: Ping Pong Ball Pickers & Collectors
   children: []
@@ -23833,13 +20455,7 @@
   - pattern
   - ping_pong_certification
   - ping_pong_robot_accessory_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-6-5-3
   name: Ping Pong Robot Replacement Parts
   children: []
@@ -23848,13 +20464,7 @@
   - pattern
   - ping_pong_certification
   - ping_pong_robot_accessory_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-6-6
   name: Ping Pong Robots
   children: []
@@ -23927,13 +20537,7 @@
   - ping_pong_certification
   - ping_pong_table_type
   - suitable_space
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-6-8-2
   name: Ping Pong Conversion Tops
   children: []
@@ -23945,13 +20549,7 @@
   - ping_pong_certification
   - ping_pong_table_type
   - suitable_space
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-6-9
   name: Ping Pong Court Barriers
   children: []
@@ -23959,13 +20557,7 @@
   - color
   - pattern
   - ping_pong_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-6-10
   name: Ping Pong Training Aids
   children: []
@@ -23973,13 +20565,7 @@
   - color
   - pattern
   - ping_pong_certification
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-7
   name: Table Shuffleboard
   children:
@@ -24062,13 +20648,7 @@
   - color
   - pattern
   - shuffleboard_table_length_compatibility
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-8
   name: Throwing Darts
   children:
@@ -24204,13 +20784,7 @@
   - dart_tip_compatibility
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-8-2-5
   name: Dart Barrels
   children: []
@@ -24220,13 +20794,7 @@
   - dart_tip_compatibility
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-8-3
   name: Dartboards
   children: []
@@ -24272,104 +20840,56 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-8-6
   name: Dart Cases & Wallets
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-8-7
   name: Dartboard Cabinets
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-9
   name: Ring Toss & Hook Games
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-10
   name: Crokinole
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-11
   name: Sim Racing Equipment
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-12
   name: Tabletop Curling
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-3-13
   name: Carrom
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4
   name: Outdoor Recreation
   children:
@@ -24561,13 +21081,7 @@
   - lumber/wood_type
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-2-4
   name: Canoe Seats
   children: []
@@ -24577,13 +21091,7 @@
   - lumber/wood_type
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-3
   name: Canoes
   children:
@@ -24765,13 +21273,7 @@
   - material
   - pattern
   - recommended_skill_level
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-3-8
   name: Inflatable Canoes
   children: []
@@ -24783,13 +21285,7 @@
   - pattern
   - recommended_skill_level
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-3-9
   name: Pack Canoes
   children: []
@@ -24801,13 +21297,7 @@
   - pattern
   - recommended_skill_level
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-3-10
   name: Recreational Canoes
   children: []
@@ -24819,13 +21309,7 @@
   - pattern
   - recommended_skill_level
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-3-11
   name: Expedition Canoes
   children: []
@@ -24837,13 +21321,7 @@
   - pattern
   - recommended_skill_level
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-4
   name: Kayak Accessories
   children:
@@ -24947,13 +21425,7 @@
   - color
   - kayak_storage_bag_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-4-3-2
   name: Kayak Storage Crates
   children: []
@@ -24966,13 +21438,7 @@
   - color
   - kayak_storage_bag_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-4-4
   name: Kayak Scupper Plugs
   children: []
@@ -24981,13 +21447,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-4-5
   name: Kayak Safety & Rescue Equipment
   children: []
@@ -24996,13 +21456,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-4-6
   name: Kayak Spray Skirts
   children: []
@@ -25011,13 +21465,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-4-7
   name: Kayak Outriggers
   children: []
@@ -25026,13 +21474,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-4-8
   name: Kayak Mounts & Tracks
   children: []
@@ -25041,13 +21483,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-4-9
   name: Kayak Rudders & Steering
   children: []
@@ -25056,13 +21492,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-4-10
   name: Kayak Cockpit Covers
   children: []
@@ -25071,13 +21501,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-4-11
   name: Kayak Carts
   children: []
@@ -25086,13 +21510,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-4-12
   name: Kayak Seats & Cushions
   children: []
@@ -25101,13 +21519,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-5
   name: Kayaks
   children:
@@ -25354,13 +21766,7 @@
   - pattern
   - recommended_skill_level
   - watercraft_propulsion_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-5-12
   name: Fishing Kayaks
   children: []
@@ -25370,13 +21776,7 @@
   - pattern
   - recommended_skill_level
   - watercraft_propulsion_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-6
   name: Paddle Leashes
   children: []
@@ -25462,13 +21862,7 @@
   - color
   - pattern
   - watercraft_propulsion_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-9-2
   name: Utility Row Boats
   children: []
@@ -25477,13 +21871,7 @@
   - color
   - pattern
   - watercraft_propulsion_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-9-3
   name: Row Boat Kits
   children: []
@@ -25492,13 +21880,7 @@
   - color
   - pattern
   - watercraft_propulsion_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-9-4
   name: Racing Row Boats
   children: []
@@ -25507,13 +21889,7 @@
   - color
   - pattern
   - watercraft_propulsion_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-9-5
   name: Drift Boats
   children: []
@@ -25522,13 +21898,7 @@
   - color
   - pattern
   - watercraft_propulsion_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-10
   name: Whitewater Rafts
   children:
@@ -25557,13 +21927,7 @@
   - floor_construction_type
   - pattern
   - whitewater_rating_class
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-10-2
   name: Catarafts
   children: []
@@ -25572,39 +21936,21 @@
   - floor_construction_type
   - pattern
   - whitewater_rating_class
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-11
   name: Waterway Maps & Charts
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-1-12
   name: Marine Ropes & Lines
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-2
   name: Boating & Water Sport Apparel
   children:
@@ -25744,13 +22090,7 @@
   - color
   - marine_safety_standard_compliance
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-2-2-5
   name: Life Jacket Reflective Tape & Patches
   children: []
@@ -25760,13 +22100,7 @@
   - color
   - marine_safety_standard_compliance
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-2-2-6
   name: Life Jacket CO2 Cylinders
   children: []
@@ -25776,13 +22110,7 @@
   - color
   - marine_safety_standard_compliance
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-2-2-7
   name: Life Jacket Rearming Kits
   children: []
@@ -25792,13 +22120,7 @@
   - color
   - marine_safety_standard_compliance
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-2-2-8
   name: Life Jacket Spray Hoods
   children: []
@@ -25808,13 +22130,7 @@
   - color
   - marine_safety_standard_compliance
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-2-3
   name: Life Jackets
   children: []
@@ -26101,65 +22417,35 @@
   - target_gender
   - wetsuit_entry_system
   - wetsuit_seam_construction
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-2-8
   name: Changing & Dry Robes
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-2-9
   name: Water Shoes
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-2-10
   name: Spray Tops
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-2-11
   name: Drysuit Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-3
   name: Diving & Snorkeling
   children:
@@ -26328,13 +22614,7 @@
   - fin_pocket_type
   - fin_strap_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-3-4-4
   name: Freediving Fins
   children: []
@@ -26346,13 +22626,7 @@
   - fin_pocket_type
   - fin_strap_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-3-5
   name: Diving & Snorkeling Masks
   children: []
@@ -26559,91 +22833,49 @@
   - pattern
   - snorkel_mount_position
   - snorkel_shape
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-3-10
   name: Diving Bags & Cases
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-3-11
   name: Diving Tanks & Cylinders
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-3-12
   name: Underwater Scooters & DPVs
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-3-13
   name: Dive Lights
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-3-14
   name: Buoyancy Compensator Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-3-15
   name: Dive Computer Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-4
   name: Kitesurfing
   children:
@@ -26786,52 +23018,28 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-4-2-6
   name: Kiteboard Pads
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-4-2-7
   name: Kiteboard Inflation & Valve Parts
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-4-2-8
   name: Kiteboard Mounting Hardware
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-4-3
   name: Kiteboards
   children: []
@@ -26895,52 +23103,28 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-4-7
   name: Kitesurfing Control Bars
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-4-8
   name: Kitesurfing Pumps
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-4-9
   name: Kitesurfing Sensors
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-5
   name: Surfing
   children:
@@ -27278,13 +23462,7 @@
   - surfboard_features
   - surfboard_tail_shape
   - upf_rating
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-5-8-7
   name: Fish Surfboards
   children: []
@@ -27302,13 +23480,7 @@
   - surfboard_features
   - surfboard_tail_shape
   - upf_rating
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-5-8-8
   name: Funboard Surfboards
   children: []
@@ -27326,13 +23498,7 @@
   - surfboard_features
   - surfboard_tail_shape
   - upf_rating
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-5-8-9
   name: Foil Boards
   children: []
@@ -27350,13 +23516,7 @@
   - surfboard_features
   - surfboard_tail_shape
   - upf_rating
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-5-9
   name: Surfing Gloves
   children: []
@@ -27413,13 +23573,7 @@
   - color
   - pattern
   - upf_rating
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-5-12
   name: Surfing Booties
   children: []
@@ -27428,13 +23582,7 @@
   - color
   - pattern
   - upf_rating
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-5-13
   name: Surfboard Repair Kits
   children: []
@@ -27443,13 +23591,7 @@
   - color
   - pattern
   - upf_rating
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-6
   name: Swimming
   children:
@@ -27773,13 +23915,7 @@
   - color
   - pattern
   - swim_belt_purpose
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-6-5-2
   name: Flotation Belts
   children: []
@@ -27789,13 +23925,7 @@
   - color
   - pattern
   - swim_belt_purpose
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-6-6
   name: Swim Caps
   children: []
@@ -27898,26 +24028,14 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-6-8-4
   name: Goggle Straps
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-6-9
   name: Swim Goggles & Masks
   children:
@@ -27963,13 +24081,7 @@
   - goggle_strap_material
   - nose_bridge_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-6-9-2
   name: Swim Masks
   children: []
@@ -27986,13 +24098,7 @@
   - goggle_strap_material
   - nose_bridge_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-6-10
   name: Swim Weights
   children: []
@@ -28104,65 +24210,35 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-6-15
   name: Swim Earplugs
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-6-16
   name: Swim Snorkels
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-6-17
   name: Swim Bags & Mesh Bags
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-6-18
   name: Swim Resistance Cords
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7
   name: Towed Water Sports
   children:
@@ -28239,13 +24315,7 @@
   - kneeboard_strap_type
   - pattern
   - tow_hook_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-1-3
   name: Kneeboard Bags & Covers
   children: []
@@ -28256,13 +24326,7 @@
   - kneeboard_strap_type
   - pattern
   - tow_hook_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-1-4
   name: Kneeboard Tow Hooks
   children: []
@@ -28273,13 +24337,7 @@
   - kneeboard_strap_type
   - pattern
   - tow_hook_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-1-5
   name: Kneeboard Ropes & Handles
   children: []
@@ -28290,13 +24348,7 @@
   - kneeboard_strap_type
   - pattern
   - tow_hook_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-2
   name: Towable Rafts & Tubes
   children: []
@@ -28482,39 +24534,21 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-4-2-6
   name: Wakeboard Bags & Covers
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-4-2-7
   name: Wakeboard Hardware & Repair Parts
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-4-3
   name: Wakeboards
   children: []
@@ -28540,52 +24574,28 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-4-5
   name: Wakeboard Ballast Bags
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-4-6
   name: Wakesurf Boards
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-4-7
   name: Wakeskates
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-5
   name: Water Skiing
   children:
@@ -28632,52 +24642,28 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-5-1-2
   name: Hydrofoil Kits
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-5-1-3
   name: Hydrofoil Hardware & Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-5-1-4
   name: Hydrofoil Wings & Stabilizers
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-5-2
   name: Water Ski Bindings
   children: []
@@ -28812,13 +24798,7 @@
   - rocker_type
   - ski_construction
   - water_ski_fin_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-5-4-5
   name: Trainer Water Skis
   children: []
@@ -28829,13 +24809,7 @@
   - rocker_type
   - ski_construction
   - water_ski_fin_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-6
   name: Water Sport Tow Cables
   children:
@@ -28866,13 +24840,7 @@
   - color
   - handle_grip_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-6-2
   name: Wakeboard & Wakesurf Ropes & Handles
   children: []
@@ -28881,13 +24849,7 @@
   - color
   - handle_grip_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-6-3
   name: Water Sport Tow Harnesses & Bridles
   children: []
@@ -28896,13 +24858,7 @@
   - color
   - handle_grip_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-6-4
   name: Towable Tube Ropes
   children: []
@@ -28911,39 +24867,21 @@
   - color
   - handle_grip_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-7
   name: Wakesurfing
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-7-8
   name: Ballast Bags & Pumps
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-8
   name: Watercraft Storage Racks
   children:
@@ -29013,13 +24951,7 @@
   - material
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-8-4
   name: Personal Watercraft Storage Racks
   children: []
@@ -29029,13 +24961,7 @@
   - material
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-9
   name: Windsurfing
   children:
@@ -29128,13 +25054,7 @@
   - color
   - pattern
   - windsurfing_connection_standard
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-9-1-4
   name: Windsurfing Board Footstraps
   children: []
@@ -29142,13 +25062,7 @@
   - color
   - pattern
   - windsurfing_connection_standard
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-9-1-5
   name: Windsurfing Board Daggerboards
   children: []
@@ -29156,13 +25070,7 @@
   - color
   - pattern
   - windsurfing_connection_standard
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-9-2
   name: Windsurfing Boards
   children: []
@@ -29208,39 +25116,21 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-9-5
   name: Windsurfing Booms
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-9-6
   name: Windsurfing Footwear
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-10
   name: Wingfoiling
   children:
@@ -29362,13 +25252,7 @@
   - pattern
   - wing_part_type
   - wingfoiling_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-10-3-1-2
   name: Wing Handles
   children: []
@@ -29378,13 +25262,7 @@
   - pattern
   - wing_part_type
   - wingfoiling_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-10-3-1-3
   name: Wing Valves
   children: []
@@ -29394,13 +25272,7 @@
   - pattern
   - wing_part_type
   - wingfoiling_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-10-3-2
   name: Foil Masts
   children: []
@@ -29530,13 +25402,7 @@
   - pattern
   - water_sports_safety_standard
   - wingfoiling_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-10-4-2-2
   name: Wingfoiling Helmets
   children: []
@@ -29545,13 +25411,7 @@
   - pattern
   - water_sports_safety_standard
   - wingfoiling_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-10-4-3
   name: Wingfoil Pumps
   children: []
@@ -29559,13 +25419,7 @@
   - color
   - pattern
   - wingfoiling_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-10-4-4
   name: Wingfoil Leashes
   children: []
@@ -29573,13 +25427,7 @@
   - color
   - pattern
   - wingfoiling_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-10-4-5
   name: Wingfoil Repair Kits
   children: []
@@ -29587,13 +25435,7 @@
   - color
   - pattern
   - wingfoiling_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-10-5
   name: Wingfoil Boards
   children: []
@@ -29622,13 +25464,7 @@
   - color
   - pattern
   - wingfoiling_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-11
   name: Windfoiling
   children:
@@ -29801,13 +25637,7 @@
   - foil_mounting_interface
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-11-5
   name: Windfoil Accessories
   children:
@@ -29875,91 +25705,49 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-11-5-2-2
   name: Windfoiling Impact Vests
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-11-5-2-3
   name: Windfoiling Helmets
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-11-5-3
   name: Windfoil Harness Lines
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-11-5-4
   name: Windfoil Leashes
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-11-5-5
   name: Windfoil Footstraps
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-11-6
   name: Windfoil Packages
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-12
   name: Boating & Water Sport Protective Gear
   children:
@@ -30032,117 +25820,63 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-12-4
   name: Boating & Water Sport Ear Protection
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-12-5
   name: Water Sport Protective Hoods & Masks
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-12-6
   name: Water Sport Impact Vests
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-12-7
   name: Boating & Water Sport Eye Protection Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-12-8
   name: Water Sport Helmet Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-13
   name: Float Tubes & Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-14
   name: Pedal Boat Parts & Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-1-15
   name: Bodyboard Fins
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2
   name: Camping & Hiking
   children:
@@ -30288,13 +26022,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-1-2
   name: Air Mattresses
   children: []
@@ -30352,13 +26080,7 @@
   - lumber/wood_type
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-1-5
   name: Camping Chairs
   children: []
@@ -30367,13 +26089,7 @@
   - lumber/wood_type
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-1-6
   name: Camping Stools
   children: []
@@ -30382,13 +26098,7 @@
   - lumber/wood_type
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-1-7
   name: Camping Wagons & Carts
   children: []
@@ -30397,13 +26107,7 @@
   - lumber/wood_type
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-1-8
   name: Camping Seat Pads & Cushions
   children: []
@@ -30412,13 +26116,7 @@
   - lumber/wood_type
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-2
   name: Camping Cookware & Dinnerware
   children:
@@ -30524,13 +26222,7 @@
   - color
   - pattern
   - product_certifications_standards
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-2-4-2
   name: Camping Utensil Sets
   children: []
@@ -30538,13 +26230,7 @@
   - color
   - pattern
   - product_certifications_standards
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-2-5
   name: Camping Bowls
   children: []
@@ -30552,13 +26238,7 @@
   - color
   - pattern
   - product_certifications_standards
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-2-6
   name: Camping Kettles
   children: []
@@ -30566,13 +26246,7 @@
   - color
   - pattern
   - product_certifications_standards
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-2-7
   name: Camping Cookware Sets
   children: []
@@ -30580,13 +26254,7 @@
   - color
   - pattern
   - product_certifications_standards
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-3
   name: Camping Lights & Lanterns
   children: []
@@ -30859,13 +26527,7 @@
   - pattern
   - sheath_material
   - tang_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-4-7-5
   name: Fixed Blade Knives
   children: []
@@ -30878,13 +26540,7 @@
   - pattern
   - sheath_material
   - tang_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-4-8
   name: Multifunction Tools & Knives
   children: []
@@ -30910,13 +26566,7 @@
   - color
   - fire_starter_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-4-10
   name: Folding Shovels & Trowels
   children: []
@@ -30924,13 +26574,7 @@
   - color
   - fire_starter_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-4-11
   name: Camping Axes & Hatchets
   children: []
@@ -30938,13 +26582,7 @@
   - color
   - fire_starter_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-4-12
   name: Paracords & Utility Cords
   children: []
@@ -30952,13 +26590,7 @@
   - color
   - fire_starter_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-4-13
   name: Camping Fire Starters
   children: []
@@ -30966,13 +26598,7 @@
   - color
   - fire_starter_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-4-14
   name: Camping Saws
   children: []
@@ -30980,13 +26606,7 @@
   - color
   - fire_starter_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-4-15
   name: Camping Accessory Straps & Buckles
   children: []
@@ -30994,13 +26614,7 @@
   - color
   - fire_starter_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-5
   name: Chemical Hand Warmers
   children: []
@@ -31185,52 +26799,28 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-7-9
   name: Hiking Pole Quivers & Carry Bags
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-7-10
   name: Hiking Pole Grips
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-7-11
   name: Hiking Pole Medallions
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-8
   name: Hiking Poles
   children: []
@@ -31320,13 +26910,7 @@
   - insecticide_treatment
   - net_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-9-4
   name: Self-Supporting Mosquito Nets
   children: []
@@ -31335,13 +26919,7 @@
   - insecticide_treatment
   - net_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-9-5
   name: Head Mosquito Nets
   children: []
@@ -31350,13 +26928,7 @@
   - insecticide_treatment
   - net_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-10
   name: Navigational Compasses
   children:
@@ -31627,13 +27199,7 @@
   - color
   - pattern
   - urination_device_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-11-2-2-2
   name: Condom Catheters
   children: []
@@ -31641,13 +27207,7 @@
   - color
   - pattern
   - urination_device_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-11-2-2-4
   name: Disposable Urinal Bags
   children: []
@@ -31655,13 +27215,7 @@
   - color
   - pattern
   - urination_device_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-11-2-3
   name: Portable Camping Toilets
   children: []
@@ -31685,52 +27239,28 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-11-2-5
   name: Portable Toilet Bags & Liners
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-11-2-6
   name: Pee Cloths
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-11-2-7
   name: Male Urination Device Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-11-3
   name: Portable Water Faucets & Taps
   children: []
@@ -31739,13 +27269,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-11-4
   name: Portable Water Containers
   children: []
@@ -31754,13 +27278,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-11-5
   name: Portable Sinks & Wash Stations
   children: []
@@ -31769,13 +27287,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-12
   name: Portable Water Filters & Purifiers
   children:
@@ -31854,13 +27366,7 @@
   - filtration_technology
   - pattern
   - water_purification_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-12-4
   name: Water Filter Bottles
   children: []
@@ -31870,13 +27376,7 @@
   - filtration_technology
   - pattern
   - water_purification_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-12-5
   name: Water Filter Straws
   children: []
@@ -31886,13 +27386,7 @@
   - filtration_technology
   - pattern
   - water_purification_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-12-6
   name: Water Purifier Drops
   children: []
@@ -31902,13 +27396,7 @@
   - filtration_technology
   - pattern
   - water_purification_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-12-7
   name: Gravity Water Filters
   children: []
@@ -31918,13 +27406,7 @@
   - filtration_technology
   - pattern
   - water_purification_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-12-8
   name: Portable Water Filter Cartridges
   children: []
@@ -31934,13 +27416,7 @@
   - filtration_technology
   - pattern
   - water_purification_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-13
   name: Sleeping Bag Liners
   children: []
@@ -32154,117 +27630,63 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-16-6
   name: Tent Awnings & Annexes
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-16-7
   name: Tent Gear Lofts & Organizers
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-16-8
   name: Tarps & Rain Flies
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-16-9
   name: Tent Repair & Maintenance Supplies
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-16-10
   name: Tent Anchors & Mounting Hardware
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-16-11
   name: Tent Mats & Carpets
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-16-12
   name: Tent Pole Parts & Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-16-13
   name: Tent Pole Repair Kits
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-17
   name: Tents
   children:
@@ -32505,13 +27927,7 @@
   - pattern
   - setup_mechanism
   - stove_jack_compatibility
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-17-12
   name: Screen Houses & Shelters
   children: []
@@ -32520,13 +27936,7 @@
   - pattern
   - setup_mechanism
   - stove_jack_compatibility
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-17-13
   name: Rooftop Tents
   children: []
@@ -32535,13 +27945,7 @@
   - pattern
   - setup_mechanism
   - stove_jack_compatibility
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-17-14
   name: Bivy Sacks & Storm Shelters
   children: []
@@ -32550,13 +27954,7 @@
   - pattern
   - setup_mechanism
   - stove_jack_compatibility
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-17-15
   name: Bell Tents
   children: []
@@ -32565,13 +27963,7 @@
   - pattern
   - setup_mechanism
   - stove_jack_compatibility
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-18
   name: Windbreaks
   children: []
@@ -32631,52 +28023,28 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-22
   name: Camping Stoves
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-23
   name: Navigational Compasses Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-2-24
   name: Windbreak Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3
   name: Climbing
   children:
@@ -32950,78 +28318,42 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-3-6
   name: Climbing Knee Pads
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-3-7
   name: Climbing Brushes
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-3-8
   name: Climbing Tape
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-3-9
   name: Belay Glasses
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-3-10
   name: Climbing Jackets
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-4
   name: Climbing Ascenders & Descenders
   children:
@@ -33049,13 +28381,7 @@
   - ascender_descender_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-4-2
   name: Climbing Ascenders
   children: []
@@ -33063,13 +28389,7 @@
   - ascender_descender_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-5
   name: Climbing Chalk Bags
   children: []
@@ -33161,13 +28481,7 @@
   - harness_type
   - leg_loop_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-8-2
   name: Chest Climbing Harnesses
   children: []
@@ -33179,13 +28493,7 @@
   - harness_type
   - leg_loop_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-8-3
   name: Full Body Climbing Harnesses
   children: []
@@ -33197,13 +28505,7 @@
   - harness_type
   - leg_loop_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-9
   name: Climbing Protection Devices
   children:
@@ -33236,13 +28538,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-9-2
   name: Climbing Bolts & Anchors
   children: []
@@ -33251,13 +28547,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-9-3
   name: Rigging Plates & Swivels
   children: []
@@ -33266,13 +28556,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-9-4
   name: Climbing Cams
   children: []
@@ -33281,13 +28565,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-9-5
   name: Climbing Nuts & Stoppers
   children: []
@@ -33296,13 +28574,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-9-6
   name: Climbing Pitons & Hooks
   children: []
@@ -33311,13 +28583,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-10
   name: Climbing Rope
   children: []
@@ -33497,26 +28763,14 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-13-5
   name: Ice Climbing Leashes & Tethers
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-14
   name: Ice Screws
   children: []
@@ -33580,78 +28834,42 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-18
   name: Climbing Packs & Backpacks
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-19
   name: Climbing Pulleys
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-20
   name: Climbing Guidebooks & Maps
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-21
   name: Climbing Accessory Cords
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-3-22
   name: Ice Screw Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4
   name: Cycling
   children:
@@ -33802,13 +29020,7 @@
   - compatible_bike_type
   - pattern
   - vehicle_placement
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-1-1-2
   name: Bicycle Trunk Bags
   children: []
@@ -33823,13 +29035,7 @@
   - compatible_bike_type
   - pattern
   - vehicle_placement
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-1-1-3
   name: Bicycle Handlebar Bags
   children: []
@@ -33844,13 +29050,7 @@
   - compatible_bike_type
   - pattern
   - vehicle_placement
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-1-1-4
   name: Bicycle Top Tube Bags
   children: []
@@ -33865,13 +29065,7 @@
   - compatible_bike_type
   - pattern
   - vehicle_placement
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-1-2
   name: Bicycle Panniers
   children: []
@@ -34030,13 +29224,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-5
   name: Bicycle Child Seat Accessories & Parts
   children:
@@ -34067,13 +29255,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-5-2
   name: Bicycle Child Seat Handlebars & Handrails
   children: []
@@ -34082,13 +29264,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-5-3
   name: Bicycle Child Seat Footrests & Pegs
   children: []
@@ -34097,13 +29273,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-5-4
   name: Bicycle Child Seat Cushions & Pads
   children: []
@@ -34112,13 +29282,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-5-5
   name: Bicycle Child Seat Windscreens & Weather Covers
   children: []
@@ -34127,13 +29291,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-6
   name: Bicycle Child Seats
   children: []
@@ -34302,13 +29460,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-7-8
   name: Bicycle Computer Chargers
   children: []
@@ -34318,13 +29470,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-8
   name: Bicycle Computers
   children: []
@@ -34418,13 +29564,7 @@
   - compatible_brake_type
   - pattern
   - vehicle_placement
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-11-2
   name: Bicycle Rear Racks
   children: []
@@ -34435,13 +29575,7 @@
   - compatible_brake_type
   - pattern
   - vehicle_placement
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-11-3
   name: Bicycle Front Racks
   children: []
@@ -34452,13 +29586,7 @@
   - compatible_brake_type
   - pattern
   - vehicle_placement
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-12
   name: Bicycle Handlebar Grips & Decor
   children:
@@ -34491,13 +29619,7 @@
   - grip_shape
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-12-2
   name: Bicycle Handlebar Streamers
   children: []
@@ -34507,13 +29629,7 @@
   - grip_shape
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-12-3
   name: Bicycle Handlebar Grips
   children: []
@@ -34523,13 +29639,7 @@
   - grip_shape
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-12-4
   name: Bicycle Bar End Plugs & Caps
   children: []
@@ -34539,13 +29649,7 @@
   - grip_shape
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-13
   name: Bicycle Locks
   children:
@@ -34827,13 +29931,7 @@
   - compatible_bike_type
   - pattern
   - pressure_gauge_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-15-3
   name: Mini Bicycle Pumps
   children: []
@@ -34845,13 +29943,7 @@
   - compatible_bike_type
   - pattern
   - pressure_gauge_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-15-4
   name: CO2 Bicycle Inflators & Cartridges
   children: []
@@ -34863,13 +29955,7 @@
   - compatible_bike_type
   - pattern
   - pressure_gauge_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-15-5
   name: Foot-Operated Bicycle Pumps
   children: []
@@ -34881,13 +29967,7 @@
   - compatible_bike_type
   - pattern
   - pressure_gauge_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-15-6
   name: Floor Bicycle Pumps
   children: []
@@ -34899,13 +29979,7 @@
   - compatible_bike_type
   - pattern
   - pressure_gauge_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-16
   name: Bicycle Saddle Pads & Seat Covers
   children: []
@@ -34990,13 +30064,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-19-2
   name: Bicycle Storage Tents & Garages
   children: []
@@ -35004,13 +30072,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-19-3
   name: Bicycle Floor Stands
   children: []
@@ -35018,13 +30080,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-19-4
   name: Wall-Mounted Bicycle Racks & Hooks
   children: []
@@ -35032,13 +30088,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-19-5
   name: Bicycle Repair Stands
   children: []
@@ -35046,13 +30096,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-20
   name: Bicycle Tire Repair Supplies & Kits
   children:
@@ -35188,13 +30232,7 @@
   - compatible_bicycle_tire_type
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-20-7
   name: Bicycle Tubeless Conversion Tapes & Valves
   children: []
@@ -35203,13 +30241,7 @@
   - compatible_bicycle_tire_type
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-20-9
   name: Bicycle Tire Inserts & Liners
   children: []
@@ -35218,13 +30250,7 @@
   - compatible_bicycle_tire_type
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-21
   name: Bicycle Toe Straps & Clips
   children:
@@ -35253,13 +30279,7 @@
   - compatible_bike_type
   - compatible_pedal_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-21-2
   name: Bicycle Toe Clips
   children: []
@@ -35268,13 +30288,7 @@
   - compatible_bike_type
   - compatible_pedal_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-22
   name: Bicycle Tools
   children:
@@ -35347,13 +30361,7 @@
   - pattern
   - suitable_riding_conditions
   - tool_functions_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-22-1-3
   name: Bicycle Chain Breakers
   children: []
@@ -35367,13 +30375,7 @@
   - pattern
   - suitable_riding_conditions
   - tool_functions_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-22-1-4
   name: Bicycle Chain Cleaning Tools
   children: []
@@ -35387,13 +30389,7 @@
   - pattern
   - suitable_riding_conditions
   - tool_functions_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-22-2
   name: Bicycle Multi-Tools
   children: []
@@ -35427,13 +30423,7 @@
   - pattern
   - suitable_riding_conditions
   - tool_functions_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-22-4
   name: Bicycle Lubricants & Cleaners
   children: []
@@ -35446,13 +30436,7 @@
   - pattern
   - suitable_riding_conditions
   - tool_functions_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-22-5
   name: Bicycle Bottom Bracket Tools
   children: []
@@ -35465,13 +30449,7 @@
   - pattern
   - suitable_riding_conditions
   - tool_functions_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-22-6
   name: Bicycle Brake Bleed Kits
   children: []
@@ -35484,13 +30462,7 @@
   - pattern
   - suitable_riding_conditions
   - tool_functions_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-22-7
   name: Bicycle Pedal Wrenches
   children: []
@@ -35503,13 +30475,7 @@
   - pattern
   - suitable_riding_conditions
   - tool_functions_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-22-8
   name: Bicycle Cassette & Freewheel Tools
   children: []
@@ -35522,13 +30488,7 @@
   - pattern
   - suitable_riding_conditions
   - tool_functions_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-22-9
   name: Chain Whips
   children: []
@@ -35541,13 +30501,7 @@
   - pattern
   - suitable_riding_conditions
   - tool_functions_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-22-10
   name: Bicycle Wheel Building Tools
   children: []
@@ -35560,13 +30514,7 @@
   - pattern
   - suitable_riding_conditions
   - tool_functions_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-23
   name: Bicycle Trailers
   children:
@@ -35599,13 +30547,7 @@
   - hitch_type
   - pattern
   - trailer_suspension_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-23-3
   name: Child Bicycle Trailers
   children: []
@@ -35615,13 +30557,7 @@
   - hitch_type
   - pattern
   - trailer_suspension_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-23-4
   name: Bicycle Cargo Trailers
   children: []
@@ -35631,13 +30567,7 @@
   - hitch_type
   - pattern
   - trailer_suspension_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-24
   name: Bicycle Trainers
   children:
@@ -35748,13 +30678,7 @@
   - compatible_bike_type
   - pattern
   - trainer_mounting_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-24-6
   name: Electromagnetic Bicycle Trainers
   children: []
@@ -35765,13 +30689,7 @@
   - compatible_bike_type
   - pattern
   - trainer_mounting_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-25
   name: Bicycle Training Wheels
   children: []
@@ -35849,13 +30767,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-28-2
   name: Mid-Drive Electric Bicycle Conversion Kits
   children: []
@@ -35863,13 +30775,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-28-3
   name: Rear Wheel Electric Bicycle Conversion Kits
   children: []
@@ -35877,13 +30783,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-29
   name: Bicycle Cleaning & Maintenance Supplies
   children: []
@@ -35893,13 +30793,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-30
   name: Bicycle Lights
   children: []
@@ -35909,13 +30803,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-31
   name: Bicycle Phone Mounts
   children: []
@@ -35925,13 +30813,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-32
   name: Bicycle Frame Protection & Decals
   children: []
@@ -35941,13 +30823,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-33
   name: Bicycle Basket Accessories
   children: []
@@ -35957,13 +30833,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-34
   name: Bicycle Bag Accessories & Mounts
   children: []
@@ -35973,13 +30843,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-35
   name: Bicycle Rack Accessories
   children: []
@@ -35989,13 +30853,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-36
   name: Bicycle Pump Parts & Accessories
   children: []
@@ -36005,13 +30863,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-1-37
   name: Bicycle Trailer Parts & Accessories
   children: []
@@ -36021,13 +30873,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2
   name: Bicycle Parts
   children:
@@ -36220,13 +31066,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-1-6
   name: Bicycle Brake Fluids
   children: []
@@ -36240,13 +31080,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-1-7
   name: Bicycle Brake Hoses & Fittings
   children: []
@@ -36260,13 +31094,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-1-8
   name: Bicycle Brake Adapters & Mounts
   children: []
@@ -36280,13 +31108,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-2
   name: Bicycle Cable Housings
   children: []
@@ -36448,13 +31270,7 @@
   - compatible_chain_width
   - freewheel_thread_standard
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-4-2-2-2
   name: Multi-Speed Freewheels
   children: []
@@ -36465,13 +31281,7 @@
   - compatible_chain_width
   - freewheel_thread_standard
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-4-3
   name: Bicycle Chainrings
   children: []
@@ -36617,13 +31427,7 @@
   - pattern
   - shifter_mounting_interface
   - shifting_mechanism
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-4-8-2
   name: Bar-End Shifters
   children: []
@@ -36635,13 +31439,7 @@
   - pattern
   - shifter_mounting_interface
   - shifting_mechanism
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-4-8-3
   name: Grip Shifters
   children: []
@@ -36653,13 +31451,7 @@
   - pattern
   - shifter_mounting_interface
   - shifting_mechanism
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-4-8-4
   name: Integrated Brake & Shift Levers
   children: []
@@ -36671,13 +31463,7 @@
   - pattern
   - shifter_mounting_interface
   - shifting_mechanism
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-4-8-5
   name: Bicycle Shifter Parts & Mounts
   children: []
@@ -36689,13 +31475,7 @@
   - pattern
   - shifter_mounting_interface
   - shifting_mechanism
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-4-8-6
   name: Trigger Shifters
   children: []
@@ -36707,13 +31487,7 @@
   - pattern
   - shifter_mounting_interface
   - shifting_mechanism
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-4-9
   name: Bicycle Derailleur Hangers
   children: []
@@ -36723,13 +31497,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-4-10
   name: Bicycle Derailleur Parts & Pulleys
   children: []
@@ -36739,13 +31507,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-5
   name: Bicycle Forks
   children:
@@ -36780,13 +31542,7 @@
   - pattern
   - steerer_tube_design
   - suspension_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-5-2
   name: Bicycle Suspension Forks
   children: []
@@ -36798,13 +31554,7 @@
   - pattern
   - steerer_tube_design
   - suspension_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-6
   name: Bicycle Frames
   children:
@@ -36848,13 +31598,7 @@
   - headset_standard
   - pattern
   - rear_axle_spacing
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-6-2
   name: Road Bike Frames
   children: []
@@ -36868,13 +31612,7 @@
   - headset_standard
   - pattern
   - rear_axle_spacing
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-6-3
   name: BMX Bike Frames
   children: []
@@ -36888,13 +31626,7 @@
   - headset_standard
   - pattern
   - rear_axle_spacing
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-6-4
   name: Folding Bicycle Frames
   children: []
@@ -36908,13 +31640,7 @@
   - headset_standard
   - pattern
   - rear_axle_spacing
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-6-5
   name: Mountain Bike Frames
   children: []
@@ -36928,13 +31654,7 @@
   - headset_standard
   - pattern
   - rear_axle_spacing
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-7
   name: Bicycle Groupsets
   children: []
@@ -37012,13 +31732,7 @@
   - compatible_bike_type
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-9-2
   name: Drop Handlebars
   children: []
@@ -37028,13 +31742,7 @@
   - compatible_bike_type
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-9-3
   name: Bicycle Flat & Riser Handlebars
   children: []
@@ -37044,13 +31752,7 @@
   - compatible_bike_type
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-9-4
   name: BMX Handlebars
   children: []
@@ -37060,13 +31762,7 @@
   - compatible_bike_type
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-10
   name: Bicycle Headset Parts
   children:
@@ -37137,13 +31833,7 @@
   - compatible_bike_type
   - compatible_shis
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-10-4
   name: Bicycle Headset Caps
   children: []
@@ -37152,13 +31842,7 @@
   - compatible_bike_type
   - compatible_shis
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-10-5
   name: Bicycle Headset Crown Races
   children: []
@@ -37167,13 +31851,7 @@
   - compatible_bike_type
   - compatible_shis
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-11
   name: Bicycle Headsets
   children: []
@@ -37361,13 +32039,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-16-5
   name: Bicycle Shock Mounting Hardware
   children: []
@@ -37375,13 +32047,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-16-6
   name: Bicycle Suspension Pivot Bearings
   children: []
@@ -37389,13 +32055,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-17
   name: Bicycle Stems
   children: []
@@ -37758,13 +32418,7 @@
   - freehub_driver_standard
   - pattern
   - rim_tubeless_compatibility
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-23-2-5
   name: Freehub Bodies
   children: []
@@ -37775,13 +32429,7 @@
   - freehub_driver_standard
   - pattern
   - rim_tubeless_compatibility
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-23-2-6
   name: Hub Guards
   children: []
@@ -37792,13 +32440,7 @@
   - freehub_driver_standard
   - pattern
   - rim_tubeless_compatibility
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-23-3
   name: Bicycle Hubs
   children: []
@@ -37936,13 +32578,7 @@
   - compatible_bike_type
   - pattern
   - rim_tubeless_compatibility
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-23-11
   name: Bicycle Wheel Decal Kits
   children: []
@@ -37952,13 +32588,7 @@
   - compatible_bike_type
   - pattern
   - rim_tubeless_compatibility
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-24
   name: Bicycle Wheels
   children:
@@ -38083,13 +32713,7 @@
   - compatible_bike_type
   - pattern
   - tubeless_compatible
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-25
   name: Bicycle Rear Shocks
   children: []
@@ -38099,13 +32723,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-26
   name: Bicycle Shock Springs
   children: []
@@ -38115,13 +32733,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-27
   name: Bicycle Fork Parts & Accessories
   children: []
@@ -38131,13 +32743,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-2-28
   name: Bicycle Stem Accessories
   children: []
@@ -38147,13 +32753,7 @@
   - color
   - compatible_bike_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3
   name: Bicycles
   children:
@@ -38235,13 +32835,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-1-2
   name: Race BMX Bikes
   children: []
@@ -38254,13 +32848,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-2
   name: City Bikes
   children: []
@@ -38384,13 +32972,7 @@
   - motor_position
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-5-2
   name: Electric Fat Bikes
   children: []
@@ -38408,13 +32990,7 @@
   - motor_position
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-5-3
   name: Electric Mountain Bikes
   children: []
@@ -38432,13 +33008,7 @@
   - motor_position
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-5-4
   name: Electric City Bikes
   children: []
@@ -38456,13 +33026,7 @@
   - motor_position
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-5-5
   name: Electric Folding Bikes
   children: []
@@ -38480,13 +33044,7 @@
   - motor_position
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-6
   name: Fatbikes
   children: []
@@ -38579,13 +33137,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-8-2
   name: Cargo Tricycles
   children: []
@@ -38600,13 +33152,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-8-3
   name: Front-Load Cargo Bicycles
   children: []
@@ -38621,13 +33167,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-9
   name: Hybrid Bikes
   children: []
@@ -38694,13 +33234,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-10-2
   name: Cross-Country Mountain Bikes
   children: []
@@ -38715,13 +33249,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-10-3
   name: Trail Mountain Bikes
   children: []
@@ -38736,13 +33264,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-10-4
   name: Downhill Mountain Bikes
   children: []
@@ -38757,13 +33279,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-11
   name: Road Bikes
   children: []
@@ -38851,13 +33367,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-15
   name: Recumbent Bikes
   children: []
@@ -38872,13 +33382,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-16
   name: Gravel Bikes
   children: []
@@ -38893,13 +33397,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-17
   name: Kids' Bikes
   children: []
@@ -38914,13 +33412,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-18
   name: Touring Bikes
   children: []
@@ -38935,13 +33427,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-3-19
   name: Balance Bikes
   children: []
@@ -38956,13 +33442,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4
   name: Cycling Apparel & Accessories
   children:
@@ -39089,13 +33569,7 @@
   - pattern
   - sun_protection_rating_upf
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-2
   name: Bicycle Cleats
   children: []
@@ -39181,13 +33655,7 @@
   - pattern
   - sun_protection_rating_upf
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-4-2
   name: Bicycle Helmet Visors
   children: []
@@ -39199,13 +33667,7 @@
   - pattern
   - sun_protection_rating_upf
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-4-3
   name: Bicycle Helmet Buckles & Straps
   children: []
@@ -39217,13 +33679,7 @@
   - pattern
   - sun_protection_rating_upf
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-4-4
   name: Bicycle Helmet Covers & Skins
   children: []
@@ -39235,13 +33691,7 @@
   - pattern
   - sun_protection_rating_upf
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-4-5
   name: Bicycle Helmet Liners & Pads
   children: []
@@ -39253,13 +33703,7 @@
   - pattern
   - sun_protection_rating_upf
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-4-6
   name: Bicycle Helmet Mounts & Adapters
   children: []
@@ -39271,13 +33715,7 @@
   - pattern
   - sun_protection_rating_upf
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-5
   name: Bicycle Helmets
   children: []
@@ -39342,13 +33780,7 @@
   - pattern
   - sun_protection_rating_upf
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-6-2
   name: Bicycle Knee Pads
   children: []
@@ -39361,13 +33793,7 @@
   - pattern
   - sun_protection_rating_upf
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-6-3
   name: Bicycle Shin Guards
   children: []
@@ -39380,13 +33806,7 @@
   - pattern
   - sun_protection_rating_upf
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-6-4
   name: Bicycle Chest & Back Protectors
   children: []
@@ -39399,13 +33819,7 @@
   - pattern
   - sun_protection_rating_upf
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-7
   name: Bicycle Shoe Covers
   children: []
@@ -39485,13 +33899,7 @@
   - target_gender
   - toe_style
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-8-2
   name: Road Cycling Shoes
   children: []
@@ -39511,13 +33919,7 @@
   - target_gender
   - toe_style
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-8-3
   name: Mountain & Gravel Cycling Shoes
   children: []
@@ -39537,13 +33939,7 @@
   - target_gender
   - toe_style
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-8-4
   name: Triathlon Cycling Shoes
   children: []
@@ -39563,13 +33959,7 @@
   - target_gender
   - toe_style
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-9
   name: Cycling Jerseys
   children: []
@@ -39581,13 +33971,7 @@
   - sun_protection_rating_upf
   - target_gender
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-10
   name: Cycling Base Layers
   children: []
@@ -39599,13 +33983,7 @@
   - sun_protection_rating_upf
   - target_gender
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-11
   name: Cycling Caps & Headwear
   children: []
@@ -39617,13 +33995,7 @@
   - sun_protection_rating_upf
   - target_gender
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-12
   name: Cycling Socks
   children: []
@@ -39635,13 +34007,7 @@
   - sun_protection_rating_upf
   - target_gender
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-13
   name: Cycling Jackets & Vests
   children: []
@@ -39653,13 +34019,7 @@
   - sun_protection_rating_upf
   - target_gender
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-14
   name: Cycling Tights & Bib Tights
   children: []
@@ -39671,13 +34031,7 @@
   - sun_protection_rating_upf
   - target_gender
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-15
   name: Cycling Eyewear
   children: []
@@ -39689,13 +34043,7 @@
   - sun_protection_rating_upf
   - target_gender
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-16
   name: Cycling Shorts & Bib Shorts
   children: []
@@ -39707,13 +34055,7 @@
   - sun_protection_rating_upf
   - target_gender
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-4-17
   name: Cycling Backpacks & Hydration Packs
   children: []
@@ -39725,13 +34067,7 @@
   - sun_protection_rating_upf
   - target_gender
   - visibility_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-4-5
   name: Tricycle Accessories
   children:
@@ -39905,13 +34241,7 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5
   name: Equestrian
   children:
@@ -40008,13 +34338,7 @@
   - material
   - neck_coverage_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-1-2
   name: Coolers & Dress Sheets
   children: []
@@ -40026,13 +34350,7 @@
   - material
   - neck_coverage_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-1-3
   name: Turnout Blankets
   children: []
@@ -40044,13 +34362,7 @@
   - material
   - neck_coverage_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-1-4
   name: Horse Blanket Liners & Accessories
   children: []
@@ -40062,13 +34374,7 @@
   - material
   - neck_coverage_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-1-5
   name: Stable Blankets & Sheets
   children: []
@@ -40080,13 +34386,7 @@
   - material
   - neck_coverage_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-2
   name: Horse Boots & Leg Wraps
   children:
@@ -40134,13 +34434,7 @@
   - shoe_size
   - target_gender
   - therapeutic_technology
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-2-2
   name: Horse Leg Wraps
   children: []
@@ -40158,13 +34452,7 @@
   - shoe_size
   - target_gender
   - therapeutic_technology
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-3
   name: Horse Feed
   children:
@@ -40219,13 +34507,7 @@
   - horse_care_purpose
   - horse_feed_stage
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-4
   name: Horse Fly Masks
   children: []
@@ -40390,13 +34672,7 @@
   - equine_application_area
   - horse_care_purpose
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-5-2-2-2
   name: Horse Quarter Marker Combs
   children: []
@@ -40408,13 +34684,7 @@
   - equine_application_area
   - horse_care_purpose
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-5-2-2-3
   name: Horse Mane & Tail Combs
   children: []
@@ -40426,13 +34696,7 @@
   - equine_application_area
   - horse_care_purpose
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-5-2-2-4
   name: Horse Mane Pulling Combs
   children: []
@@ -40444,13 +34708,7 @@
   - equine_application_area
   - horse_care_purpose
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-5-2-2-5
   name: Horse Grooming Curry Combs
   children: []
@@ -40462,13 +34720,7 @@
   - equine_application_area
   - horse_care_purpose
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-5-2-3
   name: Horse Grooming Deshedders
   children: []
@@ -40547,13 +34799,7 @@
   - horse_care_purpose
   - horse_groomer_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-5-2-5-2
   name: Horse Sweat Scrapers
   children: []
@@ -40564,13 +34810,7 @@
   - horse_care_purpose
   - horse_groomer_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-5-2-5-3
   name: Horse Grooming Blocks & Stones
   children: []
@@ -40581,13 +34821,7 @@
   - horse_care_purpose
   - horse_groomer_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-5-2-5-4
   name: Horse Hoof Picks
   children: []
@@ -40598,13 +34832,7 @@
   - horse_care_purpose
   - horse_groomer_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-5-2-5-5
   name: Horse Grooming Scissors & Shears
   children: []
@@ -40615,13 +34843,7 @@
   - horse_care_purpose
   - horse_groomer_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-5-2-6
   name: Horse Grooming Trimming Knives
   children: []
@@ -40653,13 +34875,7 @@
   - lumber/wood_type
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-5-4
   name: Horse Coat Sprays & Glosses
   children: []
@@ -40671,13 +34887,7 @@
   - lumber/wood_type
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-5-6
   name: Horse Grooming Kits
   children: []
@@ -40689,13 +34899,7 @@
   - lumber/wood_type
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-5-7
   name: Horse Clipper Blade Sharpeners
   children: []
@@ -40707,13 +34911,7 @@
   - lumber/wood_type
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-5-8
   name: Horse Clipper Blades
   children: []
@@ -40725,13 +34923,7 @@
   - lumber/wood_type
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-5-9
   name: Horse Clipper Parts & Accessories
   children: []
@@ -40743,13 +34935,7 @@
   - lumber/wood_type
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-6
   name: Horse Treats
   children: []
@@ -40810,13 +34996,7 @@
   - equestrian_discipline
   - horse_care_purpose
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-10
   name: Horse Fly & Insect Control
   children: []
@@ -40825,13 +35005,7 @@
   - equestrian_discipline
   - horse_care_purpose
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-11
   name: Horse Hoof Care
   children: []
@@ -40840,13 +35014,7 @@
   - equestrian_discipline
   - horse_care_purpose
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-12
   name: Horse Therapy & Recovery Equipment
   children: []
@@ -40855,13 +35023,7 @@
   - equestrian_discipline
   - horse_care_purpose
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-1-13
   name: Horse Health & First Aid
   children: []
@@ -40870,13 +35032,7 @@
   - equestrian_discipline
   - horse_care_purpose
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2
   name: Horse Tack
   children:
@@ -41013,13 +35169,7 @@
   - equestrian_discipline
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-1-5
   name: Pelham Bits
   children: []
@@ -41031,13 +35181,7 @@
   - equestrian_discipline
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-1-6
   name: Gag Bits
   children: []
@@ -41049,13 +35193,7 @@
   - equestrian_discipline
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-1-7
   name: Weymouth Bits
   children: []
@@ -41067,13 +35205,7 @@
   - equestrian_discipline
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-2
   name: Bridles
   children:
@@ -41139,13 +35271,7 @@
   - material
   - noseband_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-2-1-2
   name: Nosebands
   children: []
@@ -41159,13 +35285,7 @@
   - material
   - noseband_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-2-1-3
   name: Browbands
   children: []
@@ -41179,13 +35299,7 @@
   - material
   - noseband_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-2-1-4
   name: Hackamore Parts
   children: []
@@ -41199,13 +35313,7 @@
   - material
   - noseband_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-2-1-5
   name: Cheek Pieces
   children: []
@@ -41219,13 +35327,7 @@
   - material
   - noseband_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-2-2
   name: Headstalls
   children: []
@@ -41281,13 +35383,7 @@
   - equestrian_discipline
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-3-2
   name: Western Cinches
   children: []
@@ -41297,13 +35393,7 @@
   - equestrian_discipline
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-3-3
   name: English Girths
   children: []
@@ -41313,13 +35403,7 @@
   - equestrian_discipline
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-4
   name: Horse Halters
   children:
@@ -41352,13 +35436,7 @@
   - equestrian_discipline
   - halter_style
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-4-2
   name: Rope Halters
   children: []
@@ -41368,13 +35446,7 @@
   - equestrian_discipline
   - halter_style
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-4-3
   name: Breakaway Halters
   children: []
@@ -41384,13 +35456,7 @@
   - equestrian_discipline
   - halter_style
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-4-4
   name: Leather Halters
   children: []
@@ -41400,13 +35466,7 @@
   - equestrian_discipline
   - halter_style
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-5
   name: Horse Harnesses
   children:
@@ -41440,13 +35500,7 @@
   - equestrian_discipline
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-5-3
   name: Harness Breechings
   children: []
@@ -41457,13 +35511,7 @@
   - equestrian_discipline
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-6
   name: Horse Leads
   children: []
@@ -41541,13 +35589,7 @@
   - saddle_discipline
   - saddle_tree_material
   - saddle_tree_width
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-8-2
   name: Western Saddles
   children: []
@@ -41560,13 +35602,7 @@
   - saddle_discipline
   - saddle_tree_material
   - saddle_tree_width
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-9
   name: Stirrups
   children: []
@@ -41602,13 +35638,7 @@
   - equestrian_discipline
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-11
   name: Breastplates & Martingales
   children: []
@@ -41618,13 +35648,7 @@
   - equestrian_discipline
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-12
   name: Horse Grazing & Cribbing Muzzles
   children: []
@@ -41634,13 +35658,7 @@
   - equestrian_discipline
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-2-13
   name: Ropes & Roping Equipment
   children: []
@@ -41650,13 +35668,7 @@
   - equestrian_discipline
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-3
   name: Horse Tack Accessories
   children:
@@ -41814,13 +35826,7 @@
   - pattern
   - saddle_pad_shape
   - saddle_pad_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-3-2-3-2
   name: Western Saddle Pads & Blankets
   children: []
@@ -41833,13 +35839,7 @@
   - pattern
   - saddle_pad_shape
   - saddle_pad_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-3-2-4
   name: Saddle Racks
   children: []
@@ -41873,13 +35873,7 @@
   - equestrian_discipline
   - jewelry_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-3-2-6
   name: Saddle Straps & Tie Straps
   children: []
@@ -41891,13 +35885,7 @@
   - equestrian_discipline
   - jewelry_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-3-2-7
   name: Saddle Hardware & Replacement Parts
   children: []
@@ -41909,13 +35897,7 @@
   - equestrian_discipline
   - jewelry_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-3-2-8
   name: Saddle Utility Accessories
   children: []
@@ -41927,13 +35909,7 @@
   - equestrian_discipline
   - jewelry_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-3-2-9
   name: Saddle Cleaners & Conditioners
   children: []
@@ -41945,13 +35921,7 @@
   - equestrian_discipline
   - jewelry_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-3-3
   name: Tack & Bridle Racks
   children: []
@@ -41962,13 +35932,7 @@
   - equestrian_discipline
   - jewelry_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-3-4
   name: Spur Straps
   children: []
@@ -41979,13 +35943,7 @@
   - equestrian_discipline
   - jewelry_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-3-5
   name: Bridle Accessories
   children: []
@@ -41996,13 +35954,7 @@
   - equestrian_discipline
   - jewelry_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-3-6
   name: Stirrup Accessories
   children: []
@@ -42013,13 +35965,7 @@
   - equestrian_discipline
   - jewelry_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-3-7
   name: Horse Spurs
   children: []
@@ -42030,13 +35976,7 @@
   - equestrian_discipline
   - jewelry_material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-4
   name: Horse Vaulting Accessories
   children:
@@ -42125,13 +36065,7 @@
   - color
   - equestrian_discipline
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-4-5
   name: Vaulting Surcingles
   children: []
@@ -42139,13 +36073,7 @@
   - color
   - equestrian_discipline
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-5
   name: Riding Apparel & Accessories
   children:
@@ -42260,13 +36188,7 @@
   - material
   - pattern
   - whip_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-5-3-2
   name: Lunge Whips
   children: []
@@ -42277,13 +36199,7 @@
   - material
   - pattern
   - whip_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-5-3-3
   name: Dressage Whips
   children: []
@@ -42294,13 +36210,7 @@
   - material
   - pattern
   - whip_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-5-3-4
   name: Riding Crops
   children: []
@@ -42311,13 +36221,7 @@
   - material
   - pattern
   - whip_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-5-3-5
   name: Stock Whips
   children: []
@@ -42328,13 +36232,7 @@
   - material
   - pattern
   - whip_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-5-4
   name: Riding Pants
   children:
@@ -42378,13 +36276,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-5-4-2
   name: Breeches
   children: []
@@ -42399,13 +36291,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-5-4-3
   name: Jodhpurs
   children: []
@@ -42420,13 +36306,7 @@
   - material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-5-5
   name: Equestrian Helmet Bags & Cases
   children: []
@@ -42439,13 +36319,7 @@
   - jewelry_material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-5-6
   name: Equestrian Helmet Covers
   children: []
@@ -42458,13 +36332,7 @@
   - jewelry_material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-5-7
   name: Equestrian Helmet Liners & Padding
   children: []
@@ -42477,13 +36345,7 @@
   - jewelry_material
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-6
   name: Stable Supplies
   children: []
@@ -42491,13 +36353,7 @@
   - color
   - equestrian_discipline
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-5-7
   name: Rodeo & Roping Equipment
   children: []
@@ -42505,13 +36361,7 @@
   - color
   - equestrian_discipline
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6
   name: Fishing
   children:
@@ -42641,13 +36491,7 @@
   - color
   - led_indicator_color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-2
   name: Fishing & Hunting Waders
   children:
@@ -42750,13 +36594,7 @@
   - target_gender
   - wader_sole_type
   - wader_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-2-5
   name: Wader Bags & Totes
   children: []
@@ -42767,13 +36605,7 @@
   - target_gender
   - wader_sole_type
   - wader_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-3
   name: Fishing Bait & Chum Containers
   children:
@@ -42804,13 +36636,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-3-2
   name: Chum Bags
   children: []
@@ -42820,13 +36646,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-3-3
   name: Bait Boxes & Tubs
   children: []
@@ -42836,13 +36656,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-3-4
   name: Bait Buckets
   children: []
@@ -42852,13 +36666,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-4
   name: Fishing Gaffs
   children: []
@@ -43309,13 +37117,7 @@
   - jaw_shape
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-5-22
   name: Fish Lip Grippers
   children: []
@@ -43324,13 +37126,7 @@
   - jaw_shape
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-5-23
   name: Fishing Forceps & Hemostats
   children: []
@@ -43339,13 +37135,7 @@
   - jaw_shape
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-6
   name: Fishing Lines & Leaders
   children:
@@ -43458,13 +37248,7 @@
   - fishing_line_buoyancy_type
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-6-6
   name: Fly Fishing Lines
   children: []
@@ -43473,13 +37257,7 @@
   - fishing_line_buoyancy_type
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-7
   name: Fishing Nets
   children:
@@ -43511,13 +37289,7 @@
   - color
   - hoop_shape
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-7-2
   name: Casting Nets
   children: []
@@ -43527,13 +37299,7 @@
   - color
   - hoop_shape
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-7-3
   name: Landing Nets
   children: []
@@ -43543,13 +37309,7 @@
   - color
   - hoop_shape
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-7-6
   name: Bait & Dip Nets
   children: []
@@ -43559,13 +37319,7 @@
   - color
   - hoop_shape
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-8
   name: Fishing Reel Accessories
   children:
@@ -43621,13 +37375,7 @@
   - compatible_fishing_reel_type
   - compatible_reel_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-8-1-2
   name: Fishing Reel Storage Cases
   children: []
@@ -43636,13 +37384,7 @@
   - compatible_fishing_reel_type
   - compatible_reel_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-8-2
   name: Fishing Reel Lubricants
   children: []
@@ -43694,13 +37436,7 @@
   - compatible_fishing_reel_type
   - compatible_fly_line_weight
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-8-3-2
   name: Fly Fishing Reel Replacement Spools
   children: []
@@ -43710,13 +37446,7 @@
   - compatible_fishing_reel_type
   - compatible_fly_line_weight
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-8-3-3
   name: Baitcasting Fishing Reel Replacement Spools
   children: []
@@ -43726,13 +37456,7 @@
   - compatible_fishing_reel_type
   - compatible_fly_line_weight
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-8-4
   name: Fishing Reel Gears & Drive Components
   children: []
@@ -43742,13 +37466,7 @@
   - color
   - compatible_fishing_reel_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-8-5
   name: Fishing Reel Bearings
   children: []
@@ -43758,13 +37476,7 @@
   - color
   - compatible_fishing_reel_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-8-6
   name: Fishing Reel Cleaning & Maintenance Kits
   children: []
@@ -43774,13 +37486,7 @@
   - color
   - compatible_fishing_reel_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-8-7
   name: Fishing Reel Handles & Knobs
   children: []
@@ -43790,13 +37496,7 @@
   - color
   - compatible_fishing_reel_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-9
   name: Fishing Reels
   children:
@@ -44012,13 +37712,7 @@
   - spool_color
   - spool_material
   - spool_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-9-9
   name: Electric Fishing Reels
   children: []
@@ -44033,13 +37727,7 @@
   - spool_color
   - spool_material
   - spool_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-9-10
   name: Handline Fishing Reels
   children: []
@@ -44054,13 +37742,7 @@
   - spool_color
   - spool_material
   - spool_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-9-11
   name: Bowfishing Reels
   children: []
@@ -44075,13 +37757,7 @@
   - spool_color
   - spool_material
   - spool_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-9-12
   name: Ice Fishing Reels
   children: []
@@ -44096,13 +37772,7 @@
   - spool_color
   - spool_material
   - spool_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-9-13
   name: Planer Board Reels
   children: []
@@ -44117,13 +37787,7 @@
   - spool_color
   - spool_material
   - spool_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-10
   name: Fishing Rod Accessories
   children:
@@ -44189,13 +37853,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-10-4
   name: Fishing Rod Building Components
   children: []
@@ -44204,13 +37862,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-10-5
   name: Fishing Rod Repair Kits & Supplies
   children: []
@@ -44219,13 +37871,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-11
   name: Fishing Rods
   children:
@@ -44376,13 +38022,7 @@
   - rod_color
   - rod_material
   - rod_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-11-3-2
   name: Fly Fishing Rod Combos & Outfits
   children: []
@@ -44401,13 +38041,7 @@
   - rod_color
   - rod_material
   - rod_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-11-3-3
   name: Spey Fly Fishing Rods
   children: []
@@ -44426,13 +38060,7 @@
   - rod_color
   - rod_material
   - rod_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-11-4
   name: Ice Fishing Rods
   children:
@@ -44480,13 +38108,7 @@
   - rod_color
   - rod_material
   - rod_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-11-4-2
   name: Ice Fishing Rod Blanks
   children: []
@@ -44504,13 +38126,7 @@
   - rod_color
   - rod_material
   - rod_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-11-5
   name: Screw Fishing Rods
   children: []
@@ -44753,13 +38369,7 @@
   - rod_color
   - rod_material
   - rod_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-11-14
   name: Jigging Fishing Rods
   children: []
@@ -44777,13 +38387,7 @@
   - rod_color
   - rod_material
   - rod_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-11-15
   name: Pole Fishing Rods
   children: []
@@ -44801,13 +38405,7 @@
   - rod_color
   - rod_material
   - rod_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-11-16
   name: Centerpin Fishing Rods
   children: []
@@ -44825,13 +38423,7 @@
   - rod_color
   - rod_material
   - rod_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-12
   name: Fishing Spears
   children:
@@ -44863,13 +38455,7 @@
   - pattern
   - thread_connection_size
   - tip_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-12-2
   name: Pole Spears
   children: []
@@ -44878,13 +38464,7 @@
   - pattern
   - thread_connection_size
   - tip_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-12-4
   name: Hawaiian Slings
   children: []
@@ -44893,13 +38473,7 @@
   - pattern
   - thread_connection_size
   - tip_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-12-5
   name: Bowfishing Arrows
   children: []
@@ -44908,13 +38482,7 @@
   - pattern
   - thread_connection_size
   - tip_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-12-6
   name: Speargun Bands & Rubbers
   children: []
@@ -44923,13 +38491,7 @@
   - pattern
   - thread_connection_size
   - tip_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-12-7
   name: Spearguns
   children: []
@@ -44938,13 +38500,7 @@
   - pattern
   - thread_connection_size
   - tip_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13
   name: Fishing Tackle
   children:
@@ -45154,13 +38710,7 @@
   - pattern
   - spinner_blade_shape
   - spinner_subtype
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-1-6-2
   name: Spinnerbaits
   children: []
@@ -45172,13 +38722,7 @@
   - pattern
   - spinner_blade_shape
   - spinner_subtype
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-1-7
   name: Artificial Fishing Spoons
   children: []
@@ -45256,13 +38800,7 @@
   - material
   - pattern
   - wobbler_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-1-9-2
   name: Artificial Fishing Jerkbaits
   children: []
@@ -45273,13 +38811,7 @@
   - material
   - pattern
   - wobbler_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-1-10
   name: Artificial Soft Plastic Baits
   children:
@@ -45317,13 +38849,7 @@
   - material
   - pattern
   - soft_bait_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-1-10-2
   name: Soft Plastic Worms
   children: []
@@ -45335,13 +38861,7 @@
   - material
   - pattern
   - soft_bait_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-1-10-3
   name: Soft Plastic Grubs
   children: []
@@ -45353,13 +38873,7 @@
   - material
   - pattern
   - soft_bait_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-1-10-4
   name: Soft Plastic Craws & Creature Baits
   children: []
@@ -45371,13 +38885,7 @@
   - material
   - pattern
   - soft_bait_style
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-1-11
   name: Fishing Tackle Kits
   children: []
@@ -45410,13 +38918,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-1-13
   name: Fishing Bait Additives & Attractants
   children: []
@@ -45428,13 +38930,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-1-14
   name: Fishing Pellets
   children: []
@@ -45446,13 +38942,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-1-15
   name: Fishing Boilies
   children: []
@@ -45464,13 +38954,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-1-16
   name: Fishing Groundbait & Stick Mixes
   children: []
@@ -45482,13 +38966,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-2
   name: Fishing Floats
   children: []
@@ -45577,13 +39055,7 @@
   - hook_point_type
   - hook_style
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-3-1-2
   name: Double Fishing Hooks
   children: []
@@ -45598,13 +39070,7 @@
   - hook_point_type
   - hook_style
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-3-2
   name: Single Fishing Hooks
   children: []
@@ -45788,13 +39254,7 @@
   - pattern
   - sinker_finish
   - sinker_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-4-8
   name: Fishing Nail Weights
   children: []
@@ -45803,13 +39263,7 @@
   - pattern
   - sinker_finish
   - sinker_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-4-9
   name: Fishing Egg Sinkers
   children: []
@@ -45818,13 +39272,7 @@
   - pattern
   - sinker_finish
   - sinker_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-4-10
   name: Fishing Coins
   children: []
@@ -45833,13 +39281,7 @@
   - pattern
   - sinker_finish
   - sinker_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-4-11
   name: Fishing Bells
   children: []
@@ -45848,13 +39290,7 @@
   - pattern
   - sinker_finish
   - sinker_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-4-12
   name: Fishing Drop-Shots
   children: []
@@ -45863,13 +39299,7 @@
   - pattern
   - sinker_finish
   - sinker_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-13-5
   name: Fishing Snaps & Swivels
   children: []
@@ -45898,13 +39328,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-14
   name: Fishing Traps
   children:
@@ -45934,13 +39358,7 @@
   - material
   - pattern
   - trap_design
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-14-3
   name: Crab Traps
   children: []
@@ -45949,13 +39367,7 @@
   - material
   - pattern
   - trap_design
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-14-4
   name: Minnow Traps
   children: []
@@ -45964,13 +39376,7 @@
   - material
   - pattern
   - trap_design
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-14-5
   name: Lobster Traps
   children: []
@@ -45979,13 +39385,7 @@
   - material
   - pattern
   - trap_design
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-15
   name: Fly Tying Materials
   children:
@@ -46057,143 +39457,77 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-15-4
   name: Fly Tying Foam
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-15-5
   name: Fly Tying Chenille & Braids
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-15-6
   name: Fly Tying Flash Materials
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-15-7
   name: Fly Tying Fur & Hair
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-15-8
   name: Fly Tying Feathers
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-15-9
   name: Fly Tying Wire
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-15-10
   name: Fly Tying Thread & Floss
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-15-11
   name: Fly Tying Eyes & Weights
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-15-12
   name: Fly Tying Tinsel
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-15-13
   name: Fly Tying Adhesives & Resins
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-16
   name: Live Bait
   children:
@@ -46222,13 +39556,7 @@
   - color
   - live_bait_form
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-16-2
   name: Live Crustaceans
   children: []
@@ -46237,13 +39565,7 @@
   - color
   - live_bait_form
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-16-3
   name: Live Worms
   children: []
@@ -46252,13 +39574,7 @@
   - color
   - live_bait_form
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-16-4
   name: Live Minnows & Suckers
   children: []
@@ -46267,13 +39583,7 @@
   - color
   - live_bait_form
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-17
   name: Tackle Bags & Boxes
   children:
@@ -46298,156 +39608,84 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-17-2
   name: Tackle Boxes
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-18
   name: Fishing Weighing & Measuring Tools
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-19
   name: Fishing Carts & Barrows
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-20
   name: Ice Fishing Shelters & Houses
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-21
   name: Fishing Maps & Charts
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-22
   name: Fishing Bite Alarm Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-23
   name: Fishing Net Accessories
   children:
   - sg-4-6-23-1
   - sg-4-6-23-2
   attributes: []
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-23-1
   name: Fishing Net Handles & Poles
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-23-2
   name: Fishing Netting & Mesh Materials
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-24
   name: Fishing Spear Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-6-25
   name: Fishing Trap Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7
   name: Golf
   children:
@@ -46596,13 +39834,7 @@
   - pattern
   - protection_level
   - water_resistance
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-3-2-2
   name: Golf Bag Rain Covers
   children: []
@@ -46612,104 +39844,56 @@
   - pattern
   - protection_level
   - water_resistance
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-3-3
   name: Golf Club Brushes
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-3-4
   name: Golf Scorecard Holders
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-3-5
   name: Golf Cooler Bags
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-3-6
   name: Golf Phone & GPS Holders
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-3-7
   name: Golf Bag Straps
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-3-8
   name: Golf Umbrellas
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-3-9
   name: Golf Valuables & Accessory Pouches
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-4
   name: Golf Bags
   children:
@@ -46739,13 +39923,7 @@
   - color
   - golf_bag_style
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-4-2
   name: Golf Cart Bags
   children: []
@@ -46753,13 +39931,7 @@
   - color
   - golf_bag_style
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-4-3
   name: Sunday Golf Bags
   children: []
@@ -46767,13 +39939,7 @@
   - color
   - golf_bag_style
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-4-4
   name: Golf Stand Bags
   children: []
@@ -46781,13 +39947,7 @@
   - color
   - golf_bag_style
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-5
   name: Golf Ball Markers
   children: []
@@ -46934,13 +40094,7 @@
   - golf_club_part_type
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-7-5
   name: Golf Club Shaft Adapters
   children: []
@@ -46951,13 +40105,7 @@
   - golf_club_part_type
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-7-6
   name: Golf Club Weights & Screws
   children: []
@@ -46968,13 +40116,7 @@
   - golf_club_part_type
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-7-7
   name: Golf Club Ferrules
   children: []
@@ -46985,13 +40127,7 @@
   - golf_club_part_type
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-8
   name: Golf Club Sets
   children:
@@ -47030,13 +40166,7 @@
   - material
   - pattern
   - shaft_flex
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-8-2
   name: Complete Golf Club Sets
   children: []
@@ -47049,13 +40179,7 @@
   - material
   - pattern
   - shaft_flex
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-8-3
   name: Junior Golf Club Sets
   children: []
@@ -47068,13 +40192,7 @@
   - material
   - pattern
   - shaft_flex
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-9
   name: Golf Clubs
   children:
@@ -47119,13 +40237,7 @@
   - material
   - pattern
   - shaft_flex
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-9-2
   name: Golf Drivers
   children: []
@@ -47139,13 +40251,7 @@
   - material
   - pattern
   - shaft_flex
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-9-3
   name: Golf Wedges
   children: []
@@ -47159,13 +40265,7 @@
   - material
   - pattern
   - shaft_flex
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-9-4
   name: Golf Chippers
   children: []
@@ -47179,13 +40279,7 @@
   - material
   - pattern
   - shaft_flex
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-9-5
   name: Golf Hybrids
   children: []
@@ -47199,13 +40293,7 @@
   - material
   - pattern
   - shaft_flex
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-9-6
   name: Golf Fairway Woods
   children: []
@@ -47219,13 +40307,7 @@
   - material
   - pattern
   - shaft_flex
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-9-7
   name: Golf Irons
   children: []
@@ -47239,13 +40321,7 @@
   - material
   - pattern
   - shaft_flex
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-10
   name: Golf Flags
   children: []
@@ -47419,13 +40495,7 @@
   - color
   - golf_training_focus
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-14-3-2
   name: Putting Mirrors
   children: []
@@ -47434,13 +40504,7 @@
   - color
   - golf_training_focus
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-14-3-3
   name: Putting String & Gate Systems
   children: []
@@ -47449,13 +40513,7 @@
   - color
   - golf_training_focus
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-14-4
   name: Golf Swing Trainers
   children: []
@@ -47484,13 +40542,7 @@
   - color
   - golf_training_focus
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-14-6
   name: Golf Grip Trainers
   children: []
@@ -47499,13 +40551,7 @@
   - color
   - golf_training_focus
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-14-7
   name: Golf Hitting Mats
   children: []
@@ -47514,13 +40560,7 @@
   - color
   - golf_training_focus
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-14-8
   name: Golf Practice Nets
   children: []
@@ -47529,13 +40569,7 @@
   - color
   - golf_training_focus
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-14-9
   name: Golf Alignment Sticks
   children: []
@@ -47544,13 +40578,7 @@
   - color
   - golf_training_focus
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-14-10
   name: Golf Laser Alignment Aids
   children: []
@@ -47559,13 +40587,7 @@
   - color
   - golf_training_focus
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-14-11
   name: Golf Putting Simulators & Digital Trainers
   children: []
@@ -47574,13 +40596,7 @@
   - color
   - golf_training_focus
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-15
   name: Golf Shoes
   children: []
@@ -47620,26 +40636,14 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-7-17
   name: Golf Rangefinders & GPS Devices
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-8
   name: Hang Gliding & Skydiving
   children:
@@ -47703,13 +40707,7 @@
   - pattern
   - suit_fit
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-8-1-2
   name: Wingsuits
   children: []
@@ -47722,13 +40720,7 @@
   - pattern
   - suit_fit
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-8-2
   name: Hang Gliders
   children: []
@@ -47776,13 +40768,7 @@
   - color
   - paraglider_certification_rating
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-8-5
   name: Paragliders
   children: []
@@ -47790,13 +40776,7 @@
   - color
   - paraglider_certification_rating
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-8-6
   name: Paragliding & Skydiving Harnesses
   children: []
@@ -47804,13 +40784,7 @@
   - color
   - paraglider_certification_rating
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-8-7
   name: Hang Gliding Harnesses
   children: []
@@ -47818,13 +40792,7 @@
   - color
   - paraglider_certification_rating
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-8-8
   name: Hang Glider Parts & Accessories
   children: []
@@ -47832,13 +40800,7 @@
   - color
   - paraglider_certification_rating
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9
   name: Hunting & Shooting
   children:
@@ -47951,13 +40913,7 @@
   - color
   - fletching_profile
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-4-1-2
   name: Arrow Vanes
   children: []
@@ -47970,13 +40926,7 @@
   - color
   - fletching_profile
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-4-2
   name: Arrow Nocks
   children:
@@ -48116,13 +41066,7 @@
   - nock_material
   - nock_throat_size
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-4-3
   name: Broadheads & Field Points
   children:
@@ -48198,13 +41142,7 @@
   - arrow_component_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-4-5
   name: Arrow Inserts & Outserts
   children: []
@@ -48213,13 +41151,7 @@
   - arrow_component_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-4-6
   name: Arrow Bushings & Collars
   children: []
@@ -48228,13 +41160,7 @@
   - arrow_component_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-4-7
   name: Arrow Adhesives & Glues
   children: []
@@ -48243,13 +41169,7 @@
   - arrow_component_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-4-8
   name: Broadhead Replacement Blades
   children: []
@@ -48258,13 +41178,7 @@
   - arrow_component_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-5
   name: Arrows & Bolts
   children:
@@ -48352,13 +41266,7 @@
   - fletching_orientation
   - nock_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-5-2-2
   name: Pistol Crossbow Bolts
   children: []
@@ -48371,13 +41279,7 @@
   - fletching_orientation
   - nock_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-5-3
   name: Arrow Shafts
   children: []
@@ -48525,13 +41427,7 @@
   - compatible_bow_attachment_system
   - compatible_bow_crossbow_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-6-4-2
   name: Bow Risers
   children: []
@@ -48542,13 +41438,7 @@
   - compatible_bow_attachment_system
   - compatible_bow_crossbow_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-6-4-3
   name: Bow Cams & Modules
   children: []
@@ -48559,13 +41449,7 @@
   - compatible_bow_attachment_system
   - compatible_bow_crossbow_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-6-4-4
   name: Bow Strings & Cables
   children: []
@@ -48576,13 +41460,7 @@
   - compatible_bow_attachment_system
   - compatible_bow_crossbow_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-6-5
   name: Bow & Crossbow Scopes & Sights
   children: []
@@ -48637,13 +41515,7 @@
   - pattern
   - stabilizer_thread_size
   - stabilizer_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-6-6-2
   name: Stabilizer Mounts & Quick Disconnects
   children: []
@@ -48654,13 +41526,7 @@
   - pattern
   - stabilizer_thread_size
   - stabilizer_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-6-6-3
   name: Stabilizer Weights
   children: []
@@ -48671,13 +41537,7 @@
   - pattern
   - stabilizer_thread_size
   - stabilizer_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-6-6-4
   name: Bow Stabilizer Bars
   children: []
@@ -48688,13 +41548,7 @@
   - pattern
   - stabilizer_thread_size
   - stabilizer_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-6-7
   name: Bow & Crossbow Lubricants & Waxes
   children: []
@@ -48703,13 +41557,7 @@
   - color
   - compatible_bow_crossbow_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-6-8
   name: Bow & Crossbow Grips
   children: []
@@ -48718,13 +41566,7 @@
   - color
   - compatible_bow_crossbow_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-6-9
   name: Bow & Crossbow Stands & Hangers
   children: []
@@ -48733,13 +41575,7 @@
   - color
   - compatible_bow_crossbow_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-6-10
   name: Bow & Crossbow Slings & Carriers
   children: []
@@ -48748,13 +41584,7 @@
   - color
   - compatible_bow_crossbow_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-7
   name: Bows & Crossbows
   children:
@@ -48866,13 +41696,7 @@
   - string_color
   - string_material
   - string_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-7-2-2
   name: Compound Crossbows
   children: []
@@ -48890,13 +41714,7 @@
   - string_color
   - string_material
   - string_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-7-2-3
   name: Pistol Crossbows
   children: []
@@ -48914,13 +41732,7 @@
   - string_color
   - string_material
   - string_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-7-3
   name: Recurve & Longbows
   children:
@@ -49059,13 +41871,7 @@
   - string_color
   - string_material
   - string_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-7-4-2
   name: Youth Compound Bows
   children: []
@@ -49086,13 +41892,7 @@
   - string_color
   - string_material
   - string_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-7-4-3
   name: Youth Toy & Soft Bows
   children: []
@@ -49113,13 +41913,7 @@
   - string_color
   - string_material
   - string_pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-10
   name: Archery Tools & Equipment
   children:
@@ -49201,13 +41995,7 @@
   - color
   - hand_side
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-10-2-2
   name: Bowstring Wax
   children: []
@@ -49217,13 +42005,7 @@
   - color
   - hand_side
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-10-2-3
   name: Arrow Pullers
   children: []
@@ -49233,13 +42015,7 @@
   - color
   - hand_side
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-10-2-4
   name: Bow Stringers & Nocking Tools
   children: []
@@ -49249,13 +42025,7 @@
   - color
   - hand_side
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-10-2-5
   name: Fletching Tools
   children: []
@@ -49265,13 +42035,7 @@
   - color
   - hand_side
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-10-2-6
   name: Bow Vises & Clamps
   children: []
@@ -49281,13 +42045,7 @@
   - color
   - hand_side
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-10-3
   name: Bow Presses
   children: []
@@ -49316,13 +42074,7 @@
   - color
   - hand_side
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-10-5
   name: Arrow Saws & Cutters
   children: []
@@ -49332,13 +42084,7 @@
   - color
   - hand_side
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-11
   name: Archery Accessories
   children:
@@ -49427,13 +42173,7 @@
   - release_jaw_style
   - release_strap_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-11-2-2
   name: Archery Shooting Gloves & Finger Tabs
   children: []
@@ -49450,13 +42190,7 @@
   - release_jaw_style
   - release_strap_type
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-11-3
   name: Archery Targets
   children:
@@ -49493,13 +42227,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-11-3-2
   name: 3D Archery Targets
   children: []
@@ -49511,13 +42239,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-11-3-3
   name: Bag & Block Archery Targets
   children: []
@@ -49529,13 +42251,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-11-4
   name: Quivers
   children: []
@@ -49586,13 +42302,7 @@
   - color
   - hand_side
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-1-11-5-2
   name: Archery Target Stands
   children: []
@@ -49602,13 +42312,7 @@
   - color
   - hand_side
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-2
   name: Clay Pigeon Shooting
   children:
@@ -49680,13 +42384,7 @@
   - clay_shooting_discipline
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-2-4
   name: Clay Pigeon Shooting Bags & Pouches
   children: []
@@ -49694,13 +42392,7 @@
   - clay_shooting_discipline
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-2-5
   name: Clay Pigeon Thrower Accessories
   children: []
@@ -49708,13 +42400,7 @@
   - clay_shooting_discipline
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-2-6
   name: Shotgun Choke Tubes
   children: []
@@ -49722,13 +42408,7 @@
   - clay_shooting_discipline
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3
   name: Hunting
   children:
@@ -49801,13 +42481,7 @@
   - map_format
   - pattern
   - trap_spring_configuration
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-1-2
   name: Body Grip Traps
   children: []
@@ -49820,13 +42494,7 @@
   - map_format
   - pattern
   - trap_spring_configuration
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-1-3
   name: Cage & Live Traps
   children: []
@@ -49839,13 +42507,7 @@
   - map_format
   - pattern
   - trap_spring_configuration
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-1-5
   name: Snare Traps
   children: []
@@ -49858,13 +42520,7 @@
   - map_format
   - pattern
   - trap_spring_configuration
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-2
   name: Hearing Enhancers
   children: []
@@ -49946,13 +42602,7 @@
   - hunting_blind_design
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-3-1-2
   name: Synthetic Grass Blind Covers
   children: []
@@ -49963,13 +42613,7 @@
   - hunting_blind_design
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-3-1-3
   name: Camouflage Nets
   children: []
@@ -49980,13 +42624,7 @@
   - hunting_blind_design
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-3-2
   name: Hunting Blind Chairs & Seats
   children: []
@@ -49998,13 +42636,7 @@
   - hunting_blind_design
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-3-3
   name: Hunting Blind Platforms & Towers
   children: []
@@ -50016,13 +42648,7 @@
   - hunting_blind_design
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-4
   name: Hunting Dog Equipment
   children:
@@ -50114,13 +42740,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-4-5
   name: Hunting Dog Tracking Devices
   children: []
@@ -50128,13 +42748,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-4-6
   name: Hunting Dog Bird Launchers
   children: []
@@ -50142,13 +42756,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-4-7
   name: Hunting Dog Vests
   children: []
@@ -50156,13 +42764,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-4-8
   name: Hunting Dog Harnesses
   children: []
@@ -50170,13 +42772,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-5
   name: Tree Stands
   children:
@@ -50208,13 +42804,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-5-3
   name: Climbing Sticks
   children: []
@@ -50222,13 +42812,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-5-4
   name: Climbing Tree Stands
   children: []
@@ -50236,13 +42820,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-5-5
   name: Saddle Hunting Platforms
   children: []
@@ -50250,13 +42828,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-5-6
   name: Tripod Tree Stands
   children: []
@@ -50264,13 +42836,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-5-7
   name: Hang-On Tree Stands
   children: []
@@ -50278,13 +42844,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-6
   name: Wild Game Feeders
   children: []
@@ -50490,13 +43050,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-8
   name: Game Carts & Carriers
   children: []
@@ -50506,13 +43060,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-9
   name: Hunting Maps & Guides
   children: []
@@ -50522,13 +43070,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-10
   name: Game Processing & Field Dressing Equipment
   children: []
@@ -50538,13 +43080,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-11
   name: Animal Trap Accessories
   children: []
@@ -50554,13 +43090,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-12
   name: Hunting Blind Accessories
   children: []
@@ -50570,13 +43100,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-13
   name: Tree Stand Accessories
   children: []
@@ -50586,13 +43110,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-3-14
   name: Wild Game Feeder Accessories
   children: []
@@ -50602,13 +43120,7 @@
   - color
   - map_format
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-4
   name: Hunting & Shooting Protective Gear
   children:
@@ -50682,13 +43194,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-4-4
   name: Hunting & Shooting Vests
   children: []
@@ -50697,13 +43203,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-4-5
   name: Hunting & Shooting Pants & Bibs
   children: []
@@ -50712,13 +43212,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-4-6
   name: Hunting & Shooting Hearing Protection
   children: []
@@ -50727,13 +43221,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-4-7
   name: Hunting & Shooting Safety Harnesses
   children: []
@@ -50742,13 +43230,7 @@
   - color
   - pattern
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-6
   name: Shooting & Range Accessories
   children:
@@ -50807,13 +43289,7 @@
   - features
   - pattern
   - shooting_rest_design
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-6-1-2
   name: Tripod Shooting Rests
   children: []
@@ -50822,13 +43298,7 @@
   - features
   - pattern
   - shooting_rest_design
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-6-1-3
   name: Shooting Rest Bags
   children: []
@@ -50837,13 +43307,7 @@
   - features
   - pattern
   - shooting_rest_design
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-6-2
   name: Shooting Sticks & Bipods
   children:
@@ -50931,13 +43395,7 @@
   - color
   - head_movement_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-6-3
   name: Shooting Targets
   children:
@@ -50968,13 +43426,7 @@
   - pattern
   - shooting_target_type
   - target_resetting_mechanism
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-6-3-2
   name: Reactive Targets
   children: []
@@ -50984,13 +43436,7 @@
   - pattern
   - shooting_target_type
   - target_resetting_mechanism
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-6-4
   name: Shooting Mats
   children: []
@@ -51000,13 +43446,7 @@
   - color
   - mounting_rail_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-6-5
   name: Bore Sighters
   children: []
@@ -51016,13 +43456,7 @@
   - color
   - mounting_rail_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-6-6
   name: Weapon Mounts & Rails
   children: []
@@ -51032,13 +43466,7 @@
   - color
   - mounting_rail_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-6-7
   name: Recoil Pads & Shields
   children: []
@@ -51048,13 +43476,7 @@
   - color
   - mounting_rail_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-6-9
   name: Shot Timers & Chronographs
   children: []
@@ -51064,13 +43486,7 @@
   - color
   - mounting_rail_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7
   name: Airsoft
   children:
@@ -51155,13 +43571,7 @@
   - pattern
   - propellant_type
   - thread_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-1-3
   name: Airsoft Gun Internal Components
   children: []
@@ -51175,13 +43585,7 @@
   - pattern
   - propellant_type
   - thread_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-1-4
   name: Airsoft Gun Chargers
   children: []
@@ -51195,13 +43599,7 @@
   - pattern
   - propellant_type
   - thread_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-1-5
   name: Airsoft Gun Magazines
   children: []
@@ -51215,13 +43613,7 @@
   - pattern
   - propellant_type
   - thread_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-2
   name: Airsoft Guns
   children:
@@ -51259,13 +43651,7 @@
   - hop_up_type
   - pattern
   - rail_system
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-2-2
   name: Airsoft Sniper Rifles
   children: []
@@ -51276,13 +43662,7 @@
   - hop_up_type
   - pattern
   - rail_system
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-2-3
   name: Airsoft Shotguns
   children: []
@@ -51293,13 +43673,7 @@
   - hop_up_type
   - pattern
   - rail_system
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-2-4
   name: Airsoft Rifles
   children: []
@@ -51310,13 +43684,7 @@
   - hop_up_type
   - pattern
   - rail_system
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-2-5
   name: Airsoft Submachine Guns
   children: []
@@ -51327,13 +43695,7 @@
   - hop_up_type
   - pattern
   - rail_system
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-2-6
   name: Airsoft Grenade Launchers
   children: []
@@ -51344,13 +43706,7 @@
   - hop_up_type
   - pattern
   - rail_system
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-3
   name: Airsoft Pellets
   children: []
@@ -51448,13 +43804,7 @@
   - color
   - lens_color_tint
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-4-2-3
   name: Airsoft Masks
   children: []
@@ -51464,13 +43814,7 @@
   - color
   - lens_color_tint
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-4-3
   name: Airsoft Pads
   children: []
@@ -51526,13 +43870,7 @@
   - lens_color_tint
   - magazine_compatibility
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-4-4-2
   name: Plate Carriers
   children: []
@@ -51544,13 +43882,7 @@
   - lens_color_tint
   - magazine_compatibility
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-4-5
   name: Airsoft Helmets
   children: []
@@ -51558,13 +43890,7 @@
   - color
   - lens_color_tint
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-4-6
   name: Airsoft Helmet Accessories
   children: []
@@ -51572,13 +43898,7 @@
   - color
   - lens_color_tint
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-4-7
   name: Airsoft Goggle & Mask Accessories
   children: []
@@ -51586,39 +43906,21 @@
   - color
   - lens_color_tint
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-5
   name: Airsoft Grenades
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-7-6
   name: Airsoft Targets
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-8
   name: BB Guns & Accessories
   children:
@@ -51698,13 +44000,7 @@
   - pattern
   - projectile_type
   - rail_mount_standard
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-8-2-2
   name: BB Gun Sights & Sight Parts
   children: []
@@ -51716,13 +44012,7 @@
   - pattern
   - projectile_type
   - rail_mount_standard
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-8-2-3
   name: BB Gun Magazines & Speedloaders
   children: []
@@ -51734,13 +44024,7 @@
   - pattern
   - projectile_type
   - rail_mount_standard
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-8-2-4
   name: BB Gun Springs & Power Plants
   children: []
@@ -51752,13 +44036,7 @@
   - pattern
   - projectile_type
   - rail_mount_standard
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-8-2-5
   name: BB Gun Seals & O-Rings
   children: []
@@ -51770,13 +44048,7 @@
   - pattern
   - projectile_type
   - rail_mount_standard
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-8-3
   name: BB Guns
   children:
@@ -51810,13 +44082,7 @@
   - color
   - pattern
   - projectile_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-8-3-2
   name: BB Pistols
   children: []
@@ -51827,13 +44093,7 @@
   - color
   - pattern
   - projectile_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-9
   name: Gel Blasters & Accessories
   children:
@@ -51919,13 +44179,7 @@
   - color
   - gas_propellant_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-9-3-2
   name: Gel Blaster Shotguns
   children: []
@@ -51934,13 +44188,7 @@
   - color
   - gas_propellant_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-9-3-3
   name: Gel Blaster Pistols
   children: []
@@ -51949,13 +44197,7 @@
   - color
   - gas_propellant_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-9-3-4
   name: Gel Blaster Sniper Rifles
   children: []
@@ -51964,13 +44206,7 @@
   - color
   - gas_propellant_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-9-3-5
   name: Gel Blaster Submachine Guns
   children: []
@@ -51979,13 +44215,7 @@
   - color
   - gas_propellant_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-9-3-6
   name: Gel Blaster Rifles
   children: []
@@ -51994,52 +44224,28 @@
   - color
   - gas_propellant_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-9-4
   name: Gel Blaster Targets & Range Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-9-5
   name: Gel Blaster Cases & Bags
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-9-6
   name: Gel Blaster Protective Gear
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10
   name: Paintball
   children:
@@ -52114,13 +44320,7 @@
   - grenade_effect_type
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-2-2
   name: Smoke Grenades
   children: []
@@ -52129,13 +44329,7 @@
   - grenade_effect_type
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-2-3
   name: Paintball Fragmentation Grenades
   children: []
@@ -52144,13 +44338,7 @@
   - grenade_effect_type
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-3
   name: Paintball Gun Parts & Accessories
   children:
@@ -52264,13 +44452,7 @@
   - color
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-3-4-2
   name: Gravity-Fed Paintball Hoppers
   children: []
@@ -52278,13 +44460,7 @@
   - color
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-3-5
   name: Paintball Gun Stocks
   children: []
@@ -52292,13 +44468,7 @@
   - color
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-3-6
   name: Paintball Gun Triggers
   children: []
@@ -52306,13 +44476,7 @@
   - color
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-3-7
   name: Paintball Gun Feed Necks
   children: []
@@ -52320,13 +44484,7 @@
   - color
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-3-8
   name: Paintball Gun Bolts
   children: []
@@ -52334,13 +44492,7 @@
   - color
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-3-9
   name: Paintball Gun Magazines
   children: []
@@ -52348,13 +44500,7 @@
   - color
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-3-10
   name: Paintball Pods & Tubes
   children: []
@@ -52362,13 +44508,7 @@
   - color
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-3-11
   name: Paintball Gun Regulators
   children: []
@@ -52376,13 +44516,7 @@
   - color
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-3-12
   name: Paintball Air Tank Accessories
   children: []
@@ -52390,13 +44524,7 @@
   - color
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-4
   name: Paintball Guns
   children: []
@@ -52450,13 +44578,7 @@
   - paintball_caliber
   - pattern
   - pod_retention_system
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-5-2
   name: Paintball Pouches
   children: []
@@ -52465,13 +44587,7 @@
   - paintball_caliber
   - pattern
   - pod_retention_system
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-6
   name: Paintballs
   children: []
@@ -52582,13 +44698,7 @@
   - paintball_caliber
   - paintball_mask_coverage_level
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-7-2-3
   name: Paintball Goggle Straps
   children: []
@@ -52601,13 +44711,7 @@
   - paintball_caliber
   - paintball_mask_coverage_level
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-7-3
   name: Paintball Pads
   children:
@@ -52639,13 +44743,7 @@
   - padding_level
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-7-3-2
   name: Paintball Slide Shorts
   children: []
@@ -52655,13 +44753,7 @@
   - padding_level
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-7-3-3
   name: Paintball Knee Pads
   children: []
@@ -52671,13 +44763,7 @@
   - padding_level
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-7-4
   name: Paintball Vests
   children: []
@@ -52707,13 +44793,7 @@
   - padding_level
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-7-6
   name: Paintball Chest Guards
   children: []
@@ -52722,13 +44802,7 @@
   - padding_level
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-7-7
   name: Paintball Neck Protectors
   children: []
@@ -52737,13 +44811,7 @@
   - padding_level
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-7-8
   name: Paintball Helmets
   children: []
@@ -52752,13 +44820,7 @@
   - padding_level
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-7-9
   name: Paintball Pants
   children: []
@@ -52767,13 +44829,7 @@
   - padding_level
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-7-10
   name: Paintball Goggle & Mask Cases & Bags
   children: []
@@ -52782,13 +44838,7 @@
   - padding_level
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-8
   name: Paintball Mines & Booby Traps
   children: []
@@ -52796,13 +44846,7 @@
   - color
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-10-9
   name: Paintball Bunkers & Obstacles
   children: []
@@ -52810,52 +44854,28 @@
   - color
   - paintball_caliber
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-11
   name: Slingshots
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-12
   name: Blowguns & Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-9-13
   name: Slingshots & Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-10
   name: Hydration System Accessories
   children:
@@ -53093,13 +45113,7 @@
   - color
   - mouthpiece_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-10-12
   name: Hydration System Cleaning Kits
   children: []
@@ -53107,13 +45121,7 @@
   - color
   - mouthpiece_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-10-13
   name: Water Storage Jugs & Jerrycans
   children: []
@@ -53121,13 +45129,7 @@
   - color
   - mouthpiece_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-10-14
   name: Hydration System Replacement Parts
   children: []
@@ -53135,13 +45137,7 @@
   - color
   - mouthpiece_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-11
   name: Hydration Systems
   children: []
@@ -53250,13 +45246,7 @@
   - pattern
   - protective_gear_items_included
   - protective_pad_components_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-1-1-2
   name: Roller Skating Elbow Pads
   children: []
@@ -53268,13 +45258,7 @@
   - pattern
   - protective_gear_items_included
   - protective_pad_components_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-1-2
   name: Roller Skating Protective Gear Sets
   children: []
@@ -53286,13 +45270,7 @@
   - pattern
   - protective_gear_items_included
   - protective_pad_components_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-1-3
   name: Protective Shorts
   children: []
@@ -53304,13 +45282,7 @@
   - pattern
   - protective_gear_items_included
   - protective_pad_components_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-1-4
   name: Inline & Roller Skating Gloves
   children: []
@@ -53322,13 +45294,7 @@
   - pattern
   - protective_gear_items_included
   - protective_pad_components_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-1-5
   name: Roller Skating Wrist Guards
   children: []
@@ -53340,13 +45306,7 @@
   - pattern
   - protective_gear_items_included
   - protective_pad_components_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-1-6
   name: Inline & Roller Skating Helmets
   children: []
@@ -53358,13 +45318,7 @@
   - pattern
   - protective_gear_items_included
   - protective_pad_components_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-1-7
   name: Toe Guards & Toe Caps
   children: []
@@ -53376,13 +45330,7 @@
   - pattern
   - protective_gear_items_included
   - protective_pad_components_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-2
   name: Inline Skate Parts
   children:
@@ -53470,13 +45418,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-2-5
   name: Inline Skate Liners
   children: []
@@ -53484,13 +45426,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-2-6
   name: Inline Skate Laces
   children: []
@@ -53498,13 +45434,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-2-7
   name: Inline Skate Tools
   children: []
@@ -53512,13 +45442,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-2-8
   name: Inline Skate Frames
   children: []
@@ -53526,13 +45450,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-2-9
   name: Inline Skate Hardware
   children: []
@@ -53540,13 +45458,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-3
   name: Inline Skates
   children:
@@ -53711,13 +45623,7 @@
   - shell/frame_pattern
   - shoe_size
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-4
   name: Roller Skate Parts
   children:
@@ -53792,13 +45698,7 @@
   - pattern
   - roller_skate_brake_shape
   - toe_stop_stem_thread_size
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-4-2-2
   name: Bolt-On Toe Stops
   children: []
@@ -53808,13 +45708,7 @@
   - pattern
   - roller_skate_brake_shape
   - toe_stop_stem_thread_size
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-4-3
   name: Roller Skate Wheels
   children: []
@@ -53841,13 +45735,7 @@
   - color
   - pattern
   - toe_stop_stem_thread_size
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-4-5
   name: Roller Skate Trucks
   children: []
@@ -53857,13 +45745,7 @@
   - color
   - pattern
   - toe_stop_stem_thread_size
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-4-6
   name: Roller Skate Plates
   children: []
@@ -53873,13 +45755,7 @@
   - color
   - pattern
   - toe_stop_stem_thread_size
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-5
   name: Roller Skates
   children:
@@ -54043,13 +45919,7 @@
   - shell/frame_pattern
   - shoe_size
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-5-6
   name: Hockey Roller Skates
   children: []
@@ -54066,13 +45936,7 @@
   - shell/frame_pattern
   - shoe_size
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-5-7
   name: Derby Roller Skates
   children: []
@@ -54089,13 +45953,7 @@
   - shell/frame_pattern
   - shoe_size
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-5-8
   name: Jam Roller Skates
   children: []
@@ -54112,13 +45970,7 @@
   - shell/frame_pattern
   - shoe_size
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-6
   name: Roller Skis
   children:
@@ -54247,39 +46099,21 @@
   - roller_ski_technique
   - ski_construction
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-7
   name: Inline & Roller Skating Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-12-8
   name: Roller Ski Parts
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-13
   name: Kite Buggying
   children:
@@ -54395,13 +46229,7 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14
   name: Outdoor Games
   children:
@@ -54646,52 +46474,28 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-1-6
   name: Badminton Strings
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-1-7
   name: Badminton Training Aids
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-1-8
   name: Badminton Bags
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-2
   name: Deck Shuffleboard
   children:
@@ -54756,13 +46560,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-2-4
   name: Deck Shuffleboard Courts
   children: []
@@ -54770,13 +46568,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-2-5
   name: Deck Shuffleboard Sets
   children: []
@@ -54784,13 +46576,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-2-6
   name: Deck Shuffleboard Accessories
   children: []
@@ -54798,13 +46584,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-3
   name: Disc Golf
   children:
@@ -54873,13 +46653,7 @@
   - color
   - pattern
   - stability_class
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-3-2-2
   name: Mini Disc Golf Baskets
   children: []
@@ -54888,13 +46662,7 @@
   - color
   - pattern
   - stability_class
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-3-2-3
   name: Permanent Disc Golf Baskets
   children: []
@@ -54903,13 +46671,7 @@
   - color
   - pattern
   - stability_class
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-3-3
   name: Disc Golf Discs
   children: []
@@ -54937,13 +46699,7 @@
   - color
   - pattern
   - stability_class
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-3-5
   name: Disc Golf Accessories
   children: []
@@ -54951,13 +46707,7 @@
   - color
   - pattern
   - stability_class
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-4
   name: Lawn Games
   children:
@@ -55032,13 +46782,7 @@
   - color
   - cornhole_league_certification
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-4-2-2
   name: Cornhole Accessories
   children: []
@@ -55048,13 +46792,7 @@
   - color
   - cornhole_league_certification
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-4-2-3
   name: Cornhole Bags
   children: []
@@ -55064,13 +46802,7 @@
   - color
   - cornhole_league_certification
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-4-3
   name: Croquet Sets
   children: []
@@ -55111,65 +46843,35 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-4-6
   name: Slackline Sets
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-4-7
   name: Kubb Sets
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-4-8
   name: Ladder Toss Sets
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-4-9
   name: Washer Toss Sets
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-5
   name: Paddle Ball Sets
   children: []
@@ -55252,65 +46954,35 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-6-4
   name: Pickleball Sets
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-6-5
   name: Pickleball Nets
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-6-6
   name: Pickleball Accessories & Training Aids
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-6-7
   name: Pickleball Ball Machines
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-7
   name: Platform & Paddle Tennis
   children:
@@ -55376,52 +47048,28 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-7-4
   name: Platform & Paddle Tennis Grips & Tape
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-7-5
   name: Platform & Paddle Tennis Bags
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-7-6
   name: Platform & Paddle Tennis Shoes
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-8
   name: Tetherball
   children:
@@ -55502,52 +47150,28 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-10
   name: Beer Pong
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-11
   name: Zip Line Kits
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-14-12
   name: Roundnet Sets
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15
   name: Riding Scooters
   children:
@@ -55743,26 +47367,14 @@
   attributes:
   - battery_features
   - ev_battery_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-3-1-2
   name: E-Scooter Batteries
   children: []
   attributes:
   - battery_features
   - ev_battery_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-3-2
   name: Wheels & Tires
   children:
@@ -55789,39 +47401,21 @@
   attributes:
   - wheel_part_type
   - wheel_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-3-2-2
   name: E-Scooter Tubes
   children: []
   attributes:
   - wheel_part_type
   - wheel_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-3-2-3
   name: E-Scooter Tires
   children: []
   attributes:
   - wheel_part_type
   - wheel_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-3-3
   name: Braking Systems
   children:
@@ -55850,13 +47444,7 @@
   - material
   - scooter_brake_pad_material
   - scooter_brake_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-3-3-2
   name: Brake Rotors
   children: []
@@ -55864,13 +47452,7 @@
   - material
   - scooter_brake_pad_material
   - scooter_brake_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-3-3-3
   name: Brake Pads
   children: []
@@ -55878,13 +47460,7 @@
   - material
   - scooter_brake_pad_material
   - scooter_brake_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-3-3-4
   name: Brake Levers & Master Cylinders
   children: []
@@ -55892,13 +47468,7 @@
   - material
   - scooter_brake_pad_material
   - scooter_brake_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-3-3-5
   name: Brake Calipers
   children: []
@@ -55906,13 +47476,7 @@
   - material
   - scooter_brake_pad_material
   - scooter_brake_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-3-4
   name: Handlebars & Controls
   children:
@@ -55943,13 +47507,7 @@
   - e_scooter_throttle_type
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-3-4-2
   name: E-Scooter Handlebar Grips
   children: []
@@ -55958,13 +47516,7 @@
   - e_scooter_throttle_type
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-3-4-3
   name: E-Scooter Handlebars
   children: []
@@ -55973,13 +47525,7 @@
   - e_scooter_throttle_type
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-3-5
   name: Frames & Body Parts
   children: []
@@ -56022,26 +47568,14 @@
   attributes:
   - e_scooter_connector_type
   - material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-3-6-2
   name: Wiring Harnesses
   children: []
   attributes:
   - e_scooter_connector_type
   - material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-3-7
   name: Electric Motors
   children: []
@@ -56065,39 +47599,21 @@
   attributes:
   - battery_size
   - battery_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-3-9
   name: Lights & Reflectors
   children: []
   attributes:
   - battery_size
   - battery_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-3-10
   name: Suspension Parts
   children: []
   attributes:
   - battery_size
   - battery_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-4
   name: Kick Scooter Parts
   children: []
@@ -56107,13 +47623,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-15-5
   name: Self-Balancing Scooters
   children: []
@@ -56123,13 +47633,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-16
   name: Skateboarding
   children:
@@ -56295,13 +47799,7 @@
   - battery_type
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-16-2
   name: Skate Rails
   children: []
@@ -56496,13 +47994,7 @@
   - color
   - pattern
   - skateboard_nut_thread_size
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-16-4-2-4-2
   name: Skateboard Mounting Nuts
   children: []
@@ -56511,13 +48003,7 @@
   - color
   - pattern
   - skateboard_nut_thread_size
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-16-4-2-4-3
   name: Skateboard Kingpin Nuts
   children: []
@@ -56526,13 +48012,7 @@
   - color
   - pattern
   - skateboard_nut_thread_size
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-16-4-2-5
   name: Skateboard Pivot Cups
   children: []
@@ -56587,26 +48067,14 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-16-4-2-9
   name: Skateboard Bushings
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-16-4-3
   name: Skateboard Trucks
   children: []
@@ -56660,13 +48128,7 @@
   - lumber/wood_type
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-16-5
   name: Skateboarding Protective Gear
   children:
@@ -56767,13 +48229,7 @@
   - impact_protection_rating
   - pad_components_included
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-16-5-3-2
   name: Skateboarding Knee Pads
   children: []
@@ -56784,13 +48240,7 @@
   - impact_protection_rating
   - pad_components_included
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-16-5-3-3
   name: Skateboarding Pad Sets
   children: []
@@ -56801,13 +48251,7 @@
   - impact_protection_rating
   - pad_components_included
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-16-5-4
   name: Skateboarding Body Armor
   children: []
@@ -56816,13 +48260,7 @@
   - age_group
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-16-5-5
   name: Skateboarding Protective Shorts
   children: []
@@ -56831,13 +48269,7 @@
   - age_group
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-16-5-6
   name: Skateboarding Wrist Guards
   children: []
@@ -56846,52 +48278,28 @@
   - age_group
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-16-6
   name: Skateboarding Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-16-7
   name: Skateboard Tools & Maintenance
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-16-8
   name: Skateboarding Shoes
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17
   name: Winter Sports & Activities
   children:
@@ -56985,13 +48393,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-1-4
   name: Avalanche Shovels
   children: []
@@ -57001,13 +48403,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-1-5
   name: Avalanche Rescue Kits
   children: []
@@ -57017,13 +48413,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-1-6
   name: Avalanche Beacons & Transceivers
   children: []
@@ -57033,13 +48423,7 @@
   - color
   - material
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2
   name: Skiing & Snowboarding
   children:
@@ -57104,52 +48488,28 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-1-2
   name: Ski & Snowboard Boot Bags
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-1-3
   name: Ski Bags
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-1-4
   name: Ski & Snowboard Backpacks
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-2
   name: Ski & Snowboard Goggle Accessories
   children:
@@ -57209,13 +48569,7 @@
   - goggle_accessory_type
   - goggle_lens_shape
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-2-3
   name: Ski & Snowboard Goggle Cases
   children: []
@@ -57230,13 +48584,7 @@
   - goggle_accessory_type
   - goggle_lens_shape
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-2-4
   name: Ski & Snowboard Goggle Prescription Inserts
   children: []
@@ -57251,13 +48599,7 @@
   - goggle_accessory_type
   - goggle_lens_shape
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-2-5
   name: Ski & Snowboard Goggle Straps
   children: []
@@ -57272,13 +48614,7 @@
   - goggle_accessory_type
   - goggle_lens_shape
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-2-6
   name: Ski & Snowboard Goggle Nose Guards
   children: []
@@ -57293,13 +48629,7 @@
   - goggle_accessory_type
   - goggle_lens_shape
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-2-7
   name: Ski & Snowboard Goggle Cleaning & Anti-Fog Solutions
   children: []
@@ -57314,13 +48644,7 @@
   - goggle_accessory_type
   - goggle_lens_shape
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-3
   name: Ski & Snowboard Goggles
   children: []
@@ -57601,13 +48925,7 @@
   - color
   - pattern
   - sport
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-7-11
   name: Ski & Snowboard Tuning Kits
   children: []
@@ -57615,13 +48933,7 @@
   - color
   - pattern
   - sport
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-7-12
   name: Ski & Snowboard Waxing Benches & Tables
   children: []
@@ -57629,13 +48941,7 @@
   - color
   - pattern
   - sport
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-8
   name: Ski & Snowboard Wax
   children:
@@ -57721,13 +49027,7 @@
   - sport
   - wax_application_method
   - wax_hardness
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-8-4
   name: Ski & Snowboard Base Prep Wax
   children: []
@@ -57741,13 +49041,7 @@
   - sport
   - wax_application_method
   - wax_hardness
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-9
   name: Ski Binding Parts
   children:
@@ -57797,13 +49091,7 @@
   - color
   - pattern
   - ski_binding_part_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-9-3
   name: Ski Binding Brakes
   children: []
@@ -57812,13 +49100,7 @@
   - color
   - pattern
   - ski_binding_part_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-9-4
   name: Ski Binding Plates
   children: []
@@ -57827,13 +49109,7 @@
   - color
   - pattern
   - ski_binding_part_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-9-5
   name: Ski Binding Screws & Mounting Hardware
   children: []
@@ -57842,13 +49118,7 @@
   - color
   - pattern
   - ski_binding_part_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-10
   name: Ski Bindings
   children:
@@ -57884,13 +49154,7 @@
   - pattern
   - riding_style
   - ski_binding_mechanism
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-10-2
   name: Alpine Touring Ski Bindings
   children: []
@@ -57902,13 +49166,7 @@
   - pattern
   - riding_style
   - ski_binding_mechanism
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-10-3
   name: Cross-Country Ski Bindings
   children: []
@@ -57920,13 +49178,7 @@
   - pattern
   - riding_style
   - ski_binding_mechanism
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-10-4
   name: Telemark Ski Bindings
   children: []
@@ -57938,13 +49190,7 @@
   - pattern
   - riding_style
   - ski_binding_mechanism
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-11
   name: Ski Boots
   children:
@@ -58146,13 +49392,7 @@
   - ski_construction
   - skiing_style
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-14
   name: Snowboard Binding Parts
   children:
@@ -58239,52 +49479,28 @@
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-14-5
   name: Snowboard Binding Discs
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-14-6
   name: Snowboard Binding Hardware
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-14-7
   name: Snowboard Binding Buckles & Ladders
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-15
   name: Snowboard Bindings
   children:
@@ -58326,13 +49542,7 @@
   - riding_style
   - shoe_binding_type
   - toe_strap_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-15-2
   name: Splitboard Bindings
   children: []
@@ -58347,13 +49557,7 @@
   - riding_style
   - shoe_binding_type
   - toe_strap_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-16
   name: Snowboard Boots
   children: []
@@ -58420,13 +49624,7 @@
   - snowboard_width_class
   - snowboarding_style
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-17-2
   name: Snowskates
   children: []
@@ -58441,13 +49639,7 @@
   - snowboard_width_class
   - snowboarding_style
   - target_gender
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-18
   name: Ski & Snowboard Climbing Skins
   children: []
@@ -58456,13 +49648,7 @@
   - lumber/wood_type
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-19
   name: Ski & Snowboard Trail Maps
   children: []
@@ -58471,13 +49657,7 @@
   - lumber/wood_type
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-2-20
   name: Snowboard Stomp Pads
   children: []
@@ -58486,13 +49666,7 @@
   - lumber/wood_type
   - pattern
   - wood_finish
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-3
   name: Sleds
   children:
@@ -58595,13 +49769,7 @@
   - runner_material
   - sled_brake_type
   - sled_towing_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-3-3-2
   name: Child Pulks
   children: []
@@ -58612,13 +49780,7 @@
   - runner_material
   - sled_brake_type
   - sled_towing_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-3-4
   name: Snow Racers
   children: []
@@ -58693,13 +49855,7 @@
   - runner_material
   - sled_brake_type
   - sled_towing_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-3-6-2
   name: Utility & Freight Toboggans
   children: []
@@ -58711,13 +49867,7 @@
   - runner_material
   - sled_brake_type
   - sled_towing_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-3-7
   name: Utility Sleds
   children: []
@@ -58728,13 +49878,7 @@
   - runner_material
   - sled_brake_type
   - sled_towing_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-3-8
   name: Kick Sleds
   children: []
@@ -58745,13 +49889,7 @@
   - runner_material
   - sled_brake_type
   - sled_towing_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-3-10
   name: Saucer Sleds
   children: []
@@ -58762,13 +49900,7 @@
   - runner_material
   - sled_brake_type
   - sled_towing_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-4
   name: Snowshoeing
   children:
@@ -58849,13 +49981,7 @@
   - material
   - pattern
   - shoe_binding_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-4-4
   name: Snowshoe Bags
   children: []
@@ -58865,62 +49991,32 @@
   - material
   - pattern
   - shoe_binding_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-5
   name: Winter Trail Maps & Guides
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-17-6
   name: Sled Accessories
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-18
   name: Gold Prospecting & Panning Equipment
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: sg-4-19
   name: Skateboard Wax
   children: []
   attributes:
   - color
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit

--- a/data/categories/sg_sporting_goods.yml
+++ b/data/categories/sg_sporting_goods.yml
@@ -14455,6 +14455,7 @@
   - pattern
   - sports_governing_body_certification
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item
@@ -14538,6 +14539,7 @@
   - pattern
   - sports_governing_body_certification
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item

--- a/data/categories/tg_toys_games.yml
+++ b/data/categories/tg_toys_games.yml
@@ -1015,13 +1015,7 @@
   - puzzle_type
   - recommended_age_group
   - toy/game_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5
   name: Toys
   children:
@@ -2736,13 +2730,7 @@
   - puppet_puppet_theater_accessory_type
   - recommended_age_group
   - toy/game_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-8-8-2
   name: Puppet Theater Accessories
   children: []
@@ -2753,13 +2741,7 @@
   - puppet_puppet_theater_accessory_type
   - recommended_age_group
   - toy/game_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-8-9
   name: Puppet Theaters
   children: []
@@ -3088,13 +3070,7 @@
   - toy/game_material
   - toy_playset_assembly_required
   - toy_playset_items_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-8-12-11
   name: Animal Playsets
   children: []
@@ -3109,13 +3085,7 @@
   - toy/game_material
   - toy_playset_assembly_required
   - toy_playset_items_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-8-12-12
   name: Police & Firefighter Playsets
   children: []
@@ -3130,13 +3100,7 @@
   - toy/game_material
   - toy_playset_assembly_required
   - toy_playset_items_included
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-9
   name: Educational Toys
   children:
@@ -3431,13 +3395,7 @@
   - pattern
   - recommended_age_group
   - toy/game_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-9-9
   name: Math Toys
   children: []
@@ -3446,13 +3404,7 @@
   - pattern
   - recommended_age_group
   - toy/game_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-10
   name: Executive Toys
   children:
@@ -3645,13 +3597,7 @@
   - recommended_age_group
   - toy/game_material
   - toy_glider_launch_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-12-6-2
   name: Hand-Launched Toy Gliders
   children: []
@@ -3663,13 +3609,7 @@
   - recommended_age_group
   - toy/game_material
   - toy_glider_launch_method
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-12-7
   name: Toy Helicopters
   children: []
@@ -3970,13 +3910,7 @@
   - power_source
   - recommended_age_group
   - toy/game_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-13-13-2
   name: Toy Violins
   children: []
@@ -3988,13 +3922,7 @@
   - power_source
   - recommended_age_group
   - toy/game_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-13-13-3
   name: Toy Ukuleles
   children: []
@@ -4006,13 +3934,7 @@
   - power_source
   - recommended_age_group
   - toy/game_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-13-14
   name: Wind Instruments
   children: []
@@ -4386,13 +4308,7 @@
   - pretend_play_set_theme
   - recommended_age_group
   - toy/game_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-16-1-2
   name: Play Money Sets
   children: []
@@ -4408,13 +4324,7 @@
   - pretend_play_set_theme
   - recommended_age_group
   - toy/game_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-16-1-3
   name: Toy ATM & Banking Machines
   children: []
@@ -4430,13 +4340,7 @@
   - pretend_play_set_theme
   - recommended_age_group
   - toy/game_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-16-1-4
   name: Toy Safes & Lockboxes
   children: []
@@ -4452,13 +4356,7 @@
   - pretend_play_set_theme
   - recommended_age_group
   - toy/game_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-16-2
   name: Pretend Electronics
   children: []
@@ -5604,13 +5502,7 @@
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-23-16
   name: Soccer Toys
   children: []
@@ -5620,13 +5512,7 @@
   - recommended_age_group
   - sports_toy_set_contents
   - toy/game_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-24
   name: Toy Gift Baskets
   children: []
@@ -5698,13 +5584,7 @@
   - recommended_age_group
   - toy/game_material
   - toy_weapon_gadget_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-26-2
   name: Role-Play Melee Weapons & Shields
   children: []
@@ -5715,13 +5595,7 @@
   - recommended_age_group
   - toy/game_material
   - toy_weapon_gadget_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-26-3
   name: Toy Blasters & Projectile Toys
   children: []
@@ -5732,13 +5606,7 @@
   - recommended_age_group
   - toy/game_material
   - toy_weapon_gadget_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-27
   name: Visual Toys
   children:
@@ -5811,13 +5679,7 @@
   - pattern
   - recommended_age_group
   - toy/game_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-27-4
   name: Light Projection Toys
   children: []
@@ -5827,13 +5689,7 @@
   - pattern
   - recommended_age_group
   - toy/game_material
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: tg-5-28
   name: Wind-Up Toys
   children: []

--- a/data/categories/tg_toys_games.yml
+++ b/data/categories/tg_toys_games.yml
@@ -35,6 +35,7 @@
   - timer_features
   - toy/game_material
   return_reasons:
+  - size
   - changed_my_mind
   - item_not_as_described
   - received_the_wrong_item

--- a/data/categories/vp_vehicles_parts.yml
+++ b/data/categories/vp_vehicles_parts.yml
@@ -328,13 +328,7 @@
   - ev_battery_type
   - item_condition
   - manufacturer_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-2-6-2
   name: EV Battery Packs
   children: []
@@ -346,13 +340,7 @@
   - ev_battery_type
   - item_condition
   - manufacturer_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-2-6-3
   name: EV Battery Modules
   children: []
@@ -364,13 +352,7 @@
   - ev_battery_type
   - item_condition
   - manufacturer_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-2-7
   name: Power Inverters
   children: []
@@ -2319,13 +2301,7 @@
   - pattern
   - steering_component_drive_type
   - vehicle_steering_assist_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-4-8
   name: Steering Drag Links
   children: []
@@ -2338,13 +2314,7 @@
   - pattern
   - steering_component_drive_type
   - vehicle_steering_assist_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-4-9
   name: Steering Gears
   children: []
@@ -2357,13 +2327,7 @@
   - pattern
   - steering_component_drive_type
   - vehicle_steering_assist_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-4-10
   name: Steering Stabilizers
   children: []
@@ -2376,13 +2340,7 @@
   - pattern
   - steering_component_drive_type
   - vehicle_steering_assist_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-5
   name: Motor Vehicle Engine Oil Circulation
   children:
@@ -2590,13 +2548,7 @@
   - oil_system_connection_thread_standard
   - pattern
   - vehicle_oil_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-5-10
   name: Oil Filter Housings & Adapters
   children: []
@@ -2608,13 +2560,7 @@
   - oil_system_connection_thread_standard
   - pattern
   - vehicle_oil_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-5-11
   name: Oil Cooler Lines & Hoses
   children: []
@@ -2626,13 +2572,7 @@
   - oil_system_connection_thread_standard
   - pattern
   - vehicle_oil_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-6
   name: Motor Vehicle Engine Parts
   children:
@@ -3230,13 +3170,7 @@
   - motor_vehicle_type
   - pattern
   - vehicle_exhaust_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-8-2
   name: Motor Vehicle Catalytic Converters
   children: []
@@ -3252,13 +3186,7 @@
   - motor_vehicle_type
   - pattern
   - vehicle_exhaust_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-8-3
   name: Motor Vehicle Exhaust Tips
   children: []
@@ -3274,13 +3202,7 @@
   - motor_vehicle_type
   - pattern
   - vehicle_exhaust_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-8-4
   name: Motor Vehicle Exhaust Pipes & Tubings
   children: []
@@ -3296,13 +3218,7 @@
   - motor_vehicle_type
   - pattern
   - vehicle_exhaust_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-8-5
   name: Motor Vehicle Mufflers
   children: []
@@ -3318,13 +3234,7 @@
   - motor_vehicle_type
   - pattern
   - vehicle_exhaust_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-9
   name: Motor Vehicle Frame & Body Parts
   children:
@@ -3836,13 +3746,7 @@
   - item_material
   - manufacturer_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-10-10
   name: Fuel System Kits
   children: []
@@ -3853,13 +3757,7 @@
   - item_material
   - manufacturer_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-10-11
   name: Fuel Filler Necks
   children: []
@@ -3870,13 +3768,7 @@
   - item_material
   - manufacturer_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-10-12
   name: Fuel Sending Units
   children: []
@@ -3887,13 +3779,7 @@
   - item_material
   - manufacturer_type
   - pattern
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-11
   name: Motor Vehicle Interior Fittings
   children:
@@ -4982,13 +4868,7 @@
   - manufacturer_type
   - pattern
   - sensor_or_gauge_mounting_location
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-16-17
   name: Tire Pressure Monitoring System (TPMS) Sensors
   children: []
@@ -5001,13 +4881,7 @@
   - manufacturer_type
   - pattern
   - sensor_or_gauge_mounting_location
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-16-18
   name: Throttle Position Sensors
   children: []
@@ -5020,13 +4894,7 @@
   - manufacturer_type
   - pattern
   - sensor_or_gauge_mounting_location
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-16-19
   name: Crankshaft Position Sensors
   children: []
@@ -5039,13 +4907,7 @@
   - manufacturer_type
   - pattern
   - sensor_or_gauge_mounting_location
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-17
   name: Motor Vehicle Suspension Parts
   children:
@@ -5268,13 +5130,7 @@
   - motor_vehicle_placement
   - pattern
   - vehicle_suspension_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-17-10
   name: Strut Mounts
   children: []
@@ -5286,13 +5142,7 @@
   - motor_vehicle_placement
   - pattern
   - vehicle_suspension_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-17-11
   name: Track Bars
   children: []
@@ -5304,13 +5154,7 @@
   - motor_vehicle_placement
   - pattern
   - vehicle_suspension_features
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-18
   name: Motor Vehicle Towing
   children:
@@ -6275,13 +6119,7 @@
   - vehicle_drive/handling_features
   - wheel_fastener_seat_type
   - wheel_part_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-20-4-2
   name: Wheel Fasteners & Locks
   children: []
@@ -6295,13 +6133,7 @@
   - vehicle_drive/handling_features
   - wheel_fastener_seat_type
   - wheel_part_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-20-4-3
   name: Wheel Weights & Balancing
   children: []
@@ -6315,13 +6147,7 @@
   - vehicle_drive/handling_features
   - wheel_fastener_seat_type
   - wheel_part_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-20-4-4
   name: Wheel Bearings & Hubs
   children: []
@@ -6335,13 +6161,7 @@
   - vehicle_drive/handling_features
   - wheel_fastener_seat_type
   - wheel_part_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-21
   name: Motor Vehicle Window Parts & Accessories
   children:
@@ -6833,13 +6653,7 @@
   children:
   - vp-1-4-23-1
   attributes: []
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-4-23-1
   name: Engine Air Filters
   children: []
@@ -6852,13 +6666,7 @@
   - material
   - pattern
   - vehicle_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-5
   name: Vehicle Maintenance, Care & Decor
   children:
@@ -8939,13 +8747,7 @@
   - power_source
   - tire_changer_operation_type
   - vehicle_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-5-7-9-1-7
   name: Rim Protectors
   children: []
@@ -8956,13 +8758,7 @@
   - power_source
   - tire_changer_operation_type
   - vehicle_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-5-7-9-2
   name: Tire Repair Kits
   children: []
@@ -9508,13 +9304,7 @@
   - protective_gear_features
   - target_gender
   - vehicle_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-6-1-8
   name: Motorcycle Kidney Belts
   children: []
@@ -10994,13 +10784,7 @@
   - item_condition
   - material
   - vehicle_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-7-2-4
   name: Vehicle Cargo Rack Accessories
   children: []
@@ -11009,13 +10793,7 @@
   - item_condition
   - material
   - vehicle_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-7-2-5
   name: Vehicle Boat & Kayak Rack Accessories
   children: []
@@ -11024,13 +10802,7 @@
   - item_condition
   - material
   - vehicle_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-7-3
   name: Motor Vehicle Carrying Racks
   children:
@@ -12176,13 +11948,7 @@
   - item_material
   - mounting_location
   - watercraft_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-8-6-4
   name: Watercraft Exhaust Risers & Elbows
   children: []
@@ -12193,13 +11959,7 @@
   - item_material
   - mounting_location
   - watercraft_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-8-7
   name: Watercraft Fuel Systems
   children:
@@ -12296,13 +12056,7 @@
   - item_condition
   - item_material
   - watercraft_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-8-7-6
   name: Watercraft Fuel Fittings & Connectors
   children: []
@@ -12310,13 +12064,7 @@
   - item_condition
   - item_material
   - watercraft_type
-  return_reasons:
-  - changed_my_mind
-  - item_not_as_described
-  - received_the_wrong_item
-  - damaged_or_defective
-  - unknown
-  - other_reason
+  return_reasons: inherit
 - id: vp-1-8-8
   name: Watercraft Lighting
   children: []

--- a/dev/lib/product_taxonomy/cli.rb
+++ b/dev/lib/product_taxonomy/cli.rb
@@ -115,6 +115,10 @@ module ProductTaxonomy
 
     desc "add_category NAME PARENT_ID", "Add a new category to the taxonomy with NAME, as a child of PARENT_ID"
     option :id, type: :string, desc: "Override the created category's ID"
+    option :inherits_return_reasons,
+      type: :boolean,
+      default: true,
+      desc: "Whether the created category inherits its ancestors' return reasons (default: true)"
     def add_category(name, parent_id)
       AddCategoryCommand.new(options.merge(name:, parent_id:)).run
     end

--- a/dev/lib/product_taxonomy/commands/add_category_command.rb
+++ b/dev/lib/product_taxonomy/commands/add_category_command.rb
@@ -38,7 +38,7 @@ module ProductTaxonomy
       Category.add(@new_category)
       # `load_from_source` resolves inheritance for the full tree; do it here too so the in-process dump/docs below see
       # the inherited reasons for the category we just added.
-      @new_category.resolve_inherited_return_reasons
+      @new_category.resolve_return_reasons
       logger.info("Created category `#{@new_category.name}` with id=`#{@new_category.id}`")
     end
 

--- a/dev/lib/product_taxonomy/commands/add_category_command.rb
+++ b/dev/lib/product_taxonomy/commands/add_category_command.rb
@@ -8,6 +8,8 @@ module ProductTaxonomy
       @name = options[:name]
       @parent_id = options[:parent_id]
       @id = options[:id]
+      # New categories inherit ancestor return reasons unless the caller opts out.
+      @inherits_return_reasons = options.fetch(:inherits_return_reasons, true)
     end
 
     def execute
@@ -19,7 +21,13 @@ module ProductTaxonomy
 
     def create_category!
       parent = Category.find_by!(id: @parent_id)
-      @new_category = Category.new(id: @id || parent.next_child_id, name: @name, parent:)
+      # `:inherit` copies reasons from the closest defining ancestor at load time; an empty list defines its own.
+      @new_category = Category.new(
+        id: @id || parent.next_child_id,
+        name: @name,
+        return_reasons: @inherits_return_reasons ? :inherit : [],
+        parent:,
+      )
       begin
         @new_category.validate!(:create)
       rescue ActiveModel::ValidationError => e
@@ -28,6 +36,9 @@ module ProductTaxonomy
 
       parent.add_child(@new_category)
       Category.add(@new_category)
+      # `load_from_source` resolves inheritance for the full tree; do it here too so the in-process dump/docs below see
+      # the inherited reasons for the category we just added.
+      @new_category.resolve_inherited_return_reasons
       logger.info("Created category `#{@new_category.name}` with id=`#{@new_category.id}`")
     end
 

--- a/dev/lib/product_taxonomy/commands/add_return_reasons_to_categories_command.rb
+++ b/dev/lib/product_taxonomy/commands/add_return_reasons_to_categories_command.rb
@@ -25,7 +25,7 @@ module ProductTaxonomy
       @categories.each do |category|
         # A category with no reasons of its own yet — empty, or inheriting from an ancestor — is defined from
         # scratch, so it also gets the global reasons appended (ordered at the end by sort_return_reasons!).
-        from_scratch = category.inherits_return_reasons || category.return_reasons.empty?
+        from_scratch = category.inherits_return_reasons || category.defined_return_reasons.empty?
 
         if category.inherits_return_reasons
           logger.info("Category `#{category.name}` inherited its return reasons - replacing them with the new return reason(s) and the global return reasons")
@@ -49,7 +49,9 @@ module ProductTaxonomy
       # Re-resolve inheritance for descendants so inheriting children reflect their ancestors' updated reasons in
       # the generated artifacts/docs (which read the resolved list, not the literal `inherit`).
       @categories.each do |category|
-        category.descendants.each(&:resolve_inherited_return_reasons)
+        category.descendants.each do |descendant|
+          descendant.resolve_return_reasons if descendant.inherits_return_reasons
+        end
       end
 
       logger.info("Added #{@return_reasons.size} return reason(s) to #{@categories.size} categories")
@@ -57,7 +59,7 @@ module ProductTaxonomy
 
     def append_global_return_reasons!(category)
       ReturnReason.global.each do |return_reason|
-        next if category.return_reasons.include?(return_reason)
+        next if category.defined_return_reasons.include?(return_reason)
 
         category.add_return_reason(return_reason)
       end
@@ -65,7 +67,7 @@ module ProductTaxonomy
 
     # Move the global reasons to the end in their defined order, preserving the order of all other reasons.
     def sort_return_reasons!(category)
-      global, regular = category.return_reasons.partition do |return_reason|
+      global, regular = category.defined_return_reasons.partition do |return_reason|
         ReturnReason::GLOBAL_FRIENDLY_IDS.include?(return_reason.friendly_id)
       end
 
@@ -73,7 +75,8 @@ module ProductTaxonomy
         global.find { |return_reason| return_reason.friendly_id == friendly_id }
       end
 
-      category.return_reasons.replace(regular + sorted_global)
+      category.defined_return_reasons.replace(regular + sorted_global)
+      category.resolve_return_reasons
     end
 
     def update_data_files!

--- a/dev/lib/product_taxonomy/commands/add_return_reasons_to_categories_command.rb
+++ b/dev/lib/product_taxonomy/commands/add_return_reasons_to_categories_command.rb
@@ -2,18 +2,6 @@
 
 module ProductTaxonomy
   class AddReturnReasonsToCategoriesCommand < Command
-    UNKNOWN_RETURN_REASON_FRIENDLY_ID = "unknown"
-    OTHER_RETURN_REASON_FRIENDLY_ID = "other_reason"
-    # Global reasons are always ordered at the end of a category's list, in this exact order.
-    GLOBAL_RETURN_REASON_FRIENDLY_IDS = [
-      "changed_my_mind",
-      "item_not_as_described",
-      "received_the_wrong_item",
-      "damaged_or_defective",
-      UNKNOWN_RETURN_REASON_FRIENDLY_ID,
-      OTHER_RETURN_REASON_FRIENDLY_ID,
-    ].freeze
-
     def initialize(options)
       super
       load_taxonomy
@@ -68,24 +56,20 @@ module ProductTaxonomy
     end
 
     def append_global_return_reasons!(category)
-      global_return_reasons.each do |return_reason|
+      ReturnReason.global.each do |return_reason|
         next if category.return_reasons.include?(return_reason)
 
         category.add_return_reason(return_reason)
       end
     end
 
-    def global_return_reasons
-      @global_return_reasons ||= GLOBAL_RETURN_REASON_FRIENDLY_IDS.map { |friendly_id| ReturnReason.find_by!(friendly_id:) }
-    end
-
     # Move the global reasons to the end in their defined order, preserving the order of all other reasons.
     def sort_return_reasons!(category)
       global, regular = category.return_reasons.partition do |return_reason|
-        GLOBAL_RETURN_REASON_FRIENDLY_IDS.include?(return_reason.friendly_id)
+        ReturnReason::GLOBAL_FRIENDLY_IDS.include?(return_reason.friendly_id)
       end
 
-      sorted_global = GLOBAL_RETURN_REASON_FRIENDLY_IDS.filter_map do |friendly_id|
+      sorted_global = ReturnReason::GLOBAL_FRIENDLY_IDS.filter_map do |friendly_id|
         global.find { |return_reason| return_reason.friendly_id == friendly_id }
       end
 

--- a/dev/lib/product_taxonomy/commands/add_return_reasons_to_categories_command.rb
+++ b/dev/lib/product_taxonomy/commands/add_return_reasons_to_categories_command.rb
@@ -35,8 +35,12 @@ module ProductTaxonomy
       @categories = @categories.flat_map(&:descendants_and_self) if @include_descendants
 
       @categories.each do |category|
+        # A category with no reasons of its own yet — empty, or inheriting from an ancestor — is defined from
+        # scratch, so it also gets the global reasons appended (ordered at the end by sort_return_reasons!).
+        from_scratch = category.inherits_return_reasons || category.return_reasons.empty?
+
         if category.inherits_return_reasons
-          logger.info("Category `#{category.name}` inherited its return reasons - replacing them with the new return reason(s)")
+          logger.info("Category `#{category.name}` inherited its return reasons - replacing them with the new return reason(s) and the global return reasons")
         end
 
         @return_reasons.each do |return_reason|
@@ -49,10 +53,24 @@ module ProductTaxonomy
           end
         end
 
+        append_global_return_reasons!(category) if from_scratch
+
         sort_return_reasons!(category)
       end
 
       logger.info("Added #{@return_reasons.size} return reason(s) to #{@categories.size} categories")
+    end
+
+    def append_global_return_reasons!(category)
+      global_return_reasons.each do |return_reason|
+        next if category.return_reasons.include?(return_reason)
+
+        category.add_return_reason(return_reason)
+      end
+    end
+
+    def global_return_reasons
+      @global_return_reasons ||= GLOBAL_RETURN_REASON_FRIENDLY_IDS.map { |friendly_id| ReturnReason.find_by!(friendly_id:) }
     end
 
     # Move the global reasons to the end in their defined order, preserving the order of all other reasons.

--- a/dev/lib/product_taxonomy/commands/add_return_reasons_to_categories_command.rb
+++ b/dev/lib/product_taxonomy/commands/add_return_reasons_to_categories_command.rb
@@ -4,7 +4,12 @@ module ProductTaxonomy
   class AddReturnReasonsToCategoriesCommand < Command
     UNKNOWN_RETURN_REASON_FRIENDLY_ID = "unknown"
     OTHER_RETURN_REASON_FRIENDLY_ID = "other_reason"
-    SPECIAL_RETURN_REASON_FRIENDLY_IDS = [
+    # Global reasons are always ordered at the end of a category's list, in this exact order.
+    GLOBAL_RETURN_REASON_FRIENDLY_IDS = [
+      "changed_my_mind",
+      "item_not_as_described",
+      "received_the_wrong_item",
+      "damaged_or_defective",
       UNKNOWN_RETURN_REASON_FRIENDLY_ID,
       OTHER_RETURN_REASON_FRIENDLY_ID,
     ].freeze
@@ -50,26 +55,17 @@ module ProductTaxonomy
       logger.info("Added #{@return_reasons.size} return reason(s) to #{@categories.size} categories")
     end
 
+    # Move the global reasons to the end in their defined order, preserving the order of all other reasons.
     def sort_return_reasons!(category)
-      special, regular = category.return_reasons.partition do |return_reason|
-        SPECIAL_RETURN_REASON_FRIENDLY_IDS.include?(return_reason.friendly_id)
+      global, regular = category.return_reasons.partition do |return_reason|
+        GLOBAL_RETURN_REASON_FRIENDLY_IDS.include?(return_reason.friendly_id)
       end
 
-      regular_by_friendly_id = regular.each_with_object({}) do |return_reason, by_friendly_id|
-        by_friendly_id[return_reason.friendly_id] = return_reason
-      end
-      sorted_regular = AlphanumericSorter.sort(regular_by_friendly_id.keys).map do |friendly_id|
-        regular_by_friendly_id[friendly_id]
+      sorted_global = GLOBAL_RETURN_REASON_FRIENDLY_IDS.filter_map do |friendly_id|
+        global.find { |return_reason| return_reason.friendly_id == friendly_id }
       end
 
-      special_by_friendly_id = special.each_with_object({}) do |return_reason, by_friendly_id|
-        by_friendly_id[return_reason.friendly_id] = return_reason
-      end
-      sorted_special = SPECIAL_RETURN_REASON_FRIENDLY_IDS.filter_map do |friendly_id|
-        special_by_friendly_id[friendly_id]
-      end
-
-      category.return_reasons.replace(sorted_regular + sorted_special)
+      category.return_reasons.replace(regular + sorted_global)
     end
 
     def update_data_files!

--- a/dev/lib/product_taxonomy/commands/add_return_reasons_to_categories_command.rb
+++ b/dev/lib/product_taxonomy/commands/add_return_reasons_to_categories_command.rb
@@ -58,6 +58,12 @@ module ProductTaxonomy
         sort_return_reasons!(category)
       end
 
+      # Re-resolve inheritance for descendants so inheriting children reflect their ancestors' updated reasons in
+      # the generated artifacts/docs (which read the resolved list, not the literal `inherit`).
+      @categories.each do |category|
+        category.descendants.each(&:resolve_inherited_return_reasons)
+      end
+
       logger.info("Added #{@return_reasons.size} return reason(s) to #{@categories.size} categories")
     end
 

--- a/dev/lib/product_taxonomy/commands/add_return_reasons_to_categories_command.rb
+++ b/dev/lib/product_taxonomy/commands/add_return_reasons_to_categories_command.rb
@@ -30,8 +30,14 @@ module ProductTaxonomy
       @categories = @categories.flat_map(&:descendants_and_self) if @include_descendants
 
       @categories.each do |category|
+        if category.inherits_return_reasons
+          logger.info("Category `#{category.name}` inherited its return reasons - replacing them with the new return reason(s)")
+        end
+
         @return_reasons.each do |return_reason|
-          if category.return_reasons.include?(return_reason)
+          # An inheriting category's reasons come from its parent; adding materializes them, so don't treat
+          # inherited reasons as "already present" and skip.
+          if !category.inherits_return_reasons && category.return_reasons.include?(return_reason)
             logger.info("Category `#{category.name}` already has return reason `#{return_reason.friendly_id}` - skipping")
           else
             category.add_return_reason(return_reason)

--- a/dev/lib/product_taxonomy/models/category.rb
+++ b/dev/lib/product_taxonomy/models/category.rb
@@ -22,7 +22,7 @@ module ProductTaxonomy
             id: item["id"],
             name: item["name"],
             attributes: Array(item["attributes"]).map { Attribute.find_by(friendly_id: _1) || _1 },
-            return_reasons: Array(item["return_reasons"]).map { ReturnReason.find_by(friendly_id: _1) || _1 },
+            return_reasons: parse_return_reasons(item["return_reasons"]),
           )
         end
 
@@ -42,6 +42,9 @@ module ProductTaxonomy
           root_nodes << node if node.root?
         end
         @verticals.sort_by!(&:name)
+
+        # Fourth pass: resolve inherited return reasons now that ancestry is known.
+        Category.all.each(&:resolve_inherited_return_reasons)
       end
 
       # Reset all class-level state
@@ -59,6 +62,13 @@ module ProductTaxonomy
       end
 
       private
+
+      # `return_reasons: inherit` in the data marks a category as inheriting; anything else is an explicit list.
+      def parse_return_reasons(value)
+        return :inherit if value == "inherit"
+
+        Array(value).map { |friendly_id| ReturnReason.find_by(friendly_id:) || friendly_id }
+      end
 
       def add_children(type:, item:, parent:)
         item[type]&.each do |child_id|
@@ -87,13 +97,14 @@ module ProductTaxonomy
 
     localized_attr_reader :name, keyed_by: :id
 
-    attr_reader :id, :children, :secondary_children, :attributes, :return_reasons
+    attr_reader :id, :children, :secondary_children, :attributes, :return_reasons, :inherits_return_reasons
     attr_accessor :parent, :secondary_parents
 
     # @param id [String] The ID of the category.
     # @param name [String] The name of the category.
     # @param attributes [Array<Attribute>] The attributes of the category.
-    # @param return_reasons [Array<ReturnReason>] The return reasons for the category.
+    # @param return_reasons [Array<ReturnReason>, :inherit] The return reasons for the category, or `:inherit` to copy
+    #   them from the closest ancestor that defines its own.
     # @param parent [Category] The parent category of the category.
     def initialize(id:, name:, attributes: [], return_reasons: [], parent: nil)
       @id = id
@@ -101,7 +112,8 @@ module ProductTaxonomy
       @children = []
       @secondary_children = []
       @attributes = attributes
-      @return_reasons = return_reasons
+      @inherits_return_reasons = return_reasons == :inherit
+      @return_reasons = @inherits_return_reasons ? [] : return_reasons
       @parent = parent
       @secondary_parents = []
     end
@@ -144,6 +156,15 @@ module ProductTaxonomy
     # @param [ReturnReason] return_reason
     def add_return_reason(return_reason)
       @return_reasons << return_reason
+    end
+
+    # Copy return reasons from the closest ancestor that defines its own, when this category inherits. No-op for
+    # categories that define their own reasons or have no defining ancestor.
+    def resolve_inherited_return_reasons
+      return unless inherits_return_reasons
+
+      source = ancestors.find { |ancestor| !ancestor.inherits_return_reasons }
+      @return_reasons = source.return_reasons.dup if source
     end
 
     #

--- a/dev/lib/product_taxonomy/models/category.rb
+++ b/dev/lib/product_taxonomy/models/category.rb
@@ -43,7 +43,9 @@ module ProductTaxonomy
         end
         @verticals.sort_by!(&:name)
 
-        # Fourth pass: resolve inherited return reasons now that ancestry is known.
+        # Fourth pass: fall back to the global reasons where a category defines none, then resolve inheritance so
+        # that inheriting categories copy their ancestor's final list.
+        Category.all.each(&:apply_default_return_reasons)
         Category.all.each(&:resolve_inherited_return_reasons)
       end
 
@@ -162,6 +164,14 @@ module ProductTaxonomy
         @return_reasons = []
       end
       @return_reasons << return_reason
+    end
+
+    # Materialize the global return reasons for a category that defines none of its own, so runtime consumers always
+    # get the baseline set. Inheriting categories are skipped; they copy their ancestor's list once it is final.
+    def apply_default_return_reasons
+      return if inherits_return_reasons || return_reasons.any?
+
+      @return_reasons = ReturnReason.global.dup
     end
 
     # Copy return reasons from the closest ancestor that defines its own, when this category inherits. No-op for

--- a/dev/lib/product_taxonomy/models/category.rb
+++ b/dev/lib/product_taxonomy/models/category.rb
@@ -151,10 +151,15 @@ module ProductTaxonomy
       @attributes << attribute
     end
 
-    # Add a return reason to the category
+    # Add a return reason to the category. Explicitly adding a reason means the category defines its own reasons
+    # rather than inheriting them, so the first add on an inheriting category drops the inherited reasons.
     #
     # @param [ReturnReason] return_reason
     def add_return_reason(return_reason)
+      if @inherits_return_reasons
+        @inherits_return_reasons = false
+        @return_reasons = []
+      end
       @return_reasons << return_reason
     end
 

--- a/dev/lib/product_taxonomy/models/category.rb
+++ b/dev/lib/product_taxonomy/models/category.rb
@@ -94,6 +94,7 @@ module ProductTaxonomy
     validate :id_starts_with_parent_id, unless: :root?, on: :category_tree_loaded
     validate :children_found?, on: :category_tree_loaded
     validate :secondary_children_found?, on: :category_tree_loaded
+    validate :root_does_not_inherit_return_reasons, if: :root?, on: :category_tree_loaded
 
     localized_attr_reader :name, keyed_by: :id
 
@@ -334,6 +335,13 @@ module ProductTaxonomy
           message: "not found for friendly ID \"#{return_reason}\"",
         )
       end
+    end
+
+    def root_does_not_inherit_return_reasons
+      return unless inherits_return_reasons
+
+      # A root category has no ancestor to inherit from, so `inherit` cannot be resolved.
+      errors.add(:return_reasons, :root_cannot_inherit, message: "cannot be inherited by a root category")
     end
 
     def children_found?

--- a/dev/lib/product_taxonomy/models/category.rb
+++ b/dev/lib/product_taxonomy/models/category.rb
@@ -43,8 +43,8 @@ module ProductTaxonomy
         end
         @verticals.sort_by!(&:name)
 
-      # Fourth pass: derive each category's effective return reasons — inherited from the closest defining ancestor,
-      # falling back to the global reasons when nothing is defined.
+        # Fourth pass: derive each category's effective return reasons — inherited from the closest defining ancestor,
+        # falling back to the global reasons when nothing is defined.
         Category.all.each(&:resolve_return_reasons)
       end
 

--- a/dev/lib/product_taxonomy/models/category.rb
+++ b/dev/lib/product_taxonomy/models/category.rb
@@ -43,10 +43,9 @@ module ProductTaxonomy
         end
         @verticals.sort_by!(&:name)
 
-        # Fourth pass: fall back to the global reasons where a category defines none, then resolve inheritance so
-        # that inheriting categories copy their ancestor's final list.
-        Category.all.each(&:apply_default_return_reasons)
-        Category.all.each(&:resolve_inherited_return_reasons)
+      # Fourth pass: derive each category's effective return reasons — inherited from the closest defining ancestor,
+      # falling back to the global reasons when nothing is defined.
+        Category.all.each(&:resolve_return_reasons)
       end
 
       # Reset all class-level state
@@ -100,7 +99,13 @@ module ProductTaxonomy
 
     localized_attr_reader :name, keyed_by: :id
 
-    attr_reader :id, :children, :secondary_children, :attributes, :return_reasons, :inherits_return_reasons
+    attr_reader :id,
+      :children,
+      :secondary_children,
+      :attributes,
+      :return_reasons,
+      :defined_return_reasons,
+      :inherits_return_reasons
     attr_accessor :parent, :secondary_parents
 
     # @param id [String] The ID of the category.
@@ -116,7 +121,8 @@ module ProductTaxonomy
       @secondary_children = []
       @attributes = attributes
       @inherits_return_reasons = return_reasons == :inherit
-      @return_reasons = @inherits_return_reasons ? [] : return_reasons
+      @defined_return_reasons = @inherits_return_reasons ? [] : return_reasons.dup
+      @return_reasons = @defined_return_reasons.dup
       @parent = parent
       @secondary_parents = []
     end
@@ -161,26 +167,22 @@ module ProductTaxonomy
     def add_return_reason(return_reason)
       if @inherits_return_reasons
         @inherits_return_reasons = false
-        @return_reasons = []
+        @defined_return_reasons = []
       end
-      @return_reasons << return_reason
-    end
-
-    # Materialize the global return reasons for a category that defines none of its own, so runtime consumers always
-    # get the baseline set. Inheriting categories are skipped; they copy their ancestor's list once it is final.
-    def apply_default_return_reasons
-      return if inherits_return_reasons || return_reasons.any?
-
-      @return_reasons = ReturnReason.global.dup
+      @defined_return_reasons << return_reason
+      resolve_return_reasons
     end
 
     # Copy return reasons from the closest ancestor that defines its own, when this category inherits. No-op for
     # categories that define their own reasons or have no defining ancestor.
-    def resolve_inherited_return_reasons
-      return unless inherits_return_reasons
+    def resolve_return_reasons
+      @return_reasons = if inherits_return_reasons
+        ancestors.find { |ancestor| !ancestor.inherits_return_reasons }&.defined_return_reasons&.dup || []
+      else
+        defined_return_reasons.dup
+      end
 
-      source = ancestors.find { |ancestor| !ancestor.inherits_return_reasons }
-      @return_reasons = source.return_reasons.dup if source
+      @return_reasons = ReturnReason.global.dup if @return_reasons.empty?
     end
 
     #

--- a/dev/lib/product_taxonomy/models/return_reason.rb
+++ b/dev/lib/product_taxonomy/models/return_reason.rb
@@ -7,6 +7,17 @@ module ProductTaxonomy
     extend Localized
     extend Indexed
 
+    # Reasons that apply to every category, in the order they are always listed in. They sit at the end of a
+    # category's list, and stand in for categories that define no reasons of their own.
+    GLOBAL_FRIENDLY_IDS = [
+      "changed_my_mind",
+      "item_not_as_described",
+      "received_the_wrong_item",
+      "damaged_or_defective",
+      "unknown",
+      "other_reason",
+    ].freeze
+
     class << self
       # Override to match folder name convention (return_reasons vs returnreasons)
       def localizations_humanized_model_name
@@ -33,6 +44,15 @@ module ProductTaxonomy
       def reset
         @localizations = nil
         @hashed_models = nil
+        @global = nil
+      end
+
+      # The global return reasons, in their defined order. Reasons that are not loaded are skipped, so callers get
+      # whatever subset the current source data defines. Frozen because the memoized array is shared by all callers.
+      #
+      # @return [Array<ReturnReason>]
+      def global
+        @global ||= GLOBAL_FRIENDLY_IDS.filter_map { |friendly_id| find_by(friendly_id:) }.freeze
       end
 
       # Get the next ID for a newly created return reason.

--- a/dev/lib/product_taxonomy/models/serializers/category/data/data_serializer.rb
+++ b/dev/lib/product_taxonomy/models/serializers/category/data/data_serializer.rb
@@ -30,7 +30,7 @@ module ProductTaxonomy
             def serialize_return_reasons(category)
               return "inherit" if category.inherits_return_reasons
 
-              return_reason_ids = category.return_reasons.map(&:friendly_id)
+              return_reason_ids = category.defined_return_reasons.map(&:friendly_id)
               has_unknown = return_reason_ids.delete("unknown")
               has_other = return_reason_ids.delete("other_reason")
               return_reason_ids << "unknown" if has_unknown

--- a/dev/lib/product_taxonomy/models/serializers/category/data/data_serializer.rb
+++ b/dev/lib/product_taxonomy/models/serializers/category/data/data_serializer.rb
@@ -14,21 +14,28 @@ module ProductTaxonomy
             # @param [Category] category
             # @return [Hash]
             def serialize(category)
-              # The curated order in `data/categories/*.yml` is meaningful, so it is preserved as-is; only the
-              # catch-all reasons are pulled out and appended.
-              return_reason_ids = category.return_reasons.map(&:friendly_id)
-              has_unknown = return_reason_ids.delete("unknown")
-              has_other = return_reason_ids.delete("other_reason")
-              return_reason_ids << "unknown" if has_unknown
-              return_reason_ids << "other_reason" if has_other
-
               {
                 "id" => category.id,
                 "name" => category.name,
                 "children" => category.children.sort_by(&:id_parts).map(&:id),
                 "attributes" => AlphanumericSorter.sort(category.attributes.map(&:friendly_id), other_last: true),
-                "return_reasons" => return_reason_ids,
+                "return_reasons" => serialize_return_reasons(category),
               }
+            end
+
+            private
+
+            # Inheriting categories round-trip as the literal `inherit`; defining categories keep their curated order
+            # from `data/categories/*.yml`, with the catch-all reasons pulled out and appended.
+            def serialize_return_reasons(category)
+              return "inherit" if category.inherits_return_reasons
+
+              return_reason_ids = category.return_reasons.map(&:friendly_id)
+              has_unknown = return_reason_ids.delete("unknown")
+              has_other = return_reason_ids.delete("other_reason")
+              return_reason_ids << "unknown" if has_unknown
+              return_reason_ids << "other_reason" if has_other
+              return_reason_ids
             end
           end
         end

--- a/dev/lib/product_taxonomy/models/serializers/category/dist/json_serializer.rb
+++ b/dev/lib/product_taxonomy/models/serializers/category/dist/json_serializer.rb
@@ -46,6 +46,7 @@ module ProductTaxonomy
                     "description" => return_reason.description(locale:),
                   }
                 end,
+                "inherits_return_reasons" => category.inherits_return_reasons,
                 "children" => category.children.map do |child|
                   {
                     "id" => child.gid,

--- a/dev/lib/product_taxonomy/models/serializers/category/docs/siblings_serializer.rb
+++ b/dev/lib/product_taxonomy/models/serializers/category/docs/siblings_serializer.rb
@@ -30,6 +30,7 @@ module ProductTaxonomy
                 "ancestor_ids" => category.ancestors.map(&:gid).join(","),
                 "attribute_handles" => category.attributes.map(&:handle).join(","),
                 "return_reason_handles" => category.return_reasons.map(&:handle).join(","),
+                "inherits_return_reasons" => category.inherits_return_reasons,
               }
             end
           end

--- a/dev/schema/data/categories_schema.cue
+++ b/dev/schema/data/categories_schema.cue
@@ -5,5 +5,7 @@
 	name!: string
 	children!: [...string]
 	attributes!: [...string]
-	return_reasons!: [...string]
+	// Either an explicit list of return reason friendly IDs, or the literal "inherit" to copy them from the closest
+	// ancestor that defines its own.
+	return_reasons!: [...string] | "inherit"
 }]

--- a/dev/test/commands/add_category_command_test.rb
+++ b/dev/test/commands/add_category_command_test.rb
@@ -43,6 +43,42 @@ module ProductTaxonomy
       assert_not_nil Category.find_by(id: "aa-5")
     end
 
+    test "execute marks new categories as inheriting return reasons by default" do
+      stub_commands
+
+      AddCategoryCommand.new(name: "New Category", parent_id: "aa").execute
+
+      assert_equal true, Category.find_by(id: "aa-2").inherits_return_reasons
+    end
+
+    test "execute lets the caller opt out of inheriting return reasons" do
+      stub_commands
+
+      AddCategoryCommand.new(name: "New Category", parent_id: "aa", inherits_return_reasons: false).execute
+
+      new_category = Category.find_by(id: "aa-2")
+      assert_equal false, new_category.inherits_return_reasons
+      assert_equal [], new_category.return_reasons
+    end
+
+    test "execute copies inherited reasons from the closest defining ancestor onto the new category" do
+      stub_commands
+      return_reason = ReturnReason.new(
+        id: 1,
+        name: "Too big",
+        description: "Too big",
+        friendly_id: "too_big",
+        handle: "too-big",
+      )
+      @root_category.return_reasons << return_reason
+
+      AddCategoryCommand.new(name: "New Category", parent_id: "aa").execute
+
+      new_category = Category.find_by(id: "aa-2")
+      assert_equal true, new_category.inherits_return_reasons
+      assert_equal ["too_big"], new_category.return_reasons.map(&:friendly_id)
+    end
+
     test "execute raises error when parent category not found" do
       stub_commands
 

--- a/dev/test/commands/add_category_command_test.rb
+++ b/dev/test/commands/add_category_command_test.rb
@@ -59,6 +59,33 @@ module ProductTaxonomy
       new_category = Category.find_by(id: "aa-2")
       assert_equal false, new_category.inherits_return_reasons
       assert_equal [], new_category.return_reasons
+      assert_empty new_category.defined_return_reasons
+    end
+
+    test "execute gives a category that opts out of inheriting the global reasons, keeping `[]` in the data file" do
+      stub_commands
+      ReturnReason::GLOBAL_FRIENDLY_IDS.each_with_index do |friendly_id, index|
+        ReturnReason.add(ReturnReason.new(
+          id: index + 1,
+          name: friendly_id.tr("_", " ").capitalize,
+          description: friendly_id,
+          friendly_id:,
+          handle: friendly_id.tr("_", "-"),
+        ))
+      end
+
+      AddCategoryCommand.new(name: "New Category", parent_id: "aa", inherits_return_reasons: false).execute
+
+      new_category = Category.find_by(id: "aa-2")
+      # The category resolves to the global baseline like one loaded from source...
+      assert_equal ReturnReason::GLOBAL_FRIENDLY_IDS, new_category.return_reasons.map(&:friendly_id)
+      # ...but it defines none of them, so the dumped data file keeps `[]` and a future global reason is picked up
+      # automatically.
+      assert_empty new_category.defined_return_reasons
+      assert_equal(
+        [],
+        Serializers::Category::Data::DataSerializer.serialize(new_category)["return_reasons"],
+      )
     end
 
     test "execute copies inherited reasons from the closest defining ancestor onto the new category" do
@@ -70,13 +97,15 @@ module ProductTaxonomy
         friendly_id: "too_big",
         handle: "too-big",
       )
-      @root_category.return_reasons << return_reason
+      @root_category.add_return_reason(return_reason)
 
       AddCategoryCommand.new(name: "New Category", parent_id: "aa").execute
 
       new_category = Category.find_by(id: "aa-2")
       assert_equal true, new_category.inherits_return_reasons
       assert_equal ["too_big"], new_category.return_reasons.map(&:friendly_id)
+      # The reasons come from the ancestor, so the new category defines none and stays `inherit` in the data file.
+      assert_empty new_category.defined_return_reasons
     end
 
     test "execute raises error when parent category not found" do

--- a/dev/test/commands/add_return_reasons_to_categories_command_test.rb
+++ b/dev/test/commands/add_return_reasons_to_categories_command_test.rb
@@ -66,6 +66,14 @@ module ProductTaxonomy
         handle: "damaged-or-defective",
       )
 
+      @existing_reason = ReturnReason.new(
+        id: 1003,
+        name: "Existing Reason",
+        description: "A reason already present on the category before the command runs",
+        friendly_id: "existing_reason",
+        handle: "existing-reason",
+      )
+
       ReturnReason.add(@defective_reason)
       ReturnReason.add(@wrong_size_reason)
       ReturnReason.add(@unknown_reason)
@@ -74,6 +82,7 @@ module ProductTaxonomy
       ReturnReason.add(@item_not_as_described_reason)
       ReturnReason.add(@received_wrong_item_reason)
       ReturnReason.add(@damaged_or_defective_reason)
+      ReturnReason.add(@existing_reason)
 
       @root = Category.new(id: "aa", name: "Apparel & Accessories")
       @clothing = Category.new(id: "aa-1", name: "Clothing")
@@ -92,6 +101,8 @@ module ProductTaxonomy
     end
 
     test "execute adds return reasons to specified categories" do
+      @clothing.add_return_reason(@existing_reason)
+
       DumpCategoriesCommand.any_instance.expects(:execute).once
       SyncEnLocalizationsCommand.any_instance.expects(:execute).once
       GenerateDocsCommand.any_instance.expects(:execute).once
@@ -102,7 +113,8 @@ module ProductTaxonomy
         include_descendants: false,
       ).execute
 
-      assert_equal 2, @clothing.return_reasons.size
+      assert_equal 3, @clothing.return_reasons.size
+      assert_includes @clothing.return_reasons, @existing_reason
       assert_includes @clothing.return_reasons, @defective_reason
       assert_includes @clothing.return_reasons, @wrong_size_reason
 
@@ -110,10 +122,39 @@ module ProductTaxonomy
       assert_empty @shirts.return_reasons
     end
 
+    test "execute appends the global reasons when a category starts from an empty list" do
+      DumpCategoriesCommand.any_instance.expects(:execute).once
+      SyncEnLocalizationsCommand.any_instance.expects(:execute).once
+      GenerateDocsCommand.any_instance.expects(:execute).once
+
+      AddReturnReasonsToCategoriesCommand.new(
+        return_reason_friendly_ids: "wrong_size_or_fit",
+        category_ids: "aa-1",
+        include_descendants: false,
+      ).execute
+
+      # The added reason keeps its spot at the front; the six global reasons follow in their defined order.
+      assert_equal(
+        [
+          "wrong_size_or_fit",
+          "changed_my_mind",
+          "item_not_as_described",
+          "received_the_wrong_item",
+          "damaged_or_defective",
+          "unknown",
+          "other_reason",
+        ],
+        @clothing.return_reasons.map(&:friendly_id),
+      )
+    end
+
     test "execute adds return reasons to categories and their descendants when include_descendants is true" do
       DumpCategoriesCommand.any_instance.expects(:execute).once
       SyncEnLocalizationsCommand.any_instance.expects(:execute).once
       GenerateDocsCommand.any_instance.expects(:execute).once
+
+      @clothing.add_return_reason(@existing_reason)
+      @shirts.add_return_reason(@existing_reason)
 
       AddReturnReasonsToCategoriesCommand.new(
         return_reason_friendly_ids: "defective_or_doesnt_work",
@@ -121,10 +162,10 @@ module ProductTaxonomy
         include_descendants: true,
       ).execute
 
-      assert_equal 1, @clothing.return_reasons.size
+      assert_equal 2, @clothing.return_reasons.size
       assert_includes @clothing.return_reasons, @defective_reason
 
-      assert_equal 1, @shirts.return_reasons.size
+      assert_equal 2, @shirts.return_reasons.size
       assert_includes @shirts.return_reasons, @defective_reason
 
       assert_empty @root.return_reasons
@@ -135,16 +176,19 @@ module ProductTaxonomy
       SyncEnLocalizationsCommand.any_instance.expects(:execute).once
       GenerateDocsCommand.any_instance.expects(:execute).once
 
+      @root.add_return_reason(@existing_reason)
+      @clothing.add_return_reason(@existing_reason)
+
       AddReturnReasonsToCategoriesCommand.new(
         return_reason_friendly_ids: "defective_or_doesnt_work",
         category_ids: "aa,aa-1",
         include_descendants: false,
       ).execute
 
-      assert_equal 1, @root.return_reasons.size
+      assert_equal 2, @root.return_reasons.size
       assert_includes @root.return_reasons, @defective_reason
 
-      assert_equal 1, @clothing.return_reasons.size
+      assert_equal 2, @clothing.return_reasons.size
       assert_includes @clothing.return_reasons, @defective_reason
 
       assert_empty @shirts.return_reasons
@@ -230,6 +274,9 @@ module ProductTaxonomy
       Category.add(@second_root)
       Category.add(@equipment)
 
+      @clothing.add_return_reason(@existing_reason)
+      @equipment.add_return_reason(@existing_reason)
+
       dump_command = mock
       dump_command.expects(:execute).once
       DumpCategoriesCommand.expects(:new).with(verticals: ["aa", "bb"]).returns(dump_command)
@@ -243,14 +290,14 @@ module ProductTaxonomy
         include_descendants: false,
       ).execute
 
-      assert_equal 1, @clothing.return_reasons.size
+      assert_equal 2, @clothing.return_reasons.size
       assert_includes @clothing.return_reasons, @defective_reason
 
-      assert_equal 1, @equipment.return_reasons.size
+      assert_equal 2, @equipment.return_reasons.size
       assert_includes @equipment.return_reasons, @defective_reason
     end
 
-    test "execute on a category that inherits its return reasons turns off inheritance and keeps only the new reason" do
+    test "execute on a category that inherits its return reasons turns off inheritance and appends the global reasons" do
       # `aa-2` inherits from its parent `aa`, which defines its own reasons.
       @root.add_return_reason(@wrong_size_reason)
       shoes = Category.new(id: "aa-2", name: "Shoes", return_reasons: :inherit)
@@ -271,13 +318,20 @@ module ProductTaxonomy
         include_descendants: false,
       ).execute
 
-      # Adding a reason turns off inheritance and discards the inherited reasons: only the new reason remains.
+      # Adding a reason turns off inheritance and discards the inherited reasons; since the category now starts
+      # from scratch, the global reasons are appended after the new reason.
       refute shoes.inherits_return_reasons
-      assert_equal [@defective_reason], shoes.return_reasons
-      assert_equal(
-        ["defective_or_doesnt_work"],
-        Serializers::Category::Data::DataSerializer.serialize(shoes)["return_reasons"],
-      )
+      expected = [
+        "defective_or_doesnt_work",
+        "changed_my_mind",
+        "item_not_as_described",
+        "received_the_wrong_item",
+        "damaged_or_defective",
+        "unknown",
+        "other_reason",
+      ]
+      assert_equal expected, shoes.return_reasons.map(&:friendly_id)
+      assert_equal expected, Serializers::Category::Data::DataSerializer.serialize(shoes)["return_reasons"]
     end
 
     test "execute does not skip a reason the category only has through inheritance, materializing it instead" do
@@ -303,11 +357,7 @@ module ProductTaxonomy
 
       # Even though the reason is present via inheritance, the command still adds it, turning off inheritance.
       refute shoes.inherits_return_reasons
-      assert_equal [@defective_reason], shoes.return_reasons
-      assert_equal(
-        ["defective_or_doesnt_work"],
-        Serializers::Category::Data::DataSerializer.serialize(shoes)["return_reasons"],
-      )
+      assert_includes shoes.return_reasons, @defective_reason
     end
 
     test "execute handles whitespace in comma-separated lists" do
@@ -315,17 +365,20 @@ module ProductTaxonomy
       SyncEnLocalizationsCommand.any_instance.expects(:execute).once
       GenerateDocsCommand.any_instance.expects(:execute).once
 
+      @clothing.add_return_reason(@existing_reason)
+      @shirts.add_return_reason(@existing_reason)
+
       AddReturnReasonsToCategoriesCommand.new(
         return_reason_friendly_ids: "defective_or_doesnt_work , wrong_size_or_fit ",
         category_ids: " aa-1 , aa-1-1",
         include_descendants: false,
       ).execute
 
-      assert_equal 2, @clothing.return_reasons.size
+      assert_equal 3, @clothing.return_reasons.size
       assert_includes @clothing.return_reasons, @defective_reason
       assert_includes @clothing.return_reasons, @wrong_size_reason
 
-      assert_equal 2, @shirts.return_reasons.size
+      assert_equal 3, @shirts.return_reasons.size
       assert_includes @shirts.return_reasons, @defective_reason
       assert_includes @shirts.return_reasons, @wrong_size_reason
     end

--- a/dev/test/commands/add_return_reasons_to_categories_command_test.rb
+++ b/dev/test/commands/add_return_reasons_to_categories_command_test.rb
@@ -117,9 +117,13 @@ module ProductTaxonomy
       assert_includes @clothing.return_reasons, @existing_reason
       assert_includes @clothing.return_reasons, @defective_reason
       assert_includes @clothing.return_reasons, @wrong_size_reason
+      # The category defines every reason it has, so the data file and the artifacts list the same set.
+      assert_equal @clothing.return_reasons, @clothing.defined_return_reasons
 
       assert_empty @root.return_reasons
+      assert_empty @root.defined_return_reasons
       assert_empty @shirts.return_reasons
+      assert_empty @shirts.defined_return_reasons
     end
 
     test "execute appends the global reasons when a category starts from an empty list" do
@@ -148,6 +152,39 @@ module ProductTaxonomy
       )
     end
 
+    test "execute appends the global reasons when a category only resolved to them" do
+      # Mirrors a category loaded from source with `return_reasons: []`: it resolves to the global reasons without
+      # defining any of its own.
+      @clothing.resolve_return_reasons
+      assert_empty @clothing.defined_return_reasons
+      assert_equal ReturnReason::GLOBAL_FRIENDLY_IDS, @clothing.return_reasons.map(&:friendly_id)
+
+      DumpCategoriesCommand.any_instance.expects(:execute).once
+      SyncEnLocalizationsCommand.any_instance.expects(:execute).once
+      GenerateDocsCommand.any_instance.expects(:execute).once
+
+      AddReturnReasonsToCategoriesCommand.new(
+        return_reason_friendly_ids: "wrong_size_or_fit",
+        category_ids: "aa-1",
+        include_descendants: false,
+      ).execute
+
+      # The global reasons are written out explicitly alongside the new one, so the category does not lose them once
+      # its list is no longer empty in the data file.
+      expected = [
+        "wrong_size_or_fit",
+        "changed_my_mind",
+        "item_not_as_described",
+        "received_the_wrong_item",
+        "damaged_or_defective",
+        "unknown",
+        "other_reason",
+      ]
+      assert_equal expected, @clothing.return_reasons.map(&:friendly_id)
+      assert_equal expected, @clothing.defined_return_reasons.map(&:friendly_id)
+      assert_equal expected, Serializers::Category::Data::DataSerializer.serialize(@clothing)["return_reasons"]
+    end
+
     test "execute adds return reasons to categories and their descendants when include_descendants is true" do
       DumpCategoriesCommand.any_instance.expects(:execute).once
       SyncEnLocalizationsCommand.any_instance.expects(:execute).once
@@ -164,11 +201,14 @@ module ProductTaxonomy
 
       assert_equal 2, @clothing.return_reasons.size
       assert_includes @clothing.return_reasons, @defective_reason
+      assert_equal @clothing.return_reasons, @clothing.defined_return_reasons
 
       assert_equal 2, @shirts.return_reasons.size
       assert_includes @shirts.return_reasons, @defective_reason
+      assert_equal @shirts.return_reasons, @shirts.defined_return_reasons
 
       assert_empty @root.return_reasons
+      assert_empty @root.defined_return_reasons
     end
 
     test "execute adds return reasons to multiple categories" do
@@ -187,11 +227,14 @@ module ProductTaxonomy
 
       assert_equal 2, @root.return_reasons.size
       assert_includes @root.return_reasons, @defective_reason
+      assert_equal @root.return_reasons, @root.defined_return_reasons
 
       assert_equal 2, @clothing.return_reasons.size
       assert_includes @clothing.return_reasons, @defective_reason
+      assert_equal @clothing.return_reasons, @clothing.defined_return_reasons
 
       assert_empty @shirts.return_reasons
+      assert_empty @shirts.defined_return_reasons
     end
 
     test "execute skips adding return reasons that are already present" do
@@ -212,6 +255,7 @@ module ProductTaxonomy
       assert_includes @clothing.return_reasons, @wrong_size_reason
 
       assert_equal 1, @clothing.return_reasons.count { |reason| reason == @defective_reason }
+      assert_equal 1, @clothing.defined_return_reasons.count { |reason| reason == @defective_reason }
     end
 
     test "execute keeps non-global reasons in order and moves the global reasons to the end in their defined order" do
@@ -241,6 +285,8 @@ module ProductTaxonomy
         ],
         @clothing.return_reasons.map(&:friendly_id),
       )
+      # The data file is ordered the same way, so a dump/reload round-trips the order.
+      assert_equal @clothing.return_reasons, @clothing.defined_return_reasons
     end
 
     test "execute raises error when return reason is not found" do
@@ -292,9 +338,11 @@ module ProductTaxonomy
 
       assert_equal 2, @clothing.return_reasons.size
       assert_includes @clothing.return_reasons, @defective_reason
+      assert_equal @clothing.return_reasons, @clothing.defined_return_reasons
 
       assert_equal 2, @equipment.return_reasons.size
       assert_includes @equipment.return_reasons, @defective_reason
+      assert_equal @equipment.return_reasons, @equipment.defined_return_reasons
     end
 
     test "execute on a category that inherits its return reasons turns off inheritance and appends the global reasons" do
@@ -303,10 +351,11 @@ module ProductTaxonomy
       shoes = Category.new(id: "aa-2", name: "Shoes", return_reasons: :inherit)
       @root.add_child(shoes)
       Category.add(shoes)
-      shoes.resolve_inherited_return_reasons
+      shoes.resolve_return_reasons
 
       assert shoes.inherits_return_reasons
       assert_equal [@wrong_size_reason], shoes.return_reasons
+      assert_empty shoes.defined_return_reasons
 
       DumpCategoriesCommand.any_instance.expects(:execute).once
       SyncEnLocalizationsCommand.any_instance.expects(:execute).once
@@ -331,6 +380,7 @@ module ProductTaxonomy
         "other_reason",
       ]
       assert_equal expected, shoes.return_reasons.map(&:friendly_id)
+      assert_equal expected, shoes.defined_return_reasons.map(&:friendly_id)
       assert_equal expected, Serializers::Category::Data::DataSerializer.serialize(shoes)["return_reasons"]
     end
 
@@ -340,10 +390,11 @@ module ProductTaxonomy
       shoes = Category.new(id: "aa-2", name: "Shoes", return_reasons: :inherit)
       @root.add_child(shoes)
       Category.add(shoes)
-      shoes.resolve_inherited_return_reasons
+      shoes.resolve_return_reasons
 
       assert shoes.inherits_return_reasons
       assert_equal [@defective_reason], shoes.return_reasons
+      assert_empty shoes.defined_return_reasons
 
       DumpCategoriesCommand.any_instance.expects(:execute).once
       SyncEnLocalizationsCommand.any_instance.expects(:execute).once
@@ -358,6 +409,7 @@ module ProductTaxonomy
       # Even though the reason is present via inheritance, the command still adds it, turning off inheritance.
       refute shoes.inherits_return_reasons
       assert_includes shoes.return_reasons, @defective_reason
+      assert_includes shoes.defined_return_reasons, @defective_reason
     end
 
     test "execute on a category that used to inherit updates its inheriting children's values in the artifacts/docs" do
@@ -369,13 +421,15 @@ module ProductTaxonomy
       parent.add_child(child)
       Category.add(parent)
       Category.add(child)
-      parent.resolve_inherited_return_reasons
-      child.resolve_inherited_return_reasons
+      parent.resolve_return_reasons
+      child.resolve_return_reasons
 
       # Precondition: both inherit `aa`'s single reason.
       assert parent.inherits_return_reasons
       assert child.inherits_return_reasons
       assert_equal [@wrong_size_reason], child.return_reasons
+      assert_empty parent.defined_return_reasons
+      assert_empty child.defined_return_reasons
 
       DumpCategoriesCommand.any_instance.expects(:execute).once
       SyncEnLocalizationsCommand.any_instance.expects(:execute).once
@@ -403,6 +457,7 @@ module ProductTaxonomy
       assert child.inherits_return_reasons
       assert_equal "inherit", Serializers::Category::Data::DataSerializer.serialize(child)["return_reasons"]
       assert_equal expected_friendly_ids, child.return_reasons.map(&:friendly_id)
+      assert_equal [], child.defined_return_reasons.map(&:friendly_id)
 
       expected_handles = expected_friendly_ids.map { |friendly_id| ReturnReason.find_by!(friendly_id:).handle }
       assert_equal(
@@ -432,6 +487,9 @@ module ProductTaxonomy
       assert_equal 3, @shirts.return_reasons.size
       assert_includes @shirts.return_reasons, @defective_reason
       assert_includes @shirts.return_reasons, @wrong_size_reason
+
+      assert_equal @clothing.return_reasons, @clothing.defined_return_reasons
+      assert_equal @shirts.return_reasons, @shirts.defined_return_reasons
     end
   end
 end

--- a/dev/test/commands/add_return_reasons_to_categories_command_test.rb
+++ b/dev/test/commands/add_return_reasons_to_categories_command_test.rb
@@ -209,6 +209,66 @@ module ProductTaxonomy
       assert_includes @equipment.return_reasons, @defective_reason
     end
 
+    test "execute on a category that inherits its return reasons turns off inheritance and keeps only the new reason" do
+      # `aa-2` inherits from its parent `aa`, which defines its own reasons.
+      @root.add_return_reason(@wrong_size_reason)
+      shoes = Category.new(id: "aa-2", name: "Shoes", return_reasons: :inherit)
+      @root.add_child(shoes)
+      Category.add(shoes)
+      shoes.resolve_inherited_return_reasons
+
+      assert shoes.inherits_return_reasons
+      assert_equal [@wrong_size_reason], shoes.return_reasons
+
+      DumpCategoriesCommand.any_instance.expects(:execute).once
+      SyncEnLocalizationsCommand.any_instance.expects(:execute).once
+      GenerateDocsCommand.any_instance.expects(:execute).once
+
+      AddReturnReasonsToCategoriesCommand.new(
+        return_reason_friendly_ids: "defective_or_doesnt_work",
+        category_ids: "aa-2",
+        include_descendants: false,
+      ).execute
+
+      # Adding a reason turns off inheritance and discards the inherited reasons: only the new reason remains.
+      refute shoes.inherits_return_reasons
+      assert_equal [@defective_reason], shoes.return_reasons
+      assert_equal(
+        ["defective_or_doesnt_work"],
+        Serializers::Category::Data::DataSerializer.serialize(shoes)["return_reasons"],
+      )
+    end
+
+    test "execute does not skip a reason the category only has through inheritance, materializing it instead" do
+      # `aa-2` inherits from its parent `aa`, whose reasons already include the one we add.
+      @root.add_return_reason(@defective_reason)
+      shoes = Category.new(id: "aa-2", name: "Shoes", return_reasons: :inherit)
+      @root.add_child(shoes)
+      Category.add(shoes)
+      shoes.resolve_inherited_return_reasons
+
+      assert shoes.inherits_return_reasons
+      assert_equal [@defective_reason], shoes.return_reasons
+
+      DumpCategoriesCommand.any_instance.expects(:execute).once
+      SyncEnLocalizationsCommand.any_instance.expects(:execute).once
+      GenerateDocsCommand.any_instance.expects(:execute).once
+
+      AddReturnReasonsToCategoriesCommand.new(
+        return_reason_friendly_ids: "defective_or_doesnt_work",
+        category_ids: "aa-2",
+        include_descendants: false,
+      ).execute
+
+      # Even though the reason is present via inheritance, the command still adds it, turning off inheritance.
+      refute shoes.inherits_return_reasons
+      assert_equal [@defective_reason], shoes.return_reasons
+      assert_equal(
+        ["defective_or_doesnt_work"],
+        Serializers::Category::Data::DataSerializer.serialize(shoes)["return_reasons"],
+      )
+    end
+
     test "execute handles whitespace in comma-separated lists" do
       DumpCategoriesCommand.any_instance.expects(:execute).once
       SyncEnLocalizationsCommand.any_instance.expects(:execute).once

--- a/dev/test/commands/add_return_reasons_to_categories_command_test.rb
+++ b/dev/test/commands/add_return_reasons_to_categories_command_test.rb
@@ -6,38 +6,74 @@ module ProductTaxonomy
   class AddReturnReasonsToCategoriesCommandTest < TestCase
     setup do
       @defective_reason = ReturnReason.new(
-        id: 1,
+        id: 1001,
         name: "Defective or Doesn't Work",
         description: "Item is broken, defective, or doesn't function as expected",
         friendly_id: "defective_or_doesnt_work",
         handle: "defective-or-doesnt-work",
       )
       @wrong_size_reason = ReturnReason.new(
-        id: 2,
+        id: 1002,
         name: "Wrong Size or Fit",
         description: "Item doesn't fit properly or is not the expected size",
         friendly_id: "wrong_size_or_fit",
         handle: "wrong-size-or-fit",
       )
       @unknown_reason = ReturnReason.new(
-        id: 3,
+        id: 1,
         name: "Unknown",
-        description: "Unknown return reason",
+        description: "The reason for the return has not been specified or could not be determined.",
         friendly_id: "unknown",
         handle: "unknown",
       )
       @other_reason = ReturnReason.new(
-        id: 4,
+        id: 5,
         name: "Other",
-        description: "Other return reason not listed",
+        description: "The reason for the return does not fit into any of the predefined categories.",
         friendly_id: "other_reason",
         handle: "other-reason",
+      )
+
+      @changed_my_mind_reason = ReturnReason.new(
+        id: 2,
+        name: "Changed my mind",
+        description: "The customer no longer wants the item after purchasing it, regardless of product " \
+          "quality or accuracy.",
+        friendly_id: "changed_my_mind",
+        handle: "changed-my-mind",
+      )
+      @item_not_as_described_reason = ReturnReason.new(
+        id: 3,
+        name: "Item not as described",
+        description: "The product does not match the description, images, or specifications provided in " \
+          "the listing.",
+        friendly_id: "item_not_as_described",
+        handle: "item-not-as-described",
+      )
+      @received_wrong_item_reason = ReturnReason.new(
+        id: 4,
+        name: "Received the wrong item",
+        description: "The customer received a different product than what was ordered or expected.",
+        friendly_id: "received_the_wrong_item",
+        handle: "received-the-wrong-item",
+      )
+      @damaged_or_defective_reason = ReturnReason.new(
+        id: 6,
+        name: "Damaged or defective",
+        description: "The item arrived with physical damage, manufacturing defects, or does not function " \
+          "as intended.",
+        friendly_id: "damaged_or_defective",
+        handle: "damaged-or-defective",
       )
 
       ReturnReason.add(@defective_reason)
       ReturnReason.add(@wrong_size_reason)
       ReturnReason.add(@unknown_reason)
       ReturnReason.add(@other_reason)
+      ReturnReason.add(@changed_my_mind_reason)
+      ReturnReason.add(@item_not_as_described_reason)
+      ReturnReason.add(@received_wrong_item_reason)
+      ReturnReason.add(@damaged_or_defective_reason)
 
       @root = Category.new(id: "aa", name: "Apparel & Accessories")
       @clothing = Category.new(id: "aa-1", name: "Clothing")
@@ -134,28 +170,33 @@ module ProductTaxonomy
       assert_equal 1, @clothing.return_reasons.count { |reason| reason == @defective_reason }
     end
 
-    test "execute sorts return reasons with special ones at the end" do
+    test "execute keeps non-global reasons in order and moves the global reasons to the end in their defined order" do
       DumpCategoriesCommand.any_instance.expects(:execute).once
       SyncEnLocalizationsCommand.any_instance.expects(:execute).once
       GenerateDocsCommand.any_instance.expects(:execute).once
 
       AddReturnReasonsToCategoriesCommand.new(
-        return_reason_friendly_ids: "unknown,defective_or_doesnt_work,other_reason,wrong_size_or_fit",
+        return_reason_friendly_ids:
+          "other_reason,changed_my_mind,wrong_size_or_fit,unknown,damaged_or_defective," \
+          "defective_or_doesnt_work,received_the_wrong_item,item_not_as_described",
         category_ids: "aa-1",
         include_descendants: false,
       ).execute
 
-      assert_equal 4, @clothing.return_reasons.size
-
-      # Check that regular reasons are sorted alphabetically
-      regular_reasons = @clothing.return_reasons.take(2)
-      assert_equal @defective_reason, regular_reasons[0]
-      assert_equal @wrong_size_reason, regular_reasons[1]
-
-      # Check that 'unknown' and 'other' are at the end in that order
-      special_reasons = @clothing.return_reasons.drop(2)
-      assert_equal @unknown_reason, special_reasons[0]
-      assert_equal @other_reason, special_reasons[1]
+      # Non-global reasons keep the given order at the front; the global reasons follow in their defined order.
+      assert_equal(
+        [
+          "wrong_size_or_fit",
+          "defective_or_doesnt_work",
+          "changed_my_mind",
+          "item_not_as_described",
+          "received_the_wrong_item",
+          "damaged_or_defective",
+          "unknown",
+          "other_reason",
+        ],
+        @clothing.return_reasons.map(&:friendly_id),
+      )
     end
 
     test "execute raises error when return reason is not found" do

--- a/dev/test/commands/add_return_reasons_to_categories_command_test.rb
+++ b/dev/test/commands/add_return_reasons_to_categories_command_test.rb
@@ -360,6 +360,57 @@ module ProductTaxonomy
       assert_includes shoes.return_reasons, @defective_reason
     end
 
+    test "execute on a category that used to inherit updates its inheriting children's values in the artifacts/docs" do
+      # `aa` defines its own reasons; `aa-2` (parent) and its child `aa-2-1` both inherit from it.
+      @root.add_return_reason(@wrong_size_reason)
+      parent = Category.new(id: "aa-2", name: "Shoes", return_reasons: :inherit)
+      child = Category.new(id: "aa-2-1", name: "Sneakers", return_reasons: :inherit)
+      @root.add_child(parent)
+      parent.add_child(child)
+      Category.add(parent)
+      Category.add(child)
+      parent.resolve_inherited_return_reasons
+      child.resolve_inherited_return_reasons
+
+      # Precondition: both inherit `aa`'s single reason.
+      assert parent.inherits_return_reasons
+      assert child.inherits_return_reasons
+      assert_equal [@wrong_size_reason], child.return_reasons
+
+      DumpCategoriesCommand.any_instance.expects(:execute).once
+      SyncEnLocalizationsCommand.any_instance.expects(:execute).once
+      GenerateDocsCommand.any_instance.expects(:execute).once
+
+      # Add a reason only to the parent, not its descendants.
+      AddReturnReasonsToCategoriesCommand.new(
+        return_reason_friendly_ids: "defective_or_doesnt_work",
+        category_ids: "aa-2",
+        include_descendants: false,
+      ).execute
+
+      expected_friendly_ids = [
+        "defective_or_doesnt_work",
+        "changed_my_mind",
+        "item_not_as_described",
+        "received_the_wrong_item",
+        "damaged_or_defective",
+        "unknown",
+        "other_reason",
+      ]
+
+      # The child still inherits, so the data file keeps `inherit`, but it now inherits the parent's new reasons,
+      # so the resolved values feeding the docs/dist artifacts are updated.
+      assert child.inherits_return_reasons
+      assert_equal "inherit", Serializers::Category::Data::DataSerializer.serialize(child)["return_reasons"]
+      assert_equal expected_friendly_ids, child.return_reasons.map(&:friendly_id)
+
+      expected_handles = expected_friendly_ids.map { |friendly_id| ReturnReason.find_by!(friendly_id:).handle }
+      assert_equal(
+        expected_handles.join(","),
+        Serializers::Category::Docs::SiblingsSerializer.serialize(child)["return_reason_handles"],
+      )
+    end
+
     test "execute handles whitespace in comma-separated lists" do
       DumpCategoriesCommand.any_instance.expects(:execute).once
       SyncEnLocalizationsCommand.any_instance.expects(:execute).once

--- a/dev/test/models/category_test.rb
+++ b/dev/test/models/category_test.rb
@@ -416,6 +416,65 @@ module ProductTaxonomy
       refute_same Category.find_by(id: "aa").return_reasons, Category.find_by(id: "aa-1").return_reasons
     end
 
+    test "load_from_source falls back to the global return reasons when a category defines an empty list" do
+      add_return_reasons(*ReturnReason::GLOBAL_FRIENDLY_IDS)
+
+      yaml_content = <<~YAML
+        ---
+        - id: aa
+          name: Apparel & Accessories
+          children:
+          - aa-1
+          return_reasons: []
+        - id: aa-1
+          name: Clothing
+          return_reasons: inherit
+      YAML
+
+      Category.load_from_source(YAML.safe_load(yaml_content))
+
+      root = Category.find_by(id: "aa")
+      child = Category.find_by(id: "aa-1")
+
+      assert_equal ReturnReason::GLOBAL_FRIENDLY_IDS, root.return_reasons.map(&:friendly_id)
+      # The inheriting child copies the defaulted list rather than staying empty.
+      assert_equal ReturnReason::GLOBAL_FRIENDLY_IDS, child.return_reasons.map(&:friendly_id)
+    end
+
+    test "load_from_source gives each defaulted category its own copy of the global return reasons" do
+      add_return_reasons(*ReturnReason::GLOBAL_FRIENDLY_IDS)
+
+      yaml_content = <<~YAML
+        ---
+        - id: aa
+          name: Apparel & Accessories
+          return_reasons: []
+        - id: bb
+          name: Baby & Toddler
+          return_reasons: []
+      YAML
+
+      Category.load_from_source(YAML.safe_load(yaml_content))
+
+      refute_same Category.find_by(id: "aa").return_reasons, Category.find_by(id: "bb").return_reasons
+    end
+
+    test "load_from_source keeps explicitly defined return reasons instead of the global ones" do
+      add_return_reasons("size", *ReturnReason::GLOBAL_FRIENDLY_IDS)
+
+      yaml_content = <<~YAML
+        ---
+        - id: aa
+          name: Apparel & Accessories
+          return_reasons:
+          - size
+      YAML
+
+      Category.load_from_source(YAML.safe_load(yaml_content))
+
+      assert_equal ["size"], Category.find_by(id: "aa").return_reasons.map(&:friendly_id)
+    end
+
     test "load_from_source raises validation error if attribute is not found" do
       yaml_content = <<~YAML
         ---

--- a/dev/test/models/category_test.rb
+++ b/dev/test/models/category_test.rb
@@ -287,6 +287,97 @@ module ProductTaxonomy
       assert_equal ["zzz", "aaa"], actual
     end
 
+    test "inherits_return_reasons is false for a category with an explicit return_reasons list" do
+      assert_equal false, Category.new(id: "aa", name: "Root", return_reasons: []).inherits_return_reasons
+    end
+
+    test "inherits_return_reasons is true for a category created with :inherit" do
+      category = Category.new(id: "aa", name: "Root", return_reasons: :inherit)
+
+      assert_equal true, category.inherits_return_reasons
+      assert_equal [], category.return_reasons
+    end
+
+    test "load_from_source copies return reasons into inheriting descendants from the closest defining ancestor" do
+      add_return_reasons("size", "color")
+
+      yaml_content = <<~YAML
+        ---
+        - id: aa
+          name: Apparel & Accessories
+          children:
+          - aa-1
+          return_reasons:
+          - size
+          - color
+        - id: aa-1
+          name: Clothing
+          children:
+          - aa-1-1
+          return_reasons: inherit
+        - id: aa-1-1
+          name: Shirts
+          return_reasons: inherit
+      YAML
+
+      Category.load_from_source(YAML.safe_load(yaml_content))
+
+      assert_equal false, Category.find_by(id: "aa").inherits_return_reasons
+      assert_equal true, Category.find_by(id: "aa-1").inherits_return_reasons
+      assert_equal true, Category.find_by(id: "aa-1-1").inherits_return_reasons
+      assert_equal ["size", "color"], Category.find_by(id: "aa-1").return_reasons.map(&:friendly_id)
+      assert_equal ["size", "color"], Category.find_by(id: "aa-1-1").return_reasons.map(&:friendly_id)
+    end
+
+    test "load_from_source inherits from the closest ancestor that redefines its own reasons" do
+      add_return_reasons("size", "color", "damaged")
+
+      yaml_content = <<~YAML
+        ---
+        - id: aa
+          name: Apparel & Accessories
+          children:
+          - aa-1
+          return_reasons:
+          - size
+        - id: aa-1
+          name: Clothing
+          children:
+          - aa-1-1
+          return_reasons:
+          - color
+          - damaged
+        - id: aa-1-1
+          name: Shirts
+          return_reasons: inherit
+      YAML
+
+      Category.load_from_source(YAML.safe_load(yaml_content))
+
+      assert_equal ["color", "damaged"], Category.find_by(id: "aa-1-1").return_reasons.map(&:friendly_id)
+    end
+
+    test "load_from_source gives each inheriting category its own copy of the reasons" do
+      add_return_reasons("size")
+
+      yaml_content = <<~YAML
+        ---
+        - id: aa
+          name: Apparel & Accessories
+          children:
+          - aa-1
+          return_reasons:
+          - size
+        - id: aa-1
+          name: Clothing
+          return_reasons: inherit
+      YAML
+
+      Category.load_from_source(YAML.safe_load(yaml_content))
+
+      refute_same Category.find_by(id: "aa").return_reasons, Category.find_by(id: "aa-1").return_reasons
+    end
+
     test "load_from_source raises validation error if attribute is not found" do
       yaml_content = <<~YAML
         ---
@@ -511,6 +602,18 @@ module ProductTaxonomy
     end
 
     private
+
+    def add_return_reasons(*friendly_ids)
+      friendly_ids.each_with_index do |friendly_id, index|
+        ReturnReason.add(ReturnReason.new(
+          id: index + 1,
+          name: friendly_id.tr("_", " ").capitalize,
+          description: "Description for #{friendly_id}",
+          friendly_id:,
+          handle: friendly_id.tr("_", "-"),
+        ))
+      end
+    end
 
     def stub_localizations
       fr_yaml = <<~YAML

--- a/dev/test/models/category_test.rb
+++ b/dev/test/models/category_test.rb
@@ -283,8 +283,9 @@ module ProductTaxonomy
 
       Category.load_from_source(YAML.safe_load(yaml_content))
 
-      actual = Category.verticals.first.return_reasons.map(&:friendly_id)
-      assert_equal ["zzz", "aaa"], actual
+      vertical = Category.verticals.first
+      assert_equal ["zzz", "aaa"], vertical.return_reasons.map(&:friendly_id)
+      assert_equal ["zzz", "aaa"], vertical.defined_return_reasons.map(&:friendly_id)
     end
 
     test "inherits_return_reasons is false for a category with an explicit return_reasons list" do
@@ -296,6 +297,7 @@ module ProductTaxonomy
 
       assert_equal true, category.inherits_return_reasons
       assert_equal [], category.return_reasons
+      assert_empty category.defined_return_reasons
     end
 
     test "raises validation error if a root category inherits return reasons" do
@@ -323,10 +325,12 @@ module ProductTaxonomy
       root = Category.new(id: "aa", name: "Root", return_reasons: [size])
       child = Category.new(id: "aa-1", name: "Child", return_reasons: :inherit)
       root.add_child(child)
-      child.resolve_inherited_return_reasons
+      child.resolve_return_reasons
 
       assert child.inherits_return_reasons
       assert_equal [size], child.return_reasons
+      # An inheriting category defines nothing of its own, which is what keeps `inherit` in the data file.
+      assert_empty child.defined_return_reasons
 
       child.add_return_reason(color)
 
@@ -334,6 +338,32 @@ module ProductTaxonomy
       # inherited so only the newly added reason remains.
       refute child.inherits_return_reasons
       assert_equal [color], child.return_reasons
+      assert_equal [color], child.defined_return_reasons
+    end
+
+    test "add_return_reason keeps the effective reasons in sync with the defined ones" do
+      add_return_reasons("size", *ReturnReason::GLOBAL_FRIENDLY_IDS)
+      size = ReturnReason.find_by(friendly_id: "size")
+
+      yaml_content = <<~YAML
+        ---
+        - id: aa
+          name: Apparel & Accessories
+          return_reasons: []
+      YAML
+      Category.load_from_source(YAML.safe_load(yaml_content))
+      category = Category.find_by(id: "aa")
+
+      # Precondition: the category defines nothing and only resolved to the global reasons.
+      assert_empty category.defined_return_reasons
+      assert_equal ReturnReason::GLOBAL_FRIENDLY_IDS, category.return_reasons.map(&:friendly_id)
+
+      category.add_return_reason(size)
+
+      # Once the category defines a list of its own, the effective reasons are that list: the globals it had merely
+      # resolved to are not left behind, otherwise `data` and `dist` would disagree about the category.
+      assert_equal [size], category.defined_return_reasons
+      assert_equal category.defined_return_reasons, category.return_reasons
     end
 
     test "load_from_source copies return reasons into inheriting descendants from the closest defining ancestor" do
@@ -365,6 +395,10 @@ module ProductTaxonomy
       assert_equal true, Category.find_by(id: "aa-1-1").inherits_return_reasons
       assert_equal ["size", "color"], Category.find_by(id: "aa-1").return_reasons.map(&:friendly_id)
       assert_equal ["size", "color"], Category.find_by(id: "aa-1-1").return_reasons.map(&:friendly_id)
+      # Only the defining ancestor holds the reasons; the descendants resolved them without defining any.
+      assert_equal ["size", "color"], Category.find_by(id: "aa").defined_return_reasons.map(&:friendly_id)
+      assert_empty Category.find_by(id: "aa-1").defined_return_reasons
+      assert_empty Category.find_by(id: "aa-1-1").defined_return_reasons
     end
 
     test "load_from_source inherits from the closest ancestor that redefines its own reasons" do
@@ -393,6 +427,8 @@ module ProductTaxonomy
       Category.load_from_source(YAML.safe_load(yaml_content))
 
       assert_equal ["color", "damaged"], Category.find_by(id: "aa-1-1").return_reasons.map(&:friendly_id)
+      assert_equal ["color", "damaged"], Category.find_by(id: "aa-1").defined_return_reasons.map(&:friendly_id)
+      assert_empty Category.find_by(id: "aa-1-1").defined_return_reasons
     end
 
     test "load_from_source gives each inheriting category its own copy of the reasons" do
@@ -414,6 +450,7 @@ module ProductTaxonomy
       Category.load_from_source(YAML.safe_load(yaml_content))
 
       refute_same Category.find_by(id: "aa").return_reasons, Category.find_by(id: "aa-1").return_reasons
+      refute_same Category.find_by(id: "aa").defined_return_reasons, Category.find_by(id: "aa-1").defined_return_reasons
     end
 
     test "load_from_source falls back to the global return reasons when a category defines an empty list" do
@@ -437,8 +474,38 @@ module ProductTaxonomy
       child = Category.find_by(id: "aa-1")
 
       assert_equal ReturnReason::GLOBAL_FRIENDLY_IDS, root.return_reasons.map(&:friendly_id)
+      assert_equal [], root.defined_return_reasons.map(&:friendly_id)
       # The inheriting child copies the defaulted list rather than staying empty.
       assert_equal ReturnReason::GLOBAL_FRIENDLY_IDS, child.return_reasons.map(&:friendly_id)
+      assert_equal [], child.defined_return_reasons.map(&:friendly_id)
+    end
+
+    test "load_from_source resolves return reasons regardless of the order categories appear in the source" do
+      add_return_reasons(*ReturnReason::GLOBAL_FRIENDLY_IDS)
+
+      # The inheriting child is listed before the ancestor it inherits from, which is valid source data.
+      yaml_content = <<~YAML
+        ---
+        - id: aa-1
+          name: Clothing
+          return_reasons: inherit
+        - id: aa
+          name: Apparel & Accessories
+          children:
+          - aa-1
+          return_reasons: []
+      YAML
+
+      Category.load_from_source(YAML.safe_load(yaml_content))
+
+      assert_equal(
+        ReturnReason::GLOBAL_FRIENDLY_IDS,
+        Category.find_by(id: "aa-1").return_reasons.map(&:friendly_id),
+      )
+      assert_equal(
+        [],
+        Category.find_by(id: "aa-1").defined_return_reasons.map(&:friendly_id),
+      )
     end
 
     test "load_from_source gives each defaulted category its own copy of the global return reasons" do
@@ -457,6 +524,7 @@ module ProductTaxonomy
       Category.load_from_source(YAML.safe_load(yaml_content))
 
       refute_same Category.find_by(id: "aa").return_reasons, Category.find_by(id: "bb").return_reasons
+      refute_same Category.find_by(id: "aa").defined_return_reasons, Category.find_by(id: "bb").defined_return_reasons
     end
 
     test "load_from_source keeps explicitly defined return reasons instead of the global ones" do
@@ -473,6 +541,7 @@ module ProductTaxonomy
       Category.load_from_source(YAML.safe_load(yaml_content))
 
       assert_equal ["size"], Category.find_by(id: "aa").return_reasons.map(&:friendly_id)
+      assert_equal ["size"], Category.find_by(id: "aa").defined_return_reasons.map(&:friendly_id)
     end
 
     test "load_from_source raises validation error if attribute is not found" do

--- a/dev/test/models/category_test.rb
+++ b/dev/test/models/category_test.rb
@@ -298,6 +298,27 @@ module ProductTaxonomy
       assert_equal [], category.return_reasons
     end
 
+    test "add_return_reason on an inheriting category turns off inheritance and drops the inherited reasons" do
+      add_return_reasons("size", "color")
+      size = ReturnReason.find_by(friendly_id: "size")
+      color = ReturnReason.find_by(friendly_id: "color")
+
+      root = Category.new(id: "aa", name: "Root", return_reasons: [size])
+      child = Category.new(id: "aa-1", name: "Child", return_reasons: :inherit)
+      root.add_child(child)
+      child.resolve_inherited_return_reasons
+
+      assert child.inherits_return_reasons
+      assert_equal [size], child.return_reasons
+
+      child.add_return_reason(color)
+
+      # Explicitly adding a reason converts the category to defining its own reasons, discarding the ones it had
+      # inherited so only the newly added reason remains.
+      refute child.inherits_return_reasons
+      assert_equal [color], child.return_reasons
+    end
+
     test "load_from_source copies return reasons into inheriting descendants from the closest defining ancestor" do
       add_return_reasons("size", "color")
 

--- a/dev/test/models/category_test.rb
+++ b/dev/test/models/category_test.rb
@@ -298,6 +298,23 @@ module ProductTaxonomy
       assert_equal [], category.return_reasons
     end
 
+    test "raises validation error if a root category inherits return reasons" do
+      category = Category.new(id: "aa", name: "Root", return_reasons: :inherit)
+      error = assert_raises(ActiveModel::ValidationError) { category.validate!(:category_tree_loaded) }
+      expected_errors = {
+        return_reasons: [{ error: :root_cannot_inherit }],
+      }
+      assert_equal expected_errors, error.model.errors.details
+    end
+
+    test "does not raise if a non-root category inherits return reasons" do
+      root = Category.new(id: "aa", name: "Root", return_reasons: [])
+      child = Category.new(id: "aa-1", name: "Child", return_reasons: :inherit)
+      root.add_child(child)
+
+      assert_nothing_raised { child.validate!(:category_tree_loaded) }
+    end
+
     test "add_return_reason on an inheriting category turns off inheritance and drops the inherited reasons" do
       add_return_reasons("size", "color")
       size = ReturnReason.find_by(friendly_id: "size")

--- a/dev/test/models/return_reason_test.rb
+++ b/dev/test/models/return_reason_test.rb
@@ -49,6 +49,35 @@ module ProductTaxonomy
       assert_equal "wrong_item", wrong_item.handle
     end
 
+    test "global returns the global return reasons in their defined order" do
+      add_global_return_reasons
+
+      assert_equal ReturnReason::GLOBAL_FRIENDLY_IDS, ReturnReason.global.map(&:friendly_id)
+    end
+
+    test "global omits global return reasons that have not been loaded" do
+      ReturnReason.add(@return_reason)
+
+      assert_empty ReturnReason.global
+    end
+
+    test "global is memoized" do
+      add_global_return_reasons
+
+      assert_same ReturnReason.global, ReturnReason.global
+    end
+
+    test "reset clears the memoized global return reasons" do
+      add_global_return_reasons
+      memoized = ReturnReason.global
+
+      ReturnReason.reset
+      add_global_return_reasons
+
+      refute_same memoized, ReturnReason.global
+      assert_equal ReturnReason::GLOBAL_FRIENDLY_IDS, ReturnReason.global.map(&:friendly_id)
+    end
+
     test "load_from_source raises an error if the source YAML does not follow the expected schema" do
       yaml_content = <<~YAML
         ---
@@ -195,6 +224,19 @@ module ProductTaxonomy
     end
 
     private
+
+    # Added in reverse so that tests asserting on order are meaningful.
+    def add_global_return_reasons
+      ReturnReason::GLOBAL_FRIENDLY_IDS.reverse.each_with_index do |friendly_id, index|
+        ReturnReason.add(ReturnReason.new(
+          id: index + 1,
+          name: friendly_id.tr("_", " ").capitalize,
+          description: "Description for #{friendly_id}",
+          friendly_id:,
+          handle: friendly_id.tr("_", "-"),
+        ))
+      end
+    end
 
     def stub_localizations
       fr_yaml = <<~YAML

--- a/dev/test/models/serializers/category/data/data_serializer_test.rb
+++ b/dev/test/models/serializers/category/data/data_serializer_test.rb
@@ -68,6 +68,26 @@ module ProductTaxonomy
             assert_equal expected, DataSerializer.serialize(category)["return_reasons"]
           end
 
+          test "serialize writes `inherit` for categories that inherit their return reasons" do
+            category = ProductTaxonomy::Category.new(id: "bb", name: "Inheriting Root", return_reasons: :inherit)
+
+            assert_equal "inherit", DataSerializer.serialize(category)["return_reasons"]
+          end
+
+          test "serialize writes `inherit` even after inherited reasons have been resolved" do
+            root = ProductTaxonomy::Category.new(
+              id: "dd",
+              name: "Defining Root",
+              return_reasons: [return_reason(1, "color")],
+            )
+            child = ProductTaxonomy::Category.new(id: "dd-1", name: "Inheriting Child", return_reasons: :inherit)
+            root.add_child(child)
+            child.resolve_inherited_return_reasons
+
+            assert_equal ["color"], child.return_reasons.map(&:friendly_id)
+            assert_equal "inherit", DataSerializer.serialize(child)["return_reasons"]
+          end
+
           test "serialize_all returns all categories in data format" do
             expected = [
               {

--- a/dev/test/models/serializers/category/data/data_serializer_test.rb
+++ b/dev/test/models/serializers/category/data/data_serializer_test.rb
@@ -88,6 +88,19 @@ module ProductTaxonomy
             assert_equal "inherit", DataSerializer.serialize(child)["return_reasons"]
           end
 
+          test "serialize writes out the global reasons a category fell back to" do
+            ProductTaxonomy::ReturnReason::GLOBAL_FRIENDLY_IDS.each_with_index do |friendly_id, index|
+              ProductTaxonomy::ReturnReason.add(return_reason(index + 1, friendly_id))
+            end
+            category = ProductTaxonomy::Category.new(id: "ee", name: "Empty Root", return_reasons: [])
+            category.apply_default_return_reasons
+
+            assert_equal(
+              ProductTaxonomy::ReturnReason::GLOBAL_FRIENDLY_IDS,
+              DataSerializer.serialize(category)["return_reasons"],
+            )
+          end
+
           test "serialize_all returns all categories in data format" do
             expected = [
               {

--- a/dev/test/models/serializers/category/data/data_serializer_test.rb
+++ b/dev/test/models/serializers/category/data/data_serializer_test.rb
@@ -82,23 +82,46 @@ module ProductTaxonomy
             )
             child = ProductTaxonomy::Category.new(id: "dd-1", name: "Inheriting Child", return_reasons: :inherit)
             root.add_child(child)
-            child.resolve_inherited_return_reasons
+            child.resolve_return_reasons
 
             assert_equal ["color"], child.return_reasons.map(&:friendly_id)
             assert_equal "inherit", DataSerializer.serialize(child)["return_reasons"]
           end
 
-          test "serialize writes out the global reasons a category fell back to" do
+          test "serialize keeps the empty list of a category that fell back to the global reasons" do
+            ProductTaxonomy::ReturnReason::GLOBAL_FRIENDLY_IDS.each_with_index do |friendly_id, index|
+              ProductTaxonomy::ReturnReason.add(return_reason(index + 1, friendly_id))
+            end
+            ProductTaxonomy::Category.reset
+            ProductTaxonomy::Category.load_from_source([
+              { "id" => "ee", "name" => "Empty Root", "children" => [], "attributes" => [], "return_reasons" => [] },
+            ])
+            category = ProductTaxonomy::Category.find_by(id: "ee")
+
+            # The resolved list is the global set, so runtime consumers get the baseline.
+            assert_equal(
+              ProductTaxonomy::ReturnReason::GLOBAL_FRIENDLY_IDS,
+              category.return_reasons.map(&:friendly_id),
+            )
+            # But the data file keeps `[]`, otherwise dumping the taxonomy would freeze today's global reasons into
+            # `data/categories/*.yml` and the category would stop picking up new ones.
+            assert_empty category.defined_return_reasons
+            assert_equal [], DataSerializer.serialize(category)["return_reasons"]
+          end
+
+          test "serialize writes out only the reasons a category defines after falling back to the global ones" do
             ProductTaxonomy::ReturnReason::GLOBAL_FRIENDLY_IDS.each_with_index do |friendly_id, index|
               ProductTaxonomy::ReturnReason.add(return_reason(index + 1, friendly_id))
             end
             category = ProductTaxonomy::Category.new(id: "ee", name: "Empty Root", return_reasons: [])
-            category.apply_default_return_reasons
+            category.resolve_return_reasons
+            category.add_return_reason(return_reason(99, "too_big"))
 
-            assert_equal(
-              ProductTaxonomy::ReturnReason::GLOBAL_FRIENDLY_IDS,
-              DataSerializer.serialize(category)["return_reasons"],
-            )
+            # The global reasons the category only resolved to are not written back as if it defined them.
+            # `AddReturnReasonsToCategoriesCommand` is what appends them explicitly when it defines a list from
+            # scratch, so the category does not silently lose them.
+            assert_equal ["too_big"], category.defined_return_reasons.map(&:friendly_id)
+            assert_equal ["too_big"], DataSerializer.serialize(category)["return_reasons"]
           end
 
           test "serialize_all returns all categories in data format" do

--- a/dev/test/models/serializers/category/dist/json_serializer_test.rb
+++ b/dev/test/models/serializers/category/dist/json_serializer_test.rb
@@ -29,6 +29,7 @@ module ProductTaxonomy
               }],
               "ancestors" => [],
               "return_reasons" => [],
+              "inherits_return_reasons" => false,
             }
             assert_equal expected_json, JsonSerializer.serialize(@root)
           end
@@ -50,6 +51,7 @@ module ProductTaxonomy
                 "name" => "Root",
               }],
               "return_reasons" => [],
+              "inherits_return_reasons" => false,
             }
             assert_equal expected_json, JsonSerializer.serialize(@child)
           end
@@ -74,6 +76,7 @@ module ProductTaxonomy
                 },
               ],
               "return_reasons" => [],
+              "inherits_return_reasons" => false,
             }
             assert_equal expected_json, JsonSerializer.serialize(@grandchild)
           end
@@ -94,6 +97,7 @@ module ProductTaxonomy
               }],
               "ancestors" => [],
               "return_reasons" => [],
+              "inherits_return_reasons" => false,
             }
             assert_equal expected_json, JsonSerializer.serialize(@root, locale: "fr")
           end
@@ -244,11 +248,11 @@ module ProductTaxonomy
             YAML
 
             ProductTaxonomy::Category.load_from_source(YAML.safe_load(yaml_content))
-            child_handles = JsonSerializer
-              .serialize(ProductTaxonomy::Category.find_by(id: "aa-1"))["return_reasons"]
-              .map { |reason| reason["handle"] }
+            child_json = JsonSerializer.serialize(ProductTaxonomy::Category.find_by(id: "aa-1"))
+            child_handles = child_json["return_reasons"].map { |reason| reason["handle"] }
 
             assert_equal ["zzz", "aaa"], child_handles
+            assert_equal true, child_json["inherits_return_reasons"]
           end
 
           test "serialize_all returns the JSON representation of all categories" do
@@ -271,6 +275,7 @@ module ProductTaxonomy
                     "children" => [{ "id" => "gid://shopify/TaxonomyCategory/aa-1", "name" => "Child" }],
                     "ancestors" => [],
                     "return_reasons" => [],
+                    "inherits_return_reasons" => false,
                   },
                   {
                     "id" => "gid://shopify/TaxonomyCategory/aa-1",
@@ -282,6 +287,7 @@ module ProductTaxonomy
                     "children" => [{ "id" => "gid://shopify/TaxonomyCategory/aa-1-1", "name" => "Grandchild" }],
                     "ancestors" => [{ "id" => "gid://shopify/TaxonomyCategory/aa", "name" => "Root" }],
                     "return_reasons" => [],
+                    "inherits_return_reasons" => false,
                   },
                   {
                     "id" => "gid://shopify/TaxonomyCategory/aa-1-1",
@@ -296,6 +302,7 @@ module ProductTaxonomy
                       { "id" => "gid://shopify/TaxonomyCategory/aa", "name" => "Root" },
                     ],
                     "return_reasons" => [],
+                    "inherits_return_reasons" => false,
                   },
                 ],
               }],

--- a/dev/test/models/serializers/category/dist/json_serializer_test.rb
+++ b/dev/test/models/serializers/category/dist/json_serializer_test.rb
@@ -215,6 +215,42 @@ module ProductTaxonomy
             assert_equal ["zzz", "aaa"], actual_handles
           end
 
+          test "serialize includes the inherited return reasons for inheriting categories" do
+            ["zzz", "aaa"].each_with_index do |friendly_id, index|
+              ProductTaxonomy::ReturnReason.add(ProductTaxonomy::ReturnReason.new(
+                id: index + 1,
+                name: friendly_id,
+                description: friendly_id,
+                friendly_id:,
+                handle: friendly_id,
+              ))
+            end
+
+            yaml_content = <<~YAML
+              ---
+              - id: aa
+                name: Root
+                children:
+                - aa-1
+                attributes: []
+                return_reasons:
+                - zzz
+                - aaa
+              - id: aa-1
+                name: Child
+                children: []
+                attributes: []
+                return_reasons: inherit
+            YAML
+
+            ProductTaxonomy::Category.load_from_source(YAML.safe_load(yaml_content))
+            child_handles = JsonSerializer
+              .serialize(ProductTaxonomy::Category.find_by(id: "aa-1"))["return_reasons"]
+              .map { |reason| reason["handle"] }
+
+            assert_equal ["zzz", "aaa"], child_handles
+          end
+
           test "serialize_all returns the JSON representation of all categories" do
             stub_localizations
             ProductTaxonomy::Category.stubs(:verticals).returns([@root])

--- a/dev/test/models/serializers/category/dist/json_serializer_test.rb
+++ b/dev/test/models/serializers/category/dist/json_serializer_test.rb
@@ -253,6 +253,38 @@ module ProductTaxonomy
 
             assert_equal ["zzz", "aaa"], child_handles
             assert_equal true, child_json["inherits_return_reasons"]
+            # `dist` carries the materialized list even though the child defines none of the reasons itself.
+            assert_empty ProductTaxonomy::Category.find_by(id: "aa-1").defined_return_reasons
+          end
+
+          test "serialize includes the global return reasons for a category that defines an empty list" do
+            ProductTaxonomy::ReturnReason::GLOBAL_FRIENDLY_IDS.each_with_index do |friendly_id, index|
+              ProductTaxonomy::ReturnReason.add(ProductTaxonomy::ReturnReason.new(
+                id: index + 1,
+                name: friendly_id,
+                description: friendly_id,
+                friendly_id:,
+                handle: friendly_id.tr("_", "-"),
+              ))
+            end
+
+            yaml_content = <<~YAML
+              ---
+              - id: aa
+                name: Root
+                children: []
+                attributes: []
+                return_reasons: []
+            YAML
+
+            ProductTaxonomy::Category.load_from_source(YAML.safe_load(yaml_content))
+            json = JsonSerializer.serialize(ProductTaxonomy::Category.find_by(id: "aa"))
+
+            # `dist` carries the materialized baseline even though `data` keeps the empty list.
+            expected_handles = ProductTaxonomy::ReturnReason::GLOBAL_FRIENDLY_IDS.map { _1.tr("_", "-") }
+            assert_equal expected_handles, json["return_reasons"].map { _1["handle"] }
+            assert_equal false, json["inherits_return_reasons"]
+            assert_empty ProductTaxonomy::Category.find_by(id: "aa").defined_return_reasons
           end
 
           test "serialize_all returns the JSON representation of all categories" do

--- a/dev/test/models/serializers/category/docs/siblings_serializer_test.rb
+++ b/dev/test/models/serializers/category/docs/siblings_serializer_test.rb
@@ -48,6 +48,7 @@ module ProductTaxonomy
               "ancestor_ids" => "gid://shopify/TaxonomyCategory/1",
               "attribute_handles" => "test_handle",
               "return_reason_handles" => "",
+              "inherits_return_reasons" => false,
             }
 
             assert_equal expected, SiblingsSerializer.serialize(@category)
@@ -69,6 +70,7 @@ module ProductTaxonomy
               "ancestor_ids" => "",
               "attribute_handles" => "",
               "return_reason_handles" => "",
+              "inherits_return_reasons" => false,
             }
 
             assert_equal expected, SiblingsSerializer.serialize(root_category)
@@ -90,6 +92,7 @@ module ProductTaxonomy
                     "ancestor_ids" => "",
                     "attribute_handles" => "",
                     "return_reason_handles" => "",
+                    "inherits_return_reasons" => false,
                   },
                 ],
               },
@@ -105,6 +108,7 @@ module ProductTaxonomy
                     "ancestor_ids" => "gid://shopify/TaxonomyCategory/1",
                     "attribute_handles" => "test_handle",
                     "return_reason_handles" => "",
+                    "inherits_return_reasons" => false,
                   },
                 ],
               },
@@ -138,6 +142,7 @@ module ProductTaxonomy
               "ancestor_ids" => "",
               "attribute_handles" => "",
               "return_reason_handles" => "test_return_reason_handle",
+              "inherits_return_reasons" => false,
             }
 
             assert_equal expected, SiblingsSerializer.serialize(category)
@@ -176,9 +181,20 @@ module ProductTaxonomy
               "ancestor_ids" => "",
               "attribute_handles" => "",
               "return_reason_handles" => "return_reason_one,return_reason_two",
+              "inherits_return_reasons" => false,
             }
 
             assert_equal expected, SiblingsSerializer.serialize(category)
+          end
+
+          test "serialize category that inherits return reasons sets inherits_return_reasons to true" do
+            category = ProductTaxonomy::Category.new(
+              id: "te-1",
+              name: "Test Category",
+              return_reasons: :inherit,
+            )
+
+            assert_equal true, SiblingsSerializer.serialize(category)["inherits_return_reasons"]
           end
         end
       end

--- a/docs/_layouts/categories.html
+++ b/docs/_layouts/categories.html
@@ -26,6 +26,7 @@ layout: default
                 data-ancestor-ids="{{ category.ancestor_ids }}"
                 data-attribute-handles="{{ category.attribute_handles }}"
                 data-return-reason-handles="{{ category.return_reason_handles }}"
+                data-inherits-return-reasons="{{ category.inherits_return_reasons }}"
               >
                 {{ category.name }}
               </li>

--- a/docs/assets/js/nodes.js
+++ b/docs/assets/js/nodes.js
@@ -157,9 +157,14 @@ const toggleVisibleSelectedCategory = () => {
       const selectedNodeTitle =
         element.firstElementChild.firstElementChild.dataset
           .selectedCategoryName;
+      const categoryNode = q(`.category-node[id="${selectedNode}"]`);
+      const inheritsReturnReasons =
+        categoryNode?.dataset.inheritsReturnReasons === 'true';
       selectedCategoryTitle.innerText = selectedNodeTitle;
       categoryAttributesTitle.innerText = `${selectedNodeTitle} attributes`;
-      categoryReturnReasonsTitle.innerText = `${selectedNodeTitle} return reasons`;
+      categoryReturnReasonsTitle.innerText = inheritsReturnReasons
+        ? `${selectedNodeTitle} return reasons (inherited)`
+        : `${selectedNodeTitle} return reasons`;
       classes.replace(className.hidden, className.visible);
     } else {
       classes.replace(className.visible, className.hidden);


### PR DESCRIPTION
Categories can now declare that they inherit their return reasons from an ancestor instead of listing them out. This keeps return reason inheritance an explicit, data-driven concept: the source data only spells out return reasons where they actually change, and every generated artifact still contains the fully materialized set.

### Changes

**New `return_reasons: inherit` form on `Category`**
- In the category data, `return_reasons` is now either an explicit list of return reason friendly IDs or the literal value `inherit`
- A category marked `inherit` copies the return reasons of the closest ancestor that defines its own list (i.e. the nearest ancestor whose `return_reasons` is an explicit array)
- Inheritance is resolved on load, after the category tree is assembled, and each inheriting category gets its own copy of the reasons
- `Category` exposes an `inherits_return_reasons` reader so callers can tell whether a category inherits or defines its own reasons
- Root categories cannot be marked `inherit` since there is no ancestor to inherit from

**Global return reasons**
- `ReturnReason` defines a baseline set of global reasons (`changed_my_mind`, `item_not_as_described`, `received_the_wrong_item`, `damaged_or_defective`, `unknown`, `other_reason`) via `GLOBAL_FRIENDLY_IDS` and the `ReturnReason.global` accessor
- Categories that define their own list but end up with none get the global reasons as a fallback (`apply_default_return_reasons`), so every category always has at least the baseline set
- Global reasons are always ordered at the end of a category's list

**Serialization**
- The data serializer round-trips the source format: inheriting categories are written back as `return_reasons: inherit`, and defining categories keep their explicit (ordered) list
- The distribution and docs serializers read the resolved reasons, so inheriting categories emit the full, materialized return-reason set, nothing needs to be pre-expanded in the source data

**`add_category` defaults to inheriting**
- New categories default to `inherit`, so a newly added category picks up its ancestor's return reasons automatically
- `--inherits-return-reasons=false` opts a new category out, giving it its own (initially empty) list

**`add_return_reasons_to_categories` handles inheritance**
- Adding a reason to an inheriting category materializes it: the inherited reasons are dropped, and the category gets the new reason(s) plus the global reasons appended
- After adding reasons, descendants that inherit are re-resolved so they reflect the updated ancestor

**Docs site**
- The return reasons panel title shows "(inherited)" when a category inherits its reasons

**Schema updated**
- `categories_schema.cue` now allows `return_reasons` to be either a list of strings or `"inherit"`

**Data files updated**
- Categories that share their ancestor's return reasons are now marked `return_reasons: inherit` (2,237 categories); the rest keep their explicit lists
- Includes corrections for some categories that were inheriting their ancestor's return reasons but should define their own. These now carry an explicit list instead of `inherit`
