### PR TITLE
Add a Disclosures tab to the docs release explorer

### DIFF
--- a/dev/lib/product_taxonomy.rb
+++ b/dev/lib/product_taxonomy.rb
@@ -65,5 +65,7 @@ require_relative "product_taxonomy/models/serializers/return_reason/dist/json_se
 require_relative "product_taxonomy/models/serializers/return_reason/dist/txt_serializer"
 require_relative "product_taxonomy/models/serializers/disclosure/data/data_serializer"
 require_relative "product_taxonomy/models/serializers/disclosure/data/localizations_serializer"
+require_relative "product_taxonomy/models/serializers/disclosure/docs/base_serializer"
+require_relative "product_taxonomy/models/serializers/disclosure/docs/search_serializer"
 require_relative "product_taxonomy/models/serializers/disclosure/dist/json_serializer"
 require_relative "product_taxonomy/models/serializers/disclosure/dist/txt_serializer"

--- a/dev/lib/product_taxonomy.rb
+++ b/dev/lib/product_taxonomy.rb
@@ -65,7 +65,7 @@ require_relative "product_taxonomy/models/serializers/return_reason/dist/json_se
 require_relative "product_taxonomy/models/serializers/return_reason/dist/txt_serializer"
 require_relative "product_taxonomy/models/serializers/disclosure/data/data_serializer"
 require_relative "product_taxonomy/models/serializers/disclosure/data/localizations_serializer"
-require_relative "product_taxonomy/models/serializers/disclosure/docs/base_serializer"
+require_relative "product_taxonomy/models/serializers/disclosure/docs/yaml_serializer"
 require_relative "product_taxonomy/models/serializers/disclosure/docs/search_serializer"
 require_relative "product_taxonomy/models/serializers/disclosure/dist/json_serializer"
 require_relative "product_taxonomy/models/serializers/disclosure/dist/txt_serializer"

--- a/dev/lib/product_taxonomy/commands/generate_docs_command.rb
+++ b/dev/lib/product_taxonomy/commands/generate_docs_command.rb
@@ -78,7 +78,7 @@ module ProductTaxonomy
       File.write("#{data_target}/return_reason_search_index.json", return_reason_search_index_json + "\n")
 
       logger.info("Generating disclosures...")
-      disclosures_yml = YAML.dump(Serializers::Disclosure::Docs::BaseSerializer.serialize_all, line_width: -1)
+      disclosures_yml = YAML.dump(Serializers::Disclosure::Docs::YamlSerializer.serialize_all, line_width: -1)
       File.write("#{data_target}/disclosures.yml", disclosures_yml)
 
       logger.info("Generating disclosure search index...")

--- a/dev/lib/product_taxonomy/commands/generate_docs_command.rb
+++ b/dev/lib/product_taxonomy/commands/generate_docs_command.rb
@@ -77,6 +77,14 @@ module ProductTaxonomy
       return_reason_search_index_json = JSON.fast_generate(Serializers::ReturnReason::Docs::SearchSerializer.serialize_all)
       File.write("#{data_target}/return_reason_search_index.json", return_reason_search_index_json + "\n")
 
+      logger.info("Generating disclosures...")
+      disclosures_yml = YAML.dump(Serializers::Disclosure::Docs::BaseSerializer.serialize_all, line_width: -1)
+      File.write("#{data_target}/disclosures.yml", disclosures_yml)
+
+      logger.info("Generating disclosure search index...")
+      disclosure_search_index_json = JSON.fast_generate(Serializers::Disclosure::Docs::SearchSerializer.serialize_all)
+      File.write("#{data_target}/disclosure_search_index.json", disclosure_search_index_json + "\n")
+
       logger.info("Generating values with categories...")
       reversed_values_yml = YAML.dump(
         Serializers::Value::Docs::ReversedSerializer.serialize_all,
@@ -115,6 +123,13 @@ module ProductTaxonomy
       content.gsub!("TARGET", @version)
       content.gsub!("GH_URL", "https://github.com/Shopify/product-taxonomy/releases/tag/v#{@version}")
       File.write("#{release_path}/return_reasons.html", content)
+
+      logger.info("Generating disclosures.html...")
+      content = File.read(File.expand_path("_releases/_disclosures_template.html", self.class.docs_path))
+      content.gsub!("TITLE", @version.upcase)
+      content.gsub!("TARGET", @version)
+      content.gsub!("GH_URL", "https://github.com/Shopify/product-taxonomy/releases/tag/v#{@version}")
+      File.write("#{release_path}/disclosures.html", content)
 
       logger.info("Generating values.html...")
       content = File.read(File.expand_path("_releases/_values_template.html", self.class.docs_path))

--- a/dev/lib/product_taxonomy/models/serializers/disclosure/docs/base_serializer.rb
+++ b/dev/lib/product_taxonomy/models/serializers/disclosure/docs/base_serializer.rb
@@ -13,25 +13,21 @@ module ProductTaxonomy
             # @param [Disclosure] disclosure
             # @return [Hash]
             def serialize(disclosure)
-              parent = disclosure.parent
               {
                 "id" => disclosure.gid,
                 "public_id" => disclosure.public_id,
                 "name" => disclosure.name,
                 "description" => disclosure.description,
-                "kind" => kind(disclosure),
-                "parent_public_id" => parent&.public_id,
-                "parent_name" => parent&.name,
+                "parent_public_id" => disclosure.parent_public_id,
                 "jurisdictions" => disclosure.jurisdictions,
                 "legal_citation" => disclosure.legal_citation,
+                "title" => disclosure.title,
+                "content" => disclosure.content,
+                "source" => disclosure.source,
+                "symbol" => disclosure.symbol,
+                "display_requirements" => disclosure.display_requirements,
+                "children" => disclosure.children.map { { "public_id" => _1.public_id, "name" => _1.name } },
               }
-            end
-
-            private
-
-            # Every leaf must carry display preferences, so a leaf is always displayed.
-            def kind(disclosure)
-              disclosure.leaf? ? "display" : "grouping"
             end
           end
         end

--- a/dev/lib/product_taxonomy/models/serializers/disclosure/docs/base_serializer.rb
+++ b/dev/lib/product_taxonomy/models/serializers/disclosure/docs/base_serializer.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module ProductTaxonomy
+  module Serializers
+    module Disclosure
+      module Docs
+        module BaseSerializer
+          class << self
+            def serialize_all
+              ProductTaxonomy::Disclosure.all.map { serialize(_1) }
+            end
+
+            # @param [Disclosure] disclosure
+            # @return [Hash]
+            def serialize(disclosure)
+              parent = disclosure.parent
+              {
+                "id" => disclosure.gid,
+                "public_id" => disclosure.public_id,
+                "name" => disclosure.name,
+                "description" => disclosure.description,
+                "kind" => kind(disclosure),
+                "parent_public_id" => parent&.public_id,
+                "parent_name" => parent&.name,
+                "jurisdictions" => disclosure.jurisdictions,
+                "legal_citation" => disclosure.legal_citation,
+              }
+            end
+
+            private
+
+            # Every leaf must carry display preferences, so a leaf is always displayed.
+            def kind(disclosure)
+              disclosure.leaf? ? "display" : "grouping"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/dev/lib/product_taxonomy/models/serializers/disclosure/docs/search_serializer.rb
+++ b/dev/lib/product_taxonomy/models/serializers/disclosure/docs/search_serializer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module ProductTaxonomy
+  module Serializers
+    module Disclosure
+      module Docs
+        module SearchSerializer
+          class << self
+            def serialize_all
+              ProductTaxonomy::Disclosure.all.map { serialize(_1) }
+            end
+
+            # @param [Disclosure] disclosure
+            # @return [Hash]
+            def serialize(disclosure)
+              {
+                "searchIdentifier" => disclosure.public_id,
+                "title" => disclosure.name,
+                "url" => "?disclosureId=#{CGI.escapeURIComponent(disclosure.public_id)}",
+                "disclosure" => {
+                  "public_id" => disclosure.public_id,
+                  "name" => disclosure.name,
+                  "description" => disclosure.description,
+                },
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/dev/lib/product_taxonomy/models/serializers/disclosure/docs/yaml_serializer.rb
+++ b/dev/lib/product_taxonomy/models/serializers/disclosure/docs/yaml_serializer.rb
@@ -4,7 +4,7 @@ module ProductTaxonomy
   module Serializers
     module Disclosure
       module Docs
-        module BaseSerializer
+        module YamlSerializer
           class << self
             def serialize_all
               ProductTaxonomy::Disclosure.all.map { serialize(_1) }

--- a/dev/test/commands/generate_docs_command_test.rb
+++ b/dev/test/commands/generate_docs_command_test.rb
@@ -92,7 +92,7 @@ module ProductTaxonomy
       Serializers::ReturnReason::Docs::BaseSerializer.stubs(:serialize_all).returns({ "return_reasons" => "corge" })
       Serializers::ReturnReason::Docs::ReversedSerializer.stubs(:serialize_all).returns({ "reversed_return_reasons" => "grault" })
       Serializers::ReturnReason::Docs::SearchSerializer.stubs(:serialize_all).returns([{ "return_reason_search" => "garply" }])
-      Serializers::Disclosure::Docs::BaseSerializer.stubs(:serialize_all).returns({ "disclosures" => "plugh" })
+      Serializers::Disclosure::Docs::YamlSerializer.stubs(:serialize_all).returns({ "disclosures" => "plugh" })
       Serializers::Disclosure::Docs::SearchSerializer.stubs(:serialize_all).returns([{ "disclosure_search" => "xyzzy" }])
       Serializers::Value::Docs::ReversedSerializer.stubs(:serialize_all).returns({ "reversed_values" => "waldo" })
       Serializers::Value::Docs::SearchSerializer.stubs(:serialize_all).returns([{ "value_search" => "fred" }])

--- a/dev/test/commands/generate_docs_command_test.rb
+++ b/dev/test/commands/generate_docs_command_test.rb
@@ -45,7 +45,18 @@ module ProductTaxonomy
       else
         File.write(
           File.expand_path("docs/_releases/_return_reasons_template.html", @tmp_base_path),
-          "---\nlayout: return_reasons\n\ntitle: TITLE\ntarget: TARGET\npermalink: /releases/TARGET/return_reasons/\ngithub_url: GH_URL\n---"
+          "---\nlayout: return_reasons\n\ntitle: TITLE\ntarget: TARGET\npermalink: /releases/TARGET/return_reasons/\ngithub_url: GH_URL\n---",
+        )
+      end
+      if File.exist?(File.expand_path("docs/_releases/_disclosures_template.html", @real_base_path))
+        FileUtils.cp(
+          File.expand_path("docs/_releases/_disclosures_template.html", @real_base_path),
+          File.expand_path("docs/_releases/_disclosures_template.html", @tmp_base_path),
+        )
+      else
+        File.write(
+          File.expand_path("docs/_releases/_disclosures_template.html", @tmp_base_path),
+          "---\nlayout: disclosures\n\ntitle: TITLE\ntarget: TARGET\npermalink: /releases/TARGET/disclosures/\ngithub_url: GH_URL\n---",
         )
       end
       if File.exist?(File.expand_path("docs/_releases/_values_template.html", @real_base_path))
@@ -56,7 +67,7 @@ module ProductTaxonomy
       else
         File.write(
           File.expand_path("docs/_releases/_values_template.html", @tmp_base_path),
-          "---\nlayout: values\n\ntitle: TITLE\ntarget: TARGET\npermalink: /releases/TARGET/values/\ngithub_url: GH_URL\n---"
+          "---\nlayout: values\n\ntitle: TITLE\ntarget: TARGET\npermalink: /releases/TARGET/values/\ngithub_url: GH_URL\n---",
         )
       end
 
@@ -81,6 +92,8 @@ module ProductTaxonomy
       Serializers::ReturnReason::Docs::BaseSerializer.stubs(:serialize_all).returns({ "return_reasons" => "corge" })
       Serializers::ReturnReason::Docs::ReversedSerializer.stubs(:serialize_all).returns({ "reversed_return_reasons" => "grault" })
       Serializers::ReturnReason::Docs::SearchSerializer.stubs(:serialize_all).returns([{ "return_reason_search" => "garply" }])
+      Serializers::Disclosure::Docs::BaseSerializer.stubs(:serialize_all).returns({ "disclosures" => "plugh" })
+      Serializers::Disclosure::Docs::SearchSerializer.stubs(:serialize_all).returns([{ "disclosure_search" => "xyzzy" }])
       Serializers::Value::Docs::ReversedSerializer.stubs(:serialize_all).returns({ "reversed_values" => "waldo" })
       Serializers::Value::Docs::SearchSerializer.stubs(:serialize_all).returns([{ "value_search" => "fred" }])
     end
@@ -123,6 +136,8 @@ module ProductTaxonomy
         Generating return reasons...
         Generating return reasons with categories...
         Generating return reason search index...
+        Generating disclosures...
+        Generating disclosure search index...
         Generating values with categories...
         Generating value search index...
         Completed in 0.1 seconds
@@ -146,12 +161,15 @@ module ProductTaxonomy
         Generating return reasons...
         Generating return reasons with categories...
         Generating return reason search index...
+        Generating disclosures...
+        Generating disclosure search index...
         Generating values with categories...
         Generating value search index...
         Generating release folder...
         Generating index.html...
         Generating attributes.html...
         Generating return_reasons.html...
+        Generating disclosures.html...
         Generating values.html...
         Updating latest.html redirect...
         Completed in 0.1 seconds
@@ -185,6 +203,8 @@ module ProductTaxonomy
       assert File.exist?("#{data_path}/return_reasons.yml")
       assert File.exist?("#{data_path}/reversed_return_reasons.yml")
       assert File.exist?("#{data_path}/return_reason_search_index.json")
+      assert File.exist?("#{data_path}/disclosures.yml")
+      assert File.exist?("#{data_path}/disclosure_search_index.json")
       assert File.exist?("#{data_path}/reversed_values.yml")
       assert File.exist?("#{data_path}/value_search_index.json")
       assert_equal "---\nsiblings: foo\n", File.read("#{data_path}/sibling_groups.yml")
@@ -195,6 +215,8 @@ module ProductTaxonomy
       assert_equal "---\nreturn_reasons: corge\n", File.read("#{data_path}/return_reasons.yml")
       assert_equal "---\nreversed_return_reasons: grault\n", File.read("#{data_path}/reversed_return_reasons.yml")
       assert_equal '[{"return_reason_search":"garply"}]' + "\n", File.read("#{data_path}/return_reason_search_index.json")
+      assert_equal "---\ndisclosures: plugh\n", File.read("#{data_path}/disclosures.yml")
+      assert_equal '[{"disclosure_search":"xyzzy"}]' + "\n", File.read("#{data_path}/disclosure_search_index.json")
       assert_equal "---\nreversed_values: waldo\n", File.read("#{data_path}/reversed_values.yml")
       assert_equal '[{"value_search":"fred"}]' + "\n", File.read("#{data_path}/value_search_index.json")
 
@@ -217,6 +239,8 @@ module ProductTaxonomy
       assert File.exist?("#{data_path}/return_reasons.yml")
       assert File.exist?("#{data_path}/reversed_return_reasons.yml")
       assert File.exist?("#{data_path}/return_reason_search_index.json")
+      assert File.exist?("#{data_path}/disclosures.yml")
+      assert File.exist?("#{data_path}/disclosure_search_index.json")
       assert File.exist?("#{data_path}/reversed_values.yml")
       assert File.exist?("#{data_path}/value_search_index.json")
       assert_equal "---\nsiblings: foo\n", File.read("#{data_path}/sibling_groups.yml")
@@ -227,6 +251,8 @@ module ProductTaxonomy
       assert_equal "---\nreturn_reasons: corge\n", File.read("#{data_path}/return_reasons.yml")
       assert_equal "---\nreversed_return_reasons: grault\n", File.read("#{data_path}/reversed_return_reasons.yml")
       assert_equal '[{"return_reason_search":"garply"}]' + "\n", File.read("#{data_path}/return_reason_search_index.json")
+      assert_equal "---\ndisclosures: plugh\n", File.read("#{data_path}/disclosures.yml")
+      assert_equal '[{"disclosure_search":"xyzzy"}]' + "\n", File.read("#{data_path}/disclosure_search_index.json")
       assert_equal "---\nreversed_values: waldo\n", File.read("#{data_path}/reversed_values.yml")
       assert_equal '[{"value_search":"fred"}]' + "\n", File.read("#{data_path}/value_search_index.json")
 
@@ -234,6 +260,7 @@ module ProductTaxonomy
       assert File.exist?("#{release_path}/index.html")
       assert File.exist?("#{release_path}/attributes.html")
       assert File.exist?("#{release_path}/return_reasons.html")
+      assert File.exist?("#{release_path}/disclosures.html")
       assert File.exist?("#{release_path}/values.html")
 
       expected_index_content = <<~CONTENT
@@ -272,6 +299,18 @@ module ProductTaxonomy
         ---
       CONTENT
       assert_equal expected_return_reasons_content, File.read("#{release_path}/return_reasons.html")
+
+      expected_disclosures_content = <<~CONTENT
+        ---
+        layout: disclosures
+
+        title: 2024-01
+        target: 2024-01
+        permalink: /releases/2024-01/disclosures/
+        github_url: https://github.com/Shopify/product-taxonomy/releases/tag/v2024-01
+        ---
+      CONTENT
+      assert_equal expected_disclosures_content, File.read("#{release_path}/disclosures.html")
 
       expected_values_content = <<~CONTENT
         ---

--- a/dev/test/models/serializers/disclosure/docs/base_serializer_test.rb
+++ b/dev/test/models/serializers/disclosure/docs/base_serializer_test.rb
@@ -16,6 +16,11 @@ module ProductTaxonomy
               description: "Cancer warning",
               jurisdictions: ["US-CA"],
               legal_citation: "Cal. Code Regs. tit. 27",
+              title: "Prop 65 Cancer Warning",
+              content: "**WARNING:** Cancer",
+              source: "https://oehha.ca.gov/proposition-65",
+              symbol: "https://cdn.shopify.com/static/product-disclosures/default-warning-yellow.png",
+              display_requirements: "Display the disclosure pre-purchase.",
             )
           end
 
@@ -25,17 +30,33 @@ module ProductTaxonomy
               "public_id" => "us-ca-prop65-cancer",
               "name" => "Cancer",
               "description" => "Cancer warning",
-              "kind" => "display",
               "parent_public_id" => nil,
-              "parent_name" => nil,
               "jurisdictions" => ["US-CA"],
               "legal_citation" => "Cal. Code Regs. tit. 27",
+              "title" => "Prop 65 Cancer Warning",
+              "content" => "**WARNING:** Cancer",
+              "source" => "https://oehha.ca.gov/proposition-65",
+              "symbol" => "https://cdn.shopify.com/static/product-disclosures/default-warning-yellow.png",
+              "display_requirements" => "Display the disclosure pre-purchase.",
+              "children" => [],
             }
 
             assert_equal expected, BaseSerializer.serialize(@disclosure)
           end
 
-          test "serialize marks a disclosure that has children as a grouping node" do
+          test "serialize returns the parent public id of a child disclosure" do
+            child = ProductTaxonomy::Disclosure.new(
+              id: 3,
+              public_id: "us-ca-prop65-birth_defects",
+              name: "Birth defects",
+              internal_label: "Prop 65 birth defects",
+              parent_public_id: "us-ca-prop65",
+            )
+
+            assert_equal "us-ca-prop65", BaseSerializer.serialize(child)["parent_public_id"]
+          end
+
+          test "serialize lists the children of a grouping disclosure" do
             group = ProductTaxonomy::Disclosure.new(
               id: 2,
               public_id: "us-ca-prop65",
@@ -49,10 +70,12 @@ module ProductTaxonomy
               internal_label: "Prop 65 birth defects",
               parent_public_id: "us-ca-prop65",
             )
-            ProductTaxonomy::Disclosure.stubs(:all).returns([group, child])
+            ProductTaxonomy::Disclosure.add(group)
+            ProductTaxonomy::Disclosure.add(child)
 
-            assert_equal "grouping", BaseSerializer.serialize(group)["kind"]
-            assert_equal "display", BaseSerializer.serialize(child)["kind"]
+            expected_children = [{ "public_id" => "us-ca-prop65-birth_defects", "name" => "Birth defects" }]
+            assert_equal expected_children, BaseSerializer.serialize(group)["children"]
+            assert_empty BaseSerializer.serialize(child)["children"]
           end
 
           test "serialize_all returns all disclosures" do

--- a/dev/test/models/serializers/disclosure/docs/base_serializer_test.rb
+++ b/dev/test/models/serializers/disclosure/docs/base_serializer_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ProductTaxonomy
+  module Serializers
+    module Disclosure
+      module Docs
+        class BaseSerializerTest < TestCase
+          setup do
+            @disclosure = ProductTaxonomy::Disclosure.new(
+              id: 1,
+              public_id: "us-ca-prop65-cancer",
+              name: "Cancer",
+              internal_label: "Prop 65 cancer",
+              description: "Cancer warning",
+              jurisdictions: ["US-CA"],
+              legal_citation: "Cal. Code Regs. tit. 27",
+            )
+          end
+
+          test "serialize returns the expected structure" do
+            expected = {
+              "id" => "gid://shopify/TaxonomyDisclosure/1",
+              "public_id" => "us-ca-prop65-cancer",
+              "name" => "Cancer",
+              "description" => "Cancer warning",
+              "kind" => "display",
+              "parent_public_id" => nil,
+              "parent_name" => nil,
+              "jurisdictions" => ["US-CA"],
+              "legal_citation" => "Cal. Code Regs. tit. 27",
+            }
+
+            assert_equal expected, BaseSerializer.serialize(@disclosure)
+          end
+
+          test "serialize marks a disclosure that has children as a grouping node" do
+            group = ProductTaxonomy::Disclosure.new(
+              id: 2,
+              public_id: "us-ca-prop65",
+              name: "Proposition 65",
+              internal_label: "Proposition 65",
+            )
+            child = ProductTaxonomy::Disclosure.new(
+              id: 3,
+              public_id: "us-ca-prop65-birth_defects",
+              name: "Birth defects",
+              internal_label: "Prop 65 birth defects",
+              parent_public_id: "us-ca-prop65",
+            )
+            ProductTaxonomy::Disclosure.stubs(:all).returns([group, child])
+
+            assert_equal "grouping", BaseSerializer.serialize(group)["kind"]
+            assert_equal "display", BaseSerializer.serialize(child)["kind"]
+          end
+
+          test "serialize_all returns all disclosures" do
+            ProductTaxonomy::Disclosure.stubs(:all).returns([@disclosure])
+
+            assert_equal [BaseSerializer.serialize(@disclosure)], BaseSerializer.serialize_all
+          end
+        end
+      end
+    end
+  end
+end

--- a/dev/test/models/serializers/disclosure/docs/search_serializer_test.rb
+++ b/dev/test/models/serializers/disclosure/docs/search_serializer_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ProductTaxonomy
+  module Serializers
+    module Disclosure
+      module Docs
+        class SearchSerializerTest < TestCase
+          setup do
+            @disclosure = ProductTaxonomy::Disclosure.new(
+              id: 1,
+              public_id: "us-ca-prop65-cancer",
+              name: "Cancer",
+              internal_label: "Prop 65 cancer",
+              description: "Cancer warning",
+            )
+          end
+
+          test "serialize returns the expected search structure" do
+            expected = {
+              "searchIdentifier" => "us-ca-prop65-cancer",
+              "title" => "Cancer",
+              "url" => "?disclosureId=us-ca-prop65-cancer",
+              "disclosure" => {
+                "public_id" => "us-ca-prop65-cancer",
+                "name" => "Cancer",
+                "description" => "Cancer warning",
+              },
+            }
+
+            assert_equal expected, SearchSerializer.serialize(@disclosure)
+          end
+
+          test "serialize_all returns all disclosures in search format" do
+            ProductTaxonomy::Disclosure.stubs(:all).returns([@disclosure])
+
+            assert_equal [SearchSerializer.serialize(@disclosure)], SearchSerializer.serialize_all
+          end
+        end
+      end
+    end
+  end
+end

--- a/dev/test/models/serializers/disclosure/docs/yaml_serializer_test.rb
+++ b/dev/test/models/serializers/disclosure/docs/yaml_serializer_test.rb
@@ -6,7 +6,7 @@ module ProductTaxonomy
   module Serializers
     module Disclosure
       module Docs
-        class BaseSerializerTest < TestCase
+        class YamlSerializerTest < TestCase
           setup do
             @disclosure = ProductTaxonomy::Disclosure.new(
               id: 1,
@@ -41,7 +41,7 @@ module ProductTaxonomy
               "children" => [],
             }
 
-            assert_equal expected, BaseSerializer.serialize(@disclosure)
+            assert_equal expected, YamlSerializer.serialize(@disclosure)
           end
 
           test "serialize returns the parent public id of a child disclosure" do
@@ -53,7 +53,7 @@ module ProductTaxonomy
               parent_public_id: "us-ca-prop65",
             )
 
-            assert_equal "us-ca-prop65", BaseSerializer.serialize(child)["parent_public_id"]
+            assert_equal "us-ca-prop65", YamlSerializer.serialize(child)["parent_public_id"]
           end
 
           test "serialize lists the children of a grouping disclosure" do
@@ -74,14 +74,14 @@ module ProductTaxonomy
             ProductTaxonomy::Disclosure.add(child)
 
             expected_children = [{ "public_id" => "us-ca-prop65-birth_defects", "name" => "Birth defects" }]
-            assert_equal expected_children, BaseSerializer.serialize(group)["children"]
-            assert_empty BaseSerializer.serialize(child)["children"]
+            assert_equal expected_children, YamlSerializer.serialize(group)["children"]
+            assert_empty YamlSerializer.serialize(child)["children"]
           end
 
           test "serialize_all returns all disclosures" do
             ProductTaxonomy::Disclosure.stubs(:all).returns([@disclosure])
 
-            assert_equal [BaseSerializer.serialize(@disclosure)], BaseSerializer.serialize_all
+            assert_equal [YamlSerializer.serialize(@disclosure)], YamlSerializer.serialize_all
           end
         end
       end

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -6,6 +6,7 @@
     <li class="header-links__li"><a href="{{ site.baseurl }}/releases/{{ page.target }}/attributes">Attributes</a></li>
     <li class="header-links__li"><a href="{{ site.baseurl }}/releases/{{ page.target }}/values">Values</a></li>
     <li class="header-links__li"><a href="{{ site.baseurl }}/releases/{{ page.target }}/return_reasons">Return Reasons</a></li>
+    <li class="header-links__li"><a href="{{ site.baseurl }}/releases/{{ page.target }}/disclosures">Disclosures</a></li>
   </ul>
   <p>
     Shopify's public product taxonomy serves as an open-source, standardized, and global classification of products sold

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -4,9 +4,15 @@
     <li class="header-links__li header-links__li--first-child"><a href="{{ site.baseurl }}/">⬅︎ back to all releases</a></li>
     <li class="header-links__li"><a href="{{ site.baseurl }}/releases/{{ page.target }}">Categories</a></li>
     <li class="header-links__li"><a href="{{ site.baseurl }}/releases/{{ page.target }}/attributes">Attributes</a></li>
+    {% if site.data[page.target].reversed_values %}
     <li class="header-links__li"><a href="{{ site.baseurl }}/releases/{{ page.target }}/values">Values</a></li>
+    {% endif %}
+    {% if site.data[page.target].reversed_return_reasons %}
     <li class="header-links__li"><a href="{{ site.baseurl }}/releases/{{ page.target }}/return_reasons">Return Reasons</a></li>
+    {% endif %}
+    {% if site.data[page.target].disclosures %}
     <li class="header-links__li"><a href="{{ site.baseurl }}/releases/{{ page.target }}/disclosures">Disclosures</a></li>
+    {% endif %}
   </ul>
   <p>
     Shopify's public product taxonomy serves as an open-source, standardized, and global classification of products sold

--- a/docs/_layouts/disclosures.html
+++ b/docs/_layouts/disclosures.html
@@ -15,13 +15,19 @@ layout: default
   <div class="column">
     <div class="return-reasons-wrapper box">
       <div class="value-container return-reason-values">
-        <h3>{{ disclosure.name }} <span class="disclosure-kind">{{ disclosure.kind }}</span></h3>
+        <h3>{{ disclosure.name }}</h3>
         <div class="value-container__id">
-          <span class="id">{{ disclosure.public_id }}</span>
+          <span class="id">{{ disclosure.id }}</span>
         </div>
-        {% if disclosure.description %}
-        <div class="return-reason-description-wrapper">
-          <p class="return-reason-description">{{ disclosure.description }}</p>
+        {% if disclosure.children.size > 0 %}
+        <div>
+          <ul class="values-container__list">
+            {% for child in disclosure.children %}
+            <li class="values-container__list-item">
+              <div class="values-container__list-item-content disclosure-node" tabindex="0" data-public-id="{{ child.public_id }}">{{ child.name }}</div>
+            </li>
+            {% endfor %}
+          </ul>
         </div>
         {% endif %}
       </div>
@@ -31,23 +37,58 @@ layout: default
     <div class="return-reason-categories-wrapper box">
       <div class="categories-container return-reason-categories">
         <h3>Details</h3>
-        <ul class="values-container__list">
-          {% if disclosure.parent_name %}
-          <li class="values-container__list-item">
-            <div class="values-container__list-item-content">Parent: {{ disclosure.parent_name }}</div>
-          </li>
-          {% endif %}
-          {% if disclosure.jurisdictions %}
-          <li class="values-container__list-item">
-            <div class="values-container__list-item-content">Jurisdictions: {{ disclosure.jurisdictions | join: ", " }}</div>
-          </li>
-          {% endif %}
-          {% if disclosure.legal_citation %}
-          <li class="values-container__list-item">
-            <div class="values-container__list-item-content">Legal citation: {{ disclosure.legal_citation }}</div>
-          </li>
-          {% endif %}
-        </ul>
+        <div>
+          <ul class="values-container__list">
+            <li class="values-container__list-item">
+              <div class="values-container__list-item-content">Public id: {{ disclosure.public_id }}</div>
+            </li>
+            {% if disclosure.description %}
+            <li class="values-container__list-item">
+              <div class="values-container__list-item-content">Description: {{ disclosure.description }}</div>
+            </li>
+            {% endif %}
+            {% if disclosure.parent_public_id %}
+            <li class="values-container__list-item">
+              <div class="values-container__list-item-content">Parent: <span class="disclosure-node" tabindex="0" data-public-id="{{ disclosure.parent_public_id }}">{{ disclosure.parent_public_id }}</span></div>
+            </li>
+            {% endif %}
+            {% if disclosure.jurisdictions %}
+            <li class="values-container__list-item">
+              <div class="values-container__list-item-content">Jurisdictions: {{ disclosure.jurisdictions | join: ", " }}</div>
+            </li>
+            {% endif %}
+            {% if disclosure.legal_citation %}
+            <li class="values-container__list-item">
+              <div class="values-container__list-item-content">Legal citation: {{ disclosure.legal_citation }}</div>
+            </li>
+            {% endif %}
+            {% if disclosure.symbol %}
+            <li class="values-container__list-item">
+              <div class="values-container__list-item-content">Symbol: <a href="{{ disclosure.symbol }}">{{ disclosure.symbol }}</a></div>
+            </li>
+            {% endif %}
+            {% if disclosure.display_requirements %}
+            <li class="values-container__list-item">
+              <div class="values-container__list-item-content">Display requirements: {{ disclosure.display_requirements }}</div>
+            </li>
+            {% endif %}
+            {% if disclosure.source %}
+            <li class="values-container__list-item">
+              <div class="values-container__list-item-content">Source: <a href="{{ disclosure.source }}">{{ disclosure.source }}</a></div>
+            </li>
+            {% endif %}
+            {% if disclosure.title %}
+            <li class="values-container__list-item">
+              <div class="values-container__list-item-content">Title: {{ disclosure.title }}</div>
+            </li>
+            {% endif %}
+            {% if disclosure.content %}
+            <li class="values-container__list-item">
+              <div class="values-container__list-item-content disclosure-content">Content: {{ disclosure.content | markdownify }}</div>
+            </li>
+            {% endif %}
+          </ul>
+        </div>
       </div>
     </div>
   </div>

--- a/docs/_layouts/disclosures.html
+++ b/docs/_layouts/disclosures.html
@@ -1,0 +1,56 @@
+---
+layout: default
+---
+
+{% include header.html %}
+<div class="attribute-search-wrapper">
+  <div class="search-container">
+    <label for="disclosure-search" class="search-container__label">Disclosure Search:</label>
+    <input class="search-container__input" type="text" id="disclosure-search" placeholder="Loading…">
+    <ul class="search-container__ul" id="disclosure-search-results"></ul>
+  </div>
+</div>
+{% for disclosure in site.data[page.target].disclosures %}
+<div class="return-reason-container hidden" data-public-id="{{ disclosure.public_id }}">
+  <div class="column">
+    <div class="return-reasons-wrapper box">
+      <div class="value-container return-reason-values">
+        <h3>{{ disclosure.name }} <span class="disclosure-kind">{{ disclosure.kind }}</span></h3>
+        <div class="value-container__id">
+          <span class="id">{{ disclosure.public_id }}</span>
+        </div>
+        {% if disclosure.description %}
+        <div class="return-reason-description-wrapper">
+          <p class="return-reason-description">{{ disclosure.description }}</p>
+        </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="column">
+    <div class="return-reason-categories-wrapper box">
+      <div class="categories-container return-reason-categories">
+        <h3>Details</h3>
+        <ul class="values-container__list">
+          {% if disclosure.parent_name %}
+          <li class="values-container__list-item">
+            <div class="values-container__list-item-content">Parent: {{ disclosure.parent_name }}</div>
+          </li>
+          {% endif %}
+          {% if disclosure.jurisdictions %}
+          <li class="values-container__list-item">
+            <div class="values-container__list-item-content">Jurisdictions: {{ disclosure.jurisdictions | join: ", " }}</div>
+          </li>
+          {% endif %}
+          {% if disclosure.legal_citation %}
+          <li class="values-container__list-item">
+            <div class="values-container__list-item-content">Legal citation: {{ disclosure.legal_citation }}</div>
+          </li>
+          {% endif %}
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+{% endfor %}
+<script type="module" src="{{ site.baseurl }}/assets/js/disclosure_release.js"></script>

--- a/docs/_layouts/disclosures.html
+++ b/docs/_layouts/disclosures.html
@@ -11,10 +11,10 @@ layout: default
   </div>
 </div>
 {% for disclosure in site.data[page.target].disclosures %}
-<div class="return-reason-container hidden" data-public-id="{{ disclosure.public_id }}">
+<div class="disclosure-container hidden" data-public-id="{{ disclosure.public_id }}">
   <div class="column">
-    <div class="return-reasons-wrapper box">
-      <div class="value-container return-reason-values">
+    <div class="box">
+      <div class="value-container">
         <h3>{{ disclosure.name }}</h3>
         <div class="value-container__id">
           <span class="id">{{ disclosure.id }}</span>
@@ -34,8 +34,8 @@ layout: default
     </div>
   </div>
   <div class="column">
-    <div class="return-reason-categories-wrapper box">
-      <div class="categories-container return-reason-categories">
+    <div class="box">
+      <div class="categories-container">
         <h3>Details</h3>
         <div>
           <ul class="values-container__list">

--- a/docs/_plugins/copy_search.rb
+++ b/docs/_plugins/copy_search.rb
@@ -11,7 +11,7 @@ Jekyll::Hooks.register(:site, :post_write) do |site|
     target_dir = File.join(site_dest, "releases", version)
     Dir.mkdir(target_dir) unless Dir.exist?(target_dir)
 
-    ["search_index.json", "attribute_search_index.json", "return_reason_search_index.json", "value_search_index.json"].each do |file|
+    ["search_index.json", "attribute_search_index.json", "return_reason_search_index.json", "disclosure_search_index.json", "value_search_index.json"].each do |file|
       source_file = File.join(version_dir, file)
       target_file = File.join(target_dir, file)
 

--- a/docs/_releases/_disclosures_template.html
+++ b/docs/_releases/_disclosures_template.html
@@ -1,0 +1,8 @@
+---
+layout: disclosures
+
+title: TITLE
+target: TARGET
+permalink: /releases/TARGET/disclosures/
+github_url: GH_URL
+---

--- a/docs/_releases/unstable/disclosures.html
+++ b/docs/_releases/unstable/disclosures.html
@@ -1,0 +1,8 @@
+---
+layout: disclosures
+
+title: unstable
+target: unstable
+permalink: /releases/unstable/disclosures/
+github_url: https://github.com/Shopify/product-taxonomy
+---

--- a/docs/assets/js/disclosure_release.js
+++ b/docs/assets/js/disclosure_release.js
@@ -29,6 +29,19 @@ const resetToDisclosure = (publicId) => {
   showDisclosureByPublicId(publicId);
 };
 
+const setupNodeClicks = () => {
+  qq('.disclosure-node').forEach((node) => {
+    const showNode = () => resetToDisclosure(node.dataset.publicId);
+    node.addEventListener('click', showNode);
+    node.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        showNode();
+      }
+    });
+  });
+};
+
 const setInitialDisclosure = () => {
   const publicId = getQueryParam(disclosureQueryParamKey);
   if (publicId) {
@@ -49,5 +62,6 @@ document.addEventListener('DOMContentLoaded', () => {
       {name: 'disclosure.description', weight: 0.5},
     ],
   );
+  setupNodeClicks();
   setInitialDisclosure();
 });

--- a/docs/assets/js/disclosure_release.js
+++ b/docs/assets/js/disclosure_release.js
@@ -4,7 +4,7 @@ import {qq, getQueryParam} from './util.js';
 const disclosureQueryParamKey = 'disclosureId';
 
 const showDisclosureByPublicId = (publicId) => {
-  const disclosureContainers = qq('.return-reason-container');
+  const disclosureContainers = qq('.disclosure-container');
   disclosureContainers.forEach((container) => {
     if (container.dataset.publicId === publicId) {
       container.classList.remove('hidden');

--- a/docs/assets/js/disclosure_release.js
+++ b/docs/assets/js/disclosure_release.js
@@ -1,0 +1,53 @@
+import {setupSearch} from './search.js';
+import {qq, getQueryParam} from './util.js';
+
+const disclosureQueryParamKey = 'disclosureId';
+
+const showDisclosureByPublicId = (publicId) => {
+  const disclosureContainers = qq('.return-reason-container');
+  disclosureContainers.forEach((container) => {
+    if (container.dataset.publicId === publicId) {
+      container.classList.remove('hidden');
+    } else {
+      container.classList.add('hidden');
+    }
+  });
+};
+
+const setDisclosureQueryParam = (publicId) => {
+  const url = new URL(window.location);
+  if (publicId != null) {
+    url.searchParams.set(disclosureQueryParamKey, publicId);
+  } else {
+    url.searchParams.delete(disclosureQueryParamKey);
+  }
+  window.history.pushState({}, '', url);
+};
+
+const resetToDisclosure = (publicId) => {
+  setDisclosureQueryParam(publicId);
+  showDisclosureByPublicId(publicId);
+};
+
+const setInitialDisclosure = () => {
+  const publicId = getQueryParam(disclosureQueryParamKey);
+  if (publicId) {
+    showDisclosureByPublicId(publicId);
+  }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  setupSearch(
+    'disclosure-search',
+    'disclosure-search-results',
+    '../disclosure_search_index.json',
+    resetToDisclosure,
+    10,
+    [
+      {name: 'title', weight: 1},
+      {name: 'disclosure.name', weight: 1},
+      {name: 'disclosure.description', weight: 0.5},
+    ],
+  );
+  setInitialDisclosure();
+});

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -325,7 +325,8 @@ a:active {
     display: grid;
     grid-template-columns: 0.75fr 1.25fr;
   }
-  .return-reason-container {
+  .return-reason-container,
+  .disclosure-container {
     display: grid;
     grid-template-columns: 0.75fr 1.25fr;
   }

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -229,6 +229,23 @@ a:active {
   display: block;
 }
 
+.disclosure-node {
+  cursor: pointer;
+  width: fit-content;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.5rem;
+}
+
+.disclosure-node:hover,
+.disclosure-node:focus-visible {
+  background-color: rgba(241, 241, 241, 1);
+}
+
+.disclosure-content p {
+  display: inline;
+  margin: 0;
+}
+
 .value-container__id {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## TL;DR

Add a **Disclosures** tab to the taxonomy docs site, so the disclosure axis is visible at https://shopify.github.io/product-taxonomy/releases/unstable/disclosures/.

## Screenshots

**A grouping node.** The left box holds the name, the GID, and the names of the child nodes. A click on a child node opens that node.

<img width="1280" height="540" alt="grouping-view" src="https://github.com/user-attachments/assets/c04f0423-a3ba-4ff0-95c0-5e01a171966b" />

**A leaf node.** The Details box holds the copy, the display rules, and the public id of the parent. A click on the parent opens the grouping above.

<img width="1280" height="640" alt="leaf-view" src="https://github.com/user-attachments/assets/7c06516e-6e56-4648-84e4-a00a496ec2b6" />


## Why

Shopify/product-taxonomy#956 landed the disclosure data, the model, and the loader. Shopify/product-taxonomy#986 landed the dist serializers. Neither change made the axis visible on the docs site, so partners and internal teams cannot browse disclosures the way they browse categories, attributes, and return reasons. This is the last piece that makes the disclosure axis public, and it unblocks epic shop/issues-product-foundations#4930.

## What

- **Docs serializers:** `Disclosure::Docs::BaseSerializer` writes `docs/_data/<version>/disclosures.yml`, and `Disclosure::Docs::SearchSerializer` writes the search index. Both emit a flat list, because the layout reads the nodes directly.
- **Command:** `GenerateDocsCommand` writes both files, and writes `disclosures.html` in each release folder from `_disclosures_template.html`.
- **Page:** a `disclosures` layout, a nav entry in `_includes/header.html`, and `docs/assets/js/disclosure_release.js` for the client-side filter.
- **Search:** `docs/_plugins/copy_search.rb` copies `disclosure_search_index.json`. Without that entry the page search gets a 404.
- **Unstable release page:** `docs/_releases/unstable/disclosures.html` is committed by hand, because the command skips the release folder for the `unstable` target.

The right box holds the public id, the description, the parent, the jurisdictions, the legal citation, the symbol, the display requirements, the source, the title, and the content. The content comes last, because it is the longest value. The content is markdown, so the layout renders it through `markdownify`.

The Parent row holds the public id of the parent, not the name. The name of a node and the public id of the same node look very different, so the id keeps the row easy to match against the Public id row above it.

A click on a child node, or on the parent, shows that node. The rows are not links, because the page keeps one document and swaps the visible node, as the categories tab does with `.category-node`. Every row takes the focus, so the keyboard reaches it too.

The page leaves out four fields that the dist serializer publishes: `internal_label`, `display_preferences`, `disclosure_attributes`, and `disclosure_attribute_values`. The first one is internal. The other three need a nested row shape, so they stay for a later change.

## Verification

- `rake test:unit` — 505 runs, 0 failures.
- `rake test:integration` — 13 runs, 0 failures.
- RuboCop clean on the changed files.
- A local Jekyll build renders `/releases/unstable/disclosures/` with 10 nodes: 2 groupings and 8 leaves. The build also copies the search index.
- A browser check confirms both directions. A click on the parent row shows the grouping. A click on a child row shows that leaf. The `Enter` key on a focused row does the same.

After merge, the `deploy_github_pages` workflow runs `bin/product_taxonomy docs` on `main`, which regenerates `docs/_data/unstable/`. The page then goes live on the `unstable` release without a wait for the next release cut.

## Known cosmetic issue

The Disclosures nav link renders on every release page, and the older releases have no disclosures page. The link is dead there. Return Reasons has the same flaw today, so this change does not make the behavior worse.
