### PR TITLE
Add numeric ids to disclosures

### DIFF
--- a/data/disclosures.yml
+++ b/data/disclosures.yml
@@ -5,9 +5,9 @@
 # warnings, chemical exposure notices, etc.) that a merchant may need to show
 # for a product in a given jurisdiction.
 #
-# Row-shaped: each entry maps 1:1 to a disclosure node, keyed by a stable
-# `public_id` slug — never rename an existing `public_id`, as downstream systems
-# reference it by global ID.
+# Row-shaped: each entry maps 1:1 to a disclosure node. `id` is the numeric
+# identity that global IDs use, and `public_id` is a stable slug. Never change
+# an existing `id` or `public_id`, as downstream systems reference both.
 #
 # Hierarchy is expressed via `parent_public_id`. A node with no `parent_public_id`
 # is a grouping/root node; a node that no other node points at is a leaf.
@@ -19,7 +19,8 @@
 #     product_page, cart, checkout.
 
 # Choking hazards
-- public_id: choking_hazard
+- id: 1
+  public_id: choking_hazard
   parent_public_id:
   name: Choking hazards
   internal_label: Choking hazards
@@ -33,7 +34,8 @@
   disclosure_attributes: []
   disclosure_attribute_values: []
 
-- public_id: us-cpsc-choking_small_parts
+- id: 2
+  public_id: us-cpsc-choking_small_parts
   parent_public_id: choking_hazard
   name: "Choking Hazard — Small Parts (US)"
   internal_label: "Choking Hazard — Small Parts (US)"
@@ -53,7 +55,8 @@
   disclosure_attributes: []
   disclosure_attribute_values: []
 
-- public_id: us-cpsc-choking_balloons
+- id: 3
+  public_id: us-cpsc-choking_balloons
   parent_public_id: choking_hazard
   name: "Choking Hazard — Balloons (US)"
   internal_label: "Choking Hazard — Balloons (US)"
@@ -73,7 +76,8 @@
   disclosure_attributes: []
   disclosure_attribute_values: []
 
-- public_id: us-cpsc-choking_marbles
+- id: 4
+  public_id: us-cpsc-choking_marbles
   parent_public_id: choking_hazard
   name: "Choking Hazard — Marbles (US)"
   internal_label: "Choking Hazard — Marbles (US)"
@@ -93,7 +97,8 @@
   disclosure_attributes: []
   disclosure_attribute_values: []
 
-- public_id: us-cpsc-choking_small_balls
+- id: 5
+  public_id: us-cpsc-choking_small_balls
   parent_public_id: choking_hazard
   name: "Choking Hazard — Small Balls (US)"
   internal_label: "Choking Hazard — Small Balls (US)"
@@ -114,7 +119,8 @@
   disclosure_attribute_values: []
 
 # Chemical exposures
-- public_id: chemical_exposure
+- id: 12
+  public_id: chemical_exposure
   parent_public_id:
   name: Chemical exposures
   internal_label: Chemical exposures
@@ -128,7 +134,8 @@
   disclosure_attributes: []
   disclosure_attribute_values: []
 
-- public_id: us-ca-prop65-cancer
+- id: 13
+  public_id: us-ca-prop65-cancer
   parent_public_id: chemical_exposure
   name: "Prop 65 — Cancer (US-CA)"
   internal_label: "Prop 65 — Cancer (US-CA)"
@@ -148,7 +155,8 @@
   disclosure_attributes: []
   disclosure_attribute_values: []
 
-- public_id: us-ca-prop65-reproductive
+- id: 14
+  public_id: us-ca-prop65-reproductive
   parent_public_id: chemical_exposure
   name: "Prop 65 — Reproductive Harm (US-CA)"
   internal_label: "Prop 65 — Reproductive Harm (US-CA)"
@@ -168,7 +176,8 @@
   disclosure_attributes: []
   disclosure_attribute_values: []
 
-- public_id: us-ca-prop65-cancer_reproductive
+- id: 15
+  public_id: us-ca-prop65-cancer_reproductive
   parent_public_id: chemical_exposure
   name: "Prop 65 — Cancer and Reproductive Harm (US-CA)"
   internal_label: "Prop 65 — Cancer and Reproductive Harm (US-CA)"
@@ -188,7 +197,8 @@
   disclosure_attributes: []
   disclosure_attribute_values: []
 
-- public_id: us-ca-prop65-alcohol
+- id: 16
+  public_id: us-ca-prop65-alcohol
   parent_public_id: chemical_exposure
   name: "Prop 65 — Alcohol (US-CA)"
   internal_label: "Prop 65 — Alcohol (US-CA)"

--- a/dev/lib/product_taxonomy/models/disclosure.rb
+++ b/dev/lib/product_taxonomy/models/disclosure.rb
@@ -61,6 +61,7 @@ module ProductTaxonomy
 
       def disclosure_from(data)
         Disclosure.new(
+          id: data["id"],
           public_id: data["public_id"],
           parent_public_id: data["parent_public_id"],
           name: data["name"],
@@ -80,10 +81,11 @@ module ProductTaxonomy
       end
     end
 
+    validates :id, presence: true, numericality: { only_integer: true }, on: :create
     validates :public_id, presence: true, format: { with: PUBLIC_ID_FORMAT, allow_blank: true }, on: :create
     validates :name, presence: true, on: :create
     validates :internal_label, presence: true, on: :create
-    validates_with ProductTaxonomy::Indexed::UniquenessValidator, attributes: [:public_id], on: :create
+    validates_with ProductTaxonomy::Indexed::UniquenessValidator, attributes: [:public_id, :id], on: :create
     validate :field_types_are_valid, on: :create
     validate :not_self_parenting, on: :create
 
@@ -96,7 +98,8 @@ module ProductTaxonomy
 
     localized_attr_reader :name, :description, :title, :content, keyed_by: :public_id
 
-    attr_reader :public_id,
+    attr_reader :id,
+      :public_id,
       :parent_public_id,
       :internal_label,
       :jurisdictions,
@@ -109,6 +112,7 @@ module ProductTaxonomy
       :disclosure_attribute_values
 
     def initialize(
+      id:,
       public_id:,
       name:,
       internal_label:,
@@ -125,6 +129,7 @@ module ProductTaxonomy
       disclosure_attributes: nil,
       disclosure_attribute_values: nil
     )
+      @id = id
       @public_id = public_id
       @parent_public_id = parent_public_id
       @name = name
@@ -146,7 +151,7 @@ module ProductTaxonomy
     #
     # @return [String]
     def gid
-      "gid://shopify/TaxonomyDisclosure/#{public_id}"
+      "gid://shopify/TaxonomyDisclosure/#{id}"
     end
 
     # Whether this is a grouping/root node (has no parent).

--- a/dev/test/integration/all_data_files_import_test.rb
+++ b/dev/test/integration/all_data_files_import_test.rb
@@ -97,11 +97,19 @@ module ProductTaxonomy
 
         refute_nil real_disclosure, "Disclosure #{public_id} not found"
         assert_equal public_id, real_disclosure.public_id
+        assert_equal raw_disclosure.fetch("id"), real_disclosure.id
         assert_equal raw_disclosure["parent_public_id"], real_disclosure.parent_public_id
         assert_equal raw_disclosure.fetch("name"), real_disclosure.name
         assert_equal raw_disclosure["jurisdictions"], real_disclosure.jurisdictions
         assert_equal raw_disclosure["display_preferences"], real_disclosure.display_preferences
       end
+    end
+
+    test "every disclosure in disclosures.yml carries a unique integer id" do
+      ids = @raw_disclosures_data.map { |raw_disclosure| raw_disclosure.fetch("id") }
+
+      assert ids.all?(Integer), "every disclosure needs an integer id"
+      assert_equal ids.uniq, ids
     end
 
     # more fragile, but easier sanity check

--- a/dev/test/models/disclosure_test.rb
+++ b/dev/test/models/disclosure_test.rb
@@ -11,6 +11,8 @@ module ProductTaxonomy
 
       group = Disclosure.find_by(public_id: "choking_hazard")
       assert_instance_of Disclosure, group
+      assert_equal 1, group.id
+      assert_equal group, Disclosure.find_by(id: 1)
       assert_nil group.parent_public_id
       assert group.root?
       refute group.leaf?
@@ -42,10 +44,12 @@ module ProductTaxonomy
 
     test "load_from_source raises an error if the source data contains duplicate public IDs" do
       yaml_content = <<~YAML
-        - public_id: choking_hazard
+        - id: 1
+          public_id: choking_hazard
           name: Choking hazards
           internal_label: Choking hazards
-        - public_id: choking_hazard
+        - id: 2
+          public_id: choking_hazard
           name: Duplicate
           internal_label: Duplicate
       YAML
@@ -57,8 +61,8 @@ module ProductTaxonomy
     end
 
     test "gid returns the global ID of the disclosure" do
-      disclosure = Disclosure.new(public_id: "us-cpsc-choking_small_parts", name: "X", internal_label: "X")
-      assert_equal "gid://shopify/TaxonomyDisclosure/us-cpsc-choking_small_parts", disclosure.gid
+      disclosure = Disclosure.new(id: 2, public_id: "us-cpsc-choking_small_parts", name: "X", internal_label: "X")
+      assert_equal "gid://shopify/TaxonomyDisclosure/2", disclosure.gid
     end
 
     test "taxonomy_loaded validation passes for a well-formed hierarchy" do
@@ -69,10 +73,12 @@ module ProductTaxonomy
 
     test "taxonomy_loaded validation fails when a leaf is missing jurisdictions or display preferences" do
       Disclosure.load_from_source(YAML.safe_load(<<~YAML))
-        - public_id: group
+        - id: 1
+          public_id: group
           name: Group
           internal_label: Group
-        - public_id: leaf
+        - id: 2
+          public_id: leaf
           parent_public_id: group
           name: Leaf
           internal_label: Leaf
@@ -86,12 +92,14 @@ module ProductTaxonomy
 
     test "taxonomy_loaded validation fails when a grouping node defines jurisdictions" do
       Disclosure.load_from_source(YAML.safe_load(<<~YAML))
-        - public_id: group
+        - id: 1
+          public_id: group
           name: Group
           internal_label: Group
           jurisdictions:
           - US
-        - public_id: leaf
+        - id: 2
+          public_id: leaf
           parent_public_id: group
           name: Leaf
           internal_label: Leaf
@@ -109,10 +117,12 @@ module ProductTaxonomy
 
     test "taxonomy_loaded validation fails on an unknown display surface" do
       Disclosure.load_from_source(YAML.safe_load(<<~YAML))
-        - public_id: group
+        - id: 1
+          public_id: group
           name: Group
           internal_label: Group
-        - public_id: leaf
+        - id: 2
+          public_id: leaf
           parent_public_id: group
           name: Leaf
           internal_label: Leaf
@@ -130,7 +140,8 @@ module ProductTaxonomy
 
     test "taxonomy_loaded validation fails when parent_public_id references a missing disclosure" do
       Disclosure.load_from_source(YAML.safe_load(<<~YAML))
-        - public_id: leaf
+        - id: 1
+          public_id: leaf
           parent_public_id: missing_group
           name: Leaf
           internal_label: Leaf
@@ -148,7 +159,8 @@ module ProductTaxonomy
 
     test "load_from_source raises an error if public_id is not a valid slug" do
       yaml_content = <<~YAML
-        - public_id: Not A Slug
+        - id: 1
+          public_id: Not A Slug
           name: Choking hazards
           internal_label: Choking hazards
       YAML
@@ -161,7 +173,8 @@ module ProductTaxonomy
 
     test "load_from_source raises an error if a field has the wrong type" do
       yaml_content = <<~YAML
-        - public_id: leaf
+        - id: 1
+          public_id: leaf
           name: Leaf
           internal_label: Leaf
           jurisdictions: US
@@ -175,7 +188,8 @@ module ProductTaxonomy
 
     test "load_from_source raises an error if a disclosure is its own parent" do
       yaml_content = <<~YAML
-        - public_id: loop
+        - id: 1
+          public_id: loop
           parent_public_id: loop
           name: Loop
           internal_label: Loop
@@ -189,14 +203,17 @@ module ProductTaxonomy
 
     test "taxonomy_loaded validation fails when the hierarchy is more than two levels deep" do
       Disclosure.load_from_source(YAML.safe_load(<<~YAML))
-        - public_id: root
+        - id: 1
+          public_id: root
           name: Root
           internal_label: Root
-        - public_id: mid
+        - id: 2
+          public_id: mid
           parent_public_id: root
           name: Mid
           internal_label: Mid
-        - public_id: leaf
+        - id: 3
+          public_id: leaf
           parent_public_id: mid
           name: Leaf
           internal_label: Leaf
@@ -218,11 +235,13 @@ module ProductTaxonomy
 
     test "taxonomy_loaded validation fails when the hierarchy contains a cycle" do
       Disclosure.load_from_source(YAML.safe_load(<<~YAML))
-        - public_id: a
+        - id: 1
+          public_id: a
           parent_public_id: b
           name: A
           internal_label: A
-        - public_id: b
+        - id: 2
+          public_id: b
           parent_public_id: a
           name: B
           internal_label: B
@@ -235,10 +254,12 @@ module ProductTaxonomy
 
     test "taxonomy_loaded validation fails when a leaf is missing required legal fields" do
       Disclosure.load_from_source(YAML.safe_load(<<~YAML))
-        - public_id: group
+        - id: 1
+          public_id: group
           name: Group
           internal_label: Group
-        - public_id: leaf
+        - id: 2
+          public_id: leaf
           parent_public_id: group
           name: Leaf
           internal_label: Leaf
@@ -265,18 +286,65 @@ module ProductTaxonomy
       assert_equal "Choking Hazard: Small Parts", leaf.title(locale: "en")
     end
 
+    test "load_from_source raises an error if id is missing" do
+      yaml_content = <<~YAML
+        - public_id: choking_hazard
+          name: Choking hazards
+          internal_label: Choking hazards
+      YAML
+
+      error = assert_raises(ActiveModel::ValidationError) do
+        Disclosure.load_from_source(YAML.safe_load(yaml_content))
+      end
+      assert_includes error.model.errors.attribute_names, :id
+    end
+
+    test "load_from_source raises an error if id is not an integer" do
+      yaml_content = <<~YAML
+        - id: one
+          public_id: choking_hazard
+          name: Choking hazards
+          internal_label: Choking hazards
+      YAML
+
+      error = assert_raises(ActiveModel::ValidationError) do
+        Disclosure.load_from_source(YAML.safe_load(yaml_content))
+      end
+      assert_includes error.model.errors.attribute_names, :id
+    end
+
+    test "load_from_source raises an error if the source data contains duplicate ids" do
+      yaml_content = <<~YAML
+        - id: 1
+          public_id: choking_hazard
+          name: Choking hazards
+          internal_label: Choking hazards
+        - id: 1
+          public_id: chemical_exposure
+          name: Chemical exposure
+          internal_label: Chemical exposure
+      YAML
+
+      error = assert_raises(ActiveModel::ValidationError) do
+        Disclosure.load_from_source(YAML.safe_load(yaml_content))
+      end
+      assert_equal [{ error: :taken }], error.model.errors.details[:id]
+    end
+
     private
 
     def valid_source
       <<~YAML
-        - public_id: choking_hazard
+        - id: 1
+          public_id: choking_hazard
           parent_public_id:
           name: Choking hazards
           internal_label: Choking hazards
           description: Choking and suffocation hazards for children
           disclosure_attributes: []
           disclosure_attribute_values: []
-        - public_id: us-cpsc-choking_small_parts
+        - id: 2
+          public_id: us-cpsc-choking_small_parts
           parent_public_id: choking_hazard
           name: Choking Hazard — Small Parts (US)
           internal_label: Choking Hazard — Small Parts (US)
@@ -289,7 +357,8 @@ module ProductTaxonomy
           title: "Choking Hazard: Small Parts"
           content: Not for children under 3 years.
           source: https://www.ecfr.gov/current/title-16/part-1501
-        - public_id: us-cpsc-choking_balloons
+        - id: 3
+          public_id: us-cpsc-choking_balloons
           parent_public_id: choking_hazard
           name: Choking Hazard — Balloons (US)
           internal_label: Choking Hazard — Balloons (US)


### PR DESCRIPTION
## TL;DR

Give each disclosure a stable numeric `id`, and build the global ID from it.

## Why

Shopify Core keys a disclosure by a numeric id. It reads `gid.model_id.to_i` and
rejects a slug, so a slug global ID does not work through the Admin API. This
repo held only `public_id`, so the disclosure axis was not usable from the API.

An internal copy of this data is the live source today. The plan moves the source
to this repo. The ids here match the internal copy, so the global IDs that
merchants already store stay correct after that change.

## What

Data (`data/disclosures.yml`):

- Add a stable numeric `id` to each of the 10 nodes. The values match the
  internal copy.

The hierarchy keeps the slug `parent_public_id`.

Model (`ProductTaxonomy::Disclosure`):

- Build the global ID from `id`.
- Validate that `id` is present, is an integer, and is unique.
- Index disclosures by `id`, so `find_by(id:)` works.

## Product impact

Merchants who set a product disclosure through the Admin API benefit. A slug
global ID fails today, which blocks the disclosure work for product safety and
compliance requirements.

## Verification

- `rake test:unit`: 480 runs, 0 failures.
- `rake test:integration`: 12 runs, 0 failures. The integration suite loads the
  real data file and validates every node.
- RuboCop reports no offenses.
- A new integration test fails if a node loses its `id`, or if two nodes share an
  `id`.
- After the merge, confirm that the downstream table keeps the same ids, and that
  `gid://shopify/TaxonomyDisclosure/{id}` still resolves for the
  `shopify--disclosure-*` metaobjects.
