### PR TITLE
Stub data_path in GenerateDocsCommandTest setup

### DIFF
--- a/dev/test/commands/generate_docs_command_test.rb
+++ b/dev/test/commands/generate_docs_command_test.rb
@@ -11,6 +11,7 @@ module ProductTaxonomy
 
       # Create test files
       FileUtils.mkdir_p(File.expand_path("data", @tmp_base_path))
+      ProductTaxonomy.stubs(:data_path).returns(File.expand_path("data", @tmp_base_path))
       FileUtils.mkdir_p(File.expand_path("dist/en/integrations", @tmp_base_path))
       File.write(
         File.expand_path("dist/en/integrations/all_mappings.json", @tmp_base_path),


### PR DESCRIPTION
## What

Adds the standard `data_path` stub to `GenerateDocsCommandTest` setup — the same line every other command test already has:

```ruby
ProductTaxonomy.stubs(:data_path).returns(File.expand_path("data", @tmp_base_path))
```

## Why

`GenerateDocsCommand` reads `dist/en/integrations/all_mappings.json` relative to `ProductTaxonomy.data_path` ([generate_docs_command.rb:46](https://github.com/Shopify/product-taxonomy/blob/main/dev/lib/product_taxonomy/commands/generate_docs_command.rb#L46)). The test setup writes a small `all_mappings.json` fixture into its tmp dir, but never redirected `data_path` there — so all 7 tests silently read the real 10 MB `dist/` file from the repo instead, and the fixture was never used.

Two consequences:

- The tests only pass when the committed `dist/` tree exists on disk. Any PR that removes `dist/` from git (#546, currently #987) fails `test_unit` with 7 × `Errno::ENOENT`.
- Each test parses 10 MB of production JSON instead of the ~200-byte fixture written for it.

This was the only command test missing the stub — `dump_categories`, `dump_values`, `dump_attributes`, `dump_return_reasons`, `dump_disclosures`, `sync_en_localizations`, and `generate_release` all sandbox `data_path` in setup already.

## Verification

- `test/commands/generate_docs_command_test.rb`: 12 runs, 0 failures, 0 errors
- Full `rake test:unit`: 499 runs, 287,779 assertions, 0 failures, 0 errors
- Also verified with the repo `dist/en/` directory removed from disk entirely — same result, proving the tests no longer depend on the committed `dist/` tree.

## Notes

Unblocks #987 (`test_unit` currently red for exactly this reason) and removes the last `test_unit` dependency on committed `dist/` files ahead of #546.

---
_Generated with Pi._
<!-- github-gate:footer -->
<!-- github-gate:idempotency=github-gate:create_pr:66d305ebd92723bc5e1ab124 -->