### PR TITLE
Add disclosure requests issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-disclosures-requests.yml
+++ b/.github/ISSUE_TEMPLATE/3-disclosures-requests.yml
@@ -1,4 +1,4 @@
-name: Disclosure requests
+name: Disclosure Requests
 description: File a request to change disclosures
 title: "[Disclosure]: "
 assignees: Shopklaw, billdevine00

--- a/.github/ISSUE_TEMPLATE/3-disclosures-requests.yml
+++ b/.github/ISSUE_TEMPLATE/3-disclosures-requests.yml
@@ -1,0 +1,47 @@
+name: Disclosure requests
+description: File a request to change disclosures
+title: "[Disclosure]: "
+assignees: Shopklaw, billdevine00
+labels:
+  - "disclosure-requests"
+body:
+  - type: dropdown
+    id: change_type
+    attributes:
+      label: Change Type
+      multiple: false
+      options:
+        - Update to existing disclosure
+        - Support additional disclosure
+
+  - type: textarea
+    id: issue
+    attributes:
+      label: Issue
+      description: Provide a brief summary of the disclosure change you're requesting.
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the disclosure, why the change is needed, and how it will improve the taxonomy. Include any relevant jurisdiction, regulation, or source.
+    validations:
+      required: true
+
+  - type: textarea
+    id: video_screenshot
+    attributes:
+      label: Video/Screenshot
+      description: Attach any relevant videos or screenshots to this text area.
+    validations:
+      required: false
+
+  - type: input
+    id: merchant_store
+    attributes:
+      label: Store Public URL
+      description: Please share a link to your store or any other relevant link to help us review and support your request. **This is a public repo; do not include any sensitive info.**
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/3-disclosures-requests.yml
+++ b/.github/ISSUE_TEMPLATE/3-disclosures-requests.yml
@@ -1,7 +1,7 @@
 name: Disclosure Requests
 description: File a request to change disclosures
 title: "[Disclosure]: "
-assignees: Shopklaw, billdevine00
+assignees: Shopklaw,billdevine00
 labels:
   - "disclosure-requests"
 body:


### PR DESCRIPTION
This file allows users to submit requests for changes to disclosures, including various fields for details and attachments.

per convo with @ricardotejedorsanz I've setup a distinct disclosures template so we can receive and process community feedback.