### PR TITLE
Bump ProductTaxonomy version to 1.2.0

### DIFF
--- a/dev/lib/product_taxonomy/version.rb
+++ b/dev/lib/product_taxonomy/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module ProductTaxonomy
-  VERSION = "1.1.1"
+  VERSION = "1.2.0"
 end
 


### PR DESCRIPTION
Bumps the gem version from 1.1.1 to 1.2.0 so the parser changes from #983 (`return_reasons: inherit` support) get published to RubyGems.

## Why

The published gem (1.1.1) predates #983 and cannot parse the `return_reasons: inherit` dialect now used in `data/categories/*.yml`. Any consumer that installs the gem from RubyGems and loads current `main` data fails validation with:

```
Validation failed for category with id=`aa-1-1-2-4`: return_reasons not found for friendly ID "inherit"
```

This blocks Shopify-internal BigQuery dataset builds from `main` (the build pipeline installs the published gem and fetches data at a git ref).

## What

One-line bump of `dev/lib/product_taxonomy/version.rb` (1.1.1 → 1.2.0), following the precedent of #861. Merging triggers `.github/workflows/publish_gem.yml` (push to main, path-filtered on this file), which builds and publishes to RubyGems automatically.

Minor version bump because #983 added a feature (inherit resolution for return reasons) in a backwards-compatible way.

---
_Generated with Pi._
<!-- github-gate:footer -->
<!-- github-gate:idempotency=github-gate:create_pr:058923917e861016930a56d0 -->